### PR TITLE
pycbc.events: fixes to clustering code

### DIFF
--- a/pycbc/events/threshold_cuda.py
+++ b/pycbc/events/threshold_cuda.py
@@ -391,7 +391,7 @@ threshold_cluster_krnl = threshold_cluster_mod.get_function("threshold_and_clust
   
 
 def threshold_and_cluster(series, threshold, window):
-     
+    assert window > 0, 'Clustering window length is not positive'
     threshold = numpy.float32(threshold)
     window = numpy.uint32(window)
     tlen = numpy.uint32(len(series))


### PR DESCRIPTION
Catch invalid cluster window length (see https://github.com/ligo-cbc/pycbc/issues/31). Also remove the slow unused version of the clustering function and rename the optimized version actually in use.