### PR TITLE
Combined new snr

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -44,7 +44,7 @@ def get_statistic(option, files):
     elif option == 'phasetd_newsnr':
         return PhaseTDStatistic(files)
     elif option == 'combnewsnr':
-        return CombSNRStatistic()
+        return CombSNRStatistic(files)
     else:
         raise ValueError('%s is not an available detection statistic' % option)
 

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -39,10 +39,12 @@ if args.verbose:
 def get_statistic(option, files):
     if option == 'newsnr':
         return NewSNRStatistic(files)
-    if option == 'newsnr_cut':
+    elif option == 'newsnr_cut':
         return NewSNRCutStatistic(files)
-    if option == 'phasetd_newsnr':
+    elif option == 'phasetd_newsnr':
         return PhaseTDStatistic(files)
+    elif option == 'combnewsnr':
+        return CombSNRStatistic()
     else:
         raise ValueError('%s is not an available detection statistic' % option)
 
@@ -118,6 +120,18 @@ class PhaseTDStatistic(NewSNRStatistic):
         cstat = (s1[:,0]**2.0 + s2[:,0]**2.0 + 2.0 * numpy.log(m))**0.5  
          
         return cstat
+
+class CombSNRStatistic(NewSNRStatistic):
+    def single(self, trigs):
+        """Combined chisq calculation for each trigger."""
+        chisq_dof = 2 * trigs['chisq_dof'] - 2
+        chisq_newsnr = events.newsnr(trigs['snr'], trigs['chisq'] / chisq_dof)
+        # FIXME: Remove hardcoding
+        autochisq_dof = 15
+        autochisq_newsnr = events.newsnr(trigs['snr'],
+                                         trigs['cont_chisq'] / autochisq_dof)
+        return numpy.array(numpy.minimum(chisq_newsnr, autochisq_newsnr,
+                             dtype=numpy.float32), ndmin=1, copy=False)
 
 class ReadByTemplate(object):
     def __init__(self, filename, bank=None, segment_name=None, veto_files=[]):

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -43,8 +43,8 @@ def get_statistic(option, files):
         return NewSNRCutStatistic(files)
     elif option == 'phasetd_newsnr':
         return PhaseTDStatistic(files)
-    elif option == 'combnewsnr':
-        return CombSNRStatistic(files)
+    elif option == 'max_cont_trad_newsnr':
+        return MaxContTradNewSNRStatistic(files)
     else:
         raise ValueError('%s is not an available detection statistic' % option)
 
@@ -121,7 +121,7 @@ class PhaseTDStatistic(NewSNRStatistic):
          
         return cstat
 
-class CombSNRStatistic(NewSNRStatistic):
+class MaxContTradNewSNRStatistic(NewSNRStatistic):
     def single(self, trigs):
         """Combined chisq calculation for each trigger."""
         chisq_dof = 2 * trigs['chisq_dof'] - 2

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -126,7 +126,6 @@ class CombSNRStatistic(NewSNRStatistic):
         """Combined chisq calculation for each trigger."""
         chisq_dof = 2 * trigs['chisq_dof'] - 2
         chisq_newsnr = events.newsnr(trigs['snr'], trigs['chisq'] / chisq_dof)
-        # FIXME: Remove hardcoding
         autochisq_dof = trigs['cont_chisq_dof']
         autochisq_newsnr = events.newsnr(trigs['snr'],
                                          trigs['cont_chisq'] / autochisq_dof)

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -127,7 +127,7 @@ class CombSNRStatistic(NewSNRStatistic):
         chisq_dof = 2 * trigs['chisq_dof'] - 2
         chisq_newsnr = events.newsnr(trigs['snr'], trigs['chisq'] / chisq_dof)
         # FIXME: Remove hardcoding
-        autochisq_dof = 15
+        autochisq_dof = trigs['cont_chisq_dof']
         autochisq_newsnr = events.newsnr(trigs['snr'],
                                          trigs['cont_chisq'] / autochisq_dof)
         return numpy.array(numpy.minimum(chisq_newsnr, autochisq_newsnr,

--- a/bin/hdfcoinc/pycbc_page_coinc_snrchi
+++ b/bin/hdfcoinc/pycbc_page_coinc_snrchi
@@ -40,6 +40,12 @@ snr = f['snr'][:][tid]
 chisq = f['chisq'][:][tid]
 l = chisq == 0
 chisq_dof = f['chisq_dof'][:][tid]
+chisq /= (chisq_dof * 2 - 2)
+cont_chisq = f['cont_chisq'][:][tid]
+cont_chisq_dof = 15
+cont_chisq /= cont_chisq_dof
+chisq = numpy.maximum(chisq, cont_chisq)
+
 chisq /= (chisq_dof * 2 - 2) 
 chisq[l] = 0.1
 

--- a/bin/hdfcoinc/pycbc_page_coinc_snrchi
+++ b/bin/hdfcoinc/pycbc_page_coinc_snrchi
@@ -20,7 +20,7 @@ parser.add_argument('--coinc-statistic-file', help='HDF format statistic file')
 parser.add_argument('--single-trigger-file', help='Single detector triggers files from the zero lag run')
 parser.add_argument('--newsnr-contours', nargs='*', help="List of newsnr values to draw contours at.", default=[])
 parser.add_argument('--background-front', action='store_true', default=False)
-parser.add_argument('--chisq-choice', choices=['traditional','combined'],
+parser.add_argument('--chisq-choice', choices=['traditional','max_cont_trad'],
                     default='traditional',
                     help='Which chisquared to plot. Default=traditional')
 parser.add_argument('--output-file')
@@ -40,25 +40,22 @@ f = f[ifo]
 tid = b_tids[ifo][:]
 snr = f['snr'][:][tid]
 
-if args.chisq_choice in ['traditional','combined']:
+if args.chisq_choice in ['traditional','max_cont_trad']:
     trad_chisq = f['chisq'][:][tid]
     l = trad_chisq == 0
     trad_chisq_dof = f['chisq_dof'][:][tid]
     trad_chisq /= (trad_chisq_dof * 2 - 2)
-if args.chisq_choice in ['combined']:
+if args.chisq_choice in ['max_cont_trad']:
     cont_chisq = f['cont_chisq'][:][tid]
     cont_chisq_dof = f['cont_chisq_dof'][:][tid]
     cont_chisq /= cont_chisq_dof
 if args.chisq_choice == 'traditional':
     chisq = trad_chisq
-elif args.chisq_choice == 'combined':
+elif args.chisq_choice == 'max_cont_trad':
     chisq = numpy.maximum(trad_chisq, cont_chisq)
 else:
     err_msg="Do not recognized --chisq-choice %s" %(args.chisq_choice,)
     raise ValueError(err_msg)
-
-chisq /= (chisq_dof * 2 - 2) 
-chisq[l] = 0.1
 
 fig = pylab.figure()
 pylab.scatter(snr, chisq, marker='o', color='black',

--- a/bin/hdfcoinc/pycbc_page_coinc_snrchi
+++ b/bin/hdfcoinc/pycbc_page_coinc_snrchi
@@ -20,6 +20,9 @@ parser.add_argument('--coinc-statistic-file', help='HDF format statistic file')
 parser.add_argument('--single-trigger-file', help='Single detector triggers files from the zero lag run')
 parser.add_argument('--newsnr-contours', nargs='*', help="List of newsnr values to draw contours at.", default=[])
 parser.add_argument('--background-front', action='store_true', default=False)
+parser.add_argument('--chisq-choice', choices=['traditional','combined'],
+                    default='traditional',
+                    help='Which chisquared to plot. Default=traditional')
 parser.add_argument('--output-file')
 args = parser.parse_args()
 
@@ -37,14 +40,22 @@ f = f[ifo]
 tid = b_tids[ifo][:]
 snr = f['snr'][:][tid]
 
-chisq = f['chisq'][:][tid]
-l = chisq == 0
-chisq_dof = f['chisq_dof'][:][tid]
-chisq /= (chisq_dof * 2 - 2)
-cont_chisq = f['cont_chisq'][:][tid]
-cont_chisq_dof = f['cont_chisq_dof'][:][tid]
-cont_chisq /= cont_chisq_dof
-chisq = numpy.maximum(chisq, cont_chisq)
+if args.chisq_choice in ['traditional','combined']:
+    trad_chisq = f['chisq'][:][tid]
+    l = trad_chisq == 0
+    trad_chisq_dof = f['chisq_dof'][:][tid]
+    trad_chisq /= (trad_chisq_dof * 2 - 2)
+if args.chisq_choice in ['combined']:
+    cont_chisq = f['cont_chisq'][:][tid]
+    cont_chisq_dof = f['cont_chisq_dof'][:][tid]
+    cont_chisq /= cont_chisq_dof
+if args.chisq_choice == 'traditional':
+    chisq = trad_chisq
+elif args.chisq_choice == 'combined':
+    chisq = numpy.maximum(trad_chisq, cont_chisq)
+else:
+    err_msg="Do not recognized --chisq-choice %s" %(args.chisq_choice,)
+    raise ValueError(err_msg)
 
 chisq /= (chisq_dof * 2 - 2) 
 chisq[l] = 0.1

--- a/bin/hdfcoinc/pycbc_page_coinc_snrchi
+++ b/bin/hdfcoinc/pycbc_page_coinc_snrchi
@@ -42,7 +42,7 @@ l = chisq == 0
 chisq_dof = f['chisq_dof'][:][tid]
 chisq /= (chisq_dof * 2 - 2)
 cont_chisq = f['cont_chisq'][:][tid]
-cont_chisq_dof = 15
+cont_chisq_dof = f['cont_chisq_dof'][:][tid]
 cont_chisq /= cont_chisq_dof
 chisq = numpy.maximum(chisq, cont_chisq)
 

--- a/bin/hdfcoinc/pycbc_page_injtable
+++ b/bin/hdfcoinc/pycbc_page_injtable
@@ -12,7 +12,7 @@ args = parser.parse_args()
 f = h5py.File(args.injection_file)
 found = f['found_after_vetoes']
 inj = f['injections']
-idx = found['injection_index']
+idx = found['injection_index'][:]
 
 tdiff = (found['time1'][:] - found['time2'][:]) * 1000
 tdiff_str = '%s - %s time (ms)' % (f.attrs['detector_1'], f.attrs['detector_2'])

--- a/bin/hdfcoinc/pycbc_page_snrchi
+++ b/bin/hdfcoinc/pycbc_page_snrchi
@@ -12,7 +12,7 @@ parser.add_argument('--segment-name', default=None, type=str,
 parser.add_argument('--min-snr', type=float, help='Optional, Minimum SNR to plot')
 parser.add_argument('--output-file')
 parser.add_argument('--newsnr-contours', nargs='*', help="List of newsnr values to draw contours at.", default=[])
-parser.add_argument('--chisq-choice', choices=['traditional','combined'],
+parser.add_argument('--chisq-choice', choices=['traditional','max_cont_trad'],
                     default='traditional',
                     help='Which chisquared to plot. Default=traditional')
 args = parser.parse_args()
@@ -22,20 +22,20 @@ ifo = f.keys()[0]
 f = f[ifo]
 snr = f['snr'][:]
 
-if args.chisq_choice in ['traditional','combined']:
+if args.chisq_choice in ['traditional','max_cont_trad']:
     trad_chisq = f['chisq'][:]
     # We now need to handle the case where chisq is not actually calculated
     # 0 is used as a sentinel value
     l = trad_chisq == 0
     trad_chisq_dof = f['chisq_dof'][:]
     trad_chisq /= (trad_chisq_dof * 2 - 2)
-if args.chisq_choice in ['combined']:
+if args.chisq_choice in ['max_cont_trad']:
     cont_chisq = f['cont_chisq'][:]
     cont_chisq_dof = f['cont_chisq_dof'][:]
     cont_chisq /= cont_chisq_dof
 if args.chisq_choice == 'traditional':
     chisq = trad_chisq
-elif args.chisq_choice == 'combined':
+elif args.chisq_choice == 'max_cont_trad':
     chisq = numpy.maximum(trad_chisq, cont_chisq)
 else:
     err_msg="Do not recognized --chisq-choice %s" %(args.chisq_choice,)

--- a/bin/hdfcoinc/pycbc_page_snrchi
+++ b/bin/hdfcoinc/pycbc_page_snrchi
@@ -27,7 +27,7 @@ chisq_dof = f['chisq_dof'][:]
 chisq /= (chisq_dof * 2 - 2)
 chisq[l] = .1
 cont_chisq = f['cont_chisq'][:]
-cont_chisq_dof = 15
+cont_chisq_dof = f['cont_chisq_dof'][:]
 cont_chisq /= cont_chisq_dof
 chisq = numpy.maximum(chisq, cont_chisq)
 

--- a/bin/hdfcoinc/pycbc_page_snrchi
+++ b/bin/hdfcoinc/pycbc_page_snrchi
@@ -26,6 +26,10 @@ l = chisq == 0
 chisq_dof = f['chisq_dof'][:]
 chisq /= (chisq_dof * 2 - 2)
 chisq[l] = .1
+cont_chisq = f['cont_chisq'][:]
+cont_chisq_dof = 15
+cont_chisq /= cont_chisq_dof
+chisq = numpy.maximum(chisq, cont_chisq)
 
 def snr_from_chisq(chisq, newsnr, q=6.):
     snr = numpy.zeros(len(chisq)) + float(newsnr)

--- a/bin/hdfcoinc/pycbc_page_snrchi
+++ b/bin/hdfcoinc/pycbc_page_snrchi
@@ -12,6 +12,9 @@ parser.add_argument('--segment-name', default=None, type=str,
 parser.add_argument('--min-snr', type=float, help='Optional, Minimum SNR to plot')
 parser.add_argument('--output-file')
 parser.add_argument('--newsnr-contours', nargs='*', help="List of newsnr values to draw contours at.", default=[])
+parser.add_argument('--chisq-choice', choices=['traditional','combined'],
+                    default='traditional',
+                    help='Which chisquared to plot. Default=traditional')
 args = parser.parse_args()
 
 f = h5py.File(args.trigger_file, 'r')
@@ -19,17 +22,24 @@ ifo = f.keys()[0]
 f = f[ifo]
 snr = f['snr'][:]
 
-# We now need to handle the case where chisq is not actually calculated
-# 0 is used as a sentinel value
-chisq = f['chisq'][:]
-l = chisq == 0
-chisq_dof = f['chisq_dof'][:]
-chisq /= (chisq_dof * 2 - 2)
-chisq[l] = .1
-cont_chisq = f['cont_chisq'][:]
-cont_chisq_dof = f['cont_chisq_dof'][:]
-cont_chisq /= cont_chisq_dof
-chisq = numpy.maximum(chisq, cont_chisq)
+if args.chisq_choice in ['traditional','combined']:
+    trad_chisq = f['chisq'][:]
+    # We now need to handle the case where chisq is not actually calculated
+    # 0 is used as a sentinel value
+    l = trad_chisq == 0
+    trad_chisq_dof = f['chisq_dof'][:]
+    trad_chisq /= (trad_chisq_dof * 2 - 2)
+if args.chisq_choice in ['combined']:
+    cont_chisq = f['cont_chisq'][:]
+    cont_chisq_dof = f['cont_chisq_dof'][:]
+    cont_chisq /= cont_chisq_dof
+if args.chisq_choice == 'traditional':
+    chisq = trad_chisq
+elif args.chisq_choice == 'combined':
+    chisq = numpy.maximum(trad_chisq, cont_chisq)
+else:
+    err_msg="Do not recognized --chisq-choice %s" %(args.chisq_choice,)
+    raise ValueError(err_msg)
 
 def snr_from_chisq(chisq, newsnr, q=6.):
     snr = numpy.zeros(len(chisq)) + float(newsnr)


### PR DESCRIPTION
These are the changes needed to run combined new SNR in a workflow. For ER7 I ran the traditional chisq with 16 bins .... although I definitely see better performance at shorter duration with fewer bins, and better performance at longer duration with more bins .... Maybe there is some way to automatically choose the number of bins based on some minimal spacing [in the time domain?] between the bins??

The auto-chisquared parameters are:

autochi-number-points = 100
autochi-stride = 4
autochi-reverse-template =
autochi-two-phase =

**NOTE**: This is *not* max-valued as in ER6, which makes getting the DOF easy.

You also need to supply:

ranking-statistic = combnewsnr

to pycbc_coinc_findtrigs.

Finally the chi-squared plotting codes add a command line option to choose which chi-squared to plot. This can be extended, but you can give the combined option in addition to the traditional chisq (note that if no option is given we use traditional as usual) .... I haven't actually tested this as I just hardcoded the plotting codes to make my plots.

Finally there is a fix to pycbc_page_injtable similar to others I have made recently .... Not sure why this only seems to affect me!