### PR TITLE
Add IFO to process table in output_sngl_inspiral_table function

### DIFF
--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -356,6 +356,13 @@ def output_sngl_inspiral_table(outputFile, tempBank, metricParams,
 
     outdoc.childNodes[0].appendChild(sngl_inspiral_table)
 
+    # get times to put in search summary table
+    start_time = 0
+    end_time = 0
+    if 'gps_start_time' in optDict.keys() and 'gps_end_time' in optDict.keys():
+        start_time = optDict['gps_start_time']
+        end_time = optDict['gps_end_time']
+
     # make search summary table
     search_summary_table = lsctables.New(lsctables.SearchSummaryTable) 
     search_summary = return_search_summary(start_time, end_time,

--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -320,8 +320,15 @@ def output_sngl_inspiral_table(outputFile, tempBank, metricParams,
     if outdoc is None:
         outdoc = ligolw.Document()
         outdoc.appendChild(ligolw.LIGO_LW())
+
+    # get IFO to put in search summary table
+    ifos = []
+    if 'channel_name' in optDict.keys():
+        if optDict['channel_name'] is not None:
+            ifos = [optDict['channel_name'][0:2]]
+
     proc_id = ligolw_process.register_to_xmldoc(outdoc, programName, optDict,
-                                                **kwargs).process_id
+                                                ifos=ifos, **kwargs).process_id
     sngl_inspiral_table = convert_to_sngl_inspiral_table(tempBank, proc_id)
     # Calculate Gamma components if needed
     if ethincaParams is not None:
@@ -348,19 +355,6 @@ def output_sngl_inspiral_table(outputFile, tempBank, metricParams,
                     sngl.mass1, sngl.mass2, sngl.spin1z, sngl.spin2z)
 
     outdoc.childNodes[0].appendChild(sngl_inspiral_table)
-
-    # get times to put in search summary table
-    start_time = 0
-    end_time = 0
-    if 'gps_start_time' in optDict.keys() and 'gps_end_time' in optDict.keys():
-        start_time = optDict['gps_start_time']
-        end_time = optDict['gps_end_time']
-
-    # get IFO to put in search summary table
-    ifos = []
-    if 'channel_name' in optDict.keys():
-        if optDict['channel_name'] is not None:
-            ifos = [optDict['channel_name'][0:2]]
 
     # make search summary table
     search_summary_table = lsctables.New(lsctables.SearchSummaryTable) 


### PR DESCRIPTION
Populates the IFO column when `output_sngl_inspiral_table` is called by tmplate bank placement code.