### PR TITLE
remove triggers not near injections

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -291,6 +291,11 @@ if opt.newsnr_threshold and opt.chisq_bins:
     event_mgr.newsnr_threshold(opt.newsnr_threshold)
     logging.info("%d remaining triggers" % len(event_mgr.events))
 
+if opt.injection_window and hasattr(gwstrain, 'injections'):
+    logging.info("Keeping triggers within %s seconds of injection" % opt.injection_window)
+    event_mgr.keep_near_injection(opt.injection_window, gwstrain.injections)
+    logging.info("%d remaining triggers" % len(event_mgr.events))   
+    
 if opt.maximization_interval:
     logging.info("Maximizing triggers over %s ms window" % opt.maximization_interval)
     window = int(opt.maximization_interval * gwstrain.sample_rate / 1000)

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -199,6 +199,17 @@ class EventManager(object):
         remove = [i for i, e in enumerate(self.events) if \
             newsnr(abs(e['snr']), e['chisq'] / e['chisq_dof']) < threshold]
         self.events = numpy.delete(self.events, remove)
+        
+    def keep_near_injection(self, window, injections):
+        from pycbc.events.veto import indices_within_times
+        if len(self.events) == 0:
+            return
+        
+        inj_time = numpy.array(injections.end_times())
+        gpstime = self.events['time_index'].astype(numpy.float64)
+        gpstime = gpstime / self.opt.sample_rate + self.opt.gps_start_time
+        i = indices_within_times(gpstime, inj_time - window, inj_time + window)
+        self.events = self.events[i]
 
     def maximize_over_bank(self, tcolumn, column, window):
         if len(self.events) == 0:


### PR DESCRIPTION
This extends the current functionality of the --injection-window option to keep only those triggers near an injection, even where there are multiple injections / segments and the slice operation itself cannot be changed. This is implemented as a final cleanup step, like the newsnr cut. 