### PR TITLE
save/load array, timeseries, frequencyseries to hdf

### DIFF
--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -875,7 +875,7 @@ class Array(object):
         Parameters
         ----------
         path: string
-            Destination file path. Must end with either .npy or .txt.
+            Destination file path. Must end with either .hdf, .npy or .txt.
             
         group: string 
             Additional name for internal storage use. Ex. hdf storage uses

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -867,9 +867,10 @@ class Array(object):
     
     def save(self, path, group=None):
         """
-        Save array to a Numpy .npy or text file. When saving a complex array as
+        Save array to a Numpy .npy, hdf, or text file. When saving a complex array as
         text, the real and imaginary parts are saved as the first and second
-        column respectively.
+        column respectively. When using hdf format, the data is stored
+        as a single vector, along with relevant attributes.
 
         Parameters
         ----------
@@ -952,7 +953,7 @@ def zeros(length, dtype=float64):
 
 def load_array(path, group=None):
     """
-    Load an Array from a .txt or .npy file. The
+    Load an Array from a .hdf, .txt or .npy file. The
     default data types will be double precision floating point.
 
     Parameters

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -29,7 +29,7 @@ PyOpenCL, and Numpy.
 
 BACKEND_PREFIX="pycbc.types.array_"
 
-import logging
+import logging, h5py
 import os as _os
 
 import functools as _functools
@@ -865,7 +865,7 @@ class Array(object):
     def dtype(self):
         return self._data.dtype
     
-    def save(self, path):
+    def save(self, path, group=None):
         """
         Save array to a Numpy .npy or text file. When saving a complex array as
         text, the real and imaginary parts are saved as the first and second
@@ -873,8 +873,12 @@ class Array(object):
 
         Parameters
         ----------
-        path : string
+        path: string
             Destination file path. Must end with either .npy or .txt.
+            
+        group: string 
+            Additional name for internal storage use. Ex. hdf storage uses
+            this as the key value.
 
         Raises
         ------
@@ -892,8 +896,11 @@ class Array(object):
                 output = _numpy.vstack((self.numpy().real,
                                         self.numpy().imag)).T
                 _numpy.savetxt(path, output)
+        elif ext == '.hdf':
+            key = 'data' if group is None else group
+            h5py.File(path)[key] = self.numpy()
         else:
-            raise ValueError('Path must end with .npy or .txt')  
+            raise ValueError('Path must end with .npy, .txt, or hdf')  
            
     @_convert 
     def trim_zeros(self):
@@ -943,7 +950,7 @@ def zeros(length, dtype=float64):
     """
     pass
 
-def load_array(path):
+def load_array(path, group=None):
     """
     Load an Array from a .txt or .npy file. The
     default data types will be double precision floating point.
@@ -952,6 +959,10 @@ def load_array(path):
     ----------
     path : string
         source file path. Must end with either .npy or .txt.
+
+    group: string 
+        Additional name for internal storage use. Ex. hdf storage uses
+        this as the key value.
 
     Raises
     ------
@@ -966,8 +977,11 @@ def load_array(path):
         data = numpy.load(path)    
     elif ext == '.txt':
         data = numpy.loadtxt(path)
+    elif ext == '.hdf':
+        key = 'data' if group is None else group
+        return Array(h5py.File(path)[key]) 
     else:
-        raise ValueError('Path must end with .npy or .txt')
+        raise ValueError('Path must end with .npy, .hdf, or .txt')
         
     if data.ndim == 1:
         return Array(data)

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -312,7 +312,7 @@ class FrequencySeries(Array):
         Parameters
         ----------
         path: string
-            Destination file path. Must end with either .npy or .txt.
+            Destination file path. Must end with either .hdf, .npy or .txt.
             
         group: string 
             Additional name for internal storage use. Ex. hdf storage uses

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -303,10 +303,11 @@ class FrequencySeries(Array):
 
     def save(self, path, group=None):
         """
-        Save frequency series to a Numpy .npy or text file. The first column
+        Save frequency series to a Numpy .npy, hdf, or text file. The first column
         contains the sample frequencies, the second contains the values.
         In the case of a complex frequency series saved as text, the imaginary
-        part is written as a third column.
+        part is written as a third column.  When using hdf format, the data is stored
+        as a single vector, along with relevant attributes.
 
         Parameters
         ----------
@@ -391,7 +392,7 @@ class FrequencySeries(Array):
 
 def load_frequencyseries(path, group=None):
     """
-    Load a FrequencySeries from a .txt or .npy file. The
+    Load a FrequencySeries from a .hdf, .txt or .npy file. The
     default data types will be double precision floating point.
 
     Parameters

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -343,7 +343,7 @@ class FrequencySeries(Array):
             d = h5py.File(path)
             d[key] = self.numpy()
             d[key].attrs['epoch'] = float(self.epoch)
-            d[key].attrs['delta_f'] = int(self.delta_f)
+            d[key].attrs['delta_f'] = float(self.delta_f)
         else:
             raise ValueError('Path must end with .npy or .txt')
             

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -18,7 +18,7 @@
 Provides a class representing a frequency series.
 """
 
-import os as _os
+import os as _os, h5py
 from pycbc.types.array import Array, _convert, zeros, _noreal
 import lal as _lal
 import numpy as _numpy
@@ -301,7 +301,7 @@ class FrequencySeries(Array):
 
         return lal_data
 
-    def save(self, path):
+    def save(self, path, group=None):
         """
         Save frequency series to a Numpy .npy or text file. The first column
         contains the sample frequencies, the second contains the values.
@@ -310,8 +310,12 @@ class FrequencySeries(Array):
 
         Parameters
         ----------
-        path : string
+        path: string
             Destination file path. Must end with either .npy or .txt.
+            
+        group: string 
+            Additional name for internal storage use. Ex. hdf storage uses
+            this as the key value.
 
         Raises
         ------
@@ -333,6 +337,12 @@ class FrequencySeries(Array):
                                         self.numpy().real,
                                         self.numpy().imag)).T
             _numpy.savetxt(path, output)
+        elif ext =='.hdf':
+            key = 'data' if group is None else group
+            d = h5py.File(path)
+            d[key] = self.numpy()
+            d[key].attrs['epoch'] = float(self.epoch)
+            d[key].attrs['delta_f'] = int(self.delta_f)
         else:
             raise ValueError('Path must end with .npy or .txt')
             
@@ -379,15 +389,19 @@ class FrequencySeries(Array):
         return f
             
 
-def load_frequencyseries(path):
+def load_frequencyseries(path, group=None):
     """
     Load a FrequencySeries from a .txt or .npy file. The
     default data types will be double precision floating point.
 
     Parameters
     ----------
-    path : string
+    path: string
         source file path. Must end with either .npy or .txt.
+
+    group: string 
+        Additional name for internal storage use. Ex. hdf storage uses
+        this as the key value.
 
     Raises
     ------
@@ -403,8 +417,12 @@ def load_frequencyseries(path):
         data = numpy.load(path)    
     elif ext == '.txt':
         data = numpy.loadtxt(path)
+    elif ext == '.hdf':
+        key = 'data' if group is None else group
+        f = h5py.File(path)[key]
+        return FrequencySeries(f, delta_f=f.attrs['delta_f'], epoch=f.attrs['epoch']) 
     else:
-        raise ValueError('Path must end with .npy or .txt')
+        raise ValueError('Path must end with .npy, .hdf, or .txt')
         
     if data.ndim == 2:
         delta_f = (data[-1][0] - data[0][0]) / (len(data)-1)

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -361,10 +361,11 @@ class TimeSeries(Array):
 
     def save(self, path, group = None):
         """
-        Save time series to a Numpy .npy or text file. The first column
+        Save time series to a Numpy .npy, hdf, or text file. The first column
         contains the sample times, the second contains the values.
         In the case of a complex time series saved as text, the imaginary
-        part is written as a third column.
+        part is written as a third column. When using hdf format, the data is stored
+        as a single vector, along with relevant attributes.
 
         Parameters
         ----------
@@ -446,7 +447,7 @@ class TimeSeries(Array):
 
 def load_timeseries(path, group=None):
     """
-    Load a TimeSeries from a .txt or .npy file. The
+    Load a TimeSeries from a .hdf, .txt or .npy file. The
     default data types will be double precision floating point.
 
     Parameters

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -400,7 +400,7 @@ class TimeSeries(Array):
             f = h5py.File(path)
             f[key] = self.numpy()
             f[key].attrs['start_time'] = float(self.start_time)
-            f[key].attrs['delta_t'] = int(self.delta_t)
+            f[key].attrs['delta_t'] = float(self.delta_t)
         else:
             raise ValueError('Path must end with .npy or .txt')
                 

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -18,7 +18,7 @@
 Provides a class representing a time series.
 """
 
-import os as _os
+import os as _os, h5py
 from pycbc.types.array import Array, _convert, complex_same_precision_as, zeros
 from pycbc.types.array import _nocomplex
 from pycbc.types.frequencyseries import FrequencySeries
@@ -359,7 +359,7 @@ class TimeSeries(Array):
         scaled = _numpy.int16(self.numpy()/max(abs(self)) * 32767)
         write_wav(file_name, self.sample_rate, scaled)
 
-    def save(self, path):
+    def save(self, path, group = None):
         """
         Save time series to a Numpy .npy or text file. The first column
         contains the sample times, the second contains the values.
@@ -368,8 +368,12 @@ class TimeSeries(Array):
 
         Parameters
         ----------
-        path : string
+        path: string
             Destination file path. Must end with either .npy or .txt.
+
+        group: string 
+            Additional name for internal storage use. Ex. hdf storage uses
+            this as the key value.
 
         Raises
         ------
@@ -390,6 +394,12 @@ class TimeSeries(Array):
                                         self.numpy().real,
                                         self.numpy().imag)).T
             _numpy.savetxt(path, output)
+        elif ext =='.hdf':
+            key = 'data' if group is None else group
+            f = h5py.File(path)
+            f[key] = self.numpy()
+            f[key].attrs['start_time'] = float(self.start_time)
+            f[key].attrs['delta_t'] = int(self.delta_t)
         else:
             raise ValueError('Path must end with .npy or .txt')
                 
@@ -434,15 +444,19 @@ class TimeSeries(Array):
         
         
 
-def load_timeseries(path):
+def load_timeseries(path, group=None):
     """
     Load a TimeSeries from a .txt or .npy file. The
     default data types will be double precision floating point.
 
     Parameters
     ----------
-    path : string
+    path: string
         source file path. Must end with either .npy or .txt.
+
+    group: string 
+        Additional name for internal storage use. Ex. hdf storage uses
+        this as the key value.
 
     Raises
     ------
@@ -458,8 +472,13 @@ def load_timeseries(path):
         data = numpy.load(path)    
     elif ext == '.txt':
         data = numpy.loadtxt(path)
+    elif ext == '.hdf':
+        key = 'data' if group is None else group
+        f = h5py.File(path)[key]
+        return TimeSeries(f, delta_t=f.attrs['delta_t'],
+                             epoch=f.attrs['start_time']) 
     else:
-        raise ValueError('Path must end with .npy or .txt')
+        raise ValueError('Path must end with .npy, .hdf, or .txt')
         
     if data.ndim == 2:
         delta_t = (data[-1][0] - data[0][0]) / (len(data)-1)

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -370,7 +370,7 @@ class TimeSeries(Array):
         Parameters
         ----------
         path: string
-            Destination file path. Must end with either .npy or .txt.
+            Destination file path. Must end with either .hdf, .npy or .txt.
 
         group: string 
             Additional name for internal storage use. Ex. hdf storage uses


### PR DESCRIPTION
Add the ability to save and load pycbc types to hdf files using the 'save' method or the load_* methods. 