### PR TITLE
Pass segment name to executables can apply vetoes

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -118,10 +118,10 @@ if len(zdata['stat']) > 0:
     
     fore_fan = fanmap_exc(zdata['stat'][zcid])
     ifar_exc = background_time / fore_fan
-    fap = numpy.clip(coinc_time / ifar_exc, 0, 1)
+    fap_exc = numpy.clip(coinc_time / ifar_exc, 0, 1)
     f['foreground/fan_exc'] = fore_fan
     f['foreground/ifar_exc'] = sec_to_year(ifar_exc)
-    f['foreground/fap_exc'] = fap
+    f['foreground/fap_exc'] = fap_exc
     
     logging.info('calculating injection backgrounds')
     ftimes = (zdata['time1'][zcid] + zdata['time2'][zcid]) / 2

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -91,23 +91,26 @@ for inj_file, tag, output_dir in zip([None]+inj_files, tags, output_dirs):
     # setup coinc for the filtering jobs
     if tag == 'full_data':
         full_insps = insps
-        bg_files = wf.setup_interval_coinc(workflow, hdfbank, insps, cum_veto_files,
+        bg_files = wf.setup_interval_coinc(workflow, hdfbank, insps, cum_veto_files, veto_names,
                                        output_dir, tags=ctags)  
-        final_bg_file =  wf.setup_interval_coinc(workflow, hdfbank, insps, final_veto_file,
+        final_bg_file =  wf.setup_interval_coinc(workflow, hdfbank, insps,
+                                       final_veto_file, final_veto_name,
                                        output_dir, tags=ctags)   
         for bg_file in (final_bg_file + bg_files):
             wf.make_snrifar_plot(workflow, bg_file, 'plots/background', tags=bg_file.tags)
 
         wf.make_foreground_table(workflow, final_bg_file[0], hdfbank[0], tag, 'plots/foreground')
-        wf.make_snrchi_plot(workflow, insps, final_veto_file[0], 'plots/background', tags=[tag])
-        wf.make_singles_plot(workflow, insps, hdfbank[0], final_veto_file[0], 'plots/background', tags=[tag])
+        wf.make_snrchi_plot(workflow, insps, final_veto_file[0], final_veto_name[0], 'plots/background', tags=[tag])
+        wf.make_singles_plot(workflow, insps, hdfbank[0], final_veto_file[0], final_veto_name[0], 'plots/background', tags=[tag])
 
     else:
         inj_coinc = wf.setup_interval_coinc_inj(workflow, hdfbank,
-                                                full_insps, insps, final_bg_file, final_veto_file,
+                                                full_insps, insps, final_bg_file, 
+                                                final_veto_file[0], final_veto_name[0],
                                                 output_dir, tags = ctags)
         found_inj = wf.find_injections_in_hdf_coinc(workflow, wf.FileList([inj_coinc]),
                                                 wf.FileList([inj_file]), final_veto_file[0], 
+                                                final_veto_name[0],
                                                 output_dir, tags=ctags)
         inj_coincs += [inj_coinc]                      
         wf.make_sensitivity_plot(workflow, found_inj, 'plots/sensitivity/%s' % tag,
@@ -137,7 +140,7 @@ wf.make_segments_plot(workflow, science_seg_file, 'plots/segments', tags=['SCIEN
 
 if len(inj_files) > 0:
     found_inj = wf.find_injections_in_hdf_coinc(workflow, inj_coincs,
-                                            inj_files, final_veto_file[0], 
+                                            inj_files, final_veto_file[0], final_veto_name[0],
                                             output_dir, tags=['ALLINJ'])                                                
     wf.make_sensitivity_plot(workflow, found_inj, 'plots/sensitivity', 
                                             tags=['ALLINJ'])

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -49,9 +49,9 @@ science_segs, science_seg_file = wf.get_analyzable_segments(workflow, "segments"
 datafind_files, science_segs = wf.setup_datafind_workflow(workflow, 
                                          science_segs, "datafind", science_seg_file)
 
-cum_veto_files, ind_cats = wf.get_cumulative_veto_group_files(workflow, 
+cum_veto_files, veto_names, ind_cats = wf.get_cumulative_veto_group_files(workflow, 
                                         'segments-veto-groups', "segments")
-final_veto_file, ind_cats = wf.get_cumulative_veto_group_files(workflow, 
+final_veto_file, final_veto_name, ind_cats = wf.get_cumulative_veto_group_files(workflow, 
                                         'segments-final-veto-group', "segments")
 
 # Template bank stuff

--- a/bin/pycbc_make_coinc_workflow
+++ b/bin/pycbc_make_coinc_workflow
@@ -127,6 +127,7 @@ for inj_file, tag, output_dir in zip([None]+inj_files, tags, output_dirs):
     if args.enable_hdf_post_processing:
         # Workaround for the current segment module HARDCODED!!!
         final_veto_file = segsFileList.find_output_with_tag('CUMULATIVE_CAT_3')
+        final_veto_name = ['CUMULATIVE_CAT_3']
         cum_veto_files = _workflow.FileList()
 
         insps_hdf = _workflow.convert_trig_to_hdf(workflow, hdfbank, insps, output_dir, tags=[tag])
@@ -135,25 +136,26 @@ for inj_file, tag, output_dir in zip([None]+inj_files, tags, output_dirs):
         if tag == 'full_data':
             ctags = [tag, 'full']
             full_insps = insps_hdf
-            bg_files = _workflow.setup_interval_coinc(workflow, hdfbank,
-                                                      insps_hdf, cum_veto_files,
-                                                      output_dir, tags=ctags)
             final_bg_file =  _workflow.setup_interval_coinc(workflow, hdfbank,
-                            insps_hdf, final_veto_file, output_dir, tags=ctags)
-            _workflow.make_foreground_table(workflow, final_bg_file[0],
+                            insps_hdf, final_veto_file, final_veto_name,
+                            output_dir, tags=ctags)
+            _workflow.make_foreground_table(workflow, final_bg_file[0], final_veto_name[0],
                             hdfbank[0], tag, 'plots/foreground')
 
-            _workflow.make_snrchi_plot(workflow, insps_hdf, final_veto_file[0], 
+            _workflow.make_snrchi_plot(workflow, insps_hdf, final_veto_file[0], final_veto_name[0],
                                       'plots/background', tags=[tag])
 
         else:
             ctags = [tag, 'inj']
 
             inj_coinc = _workflow.setup_interval_coinc_inj(workflow, hdfbank, 
-                            full_insps, insps_hdf, final_bg_file, final_veto_file,
+                            full_insps, insps_hdf, final_bg_file,
+                            final_veto_file[0], final_veto_name[0],
                             output_dir, tags = ctags)
             found_inj = _workflow.find_injections_in_hdf_coinc(workflow, _workflow.FileList([inj_coinc]),
-                            _workflow.FileList([inj_file]), final_veto_file[0], output_dir, tags=ctags)                                          
+                            _workflow.FileList([inj_file]), 
+                            final_veto_file[0], final_veto_name[[0], 
+                            output_dir, tags=ctags)                                          
 
             _workflow.make_sensitivity_plot(workflow, found_inj, 'plots/sensitivity',
                                      tags=ctags)

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -522,7 +522,8 @@ class PyCBCHDFInjFindExecutable(Executable):
         node = Node(self)        
         node.add_input_list_opt('--trigger-file', inj_coinc_file)
         node.add_input_list_opt('--injection-file', inj_xml_file)
-        node.add_input_opt('--veto-file', veto_file)
+        if veto_name is not None:
+            node.add_input_opt('--veto-file', veto_file)
         node.add_opt('--segment-name', veto_name)
         node.new_output_file_opt(inj_xml_file[0].segment, '.hdf', '--output-file', 
                                  tags=tags)

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -79,7 +79,7 @@ def make_inj_table(workflow, inj_file, out_dir, tags=[]):
     node.new_output_file_opt(inj_file.segment, '.html', '--output-file')
     workflow += node   
 
-def make_snrchi_plot(workflow, trig_files, veto_file, out_dir, tags=[]):
+def make_snrchi_plot(workflow, trig_files, veto_file, veto_name, out_dir, tags=[]):
     makedir(out_dir)    
     for tag in workflow.cp.get_subsections('plot_snrchi'):
         for trig_file in trig_files:
@@ -89,6 +89,7 @@ def make_snrchi_plot(workflow, trig_files, veto_file, out_dir, tags=[]):
                         tags=[tag] + tags).create_node()
 
             node.set_memory(15000)
+            node.add_opt('--segment-name', veto_name)
             node.add_input_opt('--trigger-file', trig_file)
             node.add_input_opt('--veto-file', veto_file)
             node.new_output_file_opt(trig_file.segment, '.png', '--output-file')
@@ -125,7 +126,7 @@ def make_results_web_page(workflow, results_dir):
     node.add_opt('--template-file', template_path)
     workflow += node
 
-def make_singles_plot(workflow, trig_files, bank_file, veto_file, out_dir, tags=[]):
+def make_singles_plot(workflow, trig_files, bank_file, veto_file, veto_name, out_dir, tags=[]):
     makedir(out_dir)    
     for tag in workflow.cp.get_subsections('plot_singles'):
         for trig_file in trig_files:
@@ -135,6 +136,7 @@ def make_singles_plot(workflow, trig_files, bank_file, veto_file, out_dir, tags=
                         tags=[tag] + tags).create_node()
 
             node.set_memory(15000)
+            node.add_opt('--segment-name', veto_name)
             node.add_input_opt('--bank-file', bank_file)
             node.add_input_opt('--veto-file', veto_file)
             node.add_opt('--detector', trig_file.ifo)

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1136,12 +1136,13 @@ def get_cumulative_veto_group_files(workflow, option, out_dir, tags=[]):
                                         start_time, end_time, out_dir,
                                         veto_gen_job, execute_now=True))
 
-    cum_seg_files = FileList()        
+    cum_seg_files = FileList()     
+    names = []   
     for cat_set in cat_sets:
-        segment_name = ''.join(sorted(cat_set))
-        logging.info('getting information for cumulative CAT %s' % segment_name)
+        segment_name = "CUMULATIVE_CAT_%s" % (''.join(sorted(cat_set)))
+        logging.info('getting information for %s' % segment_name)
         categories = [cat_to_pipedown_cat(c) for c in cat_set]
-        path = os.path.join(out_dir, '%s-CUMULATIVE_CAT_%s_VETO_SEGMENTS.xml' \
+        path = os.path.join(out_dir, '%s-%s_VETO_SEGMENTS.xml' \
                             % (workflow.ifo_string, segment_name))
         path = os.path.abspath(path)
         url = urlparse.urlunparse(['file', 'localhost', path, None, None, None])
@@ -1150,8 +1151,9 @@ def get_cumulative_veto_group_files(workflow, option, out_dir, tags=[]):
                         
         cum_seg_files += [get_cumulative_segs(workflow, seg_file,  categories,
               cat_files, out_dir, execute_now=False, segment_name=segment_name)]
+        names.append(segment_name)
               
-    return cum_seg_files, cat_files
+    return cum_seg_files, names, cat_files
 
 def file_needs_generating(file_path):
     """


### PR DESCRIPTION
The segment setup functions used by the hdf workflow now return the list of segment names that should be used. Executable that apply vetoes now get the segment name to use from the workflow. 