### PR TITLE
update dependencies and references to glue/pylal in pycbc install instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -76,9 +76,8 @@ while on Mac OS this is
 where ``X.Y`` is the python major and minor version numbers, e.g. ``2.7``. In either case, python will autmatically know about these directories, so you don't have to fiddle with any environment variables.
 
 
-===============================
 Setting up the user environment
-===============================
+********************************
 
 Add the following to your ``.bash_profile``
 
@@ -86,6 +85,61 @@ Add the following to your ``.bash_profile``
 
    source /path/to/pycbc/install/directory/etc/pycbc-user-env.sh
    
+===========================
+Installing in a virtualenv
+===========================
+
+Installing PyCBC into a virtual environment provides isolation between different sets of 
+python packages. The following instructions will create a working PyCBC environment on an LDG
+cluster. 
+
+The first task is to clear out your current PYTHONPATH in case you had been using that
+before, and to make sure you have the latest virtualenv code installed.:
+
+.. code-block:: bash
+
+    export PYTHONPATH=””
+    pip install virtualenv --upgrade --user
+    export PATH=$HOME/.local/bin:$PATH
+    
+The previous step may be skipped if you do not have conflicting python packages in 
+your PYTHONPATH.
+
+Next, you need to choose a directory name where you'd like to make your virtual environment, and
+then make it.: 
+
+.. code-block:: bash
+
+    virtualenv $NAME
+    source $NAME/bin/activate
+    
+You will now be 'inside' your virtual environment, and so you can install packages, etc, without
+conflicting with either the system build, or other builds that you may have sitting around. You may
+install c-dependencies such as lalsuite (:ref:`lalsuite_install`), or rely on the system versions.
+
+Install pycbc from source as follows. This will create a $NAME/src/pycbc git checkout
+which is fully edittable, and will also install all the listed dependencies.:
+
+.. code-block:: bash
+
+    pip install “numpy>=1.6.4” unittest2
+    pip install -e git+https://github.com/ligo-cbc/pycbc#egg=pycbc --process-dependency-links
+
+Finally, if you need to use system python libraries (such as Pegasus.DAX3), etc you can
+add that to your own activation script.:
+
+.. code-block:: bash
+
+    echo 'source $NAME/bin/activate' > activate
+    echo 'source $NAME/etc/pycbc-user-env.sh' >> activate
+    echo 'source $NAME/etc/glue-user-env.sh' >> activate
+    echo 'export PYTHONPATH=/usr/lib64/python2.6/site-packages/:$PYTHONPATH' >> activate
+    chmod 755 activate
+    
+You may now enter your environement by sourcing 'activate', and leave by running
+the command 'deactivate'.
+
+
 ===============================
 Optional GPU acceleration
 ===============================

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,21 +9,19 @@ Prerequisites
 In order to install PyCBC, you need to have installed the following prerequisite packages:
 
 * Python 2.6 or 2.7
-* `NumPy <http://www.numpy.org>`_ >= 1.4.1 and `SciPy <http://www.scipy.org>`_ >= 0.7.2
-* `decorator <https://pypi.python.org/pypi/decorator>`_
-* `argparse <https://pypi.python.org/pypi/argparse>`_ >= 1.2.0
 * `LALSuite <https://www.lsc-group.phys.uwm.edu/daswg/projects/lalsuite.html>`_ (with swig bindings enabled)
-* `GLUE <https://www.lsc-group.phys.uwm.edu/daswg/projects/glue.html>`_
-* `pylal <https://www.lsc-group.phys.uwm.edu/daswg/projects/pylal.html>`_
-* `jinja2 <https://pypi.python.org/pypi/jinja2>`
+* `NumPy <http://www.numpy.org>`_ >= 1.6.4 and `SciPy <http://www.scipy.org>`_ >= 0.13.0
+* `decorator <https://pypi.python.org/pypi/decorator>`_ >=3.4.2
+* `argparse <https://pypi.python.org/pypi/argparse>`_ >= 1.3.0
+* `pycbc-glue <https://github.com/ligo-cbc/pycbc-glue>`_ >=0.9.1
+* `pycbc-pylal <https://github.com/ligo-cbc/pycbc-glue>`_ >=0.9.2
+* `jinja2 <https://pypi.python.org/pypi/jinja2>`_
+* `mako <https://pypi.python.org/pypi/mako>`_
+* `h5py <https://pypi.python.org/pypi/h5py>`_ >=2.5
 
 .. note::
-    
-    Python, numpy, decorator and argparse should already be installed on LDG clusters.
 
-.. note::
-
-    A version of lalsuite and glue are installed on LDG clusters, but you may want to build your own version. Please see :ref:`lalsuite_install` for instructions and details about building your own version of lalsuite, glue and pylal.
+    A version of lalsuite is installed on LDG clusters, but you may want to build your own version. Please see :ref:`lalsuite_install` for instructions and details about building your own version of lalsuite.
 
 ===========================================================
 Additional Dependencies for HDF post processing and Plots
@@ -33,7 +31,6 @@ that are in active development and have not yet been reviewed, the following
 additional dependencies are needed. Eventually these will become
 mandatory dependencies. 
 
-* numpy>=1.6.4
 * matplotlib>=1.3.1
 * `mpld3>=0.3.0 <https://github.com/jakevdp/mpld3/tarball/master>`_
 * `PIL <https://pypi.python.org/pypi/PIL>`_

--- a/docs/install_lalsuite.rst
+++ b/docs/install_lalsuite.rst
@@ -1,16 +1,20 @@
 .. _lalsuite_install:
 
 ##############################################
-Installing lalsuite, glue and pylal for PyCBC
+Installing lalsuite for PyCBC
 ##############################################
 
-The following page describes how to build lalsuite, glue and pylal from source for use with PyCBC. 
+The following page describes how to build lalsuite from source for use with PyCBC. 
 
 ---------------------------------
 Choose a lalsuite install method
 ---------------------------------
 
-A version of lalsuite and glue (but not pylal) is installed system-wide on LDG and XSEDE clusters. During science runs this version is recommended for use, but between science runs, and for development, it is better to install lalsuite, glue and pylal from source. To use this system version and just install pylal follow :ref:`systeminstall`. To install lalsuite, glue and pylal from source follow :ref:`sourceinstall`.
+A version of lalsuite is installed system-wide on LDG and XSEDE clusters. 
+During science runs this version is recommended for use, but between science 
+uns, and for development, it is better to install lalsuite
+from source. To use this system version and just install pylal follow :ref:`systeminstall`.
+To install lalsuite from source follow :ref:`sourceinstall`.
 
 .. _systeminstall:
 
@@ -94,7 +98,7 @@ The attached :download:`example script <resources/build_new_lalsuite.sh>` can be
 * INSTALLDIR is the directory where you want the code installed. *This must be under your NFS-mounted home directory so it is accessible to the cluster nodes running your jobs.*
 * NUMCORES is the number of cores for a parallel build (e.g. 8).
 
-For example, the following will build lalsuite, glue and pylal and install it in /home/$USER/local/master/
+For example, the following will build lalsuite and install it in /home/$USER/local/master/
 
 .. code-block:: bash
 
@@ -108,4 +112,4 @@ This script will create a file INSTALLDIR/etc/lscsoftrc that can be sourced to s
 
 to set up your environment to use the installed code.
 
-Congratulations, you now have lalsuite, glue and python set up and ready to use!
+Congratulations, you now have lalsuite set up and ready to use!

--- a/docs/resources/build_new_lalsuite.sh
+++ b/docs/resources/build_new_lalsuite.sh
@@ -73,16 +73,6 @@ popd
 echo "source ${INSTALL_DIR}/etc/lalapps-user-env.sh" >> ${SOURCE_SCRIPTDIR}/lscsoftrc
 source ${SOURCE_SCRIPTDIR}/lscsoftrc
 
-# Build and Install pylal & glue
-for d in glue pylal;
-    do pushd $d;
-    python setup.py clean --all
-    python setup.py install --prefix=${INSTALL_DIR}
-    echo "source ${INSTALL_DIR}/etc/${d}-user-env.sh" >> ${SOURCE_SCRIPTDIR}/lscsoftrc;
-    popd;
-    source ${SOURCE_SCRIPTDIR}/lscsoftrc;
-done
-
 cd ~
 
 lal-version


### PR DESCRIPTION
Update the references to glue/pylal to refer to pycbc-glue/pycbc-pylal and point to their github pages. Also update the list of dependencies to reflect the current requirements. 