### PR TITLE
add ability to plot ranking statistic in x-axis 

### DIFF
--- a/bin/hdfcoinc/pycbc_page_sensitivity
+++ b/bin/hdfcoinc/pycbc_page_sensitivity
@@ -18,7 +18,7 @@ parser.add_argument('--bin-type', choices=['spin', 'mchirp',
                    help="Optional, parameter bin boundaries")
 parser.add_argument('--sig-bins', nargs='*',
                    help="Optional, boundaries of x-axis significance bins"),
-parser.add_argument('--sig-type', choices=['ifar', 'fap'], default='ifar',
+parser.add_argument('--sig-type', choices=['ifar', 'fap', 'stat'], default='ifar',
                    help="Optional, x-axis significance type")
 parser.add_argument('--min-dist', type=float, 
                    help="Optional, minimum sensitive distance to plot")
@@ -79,6 +79,15 @@ labels['mchirp'] = "$ M_{chirp} \in [%5.2f, %5.2f] M_\odot $"
 labels['total_mass'] = "$ M_{total} \in [%5.2f, %5.2f] M_\odot $"
 labels['spin'] = "$Eff Spin \in [%5.2f, %5.2f] $"
 
+if args.sig_type == 'stat':
+    sig = f['found_after_vetoes/stat'][:]
+    sig_exc = None
+    xlabel = 'Ranking Statistic Value'
+    if args.sig_bins:
+        x_values = [float(v) for v in args.sig_bins]
+    else:
+        x_values = 10 ** (numpy.arange(9, 14, .05))
+
 if args.sig_type == 'ifar':
     sig = f['found_after_vetoes/ifar'][:]
     sig_exc = f['found_after_vetoes/ifar_exc'][:]
@@ -110,6 +119,9 @@ for j in range(len(args.bins)-1):
     
     # Plot both the inclusive and exclusive significance 
     for sig_val, do_label, alpha in zip(fvalues, do_labels, alphas):
+        if sig_val is None:
+            continue
+            
         left =  float(args.bins[j])
         right = float(args.bins[j+1])
         binval = values[args.bin_type]

--- a/bin/hdfcoinc/pycbc_page_sensitivity
+++ b/bin/hdfcoinc/pycbc_page_sensitivity
@@ -86,7 +86,7 @@ if args.sig_type == 'stat':
     if args.sig_bins:
         x_values = [float(v) for v in args.sig_bins]
     else:
-        x_values = 10 ** (numpy.arange(9, 14, .05))
+        x_values = numpy.arange(9, 14, .05)
 
 if args.sig_type == 'ifar':
     sig = f['found_after_vetoes/ifar'][:]
@@ -138,7 +138,7 @@ for j in range(len(args.bins)-1):
 
         # Calculate each sensitive distance at a given significance threshold
         for x_val in x_values:
-            if args.sig_type == 'ifar':
+            if args.sig_type == 'ifar' or args.sig_type == 'stat':
                 foundg = found[sig_val >= x_val]
                 foundm = found[sig_val < x_val]
             elif args.sig_type == 'fap':
@@ -185,7 +185,9 @@ for j in range(len(args.bins)-1):
                            facecolor=c, edgecolor=c, alpha=alpha)
                            
 ax = pylab.gca()
-ax.set_xscale('log')
+
+if args.sig_type != 'stat':
+    ax.set_xscale('log')
 
 if args.sig_type == 'fap':
     ax.invert_xaxis()


### PR DESCRIPTION
Add option to use whatever the ranking statistic is as the x-axis in pycbc_page_sensitvity.

This can be turned on by 

--sig-type stat

![out](https://cloud.githubusercontent.com/assets/2206534/8334529/6dbd0ae0-1a66-11e5-8dcc-152b372e0b1c.png)
