### PR TITLE
Move versioning from html generator to workflow generator

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -175,7 +175,7 @@ dep = dax.Dependency(parent=workflow.as_job, child=finalize_workflow.as_job)
 container._adag.addDependency(dep)
 
 # Create versioning information
-create_versioning_page(os.path.join(opts.plots_dir,'versioning'))
+create_versioning_page(os.path.join(opts.plots_dir,'versioning'), container.cp)
 
 container.save()
 logging.info("Written dax.")

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -22,6 +22,7 @@ generate post-processing and plots.
 """
 import pycbc, pycbc.version, pycbc.events, pycbc.workflow as wf
 import os, argparse, ConfigParser, logging, glue.segments
+from pycbc.workflow.core import make_analysis_dir
 from pycbc.results import create_versioning_page
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
@@ -40,8 +41,7 @@ container = wf.Workflow(args, args.workflow_name)
 workflow = wf.Workflow(args, 'main')
 finalize_workflow = wf.Workflow(args, 'finalization')
 
-if not os.path.exists(args.output_dir):
-    os.makedirs(args.output_dir)
+make_analysis_dir(args.output_dir)
 os.chdir(args.output_dir)
 
 # Get segments and find where the data is
@@ -104,7 +104,7 @@ for inj_file, tag, output_dir in zip([None]+inj_files, tags, output_dirs):
             wf.make_foreground_table(workflow, bg_file, hdfbank[0], tag, 'results/coincident_triggers')
 
         
-        wf.make_snrifar_plot(workflow, final_bg_file[0], 'results/result', tags=bg_file.tags)
+        wf.make_snrifar_plot(workflow, final_bg_file[0], 'results/result', tags=final_bg_file[0].tags)
         wf.make_foreground_table(workflow, final_bg_file[0], hdfbank[0], tag, 'results/result')
 
         wf.make_snrchi_plot(workflow, insps, final_veto_file[0], 
@@ -161,7 +161,7 @@ if len(inj_files) > 0:
 
 # save global config file to results directory
 ini_file_path = 'results/configuration/configuration.ini'
-wf.make_analysis_dir('results/configuration/')
+make_analysis_dir('results/configuration/')
 with open(ini_file_path, 'wb') as ini_fh:
     container.cp.write(ini_fh)
 

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -22,7 +22,7 @@ generate post-processing and plots.
 """
 import pycbc, pycbc.version, pycbc.events, pycbc.workflow as wf
 import os, argparse, ConfigParser, logging, glue.segments
-
+from pycbc.results import create_versioning_page
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
 parser.add_argument('--version', action='version', 
@@ -173,6 +173,9 @@ container += finalize_workflow
 import Pegasus.DAX3 as dax
 dep = dax.Dependency(parent=workflow.as_job, child=finalize_workflow.as_job)
 container._adag.addDependency(dep)
+
+# Create versioning information
+create_versioning_page(os.path.join(opts.plots_dir,'versioning'))
 
 container.save()
 logging.info("Written dax.")

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -175,7 +175,7 @@ dep = dax.Dependency(parent=workflow.as_job, child=finalize_workflow.as_job)
 container._adag.addDependency(dep)
 
 # Create versioning information
-create_versioning_page(os.path.join(opts.plots_dir,'versioning'), container.cp)
+create_versioning_page(os.path.join(os.getcwd(), 'results/versioning'), container.cp)
 
 container.save()
 logging.info("Written dax.")

--- a/bin/pycbc_make_html_page
+++ b/bin/pycbc_make_html_page
@@ -24,7 +24,6 @@ import shutil
 import zipfile
 from glue import segments
 from jinja2 import Environment, FileSystemLoader
-from pycbc.results import create_versioning_page
 from pycbc.results.render import setup_template_render
 from pycbc.workflow import segment
 
@@ -174,9 +173,6 @@ analysis_title = opts.analysis_title.strip('"').rstrip('"')
 analysis_subtitle = opts.analysis_subtitle.strip('"').rstrip('"')
 input_template = opts.template_file.split('/')[-1]
 input_path = opts.template_file.rstrip(input_template)
-
-# Create versioning information
-create_versioning_page(os.path.join(opts.plots_dir,'Versioning'))
 
 # setup template
 env = Environment(loader=FileSystemLoader(input_path))

--- a/pycbc/results/plot.py
+++ b/pycbc/results/plot.py
@@ -9,8 +9,11 @@ from xml.sax.saxutils import escape, unescape
 escape_table = {
                 '"': "&quot;",
                 "'": "&apos;",
+                "@": "&#64;",
                 }
-unescape_table = {}
+unescape_table = {
+                  "&#64;" : "@",
+                 }
 for k, v in escape_table.items():
     unescape_table[v] = k
 
@@ -41,8 +44,10 @@ def save_html_with_metadata(fig, filename, fig_kwds, kwds):
     f = open(filename, 'w')
     for key, value in kwds.items():
         value = escape(value, escape_table)
-        line = "\n<div class=pycbc-meta key=\"%s\" value=\"%s\"></div>\n" % (str(key), value) 
+        line = "<div class=pycbc-meta key=\"%s\" value=\"%s\"></div>" % (str(key), value) 
         f.write(line)    
+
+    text = escape(text, escape_table)
     f.write(text)
 
 def load_html_metadata(filename):

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -88,14 +88,6 @@ def render_default(path, cp):
         if 'SEG' in path or 'VETO' in path:
             with open(path, 'r') as xmlfile:
                 content = fromsegmentxml(xmlfile, return_dict=True)
-    elif path.endswith('.ini'):
-        with open(path, 'rb') as f_handle:
-            content = f_handle.read()
-    elif path.endswith('htmlf'):
-        cp.add_section(filename)
-        cp.set(filename,'title', filename.split('.')[0].replace('_',' '))
-        with open(path, 'r') as f_handle:
-            content = f_handle.read()
 
     # render template
     template_dir = pycbc.results.__path__[0] + '/templates/files'
@@ -130,7 +122,29 @@ def render_glitchgram(path, cp):
 
     return output
 
-def render_config_and_version_page(path, config_file):
-    """ Render a html page to show the configuration file and versioning
-    information.
+def render_text(path, config_file):
+    """ Render a file as text.
     """
+
+    # define filename and slug from path
+    filename = os.path.basename(path)
+    slug = filename.replace('.', '_')
+
+    # initializations
+    content = None
+
+    # read file as a string
+    with open(path, 'rb') as fp:
+        content = fp.read()
+
+    # render template
+    template_dir = pycbc.results.__path__[0] + '/templates/files'
+    env = Environment(loader=FileSystemLoader(template_dir))
+    env.globals.update(abs=abs)
+    template = env.get_template(cp.get(filename, 'template'))
+    context = {'filename' : filename,
+               'slug'     : slug,
+               'cp'       : cp}
+    output = template.render(context)
+
+    return output

--- a/pycbc/results/templates/files/file_pre.html
+++ b/pycbc/results/templates/files/file_pre.html
@@ -1,0 +1,46 @@
+
+
+<!--accordion--> 
+<div class="panel-group" id="accordion-{{slug}}">
+    <div class="panel panel-default">
+
+        <!--accordion title-->
+        <div class="panel-heading collapsed" data-toggle="collapse" data-parent="#accordion" href="#{{slug}}">
+            <h4 class="panel-title">
+                {% if cp.check_option(filename, 'title') %}
+                    <a href='#'>{{cp.get(filename, 'title')}}</a>
+                {% else %}
+                    <a href='#'>{{filename}}</a>
+                {% endif %}
+            </h4>
+        </div>
+
+        <!--accordion content-->
+        <div id="{{slug}}" class="panel-collapse collapse">
+            <div class="panel-body">
+
+                <!--use <pre> tag for displaying content-->
+                <pre>{{content}}</pre>
+
+                <!--make a caption to the content -->
+                {% if cp.check_option(filename, 'caption') %}
+                    <p><i>{{cp.get(filename, 'caption')}}</i></p>
+                {% endif %}            
+            
+                <!--always link to file-->
+                <p><a href={{filename}}>Link to file.</a></p>
+            
+                <!--show cmd line if there is one -->
+                {% if cp.check_option(filename, 'cmd') %}
+                    <button type="button" class="btn btn-xs"
+                            data-toggle="popover" title="command line"
+                            data-content="{{cp.get(filename, 'cmd')}}">
+                            Command Line
+                    </button>
+                {% endif %}
+
+            </div>
+        </div>
+
+     </div>
+</div>

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -21,7 +21,7 @@ import os
 import subprocess
 from ConfigParser import ConfigParser
 from pycbc.results import save_fig_with_metadata
-from pycbc.workflow.core import check_output
+from pycbc.workflow.core import check_output_error_and_retcode
 
 def get_library_version_info():
     """This will return a list of dictionaries containing versioning
@@ -161,7 +161,16 @@ def get_code_version_numbers(cp):
         path, exe_name = os.path.split(value)
         version_string = None
         try:
-            version_output = check_output([value, '--version'])
+            # FIXME: Replace with this version when python 2.7 is guaranteed
+            # version_output = subprocess.check_output([value, '--version'],
+            #                                         stderr=subprocess.STDOUT) 
+            # Start of legacy block
+            output, error, retcode = \
+                           check_output_error_and_retcode([value, '--version'])
+            if not retcode == 0:
+                raise subprocess.CalledProcessError(retcode, '')
+            # End of legacy block
+            version_output = output + error
             version_output = version_output.split('\n')
             for line in version_output:
                 line = line.split(" ")

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -139,6 +139,8 @@ def write_library_information(path):
         text = ''
         for key, value in curr_lib.items():
             text+='<li> %s : %s </li>\n' %(key,value)
+        text+= '<div class=pycbc-meta key=\"render-function\" value=\"render_text\"></div>'
+        text+= '<div class=pycbc-meta key=\"title\" value=\"%s\"></div>'%'%s Version Information'%(lib_name)
         file_p = open(os.path.join(path,
                               '%s_version_information.htmlf' %(lib_name)), 'w')
         file_p.write(text)
@@ -185,6 +187,8 @@ def write_code_versions(path, cp):
     html_text = ''
     for key,value in code_version_dict.items():
         html_text+= '<li><b>%s</b>: %s </li>\n' %(key,value)
+    html_text+= '<div class=pycbc-meta key=\"render-function\" value=\"render_text\"></div>'
+    html_text+= '<div class=pycbc-meta key=\"title\" value=\"Version Information from Executables\"></div>'
     file_p = open(os.path.join(path,
                             'Version_information_from_executables.htmlf'), 'w')
     file_p.write(html_text)

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -19,6 +19,7 @@
 import os
 import subprocess
 from ConfigParser import ConfigParser
+from pycbc.workflow.core import check_output
 
 def get_library_version_info():
     """This will return a list of dictionaries containing versioning
@@ -158,8 +159,8 @@ def get_code_version_numbers(cp):
         path, exe_name = os.path.split(value)
         version_string = None
         try:
-            version_output = subprocess.check_output([value, '--version'],
-                                                      stderr=subprocess.STDOUT)
+            version_output = check_output([value, '--version'])
+            print version_output
             version_output = version_output.split('\n')
             for line in version_output:
                 line = line.split(" ")
@@ -189,13 +190,10 @@ def write_code_versions(path, cp):
     file_p.write(html_text)
     file_p.close()
 
-
-def create_versioning_page(path):
+def create_versioning_page(path, cp):
+    logging.info("Entering versioning module")
     if not os.path.exists(path):
         os.mkdir(path)
     write_library_information(path)
-    # FIXME: Really bad hardcoding here, not sure how to fix?
-    config_file = os.path.join(path, '../configuration.ini')
-    cp = ConfigParser()
-    cp.read(config_file)
     write_code_versions(path, cp)
+    logging.info("Leaving versioning module")

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -16,6 +16,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import logging
 import os
 import subprocess
 from ConfigParser import ConfigParser

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -20,6 +20,7 @@ import logging
 import os
 import subprocess
 from ConfigParser import ConfigParser
+from pycbc.results import save_fig_with_metadata
 from pycbc.workflow.core import check_output
 
 def get_library_version_info():
@@ -140,12 +141,10 @@ def write_library_information(path):
         text = ''
         for key, value in curr_lib.items():
             text+='<li> %s : %s </li>\n' %(key,value)
-        text+= '<div class=pycbc-meta key=\"render-function\" value=\"render_text\"></div>'
-        text+= '<div class=pycbc-meta key=\"title\" value=\"%s\"></div>'%'%s Version Information'%(lib_name)
-        file_p = open(os.path.join(path,
-                              '%s_version_information.htmlf' %(lib_name)), 'w')
-        file_p.write(text)
-        file_p.close()
+        kwds = {'render-function' : 'render_text',
+                'title' : '%s Version Information'%lib_name,
+        }
+        save_fig_with_metadata(text, os.path.join(path,'%s_version_information.html' %(lib_name)), **kwds)
 
 def get_code_version_numbers(cp):
     """Will extract the version information from the executables listed in
@@ -186,13 +185,11 @@ def write_code_versions(path, cp):
     code_version_dict = get_code_version_numbers(cp)
     html_text = ''
     for key,value in code_version_dict.items():
-        html_text+= '<li><b>%s</b>: %s </li>\n' %(key,value)
-    html_text+= '<div class=pycbc-meta key=\"render-function\" value=\"render_text\"></div>'
-    html_text+= '<div class=pycbc-meta key=\"title\" value=\"Version Information from Executables\"></div>'
-    file_p = open(os.path.join(path,
-                            'Version_information_from_executables.htmlf'), 'w')
-    file_p.write(html_text)
-    file_p.close()
+        html_text+= '<li><b>%s</b>: %s </li>\n' %(key,value.replace('@', '&#64;'))
+    kwds = {'render-function' : 'render_text',
+            'title' : 'Version Information from Executables',
+    }
+    save_fig_with_metadata(html_text, os.path.join(path,'version_information_from_executables.html'), **kwds)
 
 def create_versioning_page(path, cp):
     logging.info("Entering versioning module")

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -163,7 +163,6 @@ def get_code_version_numbers(cp):
         version_string = None
         try:
             version_output = check_output([value, '--version'])
-            print version_output
             version_output = version_output.split('\n')
             for line in version_output:
                 line = line.split(" ")

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -41,7 +41,7 @@ from pycbc.workflow import pegasus_workflow
 lal.LIGOTimeGPS = lalswig.LIGOTimeGPS
 
 #REMOVE THESE FUNCTIONS  FOR PYTHON >= 2.7 ####################################
-def check_output(*popenargs, **kwargs):
+def check_output_error_and_retcode(*popenargs, **kwargs):
     """
     This function is used to obtain the stdout of a command. It is only used
     internally, recommend using the make_external_call command if you want
@@ -52,8 +52,13 @@ def check_output(*popenargs, **kwargs):
     process = subprocess.Popen(stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE,
                                *popenargs, **kwargs)
-    output, unused_err = process.communicate()
+    output, error = process.communicate()
     retcode = process.poll()
+    return output, error, retcode
+
+def check_output(*popenargs, **kwargs):
+    output, unused_error, unused_retcode = \
+                           check_output_error_and_retcode(*popenargs, **kwargs)
     return output
 
 ###############################################################################


### PR DESCRIPTION
This PR moves the call to the `versioning` module from `pycbc_make_html_page` to the workflow generator. It has been implemented in `pycbc_make_hdf_workflow`.

It is envoked by passing the path to the output dir and a `ConfigParser` object for the workflow (so that it can get all the executables).

This PR also puts meta-data in those html files to use the `render-template=render_text` so that it uses a render function that is for preformatted html/text files. Includes a `title` as well. I added the `render_text` function in `render.py` and I added a `file_pre.html` file template to do this.

A test of the HDF workflow generator versioning is here: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/html_version/versioning/