### PR TITLE
add pycbc-pyla and pycbc-glue as dependence

### DIFF
--- a/pycbc/results/templates/concrete.html
+++ b/pycbc/results/templates/concrete.html
@@ -69,25 +69,27 @@
     <!--content-->
     <div class="row">
 
-    <!--left panel-->
-    <div class="col-lg-3">
-        <div class="list-group">
-            <a href="#" class="list-group-item disabled"><h3>{{dir.title()}}</h3></a>
-            {% if dir.subdirs %}
-                {% for subdir in dir.subdirs %}
-                    <a href="./{{subdir.name()}}" class="list-group-item">{{subdir.title()}}</a>
-                {% endfor %}
-            {% else %}
-                <a href="#" class="list-group-item disabled">No subdirectories</a>
-            {% endif %}
+        <!--left panel-->
+        <div class="col-lg-3">
+            <div class="list-group">
+                <a href="#" class="list-group-item disabled"><h3>{{dir.title()}}</h3></a>
+                {% if dir.subdirs %}
+                    {% for subdir in dir.subdirs %}
+                        <a href="./{{subdir.name()}}" class="list-group-item">{{subdir.title()}}</a>
+                    {% endfor %}
+                {% else %}
+                    <a href="#" class="list-group-item disabled">No subdirectories</a>
+                {% endif %}
+            </div>
         </div>
-    </div>
 
-    <!--right panel-->
-    <div class="col-lg-9">
-        {% for file in dir.files %}
-             {{file.render()}}
-        {% endfor %}
+        <!--right panel-->
+        <div class="col-lg-9">
+            {% for file in dir.files %}
+                {{file.render()}}
+            {% endfor %}
+        </div>
+
     </div>
 
 </div>

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,8 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'h5py>=2.5',
                       'jinja2',
                       'mpld3>=0.3git',
+                      'pycbc-pylal>=0.9.1',
+                      'pycbc-glue>=0.9.1',
                       ]
 links = ['https://github.com/ahnitz/mpld3/tarball/master#egg=mpld3-0.3git']
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'jinja2',
                       'mpld3>=0.3git',
                       'pycbc-pylal>=0.9.1',
-                      'pycbc-glue>=0.9.1',
+                      'pycbc-glue>=0.9.2',
                       ]
 links = ['https://github.com/ahnitz/mpld3/tarball/master#egg=mpld3-0.3git']
 


### PR DESCRIPTION
Add pycbc-pylal as an install depency to pycbc. This should make it so python setup.py install will download pycbc-pylal and auto install it. At the moment, this sets it to pull the master version. If a tag is available, perhaps we should point to that? 