### PR TITLE
Statmap segment staging

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -251,7 +251,9 @@ if len(data['stat']) > 0:
             f[key] = data[key][cid]
         else:
             f[key] = data[key]
-f['analyzed_start'], f['analyzed_end'] = veto.segments_to_start_end(coinc_segs)
+f['segments/coinc/start'], f['segments/coinc/end'] = veto.segments_to_start_end(coinc_segs)
+for t in [trigs0, trigs1]]:
+    f['segments/%s/start' % t.ifo], f['segments/%s/start' % t.ifo] = t.valid
 f.attrs['timeslide_interval'] = args.timeslide_interval
 f.attrs['detector_1'] = det0.name
 f.attrs['detector_2'] = det1.name

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -55,7 +55,6 @@ class Stat(object):
     def __init__(self, files):
         self.files = {}
         for filename in files:
-            print files
             f = h5py.File(filename, 'r')
             stat = f.attrs['stat']
             self.files[stat] = f
@@ -214,7 +213,6 @@ for tnum in range(tmin, tmax):
             bl = []
     elif args.loudest_keep_value:
         bl, bh = [], bi[c[bi] > args.loudest_keep_value]
-        print len(bl), len(bh)
     else:
         bl, bh = [], bi
 
@@ -252,8 +250,8 @@ if len(data['stat']) > 0:
         else:
             f[key] = data[key]
 f['segments/coinc/start'], f['segments/coinc/end'] = veto.segments_to_start_end(coinc_segs)
-for t in [trigs0, trigs1]]:
-    f['segments/%s/start' % t.ifo], f['segments/%s/start' % t.ifo] = t.valid
+for t in [trigs0, trigs1]:
+    f['segments/%s/start' % t.ifo], f['segments/%s/end' % t.ifo] = t.valid
 f.attrs['timeslide_interval'] = args.timeslide_interval
 f.attrs['detector_1'] = det0.name
 f.attrs['detector_2'] = det1.name

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -74,8 +74,8 @@ for trigger_file, injection_file in zip(args.trigger_files, args.injection_files
     time2 = f['foreground/time2'][:]
     trig1 = f['foreground/trigger_id1'][:]
     trig2 = f['foreground/trigger_id2'][:]
-    ana_start = f['foreground/analyzed_start'][:]
-    ana_end = f['foreground/analyzed_end'][:]
+    ana_start = f['segments/coinc/start'][:]
+    ana_end = f['segments/coinc/end'][:]
     time = 0.5 * (time1 + time2)
     time_sorting = time.argsort()
 

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -105,8 +105,8 @@ logging.info("%s clustered foreground triggers" % fore_locs.sum())
 
 # Copy over the segment for coincs and singles
 for key in seg.keys():
-    f['segments'][key]['start'] = seg[key]['start']
-    f['segments'][key]['end'] = seg[key]['end']
+    f['segments/%s/start' % key] = seg[key]['start'][:]
+    f['segments/%s/end' % key] = seg[key]['end'][:]
 
 if fore_locs.sum() > 0:
     f['foreground/stat'] = stat_i[fore_locs]

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -97,6 +97,7 @@ f = h5py.File(args.output_file, "w")
 
 f.attrs['detector_1'] = attrs['detector_1']
 f.attrs['detector_2'] = attrs['detector_2']
+f.attrs['timeslide_interval'] = attrs['timeslide_interval']
 
 fore_locs = (sid_i == 0)
 logging.info("%s clustered foreground triggers" % fore_locs.sum())

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -32,7 +32,8 @@ def load_coincs(coinc_files):
            numpy.concatenate(time2), numpy.concatenate(timeslide_id),
            numpy.concatenate(template_id), numpy.concatenate(decimation_factor),
            numpy.concatenate(i1), numpy.concatenate(i2), attr, 
-           f['analyzed_start'][:], f['analyzed_end'][:], 
+           f['segments/coinc/start'][:], f['segments/coinc/end'][:],
+           f['segments']
            )
 
 def calculate_fan_map(combined_stat, dec):
@@ -62,7 +63,7 @@ if args.verbose:
                             level=log_level)
 
 logging.info("Loading coinc triggers")    
-stat, t1, t2, sid, tid, dec, i1, i2, attrs, start, end = load_coincs(args.coinc_files)   
+stat, t1, t2, sid, tid, dec, i1, i2, attrs, start, end, seg = load_coincs(args.coinc_files)   
 logging.info("We have %s triggers" % len(stat))
 
 unclustered_fore_locs = numpy.where((sid == 0))[0]
@@ -102,6 +103,11 @@ f.attrs['timeslide_interval'] = attrs['timeslide_interval']
 fore_locs = (sid_i == 0)
 logging.info("%s clustered foreground triggers" % fore_locs.sum())
 
+# Copy over the segment for coincs and singles
+for key in seg.keys():
+    f['segments'][key]['start'] = seg[key]['start']
+    f['segments'][key]['end'] = seg[key]['end']
+
 if fore_locs.sum() > 0:
     f['foreground/stat'] = stat_i[fore_locs]
     f['foreground/time1'] = t1_i[fore_locs]
@@ -109,8 +115,6 @@ if fore_locs.sum() > 0:
     f['foreground/trigger_id1'] = i1_i[fore_locs]
     f['foreground/trigger_id2'] = i2_i[fore_locs]
     f['foreground/template_id'] = tid_i[fore_locs]
-    f['foreground/analyzed_start'] = start
-    f['foreground/analyzed_end'] = end
 
 back_locs = numpy.where((sid_i != 0))[0]
 

--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -79,6 +79,7 @@ f = h5py.File(args.output_file, "w")
 
 f.attrs['detector_1'] = attrs['detector_1']
 f.attrs['detector_2'] = attrs['detector_2']
+f.attrs['timeslide_interval'] = attrs['timeslide_interval']
 logging.info('writing zero lag triggers')
 
 if len(zdata['stat']) > 0:

--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -80,13 +80,18 @@ f = h5py.File(args.output_file, "w")
 f.attrs['detector_1'] = attrs['detector_1']
 f.attrs['detector_2'] = attrs['detector_2']
 f.attrs['timeslide_interval'] = attrs['timeslide_interval']
+
+# Copy over the segment for coincs and singles
+for key in seg.keys():
+    f['segments/%s/start' % key] = seg[key]['start'][:]
+    f['segments/%s/end' % key] = seg[key]['end'][:]
+
 logging.info('writing zero lag triggers')
 
 if len(zdata['stat']) > 0:
     for key in zdata:
         f['foreground/%s' % key] = zdata[key][zcid]
-    f['foreground/analyzed_start'] = start
-    f['foreground/analyzed_end'] = end
+        
 
 logging.info('calculating statistics excluding zerolag')
 fb = h5py.File(args.full_data_background, "r")

--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -26,7 +26,7 @@ def load_coincs(coinc_files):
             continue            
     for key in data:
         data[key] = numpy.concatenate(data[key])              
-    return data, dict(f.attrs), f['analyzed_start'][:], f['analyzed_end'][:]
+    return data, dict(f.attrs), f['segments/coinc/start'][:], f['segments/coinc/end'][:], f['segments']
 
 def calculate_fan_map(combined_stat, dec):
     """ Return a function to map between false alarm number (FAN) and the
@@ -60,18 +60,18 @@ if args.verbose:
     logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
 
 logging.info("Loading coinc zerolag triggers")    
-zdata, attrs, start, end = load_coincs(args.zero_lag_coincs)   
+zdata, attrs, start, end, seg = load_coincs(args.zero_lag_coincs)   
 interval = attrs['timeslide_interval']
 zcid = coinc.cluster_coincs(zdata['stat'], zdata['time1'], zdata['time2'], 
                           zdata['timeslide_id'], interval, args.cluster_window)
                      
 logging.info("Loading coinc full inj triggers")    
-fidata, _, _, _ = load_coincs(args.mixed_coincs_full_inj)   
+fidata, _, _, _, _ = load_coincs(args.mixed_coincs_full_inj)   
 ficid = coinc.cluster_coincs(fidata['stat'], fidata['time1'], fidata['time2'], 
                          fidata['timeslide_id'], interval, args.cluster_window)
                      
 logging.info("Loading coinc inj full triggers")    
-izdata, _, _, _ = load_coincs(args.mixed_coincs_inj_full)   
+izdata, _, _, _, _ = load_coincs(args.mixed_coincs_inj_full)   
 ifcid = coinc.cluster_coincs(izdata['stat'], izdata['time1'], izdata['time2'], 
                          izdata['timeslide_id'], interval, args.cluster_window)
 


### PR DESCRIPTION
This set of patches stores the single detector analyzed segments that are used in the find coinc code and propagates that through. This is useful for analyzing the timeslide information.

Built on https://github.com/ligo-cbc/pycbc/pull/3 
(the patches corresponding to that will disappear automatically if that is merged)