### PR TITLE
Enable toggling verbose mode via SIGUSR1

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -17,6 +17,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import logging, argparse, numpy, itertools
+import pycbc
 from pycbc import vetoes, psd, waveform, events, strain, scheme, fft, DYN_RANGE_FAC
 from pycbc.filter import MatchedFilterControl, make_frequency_series
 from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, complex64
@@ -171,11 +172,7 @@ def associate_psd(strain_segments, gwstrain, segments, nsegs, flen, delta_f, flo
     return psds
 
 
-if opt.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
+pycbc.init_logging(opt.verbose)
 
 ctx = scheme.from_cli(opt)
 gwstrain = strain.from_cli(opt, DYN_RANGE_FAC)

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -26,6 +26,35 @@
 
 """
 import subprocess, os, sys, tempfile
+import logging
+import signal
+
+
+def init_logging(verbose=False):
+    """
+    Common utility for setting up logging in PyCBC. Installs a signal handler
+    such that verbosity can be activated at run-time by sending a SIGUSR1 to
+    the process.
+    """
+    def sig_handler(signum, frame):
+        logger = logging.getLogger()
+        log_level = logger.level
+        if log_level == logging.DEBUG:
+            log_level = logging.WARN
+        else:
+            log_level = logging.DEBUG
+        logging.warn('Got signal %d, setting log level to %d',
+                     signum, log_level)
+        logger.setLevel(log_level)
+
+    signal.signal(signal.SIGUSR1, sig_handler)
+
+    if verbose:
+        initial_level = logging.DEBUG
+    else:
+        initial_level = logging.WARN
+    logging.basicConfig(format='%(asctime)s %(message)s', level=initial_level)
+
 
 # Check for optional components of the PyCBC Package
 try:


### PR DESCRIPTION
This patch allows one to start a pycbc_inspiral process in non-verbose mode, but later turn verbosity on/off by sending the process a SIGUSR1 signal (kill -USR1 pid). This allows one to debug long-running jobs directly in production. I can use this also in banksims, bank generators etc if people think it is useful.