### PR TITLE
add option to keep loudest X triggers every Y seconds

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -125,6 +125,8 @@ parser.add_argument("--user-tag", type=str, metavar="TAG", help="""
                     compatibility with pipedown post-processing. 
                     Option will be removed when no longer needed.""")
 parser.add_argument("--psd-recalculate-segments", type=int, help="Number of segments to use before recalculating the PSD", default=0)
+parser.add_argument("--keep-loudest-interval", type=float, help="Window in seconds to maximize triggers over bank")
+parser.add_argument("--keep-loudest-num", type=int, help="Number of triggers to keep from each maximization interval")
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -291,11 +293,19 @@ if opt.newsnr_threshold and opt.chisq_bins:
     event_mgr.newsnr_threshold(opt.newsnr_threshold)
     logging.info("%d remaining triggers" % len(event_mgr.events))
 
+if opt.keep_loudest_interval:
+    logging.info("Removing triggers that are not within the top %s loudest"
+                 " of a %s second interval" % (opt.keep_loudest_num,
+                                               opt.keep_loudest_interval))
+    event_mgr.keep_loudest_in_interval(opt.keep_loudest_interval * opt.sample_rate, 
+                                       opt.keep_loudest_num)
+    logging.info("%d remaining triggers" % len(event_mgr.events))
+
 if opt.injection_window and hasattr(gwstrain, 'injections'):
     logging.info("Keeping triggers within %s seconds of injection" % opt.injection_window)
     event_mgr.keep_near_injection(opt.injection_window, gwstrain.injections)
     logging.info("%d remaining triggers" % len(event_mgr.events))   
-    
+
 if opt.maximization_interval:
     logging.info("Maximizing triggers over %s ms window" % opt.maximization_interval)
     window = int(opt.maximization_interval * gwstrain.sample_rate / 1000)

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -211,6 +211,25 @@ class EventManager(object):
         i = indices_within_times(gpstime, inj_time - window, inj_time + window)
         self.events = self.events[i]
 
+    def keep_loudest_in_interval(self, window, num_keep):
+        if len(self.events) == 0:
+            return
+        
+        e = self.events
+        stat = newsnr(abs(e['snr']), e['chisq'] / e['chisq_dof'])
+        time = e['time_index']
+        
+        wtime = (time / window).astype(numpy.int32)
+        bins = numpy.unique(wtime)
+        
+        keep = []
+        for b in bins:
+            bloc = numpy.where((wtime == b))[0]
+            bloudest = stat[bloc].argsort()[-num_keep:]
+            keep.append(bloc[bloudest])
+        keep = numpy.concatenate(keep)
+        self.events = e[keep]
+
     def maximize_over_bank(self, tcolumn, column, window):
         if len(self.events) == 0:
             return


### PR DESCRIPTION
This adds options in pycbc_inspiral to keep the loudest X number of triggers every Y seconds. This reduces the storage requirements of PyCBC when used in conjunction with #19. Initially, this is simply a storage improvement. If it turns out to work generally then it implies some further performance optimizations that could be used in conjunction with the heirarchical inspiral search. 

BNS run with 4 injection sets (injection every 130 s)
Original: 16 GB 
Keep Loudest 100 triggers every 2 seconds -> 1.5 GB for single inspiral triggers 

Sensitivity for the BNS search under these settings was unchanged. Although, I expected that as I found 100 by plotting the number of nearby triggers louder than the trigger found in coincidence for each significant injection. I think conservative settings should be safe, and may be improved by also including  scaling to the peak SNR (fewer triggers are needed the louder the peak signal). 