### PR TITLE
add segments-method to analyze all single ifo time or coinc time

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -49,9 +49,9 @@ science_segs, science_seg_file = wf.get_analyzable_segments(workflow, "segments"
 datafind_files, science_segs = wf.setup_datafind_workflow(workflow, 
                                          science_segs, "datafind", science_seg_file)
 
-cum_veto_files, ind_cats = wf.get_cumulative_veto_group_files(workflow, 
+cum_veto_files, veto_names, ind_cats = wf.get_cumulative_veto_group_files(workflow, 
                                         'segments-veto-groups', "segments")
-final_veto_file, ind_cats = wf.get_cumulative_veto_group_files(workflow, 
+final_veto_file, final_veto_name, ind_cats = wf.get_cumulative_veto_group_files(workflow, 
                                         'segments-final-veto-group', "segments")
 
 # Template bank stuff

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -234,7 +234,6 @@ def setup_datafind_workflow(workflow, scienceSegs,  outputDir, segFilesList,
         missingFlag = False
         for ifo in dfScienceSegs.keys():
             scienceFile = segFilesList.find_output_with_ifo(ifo)
-            scienceFile = scienceFile.find_output_with_tag('SCIENCE')
             if not len(scienceFile) == 1:
                 errMsg = "Did not find exactly 1 science file."
                 raise ValueError(errMsg)

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1163,12 +1163,13 @@ def get_cumulative_veto_group_files(workflow, option, out_dir, tags=[]):
                                         start_time, end_time, out_dir,
                                         veto_gen_job, execute_now=True))
 
-    cum_seg_files = FileList()        
+    cum_seg_files = FileList()     
+    names = []   
     for cat_set in cat_sets:
-        segment_name = ''.join(sorted(cat_set))
-        logging.info('getting information for cumulative CAT %s' % segment_name)
+        segment_name = "CUMULATIVE_CAT_%s" % (''.join(sorted(cat_set)))
+        logging.info('getting information for %s' % segment_name)
         categories = [cat_to_pipedown_cat(c) for c in cat_set]
-        path = os.path.join(out_dir, '%s-CUMULATIVE_CAT_%s_VETO_SEGMENTS.xml' \
+        path = os.path.join(out_dir, '%s-%s_VETO_SEGMENTS.xml' \
                             % (workflow.ifo_string, segment_name))
         path = os.path.abspath(path)
         url = urlparse.urlunparse(['file', 'localhost', path, None, None, None])
@@ -1177,8 +1178,9 @@ def get_cumulative_veto_group_files(workflow, option, out_dir, tags=[]):
                         
         cum_seg_files += [get_cumulative_segs(workflow, seg_file,  categories,
               cat_files, out_dir, execute_now=False, segment_name=segment_name)]
+        names.append(segment_name)
               
-    return cum_seg_files, cat_files
+    return cum_seg_files, names, cat_files
 
 def file_needs_generating(file_path):
     """

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1054,16 +1054,16 @@ def get_analyzable_segments(workflow, out_dir, tags=[]):
     """
     from pycbc.events import segments_to_file
     logging.info('Entering generation of science segments')
-    segments_method = workflow.cp.get_opt_tags("workflow-segments", 
-                                      "segments-method", tags)
+    segments_method = workflow.cp.get_opt_tags("workflow-science", 
+                                      "science-method", tags)
     
     make_analysis_dir(out_dir)
     start_time = workflow.analysis_time[0]
     end_time = workflow.analysis_time[1]
     save_veto_definer(workflow.cp, out_dir, tags)
     
-    cat_sets = parse_cat_ini_opt(workflow.cp.get_opt_tags('workflow-segments',
-                                                'segments-science-veto', tags))
+    cat_sets = parse_cat_ini_opt(workflow.cp.get_opt_tags('workflow-science',
+                                                'science-veto-segments', tags))
     if len(cat_sets) > 1: 
         raise ValueError('Provide only 1 category group to determine'
                          ' analyzable segments')
@@ -1141,7 +1141,7 @@ def get_cumulative_veto_group_files(workflow, option, out_dir, tags=[]):
     start_time = workflow.analysis_time[0]
     end_time = workflow.analysis_time[1]
 
-    cat_sets = parse_cat_ini_opt(workflow.cp.get_opt_tags('workflow-segments',
+    cat_sets = parse_cat_ini_opt(workflow.cp.get_opt_tags('workflow-vetoes',
                                             option, tags))
     veto_gen_job = create_segs_from_cats_job(workflow.cp, out_dir,
                                              workflow.ifo_string) 

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1054,7 +1054,7 @@ def get_analyzable_segments(workflow, out_dir, tags=[]):
     """
     from pycbc.events import segments_to_file
     logging.info('Entering generation of science segments')
-    segments_method = workflow.cp.get_opt_tags("workflow-science", 
+    science_method = workflow.cp.get_opt_tags("workflow-science", 
                                       "science-method", tags)
     
     make_analysis_dir(out_dir)
@@ -1093,9 +1093,9 @@ def get_analyzable_segments(workflow, out_dir, tags=[]):
             
         sci_segs[ifo].coalesce()
         
-    if segments_method == 'ALL_SINGLE_IFO_TIME':
+    if science_method == 'ALL_SINGLE_IFO_TIME':
         pass
-    elif segments_method == 'COINC_TIME':
+    elif science_method == 'COINC_TIME':
         cum_segs = None
         for ifo in sci_segs:
             if cum_segs is not None:
@@ -1107,8 +1107,14 @@ def get_analyzable_segments(workflow, out_dir, tags=[]):
             sci_segs[ifo] = cum_segs 
     else:
         raise ValueError("Invalid segments-method, %s. Options are "
-                         "ALL_SINGLE_IFO_TIME and COINC_TIME" % segments_method)
+                         "ALL_SINGLE_IFO_TIME and COINC_TIME" % science_method)
         
+    min_segment_length =  workflow.cp.get_opt_tags("workflow-science", 
+                                      "science-min-segment-length", tags)
+    if min_segment_length:
+        for ifo in sci_segs:
+            segs = [seg for seg in sci_segs[ifo] if abs(seg) < min_segment_length]
+            sci_segs[ifo] = segments.segmentlist(segs)
         
     logging.info('Leaving generation of science segments')
     return sci_segs, seg_files

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1054,8 +1054,6 @@ def get_analyzable_segments(workflow, out_dir, tags=[]):
     """
     from pycbc.events import segments_to_file
     logging.info('Entering generation of science segments')
-    science_method = workflow.cp.get_opt_tags("workflow-science", 
-                                      "science-method", tags)
     
     make_analysis_dir(out_dir)
     start_time = workflow.analysis_time[0]
@@ -1092,7 +1090,9 @@ def get_analyzable_segments(workflow, out_dir, tags=[]):
                                           "SCIENCE_OK", ifo=ifo)]
             
         sci_segs[ifo].coalesce()
-        
+
+    science_method = workflow.cp.get_opt_tags("workflow-science", 
+                                      "science-analyze-method", tags)        
     if science_method == 'ALL_SINGLE_IFO_TIME':
         pass
     elif science_method == 'COINC_TIME':
@@ -1110,7 +1110,7 @@ def get_analyzable_segments(workflow, out_dir, tags=[]):
                          "ALL_SINGLE_IFO_TIME and COINC_TIME" % science_method)
         
     min_segment_length =  workflow.cp.get_opt_tags("workflow-science", 
-                                      "science-min-segment-length", tags)
+                                      "science-minimum-segment-length", tags)
     if min_segment_length:
         for ifo in sci_segs:
             segs = [seg for seg in sci_segs[ifo] if abs(seg) < min_segment_length]


### PR DESCRIPTION
Allow option to only analyze coincident data.At the moment this only adds this functionality to the segment functions used by the hdf only workflow generator. I'm not sure we'll use this in a standard configuration, but I wanted the option to test if the trade off in computation time might be worth the loss in some background estimation from the extra data. 

segments-method = ALL_SINGLE_IFO_TIME

or

segments-method = COINC_TIME

 If there is interest, I think it would be straightforward to add it the segment generation used by the standard workflow generator. 