### PR TITLE
added import of logging module so the wanrning message on line 879 works

### DIFF
--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -29,6 +29,7 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope.html
 """
 
 import math, os
+import logging
 from glue import segments
 import Pegasus.DAX3 as dax
 from pycbc.workflow.core import Executable, File, FileList, Node


### PR DESCRIPTION
The class PycbcSqliteSimplifyExecutable class generated a warning message if num_inputs is greater than 20, but it does not import logging, so the module fails with

NameError: global name 'logging' is not defined
