### PR TITLE
Htmlmeta

### DIFF
--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 """ Make table of the foreground coincident events
 """
-import argparse
+import argparse, pycbc.results
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--injection-file',
@@ -83,18 +83,15 @@ if args.log_distance:
     ax.set_yscale('log')
 plot.ylim(ymin=1)
 
-if '.png' in args.output_file:   
-    pycbc.results.save_fig_with_metadata(fig, args.output_file, 
-                     fig_kwds={'dpi':500},
-                     title='%s vs %s' % (args.axis_type, args.distance_type))
-elif ('.html' in args.output_file) and args.dynamic:
+if ('.html' in args.output_file) and args.dynamic:
     import mpld3, mpld3.plugins, mpld3.utils
     mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fmt='.5g'))
     legend =  mpld3.plugins.InteractiveLegendPlugin([mpoints, points],
                                                     ['missed', 'found'],
                                                     alpha_unsel=0.1)
     mpld3.plugins.connect(fig, legend)
-    mpld3.save_html(fig, open(args.output_file, 'w'))
-else:
-    raise ValueError('Cannot save as chosen file type')
+
+pycbc.results.save_fig_with_metadata(fig, args.output_file, 
+                     fig_kwds={'dpi':500},
+                     title='%s vs %s' % (args.axis_type, args.distance_type))
 

--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -83,6 +83,9 @@ if args.log_distance:
     ax.set_yscale('log')
 plot.ylim(ymin=1)
 
+fig_kwds = {}
+if '.png' in args.output_file:
+    fig_kwds['dpi'] = 500
 if ('.html' in args.output_file) and args.dynamic:
     import mpld3, mpld3.plugins, mpld3.utils
     mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fmt='.5g'))
@@ -92,6 +95,6 @@ if ('.html' in args.output_file) and args.dynamic:
     mpld3.plugins.connect(fig, legend)
 
 pycbc.results.save_fig_with_metadata(fig, args.output_file, 
-                     fig_kwds={'dpi':500},
+                     fig_kwds=fig_kwds,
                      title='%s vs %s' % (args.axis_type, args.distance_type))
 

--- a/pycbc/results/plot.py
+++ b/pycbc/results/plot.py
@@ -5,6 +5,13 @@ PyCBC.
 import os.path, pycbc.version
 import ConfigParser
 
+def save_html_with_metadata(text, filename, fig_kwds, kwds):
+    """ Save a html output to file with metadata """
+    pass
+    
+def load_html_with_metadata(filename):
+    pass
+
 def save_png_with_metadata(fig, filename, fig_kwds, kwds):
     """ Save a matplotlib figure to a png with metadata
     """
@@ -27,8 +34,10 @@ def load_png_metadata(filename):
     return cp
     
 _metadata_saver = {'.png':save_png_with_metadata,
+                   '.html':save_html_with_metadata,
                   }
 _metadata_loader = {'.png':load_png_metadata,
+                    '.html':load_html_metadata,
                    }
 
 def save_fig_with_metadata(fig, filename, fig_kwds={}, **kwds):

--- a/pycbc/results/plot.py
+++ b/pycbc/results/plot.py
@@ -26,8 +26,14 @@ class MetaParser(HTMLParser.HTMLParser):
             self.metadata[attr['key']] = unescape(attr['value'], unescape_table)
         
 
-def save_html_with_metadata(text, filename, fig_kwds, kwds):
+def save_html_with_metadata(fig, filename, fig_kwds, kwds):
     """ Save a html output to file with metadata """
+    if isinstance(fig, str):
+        text = fig
+    else:
+        from mpld3 import fig_to_html
+        text = fig_to_html(fig, **fig_kwds)
+    
     f = open(filename, 'w')
     f.write(text)
     for key, value in kwds:

--- a/pycbc/results/plot.py
+++ b/pycbc/results/plot.py
@@ -17,6 +17,10 @@ for k, v in escape_table.items():
 class MetaParser(HTMLParser.HTMLParser):
     def __init__(self):
         self.metadata = {}
+        HTMLParser.HTMLParser.__init__(self)
+
+    def handle_data(self, data):
+        pass
 
     def handle_starttag(self, tag, attrs):
         attr= {}
@@ -35,15 +39,20 @@ def save_html_with_metadata(fig, filename, fig_kwds, kwds):
         text = fig_to_html(fig, **fig_kwds)
     
     f = open(filename, 'w')
-    f.write(text)
-    for key, value in kwds:
+    for key, value in kwds.items():
         value = escape(value, escape_table)
-        line = """<div class=pycbc-meta key="%s" value="%s"></div>\n""" % (str(key), value) 
-    
-def load_html_with_metadata(filename):
+        line = "\n<div class=pycbc-meta key=\"%s\" value=\"%s\"></div>\n" % (str(key), value) 
+        f.write(line)    
+    f.write(text)
+
+def load_html_metadata(filename):
     """ Get metadata from html file """
     parser = MetaParser()
-    parser.feed(open(filename, 'r').read())
+    data = open(filename, 'r').read()
+
+    if 'pycbc-meta' in data:
+        print "LOADING HTML FILE %s" % filename
+    parser.feed(data)
     cp = ConfigParser.ConfigParser(parser.metadata)
     cp.add_section(os.path.basename(filename))
     return cp

--- a/pycbc/results/plot.py
+++ b/pycbc/results/plot.py
@@ -3,14 +3,44 @@ This Module contains generic utility functions for creating plots within
 PyCBC. 
 """
 import os.path, pycbc.version
-import ConfigParser
+import ConfigParser, HTMLParser
+from xml.sax.saxutils import escape, unescape
+
+escape_table = {
+                '"': "&quot;",
+                "'": "&apos;",
+                }
+unescape_table = {}
+for k, v in escape_table.items():
+    unescape_table[v] = k
+
+class MetaParser(HTMLParser.HTMLParser):
+    def __init__(self):
+        self.metadata = {}
+
+    def handle_starttag(self, tag, attrs):
+        attr= {}
+        for key, value in attrs:
+            attr[key] = value
+        if tag == 'div' and 'class' in attr and attr['class'] == 'pycbc-meta':
+            self.metadata[attr['key']] = unescape(attr['value'], unescape_table)
+        
 
 def save_html_with_metadata(text, filename, fig_kwds, kwds):
     """ Save a html output to file with metadata """
-    pass
+    f = open(filename, 'w')
+    f.write(text)
+    for key, value in kwds:
+        value = escape(value, escape_table)
+        line = """<div class=pycbc-meta key="%s" value="%s"></div>\n""" % (str(key), value) 
     
 def load_html_with_metadata(filename):
-    pass
+    """ Get metadata from html file """
+    parser = MetaParser()
+    parser.feed(open(filename, 'r').read())
+    cp = ConfigParser.ConfigParser(parser.metadata)
+    cp.add_section(os.path.basename(filename))
+    return cp
 
 def save_png_with_metadata(fig, filename, fig_kwds, kwds):
     """ Save a matplotlib figure to a png with metadata


### PR DESCRIPTION
Add ability for metadata to be save in an html output file. You can use the save_fig_with_metadata function to do so. The input can either be a figure (in which case mpld3 is used to save), or an block of text. 