### PR TITLE
allow injections to be skipped by not including injection sections

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -139,10 +139,12 @@ for ifo, files in zip(*ind_cats.categorize_by_attr('ifo')):
 wf.make_segments_plot(workflow, full_segs, 'plots/segments', tags=['INSPIRAL_SEGMENTS'])
 wf.make_segments_plot(workflow, science_seg_file, 'plots/segments', tags=['SCIENCE_MINUS_CAT1'])
 
-found_inj = wf.find_injections_in_hdf_coinc(workflow, inj_coincs,
+if len(inj_files) > 0:
+    found_inj = wf.find_injections_in_hdf_coinc(workflow, inj_coincs,
                                             inj_files, final_veto_file[0], 
                                             output_dir, tags=['ALLINJ'])                                                
-wf.make_sensitivity_plot(workflow, found_inj, 'plots/sensitivity', tags=['ALLINJ'])
+    wf.make_sensitivity_plot(workflow, found_inj, 'plots/sensitivity', 
+                                            tags=['ALLINJ'])
 
 workflow.save()
 logging.info("Written dax.")

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -319,8 +319,10 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         
         if len(subsections) > 0:
             return [sec.split('-')[1] for sec in subsections]
-        else:
+        elif self.has_section(section_name):
             return ['']
+        else:
+            return []
 
     def perform_extended_interpolation(self):
         """


### PR DESCRIPTION
Make injections optional. Currently, if you don't include an injections section the injection setup function will fail. Now, it will return an empty list. 