### PR TITLE
mpld3 plots broken

### DIFF
--- a/pycbc/results/__init__.py
+++ b/pycbc/results/__init__.py
@@ -1,3 +1,3 @@
 from pycbc.results.table import *
-from pycbc.results.plot import *
+from pycbc.results.metadata import *
 from pycbc.results.versioning import *

--- a/pycbc/results/metadata.py
+++ b/pycbc/results/metadata.py
@@ -47,7 +47,7 @@ def save_html_with_metadata(fig, filename, fig_kwds, kwds):
         line = "<div class=pycbc-meta key=\"%s\" value=\"%s\"></div>" % (str(key), value) 
         f.write(line)    
 
-    text = escape(text, escape_table)
+    #text = escape(text, escape_table)
     f.write(text)
 
 def load_html_metadata(filename):

--- a/pycbc/results/metadata.py
+++ b/pycbc/results/metadata.py
@@ -16,6 +16,10 @@ unescape_table = {
                  }
 for k, v in escape_table.items():
     unescape_table[v] = k
+    
+def html_excape(text):
+    """ Sanitize text for html parsing """
+    return escape(text, escape_table)
 
 class MetaParser(HTMLParser.HTMLParser):
     def __init__(self):
@@ -47,7 +51,6 @@ def save_html_with_metadata(fig, filename, fig_kwds, kwds):
         line = "<div class=pycbc-meta key=\"%s\" value=\"%s\"></div>" % (str(key), value) 
         f.write(line)    
 
-    #text = escape(text, escape_table)
     f.write(text)
 
 def load_html_metadata(filename):

--- a/pycbc/results/metadata.py
+++ b/pycbc/results/metadata.py
@@ -17,7 +17,7 @@ unescape_table = {
 for k, v in escape_table.items():
     unescape_table[v] = k
     
-def html_excape(text):
+def html_escape(text):
     """ Sanitize text for html parsing """
     return escape(text, escape_table)
 

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -20,7 +20,7 @@ import logging
 import os
 import subprocess
 from ConfigParser import ConfigParser
-from pycbc.results import save_fig_with_metadata
+from pycbc.results import save_fig_with_metadata, html_escape
 
 def get_library_version_info():
     """This will return a list of dictionaries containing versioning
@@ -143,7 +143,9 @@ def write_library_information(path):
         kwds = {'render-function' : 'render_text',
                 'title' : '%s Version Information'%lib_name,
         }
-        save_fig_with_metadata(text, os.path.join(path,'%s_version_information.html' %(lib_name)), **kwds)
+        
+        save_fig_with_metadata(html_escape(text), 
+          os.path.join(path,'%s_version_information.html' %(lib_name)), **kwds)
 
 def get_code_version_numbers(cp):
     """Will extract the version information from the executables listed in
@@ -198,7 +200,8 @@ def write_code_versions(path, cp):
     kwds = {'render-function' : 'render_text',
             'title' : 'Version Information from Executables',
     }
-    save_fig_with_metadata(html_text, os.path.join(path,'version_information_from_executables.html'), **kwds)
+    save_fig_with_metadata(html_escape(html_text), 
+        os.path.join(path,'version_information_from_executables.html'), **kwds)
 
 def create_versioning_page(path, cp):
     logging.info("Entering versioning module")

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -21,7 +21,6 @@ import os
 import subprocess
 from ConfigParser import ConfigParser
 from pycbc.results import save_fig_with_metadata
-from pycbc.workflow.core import check_output_error_and_retcode
 
 def get_library_version_info():
     """This will return a list of dictionaries containing versioning
@@ -156,6 +155,7 @@ def get_code_version_numbers(cp):
         A dictionary keyed by the executable name with values giving the
         version string for each executable.
     """
+    from pycbc.workflow.core import check_output_error_and_retcode
     code_version_dict = {}
     for item, value in cp.items('executables'):
         path, exe_name = os.path.split(value)


### PR DESCRIPTION
The generic escaping of characters broke the mpld3 plots. This reverts that, but applies the escaping where it was needed, directly to the versioning output. I've renamed the module to metadata.py to reflect better what it does while I was at it.