### PR TITLE
raise error when using a negative start slice index, bug reported by …

### DIFF
--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -103,7 +103,7 @@ class TimeSeries(Array):
                 new_epoch = self._epoch
             else:
                 if index.start < 0:
-                    index.start += len(self)
+                    raise ValueError('Negative start index not supported')
                 new_epoch = self._epoch + index.start * self._delta_t
             return TimeSeries(Array.__getitem__(self, index), self._delta_t, new_epoch, copy=False)
         else:


### PR DESCRIPTION

Using a negative start index for slicing in a time series is now an error, instead of an unexplained failure. 

As reported by Pannarale in https://github.com/ligo-cbc/pycbc/issues/14