### PR TITLE
add mpld3 to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,9 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'pillow',
                       'h5py>=2.5',
                       'jinja2',
+                      'mpld3>=0.3git',
                       ]
-links = []
+links = ['https://github.com/ahnitz/mpld3/tarball/master#egg=mpld3-0.3git']
 
 def find_package_data(dirname):
     def find_paths(dirname):


### PR DESCRIPTION
Add mpld3 to dependencies. This uses the dependency links to pull mpld3 from my fork which I have prepared to be installable. This should work temporarily until mpld3 proper uploads their next release. 

Please let me know if this works for you. 