### PR TITLE
stand-a-lone executable to calculate all the inspiral psds from a run

### DIFF
--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -31,10 +31,15 @@ def grouper(n, iterable):
     return list([e for e in t if e != None] for t in itertools.izip_longest(*args))
 
 def get_psd((seg, i)):
+    """ Get the PSDs for the given data chunck. This follows the same rules
+    as pycbc_inspiral for determining where to calculate PSDs
+    """
     logging.info('%s: getting strain for %s - %s, %s s' % (i, seg[0], seg[1], abs(seg)))
     args.gps_start_time = int(seg[0]) + args.pad_data
     args.gps_end_time = int(seg[1]) - args.pad_data
     
+    # This helps when the filesystem is unreliable, and gives extra retries.
+    # python has an internal limit of ~100 (it is not infinite)
     try:
         gwstrain = pycbc.strain.from_cli(args, pycbc.DYN_RANGE_FAC)
     except RuntimeError:
@@ -53,6 +58,7 @@ def get_psd((seg, i)):
     nsegs = args.psd_recalculate_segments
     nsegs = nsegs if nsegs != 0 else len(strain_segments.full_segment_slices)
     groups = grouper(nsegs, strain_segments.full_segment_slices)
+    
     for psegs in groups:
         strain_part = gwstrain[psegs[0].start:psegs[-1].stop]
         psd = pycbc.psd.from_cli(args, flen, delta_f, flow, strain_part, pycbc.DYN_RANGE_FAC)        
@@ -60,15 +66,18 @@ def get_psd((seg, i)):
 
     return lpsd
 
+# Determine what times to calculate PSDs for
 ifo = args.channel_name[0:2]
 segments = pycbc.events.select_segments_by_definer(args.analysis_segment_file, 
                                                    args.segment_name, ifo=ifo)
-                                                   
+
+# Calculate the PSDs                                                   
 logging.info('%s psds to calculate' % len(segments))
 p = multiprocessing.Pool(args.cores)
 psds = p.map_async(get_psd, zip(segments, range(len(segments))))
 psds = psds.get()
 
+# Store the PSDs in an hdf file, include some basic metadata
 f = h5py.File(args.output_file, 'w')
 inc, start, end = 0, [], []
 for gpsd in psds:

--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -77,7 +77,7 @@ for gpsd in psds:
         key = ifo + '/psds/' + str(inc)
         start.append(int(s))
         end.append(int(e))
-        f.create_dataset(key, data= (psd.numpy() / pycbc.DYN_RANGE_FAC), 
+        f.create_dataset(key, data= (psd.numpy()), 
                          compression='gzip', compression_opts=9, shuffle=True)
         f[key].attrs['epoch'] = int(s)
         f[key].attrs['delta_f'] = float(psd.delta_f)

--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+""" Calculate psd estimates for analysis segments
+"""
+import logging, argparse, numpy, h5py, itertools, multiprocessing
+import pycbc, pycbc.psd, pycbc.strain, pycbc.events
+from pycbc.version import git_verbose_msg as version
+from pycbc.fft.fftw import set_measure_level
+set_measure_level(0)
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--version', action='version', version=version)
+parser.add_argument('--verbose', action="store_true")
+parser.add_argument("--low-frequency-cutoff", type=float,
+                  help="The low frequency cutoff to use for filtering (Hz)")
+parser.add_argument("--analysis-segment-file", 
+                  help="File containing the the times that were "
+                            "analyzed by the single detector inspiral jobs")
+parser.add_argument("--segment-name", help="Name of segment list to use")
+parser.add_argument("--cores", default=1, type=int)
+parser.add_argument("--psd-recalculate-segments", type=int, default=0)
+parser.add_argument("--output-file")
+
+pycbc.psd.insert_psd_option_group(parser, output=False)
+pycbc.strain.insert_strain_option_group(parser, gps_times=False)
+pycbc.strain.StrainSegments.insert_segment_option_group(parser)
+args = parser.parse_args()
+pycbc.init_logging(args.verbose)
+
+def grouper(n, iterable):
+    args = [iter(iterable)] * n
+    return list([e for e in t if e != None] for t in itertools.izip_longest(*args))
+
+def get_psd((seg, i)):
+    logging.info('%s: getting strain for %s - %s, %s s' % (i, seg[0], seg[1], abs(seg)))
+    args.gps_start_time = int(seg[0]) + args.pad_data
+    args.gps_end_time = int(seg[1]) - args.pad_data
+    
+    try:
+        gwstrain = pycbc.strain.from_cli(args, pycbc.DYN_RANGE_FAC)
+    except RuntimeError:
+        return get_psd((seg, i))
+
+    logging.info('%s: determining strain segmentation' % i)
+    strain_segments = pycbc.strain.StrainSegments.from_cli(args, gwstrain)
+
+    flow = args.low_frequency_cutoff
+    flen = strain_segments.freq_len
+    tlen = strain_segments.time_len
+    delta_f = strain_segments.delta_f
+
+    logging.info('%s: calculating psd' % i)
+    lpsd = []
+    nsegs = args.psd_recalculate_segments
+    nsegs = nsegs if nsegs != 0 else len(strain_segments.full_segment_slices)
+    groups = grouper(nsegs, strain_segments.full_segment_slices)
+    for psegs in groups:
+        strain_part = gwstrain[psegs[0].start:psegs[-1].stop]
+        psd = pycbc.psd.from_cli(args, flen, delta_f, flow, strain_part, pycbc.DYN_RANGE_FAC)        
+        lpsd.append((psd, int(strain_part.start_time), int(strain_part.end_time)))
+
+    return lpsd
+
+ifo = args.channel_name[0:2]
+segments = pycbc.events.select_segments_by_definer(args.analysis_segment_file, 
+                                                   args.segment_name, ifo=ifo)
+                                                   
+logging.info('%s psds to calculate' % len(segments))
+p = multiprocessing.Pool(args.cores)
+psds = p.map_async(get_psd, zip(segments, range(len(segments))))
+psds = psds.get()
+
+f = h5py.File(args.output_file, 'w')
+inc, start, end = 0, [], []
+for gpsd in psds:
+    for psd, s, e in gpsd:
+        logging.info('writing psd %s' % inc)
+        key = ifo + '/psds/' + str(inc)
+        start.append(int(s))
+        end.append(int(e))
+        f.create_dataset(key, data= (psd.numpy() / pycbc.DYN_RANGE_FAC), 
+                         compression='gzip', compression_opts=9, shuffle=True)
+        f[key].attrs['epoch'] = int(s)
+        f[key].attrs['delta_f'] = float(psd.delta_f)
+        inc += 1
+        
+f[ifo + '/psds/start_time'] = numpy.array(start, dtype=numpy.uint32)
+f[ifo + '/psds/end_time'] = numpy.array(end, dtype=numpy.uint32)
+logging.info('Done!')
+
+

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -140,6 +140,9 @@ for ifo, files in zip(*ind_insps.categorize_by_attr('ifo')):
     fsegs = glue.segments.segmentlist([f.segment for f in files])
     full_segs.append(pycbc.events.segments_to_file(fsegs, fname, name, ifo=ifo))
 
+    segs = glue.segments.segmentlist([f.metadata['data_seg'] for f in files])
+    pycbc.events.segments_to_file(segs, 'segments/%s-INSP_DATA.xml' % ifo, 'INSPIRAL_DATA', ifo=ifo)
+
 for ifo, files in zip(*ind_cats.categorize_by_attr('ifo')):
     wf.make_segments_plot(workflow, files, 'results/analysis_time/segments', 
                           tags=['%s_VETO_SEGMENTS' % ifo])
@@ -153,6 +156,8 @@ if len(inj_files) > 0:
                                             output_dir, tags=['ALLINJ'])                                                
     wf.make_sensitivity_plot(workflow, found_inj, 'results/search_sensitivity', 
                                             tags=['ALLINJ'])
+
+
 
 # save global config file to results directory
 ini_file_path = 'results/configuration/configuration.ini'

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -101,12 +101,16 @@ for inj_file, tag, output_dir in zip([None]+inj_files, tags, output_dirs):
                                          
         for bg_file in bg_files:
             wf.make_snrifar_plot(workflow, bg_file, 'results/coincident_triggers', tags=bg_file.tags)
+            wf.make_foreground_table(workflow, bg_file, hdfbank[0], tag, 'results/coincident_triggers')
+
         
         wf.make_snrifar_plot(workflow, final_bg_file[0], 'results/result', tags=bg_file.tags)
-
         wf.make_foreground_table(workflow, final_bg_file[0], hdfbank[0], tag, 'results/result')
-        wf.make_snrchi_plot(workflow, insps, final_veto_file[0], final_veto_name[0], 'results/single_triggers', tags=[tag])
-        wf.make_singles_plot(workflow, insps, hdfbank[0], final_veto_file[0], final_veto_name[0], 'results/single_triggers', tags=[tag])
+
+        wf.make_snrchi_plot(workflow, insps, final_veto_file[0], 
+                            final_veto_name[0], 'results/single_triggers', tags=[tag])
+        wf.make_singles_plot(workflow, insps, hdfbank[0], final_veto_file[0], 
+                            final_veto_name[0], 'results/single_triggers', tags=[tag])
 
     else:
         inj_coinc = wf.setup_interval_coinc_inj(workflow, hdfbank,
@@ -152,7 +156,7 @@ if len(inj_files) > 0:
 
 # save global config file to results directory
 ini_file_path = 'results/configuration/configuration.ini'
-os.makedirs('results/configuration/')
+wf.make_analysis_dir('results/configuration/')
 with open(ini_file_path, 'wb') as ini_fh:
     container.cp.write(ini_fh)
 

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -87,7 +87,7 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
             int(opt.psd_inverse_length * sample_rate),
             low_frequency_cutoff=f_low)
 
-    if opt.psd_output:
+    if hasattr(opt, 'psd_output') and opt.psd_output:
         (psd.astype(float64) / (dyn_range_factor ** 2)).save(opt.psd_output)
 
     return psd
@@ -118,7 +118,7 @@ def from_cli_multi_ifos(opt, length_dict, delta_f_dict,
                                        strain=strain, **kwargs)
     return psd
 
-def insert_psd_option_group(parser):
+def insert_psd_option_group(parser, output=True):
     """
     Adds the options used to call the pycbc.psd.from_cli function to an
     optparser as an OptionGroup. This should be used if you
@@ -153,7 +153,8 @@ def insert_psd_option_group(parser):
     psd_options.add_argument("--psd-inverse-length", type=float, 
                           help="(Optional) The maximum length of the impulse"
                           " response of the overwhitening filter (s)")
-    psd_options.add_argument("--psd-output", 
+    if output:
+        psd_options.add_argument("--psd-output", 
                           help="(Optional) Write PSD to specified file")
 
     return psd_options

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -166,7 +166,7 @@ def from_cli_multi_ifos(opt, ifos, **kwargs):
     return strain
 
 
-def insert_strain_option_group(parser):
+def insert_strain_option_group(parser, gps_times=True):
     """
     Adds the options used to call the pycbc.strain.from_cli function to an
     optparser as an OptionGroup. This should be used if you
@@ -185,12 +185,16 @@ def insert_strain_option_group(parser):
                   " if the --psd-estimation option is given.")
 
     # Required options
-    data_reading_group.add_argument("--gps-start-time",
-                            help="The gps start time of the data "
-                                 "(integer seconds)", type=int)
-    data_reading_group.add_argument("--gps-end-time",
-                            help="The gps end time of the data "
-                                 " (integer seconds)", type=int)
+    
+    if gps_times:
+        data_reading_group.add_argument("--gps-start-time",
+                                help="The gps start time of the data "
+                                     "(integer seconds)", type=int)
+        data_reading_group.add_argument("--gps-end-time",
+                                help="The gps end time of the data "
+                                     " (integer seconds)", type=int)
+                                     
+                                 
     data_reading_group.add_argument("--strain-high-pass", type=float,
                             help="High pass frequency")
     data_reading_group.add_argument("--pad-data",

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -599,6 +599,7 @@ class File(pegasus_workflow.File):
             e.g. this might be ["BNSINJECTIONS" ,"LOWMASS","CAT_2_VETO"].
             These are used in file naming.
         """
+        self.metadata = {}
         
         # Set the science metadata on the file
         if isinstance(ifos, (str, unicode)):
@@ -667,6 +668,10 @@ class File(pegasus_workflow.File):
         safe_dict = copy.copy(self.__dict__)
         safe_dict['cache_entry'] = None
         return safe_dict   
+
+    def add_metadata(key, value):
+        """ Add arbitrary metadata to this file """
+        self.metadata[key] = value
 
     @property
     def ifo(self):

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -518,6 +518,7 @@ class Node(pegasus_workflow.Node):
                    directory=self.executable.out_dir, tags=all_tags,
                    use_tmp_subdirs=use_tmp_subdirs)
         self.add_output_opt(option_name, fil)
+        return fil
         
     @property    
     def output_files(self):
@@ -669,7 +670,7 @@ class File(pegasus_workflow.File):
         safe_dict['cache_entry'] = None
         return safe_dict   
 
-    def add_metadata(key, value):
+    def add_metadata(self, key, value):
         """ Add arbitrary metadata to this file """
         self.metadata[key] = value
 

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -588,15 +588,15 @@ class PyCBCInspiralExecutable(Executable):
                      int_gps_time_to_str(data_seg[1] - pad_data))
         node.add_opt('--trig-start-time', int_gps_time_to_str(valid_seg[0]))
         node.add_opt('--trig-end-time', int_gps_time_to_str(valid_seg[1]))
-        node.add_metadata('data_seg', data_seg)
         node.add_profile('condor', 'request_cpus', self.num_threads)        
 
         if self.injection_file is not None:
             node.add_input_opt('--injection-file', self.injection_file)
 
         # set the input and output files        
-        node.new_output_file_opt(valid_seg, self.ext, '--output', tags=tags,
+        fil = node.new_output_file_opt(valid_seg, self.ext, '--output', tags=tags,
                          store_file=self.retain_files, use_tmp_subdirs=True)
+        fil.add_metadata('data_seg', data_seg)
         node.add_input_list_opt('--frame-files', dfParents)
         node.add_input_opt('--bank-file', parent, )
 

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -588,7 +588,7 @@ class PyCBCInspiralExecutable(Executable):
                      int_gps_time_to_str(data_seg[1] - pad_data))
         node.add_opt('--trig-start-time', int_gps_time_to_str(valid_seg[0]))
         node.add_opt('--trig-end-time', int_gps_time_to_str(valid_seg[1]))
-
+        node.add_metadata('data_seg', data_seg)
         node.add_profile('condor', 'request_cpus', self.num_threads)        
 
         if self.injection_file is not None:

--- a/setup.py
+++ b/setup.py
@@ -381,6 +381,7 @@ setup (
                'bin/pycbc_make_html_page',
                'bin/pycbc_ligolw_find_playground',
                'bin/hdfcoinc/pycbc_make_hdf_coinc_workflow',
+               'bin/hdfcoinc/pycbc_calculate_psd',
                'bin/pycbc_optimal_snr',
                'bin/pycbc_fit_sngl_trigs',
                'bin/hdfcoinc/pycbc_coinc_mergetrigs',


### PR DESCRIPTION
(Depends on commits that will be included in other pull requests, so not ready for approval yet)
#88 

Add a stand-a-long executable (pycbc_calculate_psd, better name?) that calculates all of the psds that are internally made within a run. It re-uses the same data conditioning/psd estimation codes as pycbc_inspiral. 

The input to the code, along with the standard conditioning options, is a segment file containing a set of gps start/end times. 

The output is a single HDF file, that contains every PSD in the run, in the following format. 

f[IFO/PSDS/NUM],

where NUM is an integer that identifies the PSD. Each PSD can be read in by the load_frequencyseries function directly. 

I'll also advocate we consider at some future point to add this to standard set of workflow jobs. The only concern might the storage of all the PSDS, but I've measured the storage rate (after compression) to be ~70 MB  / day of single ifo data, which I think is more than acceptable to generate. 
