### PR TITLE
add support to pycbc executables for segment-name option

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -5,8 +5,10 @@ from pycbc.events import veto, coinc
        
 parser = argparse.ArgumentParser()
 parser.add_argument("--verbose", action="count")
-parser.add_argument("--veto-files", 
-                    help="Optional veto file. Injections within these times are ignored")
+parser.add_argument("--veto-files", nargs='+',
+                    help="Optional veto file. Triggers within these times are ignored")
+parser.add_argument('--segment-name', default=None, type=str,
+                    help='Optional, name of segment list to use for vetoes')
 parser.add_argument("--trigger-files", nargs=2,
                     help="File containing the single-detector triggers")
 parser.add_argument("--template-bank",
@@ -118,29 +120,24 @@ class PhaseTDStatistic(NewSNRStatistic):
         return cstat
 
 class ReadByTemplate(object):
-    def __init__(self, filename, bank=None, vetofile=None):
+    def __init__(self, filename, bank=None, segment_name=None, veto_files=[]):
         self.filename = filename
         self.file = h5py.File(filename, 'r')
         self.ifo = self.file.keys()[0]
-        if bank is not None:
-            self.bank = h5py.File(bank)
-        else:
-            self.bank = None
+        self.valid = None
+        self.bank = h5py.File(bank) if bank else None
 
-        self.veto_segs = None
-
-        
         # Determine the segments which define the boundaries of valid times
         # to use triggers
         from glue.segments import segmentlist, segment
         key = '%s/search/' % self.ifo
         s, e = self.file[key + 'start_time'][:], self.file[key + 'end_time'][:]
         self.segs = veto.start_end_to_segments(s, e).coalesce()
-        if vetofile is not None:
-            self.veto_segs = veto.select_segments_by_definer(vetofile, 
-                                                             ifo=self.ifo)
-            self.segs = (self.segs - self.veto_segs).coalesce()
-        self.valid = veto.segments_to_start_end(self.segs)
+        for vfile in veto_files:
+            veto_segs = veto.select_segments_by_definer(vfile, ifo=self.ifo, 
+                                                     segment_name=segment_name)
+            self.segs = (self.segs - veto_segs).coalesce()
+            self.valid = veto.segments_to_start_end(self.segs)
     
     def get_data(self, col, num):
         """ Get a column of data for template with id 'num'
@@ -178,7 +175,7 @@ class ReadByTemplate(object):
         
         # Determine which of these template's triggers are kept after
         # applying vetoes
-        if self.veto_segs:
+        if self.valid:
             self.keep = veto.indices_within_times(times, self.valid[0], self.valid[1]) 
             logging.info('applying vetoes')
         else:
@@ -213,7 +210,7 @@ class ReadByTemplate(object):
             raise ValueError('You must call set_template to first pick the '
                              'template to read data from')    
         data = self.get_data(col, self.template_num)         
-        data = data[self.keep] if self.veto_segs else data
+        data = data[self.keep] if self.valid else data
         return data
 
 logging.info('Starting...')
@@ -223,9 +220,11 @@ tmin, tmax = parse_template_range(num_templates, args.template_fraction_range)
 logging.info('Analyzing template %s - %s' % (tmin, tmax-1))
 
 logging.info('Opening first trigger file: %s' % args.trigger_files[0]) 
-trigs0= ReadByTemplate(args.trigger_files[0], args.template_bank, args.veto_files)
+trigs0= ReadByTemplate(args.trigger_files[0], 
+                       args.template_bank, args.segment_name, args.veto_files)
 logging.info('Opening second trigger file: %s' % args.trigger_files[1]) 
-trigs1 = ReadByTemplate(args.trigger_files[1], args.template_bank, args.veto_files)
+trigs1 = ReadByTemplate(args.trigger_files[1], 
+                        args.template_bank, args.segment_name, args.veto_files)
 coinc_segs = (trigs0.segs & trigs1.segs).coalesce()
 
 rank_method = get_statistic(args.ranking_statistic, args.statistic_files)
@@ -290,7 +289,9 @@ for tnum in range(tmin, tmax):
     del i1
     
     data['stat'] += [c[ti]]
-    data['decimation_factor'] += [numpy.repeat([args.decimation_factor, 1, 1], [len(bl), len(bh), len(fi)]).astype(numpy.uint32)]
+    dec_fac = numpy.repeat([args.decimation_factor, 1, 1], 
+                           [len(bl), len(bh), len(fi)]).astype(numpy.uint32)
+    data['decimation_factor'] += [dec_fac]
     data['time1'] += [t0[g0]]
     data['time2'] += [t1[g1]]
     data['trigger_id1'] += [tid0[g0]]
@@ -310,10 +311,7 @@ logging.info('saving coincident triggers')
 f = h5py.File(args.output_file, 'w')
 if len(data['stat']) > 0:
     for key in data:
-        if args.cluster_window:
-            f[key] = data[key][cid]
-        else:
-            f[key] = data[key]
+        f[key] = data[key][cid] if args.cluster_window else data[key]
             
 f['segments/coinc/start'], f['segments/coinc/end'] = veto.segments_to_start_end(coinc_segs)
 

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -5,7 +5,7 @@ from pycbc.events import veto, coinc
        
 parser = argparse.ArgumentParser()
 parser.add_argument("--verbose", action="count")
-parser.add_argument("--veto-files", nargs='+',
+parser.add_argument("--veto-files", nargs='*',
                     help="Optional veto file. Triggers within these times are ignored")
 parser.add_argument('--segment-name', default=None, type=str,
                     help='Optional, name of segment list to use for vetoes')

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -122,12 +122,13 @@ class ReadByTemplate(object):
         self.filename = filename
         self.file = h5py.File(filename, 'r')
         self.ifo = self.file.keys()[0]
-        self.veto_times = None
-
         if bank is not None:
             self.bank = h5py.File(bank)
         else:
             self.bank = None
+
+        self.veto_segs = None
+
         
         # Determine the segments which define the boundaries of valid times
         # to use triggers
@@ -136,8 +137,8 @@ class ReadByTemplate(object):
         s, e = self.file[key + 'start_time'][:], self.file[key + 'end_time'][:]
         self.segs = veto.start_end_to_segments(s, e).coalesce()
         if vetofile is not None:
-            self.veto_times = veto.start_end_from_segments(vetofile)
-            self.veto_segs = veto.start_end_to_segments(*self.veto_times).coalesce()
+            self.veto_segs = veto.select_segments_by_definer(vetofile, 
+                                                             ifo=self.ifo)
             self.segs = (self.segs - self.veto_segs).coalesce()
         self.valid = veto.segments_to_start_end(self.segs)
     
@@ -177,7 +178,7 @@ class ReadByTemplate(object):
         
         # Determine which of these template's triggers are kept after
         # applying vetoes
-        if self.veto_times:
+        if self.veto_segs:
             self.keep = veto.indices_within_times(times, self.valid[0], self.valid[1]) 
             logging.info('applying vetoes')
         else:
@@ -212,7 +213,7 @@ class ReadByTemplate(object):
             raise ValueError('You must call set_template to first pick the '
                              'template to read data from')    
         data = self.get_data(col, self.template_num)         
-        data = data[self.keep] if self.veto_times else data
+        data = data[self.keep] if self.veto_segs else data
         return data
 
 logging.info('Starting...')

--- a/bin/hdfcoinc/pycbc_coinc_hdfinjfind
+++ b/bin/hdfcoinc/pycbc_coinc_hdfinjfind
@@ -49,6 +49,8 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--trigger-files', nargs='+')
 parser.add_argument('--injection-files', nargs='+')
 parser.add_argument('--veto-file')
+parser.add_argument('--segment-name', default=None, type=str,
+                    help='Optional, name of segment list to use for vetoes')
 parser.add_argument('--injection-window', type=float)
 parser.add_argument('--verbose', action='count')
 parser.add_argument('--output-file')
@@ -108,9 +110,10 @@ for trigger_file, injection_file in zip(args.trigger_files, args.injection_files
     logging.info('Found: %s, Missed: %s' % (len(found_within_time), len(missed_within_time)))
 
     logging.info('Removing injections in vetoed time')
-    i1, v1 = veto_indices(inj_time, [args.veto_file], ifo='H1')
-    i2, v2 = veto_indices(inj_time, [args.veto_file], ifo='L1')
-    
+    i1, v1 = veto_indices(inj_time, [args.veto_file], ifo='H1', 
+                                    segment_name=args.segment_name)
+    i2, v2 = veto_indices(inj_time, [args.veto_file], ifo='L1', 
+                                     segment_name=args.segment_name)
     vi = numpy.concatenate([i1, i2])
 
     found_after_vetoes = numpy.delete(found_within_time, numpy.where(numpy.in1d(found_within_time, vi))[0])

--- a/bin/hdfcoinc/pycbc_page_snrchi
+++ b/bin/hdfcoinc/pycbc_page_snrchi
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
-
 import numpy, h5py, argparse, matplotlib
 matplotlib.use('Agg')
 import pylab
 from pycbc.events import veto
 
-
 parser = argparse.ArgumentParser()
 parser.add_argument('--trigger-file', help='Single ifo trigger file')
 parser.add_argument('--veto-file', help='Optional, file of veto segments to remove triggers')
+parser.add_argument('--segment-name', default=None, type=str,
+                    help='Optional, name of segment list to use for vetoes')
 parser.add_argument('--min-snr', type=float, help='Optional, Minimum SNR to plot')
 parser.add_argument('--output-file')
 parser.add_argument('--newsnr-contours', nargs='*', help="List of newsnr values to draw contours at.", default=[])
@@ -35,7 +35,8 @@ def snr_from_chisq(chisq, newsnr, q=6.):
 
 if args.veto_file:
     time = f['end_time'][:]
-    locs, segs = veto.indices_outside_segments(time, [args.veto_file], ifo=ifo)
+    locs, segs = veto.indices_outside_segments(time, [args.veto_file], 
+                                       segment_name=args.segment_name, ifo=ifo)
     snr = snr[locs]
     chisq = chisq[locs]
 

--- a/bin/hdfcoinc/pycbc_plot_singles_vs_params
+++ b/bin/hdfcoinc/pycbc_plot_singles_vs_params
@@ -40,7 +40,7 @@ class SingleDetTriggerSet(object):
     Provides easy access to the parameters of single-detector CBC triggers.
     """
 
-    def __init__(self, trig_file, bank_file, veto_file, detector):
+    def __init__(self, trig_file, bank_file, veto_file, segment_name, detector):
         logging.info('Loading triggers')
         self.trigs_f = h5py.File(trig_file, 'r')
         self.trigs = self.trigs_f[detector]
@@ -48,7 +48,8 @@ class SingleDetTriggerSet(object):
         if veto_file:
             logging.info('Loading veto segments')
             self.veto_mask, segs = pycbc.events.veto.indices_outside_segments(
-                self.trigs['end_time'][:], [veto_file], ifo=detector)
+                self.trigs['end_time'][:], [veto_file], 
+                ifo=detector, segment_name=segment_name)
         else:
             self.veto_mask = slice(len(self.trigs['end_time']))
 
@@ -132,6 +133,8 @@ parser.add_argument('--bank-file', type=str, required=True,
                     help='Path to file containing template bank in HDF5 format')
 parser.add_argument('--veto-file', type=str,
                     help='Optional path to file containing veto segments')
+parser.add_argument('--segment-name', default=None, type=str,
+                    help='Optional, name of segment list to use for vetoes')
 parser.add_argument('--output-file', type=str, required=True,
                     help='Destination path for plot')
 parser.add_argument('--x-var', required=True,
@@ -158,7 +161,7 @@ opts = parser.parse_args()
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
 trigs = SingleDetTriggerSet(opts.single_trig_file, opts.bank_file,
-                            opts.veto_file, opts.detector)
+                            opts.veto_file, opts.segment_name, opts.detector)
 
 x = getattr(trigs, opts.x_var)
 y = getattr(trigs, opts.y_var)


### PR DESCRIPTION
This adds support to the following executables for a segment-name options which selects the segment list from the given veto file. It is optional, and if not given, all segments in the file are assumed to be used (as was assumed by the codes previously). 

 - pycbc_coinc_findtrigs
 - pycbc_coinc_hdfinjfind
 - pycbc_plot_singles_vs_params
 - pycbc_page_snrchi

These are all the codes which explicitly took a segment xml file in the hdf coinc workflow. 

Notes: 
 - Forked from #37 