### PR TITLE
Pycbc_page_coinc_snrchi fails for me

### DIFF
--- a/bin/hdfcoinc/pycbc_page_coinc_snrchi
+++ b/bin/hdfcoinc/pycbc_page_coinc_snrchi
@@ -34,7 +34,7 @@ b_tids[f.attrs['detector_2']] = f['background/trigger_id2']
 f = h5py.File(args.single_trigger_file)
 ifo = f.keys()[0]
 f = f[ifo]
-tid = b_tids[ifo]
+tid = b_tids[ifo][:]
 snr = f['snr'][:][tid]
 
 chisq = f['chisq'][:][tid]
@@ -54,12 +54,12 @@ inj_tids = {}
 inj_tids[f.attrs['detector_1']] = f['found_after_vetoes/trigger_id1']
 inj_tids[f.attrs['detector_2']] = f['found_after_vetoes/trigger_id2']
 
-inj_idx = f['found_after_vetoes/injection_index']
+inj_idx = f['found_after_vetoes/injection_index'][:]
 eff_dist = f['injections'][eff_map[ifo]][:][inj_idx]
 
 
 f = h5py.File(args.single_injection_file)[ifo]
-tid = inj_tids[ifo]
+tid = inj_tids[ifo][:]
 snr = f['snr'][:][tid]
 
 chisq = f['chisq'][:][tid]


### PR DESCRIPTION
This patch (if I've done this right) fixes an issue I've seen where pycbc_page_coinc_snrchi fails with:

  File "/.auto/home/spxiwh/lscsoft_git/executables_master/lib/python2.7/site-packages/PyCBC-8d7236-py2.7.egg/EGG-INFO/scripts/pycbc_page_coinc_snrchi", line 38, in <module>
    snr = f['snr'][:][tid]
IndexError: unsupported iterator index

I don't understand why others haven't hit this problem though! Is it a debian or dependancy version problem?