### PR TITLE
Relax versions of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,13 +52,13 @@ except ImportError:
 requires = ['lal.lal', 'lalsimulation.lalsimulation', 'glue', 'pylal']
 setup_requires = []
 install_requires =  setup_requires + ['Mako>=1.0.1',
-                      'argparse>=1.3.0',
-                      'decorator>=3.4.2',
+                      'argparse>=1.2.1',
+                      'decorator>=3.3.3',
                       'scipy>=0.13.0',
                       'matplotlib>=1.3.1',
                       'numpy>=1.6.4',
                       'pillow',
-                      'h5py>=2.5',
+                      'h5py>=2.0.1',
                       'jinja2',
                       ]
 links = []


### PR DESCRIPTION
Hi Alex, the latest bump of requirements breaks my build on Atlas. Do we really need such recent versions of h5py, decorator and argparse? It looks like what Atlas has worked fine. I reduced the versions to what Wheezy can provide. Are you ok with the changes I'm proposing? Also, do you think Mako 0.7.0 would be enough?

Somewhat related: I just noticed on travis that you're installing Swig from the tarball, but that version should also be available from apt. So you may want to get it with the apt-get command and get a slightly shorter log file.