### PR TITLE
Cosmetic fixes

### DIFF
--- a/pycbc/filter/zpk.py
+++ b/pycbc/filter/zpk.py
@@ -23,7 +23,6 @@
 #
 
 import numpy as np
-import scipy.signal
 
 from pycbc import future
 

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -21,8 +21,6 @@ import os.path, types
 from ConfigParser import ConfigParser
 from jinja2 import Environment, FileSystemLoader
 
-from glue.segments import segmentlistdict
-
 import pycbc.results
 from pycbc.workflow.segment import fromsegmentxml
 
@@ -42,84 +40,84 @@ def get_embedded_config(filename):
     return cp
 
 def setup_template_render(path, config_path):
-   """ This function is the gateway for rendering a template for a file.
-   """
+    """ This function is the gateway for rendering a template for a file.
+    """
 
-   # initialization
-   cp = get_embedded_config(path)
-   output = ''
+    # initialization
+    cp = get_embedded_config(path)
+    output = ''
 
-   # read configuration file
-   if os.path.exists(config_path):
-       cp.read(config_path)
+    # read configuration file
+    if os.path.exists(config_path):
+        cp.read(config_path)
 
-       # render template
-       filename = path.split('/')[-1]
-       if cp.has_option(filename, 'render-function'):
-           render_function_name = cp.get(filename, 'render-function')
-           render_function = eval(render_function_name)
-           output = render_function(path, cp)
-       else:
-           output = render_default(path, cp)
+        # render template
+        filename = path.split('/')[-1]
+        if cp.has_option(filename, 'render-function'):
+            render_function_name = cp.get(filename, 'render-function')
+            render_function = eval(render_function_name)
+            output = render_function(path, cp)
+        else:
+            output = render_default(path, cp)
 
-   # if no configuration file is present
-   # then render the default template
-   else:
-       output = render_default(path, cp)
+    # if no configuration file is present
+    # then render the default template
+    else:
+        output = render_default(path, cp)
 
-   return output
+    return output
 
 def render_default(path, cp):
-   """ This is the default function that will render a template to a string of HTML. The
-   string will be for a drop-down tab that contains a link to the file.
+    """ This is the default function that will render a template to a string of HTML. The
+    string will be for a drop-down tab that contains a link to the file.
 
-   If the file extension requires information to be read, then that is passed to the
-   content variable (eg. a segmentlistdict).
-   """
+    If the file extension requires information to be read, then that is passed to the
+    content variable (eg. a segmentlistdict).
+    """
 
-   # define filename and slug from path
-   filename = path.split('/')[-1]
-   slug     = path.split('/')[-1].replace('.', '_')
+    # define filename and slug from path
+    filename = path.split('/')[-1]
+    slug     = path.split('/')[-1].replace('.', '_')
 
-   # initializations
-   content = None
+    # initializations
+    content = None
 
    # XML file condition
-   if path.endswith('.xml') or path.endswith('.xml.gz'):
-       # segment or veto file return a segmentslistdict instance
-       if 'SEG' in path or 'VETO' in path:
-           with open(path, 'r') as xmlfile:
-               content = fromsegmentxml(xmlfile, dict=True)
+    if path.endswith('.xml') or path.endswith('.xml.gz'):
+        # segment or veto file return a segmentslistdict instance
+        if 'SEG' in path or 'VETO' in path:
+            with open(path, 'r') as xmlfile:
+                content = fromsegmentxml(xmlfile, dict=True)
 
-   # render template
-   template_dir = pycbc.results.__path__[0] + '/templates/files'
-   env = Environment(loader=FileSystemLoader(template_dir))
-   env.globals.update(abs=abs)
-   template = env.get_template('file_default.html')
-   context = {'filename' : filename,
-              'slug'     : slug,
-              'cp'       : cp,
-              'content'  : content}
-   output = template.render(context)
+    # render template
+    template_dir = pycbc.results.__path__[0] + '/templates/files'
+    env = Environment(loader=FileSystemLoader(template_dir))
+    env.globals.update(abs=abs)
+    template = env.get_template('file_default.html')
+    context = {'filename' : filename,
+               'slug'     : slug,
+               'cp'       : cp,
+               'content'  : content}
+    output = template.render(context)
 
-   return output
+    return output
 
 def render_glitchgram(path, cp):
-   """ Render a glitchgram file template.
-   """
+    """ Render a glitchgram file template.
+    """
 
-   # define filename and slug from path
-   filename = path.split('/')[-1]
-   slug     = path.split('/')[-1].replace('.', '_')
+    # define filename and slug from path
+    filename = path.split('/')[-1]
+    slug     = path.split('/')[-1].replace('.', '_')
 
-   # render template
-   template_dir = pycbc.results.__path__[0] + '/templates/files'
-   env = Environment(loader=FileSystemLoader(template_dir))
-   env.globals.update(abs=abs)
-   template = env.get_template(cp.get(filename, 'template'))
-   context = {'filename' : filename,
-              'slug'     : slug,
-              'cp'       : cp}
-   output = template.render(context)
+    # render template
+    template_dir = pycbc.results.__path__[0] + '/templates/files'
+    env = Environment(loader=FileSystemLoader(template_dir))
+    env.globals.update(abs=abs)
+    template = env.get_template(cp.get(filename, 'template'))
+    context = {'filename' : filename,
+               'slug'     : slug,
+               'cp'       : cp}
+    output = template.render(context)
 
-   return output
+    return output

--- a/pycbc/workflow/splittable.py
+++ b/pycbc/workflow/splittable.py
@@ -67,7 +67,7 @@ def select_splitfilejob_instance(curr_exe):
     else:
         # Should we try some sort of default class??
         err_string = "No class exists for Executable %s" %(curr_exe,)
-        raise NotImplementedError(errString)
+        raise NotImplementedError(err_string)
 
     return exe_class
 

--- a/tools/timing/match_perf.py
+++ b/tools/timing/match_perf.py
@@ -9,7 +9,7 @@ import numpy
 import numpy.random
 import sys
 from optparse import OptionParser
-from math import sin, log
+from math import sin
 import gc
 parser = OptionParser()
 


### PR DESCRIPTION
4 commits:
 * First fixes a bug where `errString` should have been `err_string`.
 * Second removes a reimport of `math.log`.
 * Third indents `pycbc.results.render` to 4 spaces instead of 3.
 * Fourth removes an unused `scipy.signal` import in the zero-pole-gain filter module.