### PR TITLE
add option to select segments by ifo/segment_name to the indices_within/outside functions

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -108,8 +108,8 @@ for trigger_file, injection_file in zip(args.trigger_files, args.injection_files
     logging.info('Found: %s, Missed: %s' % (len(found_within_time), len(missed_within_time)))
 
     logging.info('Removing injections in vetoed time')
-    i1, v1 = veto_indices(inj_time, 'H1', [args.veto_file])
-    i2, v2 = veto_indices(inj_time, 'L1', [args.veto_file])
+    i1, v1 = veto_indices(inj_time, [args.veto_file], ifo='H1')
+    i2, v2 = veto_indices(inj_time, [args.veto_file], ifo='L1')
     
     vi = numpy.concatenate([i1, i2])
 

--- a/bin/hdfcoinc/pycbc_page_snrchi
+++ b/bin/hdfcoinc/pycbc_page_snrchi
@@ -35,7 +35,7 @@ def snr_from_chisq(chisq, newsnr, q=6.):
 
 if args.veto_file:
     time = f['end_time'][:]
-    locs, segs = veto.indices_outside_segments(time, ifo, [args.veto_file])
+    locs, segs = veto.indices_outside_segments(time, [args.veto_file], ifo=ifo)
     snr = snr[locs]
     chisq = chisq[locs]
 

--- a/bin/hdfcoinc/pycbc_plot_singles_vs_params
+++ b/bin/hdfcoinc/pycbc_plot_singles_vs_params
@@ -49,7 +49,7 @@ class SingleDetTriggerSet:
         if veto_file:
             logging.info('Loading veto segments')
             self.veto_mask, segs = pycbc.events.veto.indices_outside_segments(
-                self.trigs['end_time'][:], detector, [veto_file])
+                self.trigs['end_time'][:], [veto_file], ifo=detector)
 
         logging.info('Loading bank')
         self.bank = h5py.File(bank_file, 'r')


### PR DESCRIPTION
This adds the option to select segments by ifo and segment name when finding indices of some time vector. This also updates all the calling executables.

This is the first of several incremental changes, that will make pull request #10 a lot easier to implement. A future feature, not implemented here, will expose this functionality through the command line so all the relevant pycbc executables can take standard segment xml files (which may contain multiple segment lists) and process only the set of segments they need correctly.