### PR TITLE
Add local directory option to pycbc_submit_dax

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -12,8 +12,9 @@ exec 2>&1
 
 DAX_FILE=""
 CACHE_FILE=""
+LOCAL_PEGASUS_DIR=""
 
-GETOPT_CMD=`getopt -o d:c:a:h --long dax:,cache-file:,accounting-group:,help -n 'pycbc_submit_dax' -- "$@"`
+GETOPT_CMD=`getopt -o d:c:a:h:l --long dax:,cache-file:,accounting-group:,local-dir:,help -n 'pycbc_submit_dax' -- "$@"`
 eval set -- "$GETOPT_CMD"
 
 while true ; do
@@ -33,6 +34,11 @@ while true ; do
         "") shift 2 ;;
         *) ACCOUNTING_GROUP=$2 ; shift 2 ;;
       esac ;;
+    -l|--local-dir)
+      case "$2" in
+        "") shift 2 ;;
+        *) LOCAL_PEGASUS_DIR=$2 ; shift 2 ;;
+      esac ;;
     -h|--help)
       echo "usage: pycbc_submit_dax [-h]"
       echo "                        --dax DAX"
@@ -46,9 +52,11 @@ while true ; do
       echo "  -c, --cache-file FILE   replica cache file for data reuse"
       echo "  -a, --accounting-group GROUP tagged string used for site "
       echo "                               resource accounting."
+      echo "  -l, --local-dir         Directory to put condor files under. "
       echo
       echo "If the environment variable TMPDIR is set then this is prepended to the "
       echo "path to the temporary workflow execte directory passed to pegasus-plan."
+      echo "If the --local-dir option is not given."
       echo
       exit 0 ;;
     --) shift ; break ;;
@@ -62,7 +70,7 @@ if [ "x$DAX_FILE" == "x" ]; then
 fi
 
 #Make a directory for the submit files
-SUBMIT_DIR=`mktemp -t -d pycbc-tmp.XXXXXXXXXX`
+SUBMIT_DIR=`mktemp --tmpdir=${LOCAL_PEGASUS_DIR} -d pycbc-tmp.XXXXXXXXXX`
 
 #Make sure the directory is world readable
 chmod 755 $SUBMIT_DIR

--- a/bin/pycbc_submit_dax_stampede
+++ b/bin/pycbc_submit_dax_stampede
@@ -2,10 +2,11 @@
 
 DAX_FILE=""
 CACHE_FILE=""
+LOCAL_PEGASUS_DIR=""
 HOSTS=""
 DEVELOPMENT=""
 
-GETOPT_CMD=`getopt -o d:n:Dc:a:h --long dax:,number-of-hosts:,development,cache-file:,accounting-group:,help -n 'pycbc_submit_dax' -- "$@"`
+GETOPT_CMD=`getopt -o d:n:Dc:a:h:l --long dax:,number-of-hosts:,development,cache-file:,accounting-group:,local-dir:,help -n 'pycbc_submit_dax' -- "$@"`
 eval set -- "$GETOPT_CMD"
 
 while true ; do
@@ -30,6 +31,11 @@ while true ; do
       case "$2" in
         "") shift 2 ;;
         *) ACCOUNTING_GROUP=$2 ; shift 2 ;;
+      esac ;;
+    -l|--local-dir)
+      case "$2" in
+        "") shift 2 ;;
+        *) LOCAL_PEGASUS_DIR=$2 ; shift 2 ;;
       esac ;;
     -h|--help)
       echo "usage: pycbc_submit_dax [-h]"
@@ -79,7 +85,7 @@ if [ "x$2" == "x" ]; then
 fi
 
 echo 'making a directory for the submit files'
-export SUBMIT_DIR=`mktemp -t -d pycbc-tmp.XXXXXXXXXX`
+export SUBMIT_DIR=`mktemp --tmpdir=${LOCAL_PEGASUS_DIR} -d pycbc-tmp.XXXXXXXXXX`
 echo $SUBMIT_DIR
 
 #Make sure the directory is world readable


### PR DESCRIPTION
Not having a local-directory option and having to set TMPDIR is a *real* pain. TMPDIR is used for other things (for e.g. the scipy compilation directory), and I don't want to *have* to have that the same as the pegasus submit directory. Not to mention that I am repeatedly forgetting to set this and having dags fail.

This patch adds the option to specify a --local-dir option, which can be used for clusters like ARCCA and vulcan, where TMPDIR is not set by default. In the case that the option is not given the code will behave as before (--tmpdir="" to mktemp is equivalent to --tmpdir=${TMPDIR} .. and if ${TMPDIR} is not set, *that* will default to /tmp)

..... Is there a reason this is written in bash? This is *Py*CBC not *Bash*CBC ... We chose python because it is easier to code and read than C, well C is *much* easier to code and read than bash!! :-)