### PR TITLE
Make single SNR-chi² plot more readable

### DIFF
--- a/bin/hdfcoinc/pycbc_page_snrchi
+++ b/bin/hdfcoinc/pycbc_page_snrchi
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
-import numpy, h5py, argparse, logging, matplotlib
+
+import numpy, h5py, argparse, matplotlib
 matplotlib.use('Agg')
-from mpl_toolkits.axes_grid1.inset_locator import zoomed_inset_axes
 import pylab
 from pycbc.events import veto
-from matplotlib import colors
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--trigger-file', help='Single ifo trigger file')
@@ -44,26 +44,30 @@ if args.min_snr is not None:
     snr = snr[locs]
     chisq = chisq[locs]
 
-r = numpy.logspace(numpy.log(chisq.min()), numpy.log(chisq.max()), 200)
-for cval in args.newsnr_contours:
+r = numpy.logspace(numpy.log(chisq.min()), numpy.log(chisq.max()), 300)
+for i, cval in enumerate(args.newsnr_contours):
     snrv = snr_from_chisq(r, cval)
-    pylab.plot(snrv, r, label="$\\rho_{new} = %s$" % cval, color='black')
+    pylab.plot(snrv, r, color='black', lw=0.5)
+    if i == 0:
+        label = "$\\hat{\\rho} = %s$" % cval
+    else:
+        label = "$%s$" % cval
+    label_pos_idx = numpy.where(snrv > snr.max() * 0.8)[0][0]
+    pylab.text(snrv[label_pos_idx], r[label_pos_idx], label, fontsize=6,
+               horizontalalignment='center', verticalalignment='center',
+               bbox=dict(facecolor='white', lw=0, pad=0, alpha=0.9))
 
-pylab.hexbin(snr, chisq, gridsize=300,
-             xscale='log', yscale='log', mincnt=1, norm=colors.LogNorm())
+pylab.hexbin(snr, chisq, gridsize=300, xscale='log', yscale='log', lw=0.04,
+             mincnt=1, norm=matplotlib.colors.LogNorm())
 
 ax = pylab.gca()
 pylab.grid()   
 ax.set_xscale('log')
 cb = pylab.colorbar() 
-pylab.xlim(snr.min(), snr.max())
-pylab.ylim(chisq.min(), chisq.max())
+pylab.xlim(snr.min(), snr.max() * 1.1)
+pylab.ylim(chisq.min(), chisq.max() * 1.1)
 cb.set_label('Trigger Density')
 pylab.xlabel('Signal-to-Noise Ratio')
-pylab.ylabel('Reduced $\chi^2$')
+pylab.ylabel('Reduced $\\chi^2$')
 pylab.title('%s: Single Detector Trigger Distribution' % ifo)
 pylab.savefig(args.output_file, dpi=300)
-
-
-
-


### PR DESCRIPTION
Make NewSNR contours thinner and labeled, fix an issue with hexagon edges, make extremal triggers more visible and remove unused imports.

Before:
![h1-plot_snrchi__full_data-966384015-86400](https://cloud.githubusercontent.com/assets/11317236/7983266/d619bd0c-0abe-11e5-949b-d32d5b894eae.png)

After:
![snrchi_new](https://cloud.githubusercontent.com/assets/11317236/7983274/e5d23472-0abe-11e5-94c9-c334f63d2b8c.png)
