### PR TITLE
Add versioning tab to html page

### DIFF
--- a/bin/pycbc_make_html_page
+++ b/bin/pycbc_make_html_page
@@ -24,6 +24,7 @@ import shutil
 import zipfile
 from glue import segments
 from jinja2 import Environment, FileSystemLoader
+from pycbc.results import create_versioning_page
 from pycbc.results.render import setup_template_render
 from pycbc.workflow import segment
 
@@ -173,6 +174,9 @@ analysis_title = opts.analysis_title.strip('"').rstrip('"')
 analysis_subtitle = opts.analysis_subtitle.strip('"').rstrip('"')
 input_template = opts.template_file.split('/')[-1]
 input_path = opts.template_file.rstrip(input_template)
+
+# Create versioning information
+create_versioning_page(os.path.join(opts.plots_dir,'Versioning'))
 
 # setup template
 env = Environment(loader=FileSystemLoader(input_path))

--- a/bin/pycbc_write_results_page
+++ b/bin/pycbc_write_results_page
@@ -41,6 +41,7 @@ from glue.ligolw.utils import print_tables
 from glue.ligolw.utils import segments as segment_utils
 from glue.markup import oneliner as e
 import glue.pipeline
+from pycbc.results import get_library_version_info, get_code_version_numbers
 
 class ContentHandler(ligolw.LIGOLWContentHandler):
     pass
@@ -442,109 +443,7 @@ def write_general(page,opts):
 
   # Do all the libraries.
   # Collect information
-  library_list = []
-  import lal, lalframe, lalmetaio, lalinspiral, lalsimulation
-  import glue.git_version, pylal.git_version, pycbc.version
-
-  lalinfo = {}
-  lalinfo['Name'] = 'LAL'
-  lalinfo['ID'] = lal.VCSId
-  lalinfo['Status'] = lal.VCSStatus
-  lalinfo['Version'] = lal.VCSVersion
-  lalinfo['Tag'] = lal.VCSTag
-  lalinfo['Author'] = lal.VCSAuthor
-  lalinfo['Branch'] = lal.VCSBranch
-  lalinfo['Committer'] = lal.VCSCommitter
-  lalinfo['Date'] = lal.VCSDate
-  library_list.append(lalinfo)
-
-  lalframeinfo = {}
-  lalframeinfo['Name'] = 'LALFrame'
-  lalframeinfo['ID'] = lalframe.FrameVCSId
-  lalframeinfo['Status'] = lalframe.FrameVCSStatus
-  lalframeinfo['Version'] = lalframe.FrameVCSVersion
-  lalframeinfo['Tag'] = lalframe.FrameVCSTag
-  lalframeinfo['Author'] = lalframe.FrameVCSAuthor
-  lalframeinfo['Branch'] = lalframe.FrameVCSBranch
-  lalframeinfo['Committer'] = lalframe.FrameVCSCommitter
-  lalframeinfo['Date'] = lalframe.FrameVCSDate
-  library_list.append(lalframeinfo)
-
-  lalmetaioinfo = {}
-  lalmetaioinfo['Name'] = 'LALMetaIO'
-  lalmetaioinfo['ID'] = lalmetaio.MetaIOVCSId
-  lalmetaioinfo['Status'] = lalmetaio.MetaIOVCSStatus
-  lalmetaioinfo['Version'] = lalmetaio.MetaIOVCSVersion
-  lalmetaioinfo['Tag'] = lalmetaio.MetaIOVCSTag
-  lalmetaioinfo['Author'] = lalmetaio.MetaIOVCSAuthor
-  lalmetaioinfo['Branch'] = lalmetaio.MetaIOVCSBranch
-  lalmetaioinfo['Committer'] = lalmetaio.MetaIOVCSCommitter
-  lalmetaioinfo['Date'] = lalmetaio.MetaIOVCSDate
-  library_list.append(lalmetaioinfo)
-
-  lalinspiralinfo = {}
-  lalinspiralinfo['Name'] = 'LALInspiral'
-  lalinspiralinfo['ID'] = lalinspiral.InspiralVCSId
-  lalinspiralinfo['Status'] = lalinspiral.InspiralVCSStatus
-  lalinspiralinfo['Version'] = lalinspiral.InspiralVCSVersion
-  lalinspiralinfo['Tag'] = lalinspiral.InspiralVCSTag
-  lalinspiralinfo['Author'] = lalinspiral.InspiralVCSAuthor
-  lalinspiralinfo['Branch'] = lalinspiral.InspiralVCSBranch
-  lalinspiralinfo['Committer'] = lalinspiral.InspiralVCSCommitter
-  lalinspiralinfo['Date'] = lalinspiral.InspiralVCSDate
-  library_list.append(lalinspiralinfo)
-
-  lalsimulationinfo = {}
-  lalsimulationinfo['Name'] = 'LALSimulation'
-  lalsimulationinfo['ID'] = lalsimulation.SimulationVCSId
-  lalsimulationinfo['Status'] = lalsimulation.SimulationVCSStatus
-  lalsimulationinfo['Version'] = lalsimulation.SimulationVCSVersion
-  lalsimulationinfo['Tag'] = lalsimulation.SimulationVCSTag
-  lalsimulationinfo['Author'] = lalsimulation.SimulationVCSAuthor
-  lalsimulationinfo['Branch'] = lalsimulation.SimulationVCSBranch
-  lalsimulationinfo['Committer'] = lalsimulation.SimulationVCSCommitter
-  lalsimulationinfo['Date'] = lalsimulation.SimulationVCSDate
-  library_list.append(lalsimulationinfo)
-
-  glueinfo = {}
-  glueinfo['Name'] = 'Glue'
-  glueinfo['ID'] = glue.git_version.id
-  glueinfo['Status'] = glue.git_version.status
-  glueinfo['Version'] = glue.git_version.version
-  glueinfo['Tag'] = glue.git_version.tag
-  glueinfo['Author'] = glue.git_version.author
-  glueinfo['Builder'] = glue.git_version.builder
-  glueinfo['Branch'] = glue.git_version.branch
-  glueinfo['Committer'] = glue.git_version.committer
-  glueinfo['Date'] = glue.git_version.date
-  library_list.append(glueinfo)
-
-  pylalinfo = {}
-  pylalinfo['Name'] = 'Pylal'
-  pylalinfo['ID'] = pylal.git_version.id
-  pylalinfo['Status'] = pylal.git_version.status
-  pylalinfo['Version'] = pylal.git_version.version
-  pylalinfo['Tag'] = pylal.git_version.tag
-  pylalinfo['Author'] = pylal.git_version.author
-  pylalinfo['Builder'] = pylal.git_version.builder
-  pylalinfo['Branch'] = pylal.git_version.branch
-  pylalinfo['Committer'] = pylal.git_version.committer
-  pylalinfo['Date'] = pylal.git_version.date
-  library_list.append(pylalinfo)
-
-  pycbcinfo = {}
-  pycbcinfo['Name'] = 'PyCBC'
-  pycbcinfo['ID'] = pycbc.version.version
-  pycbcinfo['Status'] = pycbc.version.git_status
-  pycbcinfo['Version'] = pycbc.version.release or ''
-  pycbcinfo['Tag'] = pycbc.version.git_tag
-  pycbcinfo['Author'] = pycbc.version.git_author
-  pycbcinfo['Builder'] = pycbc.version.git_builder
-  pycbcinfo['Branch'] = pycbc.version.git_branch
-  pycbcinfo['Committer'] = pycbc.version.git_committer
-  pycbcinfo['Date'] = pycbc.version.git_build_date
-  library_list.append(pycbcinfo)
-
+  library_list = get_library_version_info()
 
   for entry in library_list:
     page = heading(page, entry['Name'] + " versioning information.")
@@ -567,21 +466,15 @@ def write_general(page,opts):
     print "Extracting the version and tag of the executables..." 
   
   page = heading(page, "Version information from executables.")
-  executables = []
-  for item,value in hipecp.items('executables'):
-    if item != 'universe':
-      executables.append([item,os.path.split(value)[1]])     
+  code_version_dict = get_code_version_numbers(hipecp)
 
   page.ol() #starts enumerate
   # first section with version number
   # get the version of each executables
   try:
     page.ul()
-    for exe in executables:
-      if exe[0] == 'mvsc_train_forest' or exe[0] == 'mvsc_use_forest':
-        text = "<b>"+exe[0]+ ': ' + exe[1] + "</b> "
-      else:
-        text = "<b>"+exe[0]+ ': ' + exe[1] + "</b> "+get_version(exe[1])
+    for exe, message in code_version_dict.items():
+      text = "<b>" + exe + "</b>: " + message
       page.li(text)   
     page.ul.close()
     page.li.close()
@@ -1924,45 +1817,6 @@ def get_ifos():
     ifos.append(ifo.upper())
 
   return ifos
-
-# ***************************************************************************
-# ***************************************************************************
-def get_version(executable): 
-  """
-  Search for the tag and version of an executable using the --version argument.
-
-  @param executable: the name of an executable (type: string)
-  return: the tag name if any and the version of the executable
-  """
-  output=[]
-  try:
-    # this is surely useless now to make a distinction with trigbank 
-    cmd = executable + " --version"
-    output,err,status = make_external_call(cmd, opts.debug, opts.debug, True,return_stderr=True)
-  except:  
-    output= '(not found)' 
-
-  output = output.split('\n')
-  err = err.split('\n')
-
-  #searching for the version, which may be empty(undefined)
-  version = '. Undefined version (does this executable have --version?).'
-  for entry in output:
-    entry = entry.split(' ')
-    if "Id:" in entry:
-      index = entry.index("Id:") + 1
-      version = 'Version is %s.' %(entry[index],)
-      break
-  else:
-    # Some codes use stderr for the version message
-    for entry in err:
-      entry = entry.split(' ')
-      if "Id:" in entry:
-        index = entry.index("Id:") + 1
-        version = 'Version is %s.' %(entry[index],)
-        break
-
-  return version
 
 # ***************************************************************************
 def copy_segments():

--- a/pycbc/results/__init__.py
+++ b/pycbc/results/__init__.py
@@ -1,2 +1,3 @@
 from pycbc.results.table import *
 from pycbc.results.plot import *
+from pycbc.results.versioning import *

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -91,6 +91,11 @@ def render_default(path, cp):
     elif path.endswith('.ini'):
         with open(path, 'rb') as f_handle:
             content = f_handle.read()
+    elif path.endswith('htmlf'):
+        cp.add_section(filename)
+        cp.set(filename,'title', filename.split('.')[0].replace('_',' '))
+        with open(path, 'r') as f_handle:
+            content = f_handle.read()
 
     # render template
     template_dir = pycbc.results.__path__[0] + '/templates/files'
@@ -124,3 +129,8 @@ def render_glitchgram(path, cp):
     output = template.render(context)
 
     return output
+
+def render_config_and_version_page(path, config_file):
+    """ Render a html page to show the configuration file and versioning
+    information.
+    """

--- a/pycbc/results/templates/files/file_default.html
+++ b/pycbc/results/templates/files/file_default.html
@@ -62,6 +62,9 @@
                 {% elif filename.endswith('.ini') %}
                     <pre>{{content}}</pre>
 
+                <!--html file fragments-->
+                {% elif filename.endswith('.htmlf') %}
+                    <pre>{{content}}</pre>
                 <!--catch-all condition-->
                 {% else %}
                     <p>Unsupported file extension.</p>

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -1,0 +1,201 @@
+#!/usr/bin/python
+
+# Copyright (C) 2015 Ian Harry
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Generals
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import os
+import subprocess
+from ConfigParser import ConfigParser
+
+def get_library_version_info():
+    """This will return a list of dictionaries containing versioning
+    information about the various LIGO libraries that PyCBC will use in an
+    analysis run."""
+    library_list = []
+    import lal, lalframe, lalmetaio, lalinspiral, lalsimulation
+    import glue.git_version, pylal.git_version, pycbc.version
+
+    lalinfo = {}
+    lalinfo['Name'] = 'LAL'
+    lalinfo['ID'] = lal.VCSId
+    lalinfo['Status'] = lal.VCSStatus
+    lalinfo['Version'] = lal.VCSVersion
+    lalinfo['Tag'] = lal.VCSTag
+    lalinfo['Author'] = lal.VCSAuthor
+    lalinfo['Branch'] = lal.VCSBranch
+    lalinfo['Committer'] = lal.VCSCommitter
+    lalinfo['Date'] = lal.VCSDate
+    library_list.append(lalinfo)
+
+    lalframeinfo = {}
+    lalframeinfo['Name'] = 'LALFrame'
+    lalframeinfo['ID'] = lalframe.FrameVCSId
+    lalframeinfo['Status'] = lalframe.FrameVCSStatus
+    lalframeinfo['Version'] = lalframe.FrameVCSVersion
+    lalframeinfo['Tag'] = lalframe.FrameVCSTag
+    lalframeinfo['Author'] = lalframe.FrameVCSAuthor
+    lalframeinfo['Branch'] = lalframe.FrameVCSBranch
+    lalframeinfo['Committer'] = lalframe.FrameVCSCommitter
+    lalframeinfo['Date'] = lalframe.FrameVCSDate
+    library_list.append(lalframeinfo)
+
+    lalmetaioinfo = {}
+    lalmetaioinfo['Name'] = 'LALMetaIO'
+    lalmetaioinfo['ID'] = lalmetaio.MetaIOVCSId
+    lalmetaioinfo['Status'] = lalmetaio.MetaIOVCSStatus
+    lalmetaioinfo['Version'] = lalmetaio.MetaIOVCSVersion
+    lalmetaioinfo['Tag'] = lalmetaio.MetaIOVCSTag
+    lalmetaioinfo['Author'] = lalmetaio.MetaIOVCSAuthor
+    lalmetaioinfo['Branch'] = lalmetaio.MetaIOVCSBranch
+    lalmetaioinfo['Committer'] = lalmetaio.MetaIOVCSCommitter
+    lalmetaioinfo['Date'] = lalmetaio.MetaIOVCSDate
+    library_list.append(lalmetaioinfo)
+
+    lalinspiralinfo = {}
+    lalinspiralinfo['Name'] = 'LALInspiral'
+    lalinspiralinfo['ID'] = lalinspiral.InspiralVCSId
+    lalinspiralinfo['Status'] = lalinspiral.InspiralVCSStatus
+    lalinspiralinfo['Version'] = lalinspiral.InspiralVCSVersion
+    lalinspiralinfo['Tag'] = lalinspiral.InspiralVCSTag
+    lalinspiralinfo['Author'] = lalinspiral.InspiralVCSAuthor
+    lalinspiralinfo['Branch'] = lalinspiral.InspiralVCSBranch
+    lalinspiralinfo['Committer'] = lalinspiral.InspiralVCSCommitter
+    lalinspiralinfo['Date'] = lalinspiral.InspiralVCSDate
+    library_list.append(lalinspiralinfo)
+
+    lalsimulationinfo = {}
+    lalsimulationinfo['Name'] = 'LALSimulation'
+    lalsimulationinfo['ID'] = lalsimulation.SimulationVCSId
+    lalsimulationinfo['Status'] = lalsimulation.SimulationVCSStatus
+    lalsimulationinfo['Version'] = lalsimulation.SimulationVCSVersion
+    lalsimulationinfo['Tag'] = lalsimulation.SimulationVCSTag
+    lalsimulationinfo['Author'] = lalsimulation.SimulationVCSAuthor
+    lalsimulationinfo['Branch'] = lalsimulation.SimulationVCSBranch
+    lalsimulationinfo['Committer'] = lalsimulation.SimulationVCSCommitter
+    lalsimulationinfo['Date'] = lalsimulation.SimulationVCSDate
+    library_list.append(lalsimulationinfo)
+
+    glueinfo = {}
+    glueinfo['Name'] = 'Glue'
+    glueinfo['ID'] = glue.git_version.id
+    glueinfo['Status'] = glue.git_version.status
+    glueinfo['Version'] = glue.git_version.version
+    glueinfo['Tag'] = glue.git_version.tag
+    glueinfo['Author'] = glue.git_version.author
+    glueinfo['Builder'] = glue.git_version.builder
+    glueinfo['Branch'] = glue.git_version.branch
+    glueinfo['Committer'] = glue.git_version.committer
+    glueinfo['Date'] = glue.git_version.date
+    library_list.append(glueinfo)
+
+    # NOTE: We hope to remove pylal dependance in the future, but it will be
+    # used in O1.
+    pylalinfo = {}
+    pylalinfo['Name'] = 'Pylal'
+    pylalinfo['ID'] = pylal.git_version.id
+    pylalinfo['Status'] = pylal.git_version.status
+    pylalinfo['Version'] = pylal.git_version.version
+    pylalinfo['Tag'] = pylal.git_version.tag
+    pylalinfo['Author'] = pylal.git_version.author
+    pylalinfo['Builder'] = pylal.git_version.builder
+    pylalinfo['Branch'] = pylal.git_version.branch
+    pylalinfo['Committer'] = pylal.git_version.committer
+    pylalinfo['Date'] = pylal.git_version.date
+    library_list.append(pylalinfo)
+
+    pycbcinfo = {}
+    pycbcinfo['Name'] = 'PyCBC'
+    pycbcinfo['ID'] = pycbc.version.version
+    pycbcinfo['Status'] = pycbc.version.git_status
+    pycbcinfo['Version'] = pycbc.version.release or ''
+    pycbcinfo['Tag'] = pycbc.version.git_tag
+    pycbcinfo['Author'] = pycbc.version.git_author
+    pycbcinfo['Builder'] = pycbc.version.git_builder
+    pycbcinfo['Branch'] = pycbc.version.git_branch
+    pycbcinfo['Committer'] = pycbc.version.git_committer
+    pycbcinfo['Date'] = pycbc.version.git_build_date
+    library_list.append(pycbcinfo)
+
+    return library_list
+
+def write_library_information(path):
+    library_list = get_library_version_info()
+    for curr_lib in library_list:
+        lib_name = curr_lib['Name']
+        text = ''
+        for key, value in curr_lib.items():
+            text+='<li> %s : %s </li>\n' %(key,value)
+        file_p = open(os.path.join(path,
+                              '%s_version_information.htmlf' %(lib_name)), 'w')
+        file_p.write(text)
+        file_p.close()
+
+def get_code_version_numbers(cp):
+    """Will extract the version information from the executables listed in
+    the executable section of the supplied ConfigParser object.
+
+    Returns
+    --------
+    dict
+        A dictionary keyed by the executable name with values giving the
+        version string for each executable.
+    """
+    code_version_dict = {}
+    for item, value in cp.items('executables'):
+        path, exe_name = os.path.split(value)
+        version_string = None
+        try:
+            version_output = subprocess.check_output([value, '--version'],
+                                                      stderr=subprocess.STDOUT)
+            version_output = version_output.split('\n')
+            for line in version_output:
+                line = line.split(" ")
+                # Look for a version
+                if "Id:" in line:
+                    index = line.index("Id:") + 1
+                    version_string = 'Version is %s.' %(line[index],)
+                elif "LALApps:" in line:
+                    index = line.index("LALApps:") + 3
+                    version_string = 'Version (lalapps) is %s.' %(line[index],)
+            if version_string is None:
+                version_string = "Cannot identify version string in output."
+        except subprocess.CalledProcessError:
+            version_string = "Executable fails on %s --version" %(value)
+        except OSError:
+            version_string = "Executable doesn't seem to exist(!)"
+        code_version_dict[exe_name] = version_string
+    return code_version_dict
+
+def write_code_versions(path, cp):
+    code_version_dict = get_code_version_numbers(cp)
+    html_text = ''
+    for key,value in code_version_dict.items():
+        html_text+= '<li><b>%s</b>: %s </li>\n' %(key,value)
+    file_p = open(os.path.join(path,
+                            'Version_information_from_executables.htmlf'), 'w')
+    file_p.write(html_text)
+    file_p.close()
+
+
+def create_versioning_page(path):
+    if not os.path.exists(path):
+        os.mkdir(path)
+    write_library_information(path)
+    # FIXME: Really bad hardcoding here, not sure how to fix?
+    config_file = os.path.join(path, '../configuration.ini')
+    cp = ConfigParser()
+    cp.read(config_file)
+    write_code_versions(path, cp)


### PR DESCRIPTION
Here is a patch to add a versioning tab to the new html pages. An example of this is here:

https://galahad.aei.mpg.de/~spxiwh/LVC/ER7/analyses/BBH_alignedspin/run7/

... There are also changes in pycbc_write_results_page, and I have also tested that that still works.

This html infrastructure produces some nice pages, but it was rather opaque to me to see how to do this simple case of just adding small blocks of text. I really don't know how to go about reproducing section II on the new output pages! Is there any advice for coding these pages, or any pointers I should see .... Am I on completely the wrong road with this patch?

An example output is here:

https://galahad.aei.mpg.de/~spxiwh/LVC/ER7/analyses/BBH_alignedspin/run7/Versioning/

(We have a large number of executables that do *not* have a --version option, that needs fixing!!)