### PR TITLE
add cuda requirements to extra package cuda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -323,6 +323,8 @@ cmdclass = { 'test'  : test,
              'test_opencl':test_opencl,
              'clean' : clean,
             }
+            
+extras_require = {'cuda': ['pycuda>=2015.1', 'scikits.cuda']}
 
 # do the actual work of building the package
 VERSION = get_version_info()
@@ -338,6 +340,7 @@ setup (
     keywords = ['ligo', 'physics', 'gravity', 'signal processing'],
     cmdclass = cmdclass,
     setup_requires = setup_requires,
+    extras_require = extras_require,
     install_requires = install_requires,
     dependency_links = links,
     scripts  = [


### PR DESCRIPTION
Add cuda to an extra requires sections. This doesn't do much at the moment, but in the future you'll be able to do 

pip install pycbc[cuda] 

To get all your cuda dependencies satisfied. 