### PR TITLE
add basic version of class interface for gpu correlate, threshold, fft

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -232,8 +232,6 @@ with ctx:
 
     template_mem = zeros(tlen, dtype = complex64)
     cluster_window = int(opt.cluster_window * gwstrain.sample_rate)
-    if opt.cluster_method == "template":
-        raise ValueError("FIXME: template clustering not supported yet with optimizations!")
 
     if opt.cluster_window == 0.0:
         use_cluster = False

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -300,7 +300,7 @@ with ctx:
                                     idx+stilde.analyze.start)
 
             out_vals['chisq'], out_vals['chisq_dof'] = \
-                  power_chisq.values(corr, snr, snrv, norm, stilde.psd,
+                  power_chisq.values(corr, snrv, norm, stilde.psd,
                                      idx+stilde.analyze.start, template)
 
             out_vals['cont_chisq'] = \

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -232,6 +232,8 @@ with ctx:
 
     template_mem = zeros(tlen, dtype = complex64)
     cluster_window = int(opt.cluster_window * gwstrain.sample_rate)
+    if opt.cluster_method == "template":
+        raise ValueError("FIXME: template clustering not supported yet with optimizations!")
 
     if opt.cluster_window == 0.0:
         use_cluster = False
@@ -276,10 +278,12 @@ with ctx:
     # from the bank.
     for t_num, template in enumerate(bank):
         event_mgr.new_template(tmplt=template.params, sigmasq=template.sigmasq(segments[0].psd))
+
         if opt.cluster_method == "window":
             cluster_window = int(opt.cluster_window * gwstrain.sample_rate)
         if opt.cluster_method == "template":
             cluster_window = int(template.chirp_length * gwstrain.sample_rate)
+
 
         for s_num, stilde in enumerate(segments):
             logging.info("Filtering template %d/%d segment %d/%d" %

--- a/pycbc/events/threshold_cpu.py
+++ b/pycbc/events/threshold_cpu.py
@@ -93,8 +93,9 @@ def threshold_inline(series, value):
 threshold=threshold_inline
 
 class CPUThresholdCluster(_BaseThresholdCluster):
-    def __init__(self, series):
-        self.series = series
+    def __init__(self, series, window):
+        self.series = series.data
+
         self.slen = len(series)
         self.outv = numpy.zeros(self.slen, numpy.complex64)
         self.outl = numpy.zeros(self.slen, numpy.uint32)

--- a/pycbc/events/threshold_cpu.py
+++ b/pycbc/events/threshold_cpu.py
@@ -93,8 +93,8 @@ def threshold_inline(series, value):
 threshold=threshold_inline
 
 class CPUThresholdCluster(_BaseThresholdCluster):
-    def __init__(self, series, window):
-        self.series = series.data
+    def __init__(self, series):
+        self.series = numpy.array(series.data, copy=False)
 
         self.slen = len(series)
         self.outv = numpy.zeros(self.slen, numpy.complex64)

--- a/pycbc/fft/cufft.py
+++ b/pycbc/fft/cufft.py
@@ -78,16 +78,16 @@ class FFT(_BaseFFT):
         self.outvec = outvec.data
 
     def execute(self):
-        cu_fft.fft(self.invec, self.outvec, cuplan)
+        cu_fft.fft(self.invec, self.outvec, self.plan)
 
 class IFFT(_BaseIFFT):
     def __init__(self, invec, outvec, nbatch=1, size=None):
         super(IFFT, self).__init__(invec, outvec, nbatch, size)
-        self.plan = cuplan = _get_inv_plan(invec.dtype, outvec.dtype, len(outvec), batch=nbatch)
+        self.plan = _get_inv_plan(invec.dtype, outvec.dtype, len(outvec), batch=nbatch)
 
         self.invec = invec.data
         self.outvec = outvec.data
 
     def execute(self):
-        cu_fft.ifft(self.invec, self.outvec, cuplan)
+        cu_fft.ifft(self.invec, self.outvec, self.plan)
 

--- a/pycbc/fft/cufft.py
+++ b/pycbc/fft/cufft.py
@@ -28,6 +28,7 @@ for the PyCBC package.
 
 import pycbc.scheme
 import scikits.cuda.fft as cu_fft
+from .core import _BaseFFT, _BaseIFFT
 
 _forward_plans = {}
 _reverse_plans = {}
@@ -40,33 +41,53 @@ def _clear_plan_dicts():
 pycbc.scheme.register_clean_cuda(_clear_plan_dicts)
 
 #itype and otype are actual dtypes here, not strings
-def _get_fwd_plan(itype,otype,inlen):
+def _get_fwd_plan(itype, otype, inlen, batch=1):
     try:
-        theplan = _forward_plans[(itype,otype,inlen)]
+        theplan = _forward_plans[(itype, otype, inlen, batch)]
     except KeyError:
-        theplan = cu_fft.Plan((inlen,),itype,otype)
-        _forward_plans.update({(itype,otype,inlen) : theplan })
+        theplan = cu_fft.Plan((inlen,), itype, otype, batch=batch)
+        _forward_plans.update({(itype, otype, inlen) : theplan })
 
     return theplan
 
 #The complex to real plan wants the actual size, not the N/2+1
 #That's why the inverse plans use the outvec length, instead of the invec
-def _get_inv_plan(itype,otype,outlen):
+def _get_inv_plan(itype, otype, outlen, batch=1):
     try:
-        theplan = _reverse_plans[(itype,otype,outlen)]
+        theplan = _reverse_plans[(itype, otype, outlen, batch)]
     except KeyError:
-        theplan = cu_fft.Plan((outlen,),itype,otype)
-        _reverse_plans.update({(itype,otype,outlen) : theplan })
+        theplan = cu_fft.Plan((outlen,), itype, otype, batch=batch)
+        _reverse_plans.update({(itype, otype, outlen) : theplan })
 
     return theplan
 
 
-def fft(invec,outvec,prec,itype,otype):
-    cuplan = _get_fwd_plan(invec.dtype,outvec.dtype,len(invec))
-    cu_fft.fft(invec.data,outvec.data,cuplan)
+def fft(invec, outvec, prec, itype, otype):
+    cuplan = _get_fwd_plan(invec.dtype, outvec.dtype, len(invec))
+    cu_fft.fft(invec.data, outvec.data, cuplan)
 
-def ifft(invec,outvec,prec,itype,otype):
-    cuplan = _get_inv_plan(invec.dtype,outvec.dtype,len(outvec))
-    cu_fft.ifft(invec.data,outvec.data,cuplan)
+def ifft(invec, outvec, prec, itype, otype):
+    cuplan = _get_inv_plan(invec.dtype, outvec.dtype, len(outvec))
+    cu_fft.ifft(invec.data, outvec.data, cuplan)
+    
+class FFT(_BaseFFT):
+    def __init__(self, invec, outvec, nbatch=1, size=None):
+        super(FFT, self).__init__(invec, outvec, nbatch, size)
+        self.plan = _get_fwd_plan(invec.dtype, outvec.dtype, len(invec), batch=nbatch)
+        self.invec = invec.data
+        self.outvec = outvec.data
 
+    def execute(self):
+        cu_fft.fft(self.invec, self.outvec, cuplan)
+
+class IFFT(_BaseIFFT):
+    def __init__(self, invec, outvec, nbatch=1, size=None):
+        super(IFFT, self).__init__(invec, outvec, nbatch, size)
+        self.plan = cuplan = _get_inv_plan(invec.dtype, outvec.dtype, len(outvec), batch=nbatch)
+
+        self.invec = invec.data
+        self.outvec = outvec.data
+
+    def execute(self):
+        cu_fft.ifft(self.invec, self.outvec, cuplan)
 

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -119,7 +119,8 @@ class MatchedFilterControl(object):
         upsample_method : {pruned_fft, str}
             The method to upsample or interpolate the reduced rate filter.
         """
-
+        # Assuming analysis time is constant across templates and segments, also
+        # delta_f is constant across segments.
         self.tlen = tlen
         self.flen = self.tlen / 2 + 1
         self.delta_f = delta_f

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -146,12 +146,11 @@ class MatchedFilterControl(object):
                                                       
             # Set up the correlation operations for each analysis segment
             corr_slice = slice(self.kmin, self.kmax)
-            self.corr_np = numpy.array(self.corr_mem.data[corr_slice], copy=False)
-            self.hcorr = numpy.array(self.htilde.data[corr_slice], copy=False)
             self.correlators = []      
             for seg in self.segments:
-                view = numpy.array(seg.data[corr_slice], copy=False)
-                corr = Correlator(self.hcorr, view, self.corr_np)
+                corr = Correlator(self.htilde[corr_slice], 
+                                  seg[corr_slice], 
+                                  self.corr_mem[corr_slice])
                 self.correlators.append(corr)
             
             # setup up the ifft we will do

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -159,8 +159,7 @@ class MatchedFilterControl(object):
             # setup the threasholding/clustering operations for each segment
             self.threshold_and_clusterers = []
             for seg in self.segments:
-                valid = numpy.array(self.snr_mem.data[seg.analyze], copy=False)
-                thresh = events.ThresholdCluster(valid, window)
+                thresh = events.ThresholdCluster(self.snr_mem[seg.analyze], window)
                 self.threshold_and_clusterers.append(thresh)
 
 

--- a/pycbc/filter/matchedfilter_cpu.py
+++ b/pycbc/filter/matchedfilter_cpu.py
@@ -75,9 +75,9 @@ correlate = correlate_inline
 
 class CPUCorrelator(_BaseCorrelator):
     def __init__(self, x, y, z):
-        self.x = x.data
-        self.y = y.data
-        self.z = z.data
+        self.x = numpy.array(x.data, copy=False)
+        self.y = numpy.array(y.data, copy=False)
+        self.z = numpy.array(z.data, copy=False)
         self.arrlen = len(self.x)
         self.code = corr_parallel_code
         self.support = corr_support

--- a/pycbc/filter/matchedfilter_cpu.py
+++ b/pycbc/filter/matchedfilter_cpu.py
@@ -75,9 +75,9 @@ correlate = correlate_inline
 
 class CPUCorrelator(_BaseCorrelator):
     def __init__(self, x, y, z):
-        self.x = x
-        self.y = y
-        self.z = z
+        self.x = x.data
+        self.y = y.data
+        self.z = z.data
         self.arrlen = len(self.x)
         self.code = corr_parallel_code
         self.support = corr_support

--- a/pycbc/filter/matchedfilter_cuda.py
+++ b/pycbc/filter/matchedfilter_cuda.py
@@ -21,11 +21,11 @@
 #
 # =============================================================================
 #
-
 from pycuda.elementwise import ElementwiseKernel
 from pycuda.tools import context_dependent_memoize
 from pycuda.tools import dtype_to_ctype
 from pycuda.gpuarray import _get_common_dtype
+from .matchedfilter import _BaseCorrelator
 
 @context_dependent_memoize
 def get_correlate_kernel(dtype_x, dtype_y,dtype_out):
@@ -41,8 +41,20 @@ def get_correlate_kernel(dtype_x, dtype_y,dtype_out):
 def correlate(a, b, out, stream=None):
     dtype_out = _get_common_dtype(a,b)
     krnl = get_correlate_kernel(a.dtype, b.dtype, dtype_out)
-    krnl(a.data,b.data,out.data)
+    krnl(a.data, b.data, out.data)
 
-
+class CUDACorrelator(_BaseCorrelator):
+    def __init__(self, x, y, z):
+        self.x = x.data
+        self.y = y.data
+        self.z = z.data
+        dtype_out = _get_common_dtype(x, y)
+        self.krnl = get_correlate_kernel(x.dtype, y.dtype, dtype_out)
+        
+    def correlate(self):
+        self.krnl(self.x, self,y, self.z)
+        
+def _correlate_factory(x, y, z):
+    return CUDACorrelator
 
 

--- a/pycbc/filter/matchedfilter_cuda.py
+++ b/pycbc/filter/matchedfilter_cuda.py
@@ -52,7 +52,7 @@ class CUDACorrelator(_BaseCorrelator):
         self.krnl = get_correlate_kernel(x.dtype, y.dtype, dtype_out)
         
     def correlate(self):
-        self.krnl(self.x, self,y, self.z)
+        self.krnl(self.x, self.y, self.z)
         
 def _correlate_factory(x, y, z):
     return CUDACorrelator

--- a/pycbc/vetoes/chisq.py
+++ b/pycbc/vetoes/chisq.py
@@ -321,7 +321,7 @@ class SingleDetPowerChisq(object):
 
         return self._bin_cache[key]
 
-    def values(self, corr, snr, snrv, snr_norm, psd, indices, template):
+    def values(self, corr, snrv, snr_norm, psd, indices, template):
         """ Calculate the chisq at points given by indices.
 
         Returns
@@ -353,7 +353,8 @@ class SingleDetPowerChisq(object):
             if num_above > 0:
                 bins = self.cached_chisq_bins(template, psd)
                 dof = (len(bins) - 1) * 2 - 2
-                chisq = fastest_power_chisq_at_points(corr, snr, above_snrv, snr_norm, bins, above_indices)
+                chisq = power_chisq_at_points_from_precomputed(corr,
+                                     above_snrv, snr_norm, bins, above_indices)
 
             if self.snr_threshold:
                 if num_above > 0:

--- a/pycbc/vetoes/chisq_cuda.py
+++ b/pycbc/vetoes/chisq_cuda.py
@@ -140,8 +140,10 @@ def get_pchisq_fn(np, fuse_correlate=False):
 
 _bcache = {}
 def get_cached_bin_layout(bins):
+    global _bcache
     key = id(bins)
     if key not in _bcache:
+        _bcache = {}
         bv, kmin, kmax = [], [], []
         for i in range(len(bins)-1):
             s, e = bins[i], bins[i+1]

--- a/pycbc/vetoes/chisq_cuda.py
+++ b/pycbc/vetoes/chisq_cuda.py
@@ -162,7 +162,9 @@ def get_cached_bin_layout(bins):
     return _bcache[key]
 
 def shift_sum_points(num, (corr, outp, phase, np, nb, N, kmin, kmax, bv, nbins)):
-    fuse = 'fuse' in corr.gpu_callback_method
+    #fuse = 'fuse' in corr.gpu_callback_method
+    fuse = False
+    
     fn, nt = get_pchisq_fn(num, fuse_correlate = fuse)   
     args = [(nb, 1), (nt, 1, 1)] 
     


### PR DESCRIPTION
Josh, Larne, 

If possible I would like you both to take a look at this. I've done the basic changes to add in GPU classes for the correlator, thresholder nad fft'er. Given that at the moment master's version of GPU support is broken, I think we should push this soon and leave complete validation for later. I have at least checked that the results don't look like garbage (snrs / chisq looks like sane values).

I've also included some format cleanup and rearangement that was needed to add GPU support. The key change was that you must only pass pycbc types. If you want something else within the class, do the type conversion it its init. 

 Callback support not yet enabled. After having to implemented it, I think the class structure is quite nice and will actually make doing the callbacks a bit less hacky when they are added back in. That will be a future request. 
