### PR TITLE
censor single trigger plots from zerolag 

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -51,7 +51,7 @@ def sec_to_year(sec):
 
 parser = argparse.ArgumentParser()
 # General required options
-parser.add_argument('--version', action='version', versoin=pycbc.version.git_verbose_msg)
+parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--coinc-files', nargs='+', help='List of coincidence files used to calculate the FAP, FAR, etc.')
 parser.add_argument('--verbose', action='count')
 parser.add_argument('--cluster-window', type=float, help='Size in seconds to maximize coinc triggers')
@@ -102,6 +102,7 @@ f.attrs['detector_1'] = attrs['detector_1']
 f.attrs['detector_2'] = attrs['detector_2']
 f.attrs['timeslide_interval'] = attrs['timeslide_interval']
 
+
 fore_locs = (sid_i == 0)
 logging.info("%s clustered foreground triggers" % fore_locs.sum())
 
@@ -109,6 +110,9 @@ logging.info("%s clustered foreground triggers" % fore_locs.sum())
 for key in seg.keys():
     f['segments/%s/start' % key] = seg[key]['start'][:]
     f['segments/%s/end' % key] = seg[key]['end'][:]
+
+f['segments/foreground_veto/start'] = veto_start
+f['segments/foreground_veto/end'] = veto_end
 
 if fore_locs.sum() > 0:
     f['foreground/stat'] = stat_i[fore_locs]

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -9,6 +9,7 @@ from scipy.interpolate import interp1d
 from pycbc.future import numpy
 from itertools import izip
 from pycbc.events import veto, coinc
+import pycbc.version
     
 def load_coincs(coinc_files):
     stat, time1, time2, timeslide_id, template_id, decimation_factor, i1, i2 = [], [], [], [], [], [], [], []
@@ -50,6 +51,7 @@ def sec_to_year(sec):
 
 parser = argparse.ArgumentParser()
 # General required options
+parser.add_argument('--version', action='version', versoin=pycbc.version.git_verbose_msg)
 parser.add_argument('--coinc-files', nargs='+', help='List of coincidence files used to calculate the FAP, FAR, etc.')
 parser.add_argument('--verbose', action='count')
 parser.add_argument('--cluster-window', type=float, help='Size in seconds to maximize coinc triggers')

--- a/bin/hdfcoinc/pycbc_foreground_censor
+++ b/bin/hdfcoinc/pycbc_foreground_censor
@@ -1,14 +1,11 @@
 #!/bin/env python
 """Make segment file to blind the results from foreground related triggers """
 
-import argparse, logging, pycbc.version, h5py
+import argparse, logging, pycbc.version, h5py, pycbc.events
 
 parser = argparse.AgumentParser(desc=__doc__)
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--verbose', action='store_true')
-parser.add_argument('--veto-window', type=float, 
-                    help="Time in seconds around each zerolag trigger to "
-                         "veto ")
 parser.add_argument('--foreground-triggers', 
                     help="HDF file containing the zerolag foreground triggers "
                          "from the analysis")
@@ -27,6 +24,17 @@ pycbc.init_logging(args.verbose)
 logging.info('start')
 
 f = h5py.File(args.foreground_triggers, 'r')
+start = f['segments/foreground_veto/start'][:]
+end = f['segments/foreground_veto/end'][:]
+vsegs = pycbc.events.start_end_to_segments(start, end)
 
+ifo1, ifo2 = f.attrs['detector_1'], f.attrs['detector_2']
 
+ifos, fsegs, names = [], [], []
+for ifo in [ifo1, ifo2]:
+    segs = pycbc.events.select_segments_by_definer(args.veto_file, args.segment_name, ifo)
+    fsegs += [(segs + vsegs).coalesce()]
+    names += [args.output_segment_name]
+    ifso += [ifo]
+pycbc.events.multi_segments_to_file(fsegs, args.output_file, names, ifos)
 logging.info('done')

--- a/bin/hdfcoinc/pycbc_foreground_censor
+++ b/bin/hdfcoinc/pycbc_foreground_censor
@@ -1,0 +1,32 @@
+#!/bin/env python
+"""Make segment file to blind the results from foreground related triggers """
+
+import argparse, logging, pycbc.version, h5py
+
+parser = argparse.AgumentParser(desc=__doc__)
+parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
+parser.add_argument('--verbose', action='store_true')
+parser.add_argument('--veto-window', type=float, 
+                    help="Time in seconds around each zerolag trigger to "
+                         "veto ")
+parser.add_argument('--foreground-triggers', 
+                    help="HDF file containing the zerolag foreground triggers "
+                         "from the analysis")
+parser.add_argument('--veto-file',
+                    help="Baseline veto information that is added to the outptut")
+parser.add_argument('--segment-name', 
+                    help="Segment name to use from the input veto file")
+parser.add_argument('--output-file', help='Name of the output segment file')
+parser.add_argument('--output-segment-name',    
+                    help="(optional), Name of output segment file list",
+                    default="censor_foreground")
+args = parser.parse_args()
+
+pycbc.init_logging(args.verbose)
+
+logging.info('start')
+
+f = h5py.File(args.foreground_triggers, 'r')
+
+
+logging.info('done')

--- a/bin/hdfcoinc/pycbc_foreground_censor
+++ b/bin/hdfcoinc/pycbc_foreground_censor
@@ -3,7 +3,7 @@
 
 import argparse, logging, pycbc.version, h5py, pycbc.events
 
-parser = argparse.AgumentParser(desc=__doc__)
+parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--foreground-triggers', 
@@ -35,6 +35,6 @@ for ifo in [ifo1, ifo2]:
     segs = pycbc.events.select_segments_by_definer(args.veto_file, args.segment_name, ifo)
     fsegs += [(segs + vsegs).coalesce()]
     names += [args.output_segment_name]
-    ifso += [ifo]
+    ifos += [ifo]
 pycbc.events.multi_segments_to_file(fsegs, args.output_file, names, ifos)
 logging.info('done')

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -98,6 +98,10 @@ for inj_file, tag, output_dir in zip([None]+inj_files, tags, output_dirs):
         final_bg_file =  wf.setup_interval_coinc(workflow, hdfbank, insps, 
                                        final_veto_file, final_veto_name,
                                        output_dir, tags=ctags)
+             
+        censored_veto = wf.make_foreground_censored_veto(workflow, 
+                               final_bg_file[0], final_veto_file[0], final_veto_name,
+                               'closed_box', 'segments')      
                                          
         for bg_file in bg_files:
             wf.make_snrifar_plot(workflow, bg_file, 'results/coincident_triggers', tags=bg_file.tags)
@@ -107,10 +111,10 @@ for inj_file, tag, output_dir in zip([None]+inj_files, tags, output_dirs):
         wf.make_snrifar_plot(workflow, final_bg_file[0], 'results/result', tags=final_bg_file[0].tags)
         wf.make_foreground_table(workflow, final_bg_file[0], hdfbank[0], tag, 'results/result')
 
-        wf.make_snrchi_plot(workflow, insps, final_veto_file[0], 
-                            final_veto_name[0], 'results/single_triggers', tags=[tag])
-        wf.make_singles_plot(workflow, insps, hdfbank[0], final_veto_file[0], 
-                            final_veto_name[0], 'results/single_triggers', tags=[tag])
+        wf.make_snrchi_plot(workflow, insps, censored_veto, 
+                            'closed_box', 'results/single_triggers', tags=[tag])
+        wf.make_singles_plot(workflow, insps, hdfbank[0], censored_veto, 
+                            'closed_box', 'results/single_triggers', tags=[tag])
 
     else:
         inj_coinc = wf.setup_interval_coinc_inj(workflow, hdfbank,

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -100,7 +100,7 @@ for inj_file, tag, output_dir in zip([None]+inj_files, tags, output_dirs):
                                        output_dir, tags=ctags)
              
         censored_veto = wf.make_foreground_censored_veto(workflow, 
-                               final_bg_file[0], final_veto_file[0], final_veto_name,
+                               final_bg_file[0], final_veto_file[0], final_veto_name[0],
                                'closed_box', 'segments')      
                                          
         for bg_file in (bg_files + final_bg_file):

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -103,7 +103,7 @@ for inj_file, tag, output_dir in zip([None]+inj_files, tags, output_dirs):
                                final_bg_file[0], final_veto_file[0], final_veto_name,
                                'closed_box', 'segments')      
                                          
-        for bg_file in bg_files:
+        for bg_file in (bg_files + final_bg_file):
             wf.make_snrifar_plot(workflow, bg_file, 'results/coincident_triggers', tags=bg_file.tags)
             wf.make_foreground_table(workflow, bg_file, hdfbank[0], tag, 'results/coincident_triggers')
 

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -41,7 +41,7 @@ err_low = far_back * ((back_fan - numpy.sqrt(back_fan)) / back_fan)
 err_low[err_low == 0] = 1e-100
 err_high = far_back * ((back_fan + numpy.sqrt(back_fan)) / back_fan)
 
-logging.info('Found %s background (inclusive zerolage) triggers' % len(cstat_back))
+logging.info('Found %s background (inclusive zerolag) triggers' % len(cstat_back))
 
 back_ifar_exc = f['background_exc/ifar'][:]
 cstat_back_exc = f['background_exc/stat'][:]

--- a/pycbc/events/veto.py
+++ b/pycbc/events/veto.py
@@ -34,6 +34,27 @@ def segments_to_file(segs, filename, name, ifo=""):
     -------
     File : Return a pycbc.core.File reference to the file
     """
+    return multi_segments_to_file([segs], filename, [name], [ifo])
+
+
+def multi_segments_to_file(seg_list, filename, names, ifos):
+    """ Save segments to an xml file
+    
+    Parameters
+    ----------
+    seg_list: glue.segments.segmentlist
+        List of segment lists to write to disk
+    filename : str
+        name of the output file
+    names : 
+        name of each segment list
+    ifos :
+        list of ifos
+        
+    Returns
+    -------
+    File : Return a pycbc.core.File reference to the file
+    """
     from pycbc.workflow.core import File
 
     # create XML doc and add process table
@@ -41,12 +62,13 @@ def segments_to_file(segs, filename, name, ifo=""):
     outdoc.appendChild(ligolw.LIGO_LW())
     process = ligolw_utils.process.register_to_xmldoc(outdoc, argv[0], {})
 
-    fsegs = [(lal.LIGOTimeGPS(seg[0]), lal.LIGOTimeGPS(seg[1])) \
-        for seg in segs]
+    for segs, ifo, name in zip(seg_list, ifos, names):
+        fsegs = [(lal.LIGOTimeGPS(seg[0]), lal.LIGOTimeGPS(seg[1])) \
+            for seg in segs]
 
-    # add segments, segments summary, and segment definer tables using glue library
-    with ligolw_segments.LigolwSegments(outdoc, process) as xmlsegs:
-        xmlsegs.insert_from_segmentlistdict({ifo : fsegs}, name)
+        # add segments, segments summary, and segment definer tables using glue library
+        with ligolw_segments.LigolwSegments(outdoc, process) as xmlsegs:
+            xmlsegs.insert_from_segmentlistdict({ifo : fsegs}, name)
 
     # write file
     ligolw_utils.write_filename(outdoc, filename)
@@ -56,7 +78,6 @@ def segments_to_file(segs, filename, name, ifo=""):
     f = File(ifo, name, segs, file_url=url, tags=[name])
     f.PFN(os.path.abspath(filename), site='local')
     return f
-    
 
 def start_end_from_segments(segment_file):
     """ Return the start and end time arrays from a segment file.

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -544,6 +544,7 @@ def make_foreground_censored_veto(workflow, bg_file, veto_file, veto_name,
     node.add_input_opt('--veto-file', veto_file)
     node.add_opt('--segment-name', veto_name)
     node.add_opt('--output-segment-name', censored_name)
+    node.new_output_file_opt(workflow.analysis_time, '.xml', '--output-file')
     workflow += node
     return node.output_files[0]
 

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -532,6 +532,21 @@ class PyCBCHDFInjFindExecutable(Executable):
 class MergeExecutable(Executable):
     current_retention_level = Executable.CRITICAL
 
+class CensorForeground(Executable):
+    current_retention_level = Executable.CRITICAL
+
+def make_foreground_censored_veto(workflow, bg_file, veto_file, veto_name, 
+                                  censored_name, out_dir, tags=None):
+    tags = [] if tags is None else tags
+    node = CensorForeground(workflow.cp, 'foreground_censor', ifos=workflow.ifos,
+                            out_dir=out_dir, tags=tags).create_node()
+    node.add_input_opt('--foreground-triggers', bg_file)
+    node.add_input_opt('--veto-file', veto_file)
+    node.add_opt('--segment-name', veto_name)
+    node.add_opt('--output-segment-name', censored_name)
+    workflow += node
+    return node.output_files[0]
+
 def merge_single_detector_hdf_files(workflow, bank_file, trigger_files, out_dir, tags=[]):
     make_analysis_dir(out_dir)
     out = FileList()

--- a/setup.py
+++ b/setup.py
@@ -399,6 +399,7 @@ setup (
                'bin/hdfcoinc/pycbc_page_segments',
                'bin/hdfcoinc/pycbc_plot_psd_file',
                'bin/hdfcoinc/pycbc_plot_range',
+               'bin/hdfcoinc/pycbc_foreground_censor',
                'bin/sngl/pycbc_ligolw_cluster',
                'bin/sngl/pycbc_plot_bank',
                'bin/sngl/pycbc_plot_glitchgram',


### PR DESCRIPTION
Veto triggers from the single detector plots that are near to a zerolag trigger. This is done by creating a segment list from the times used to veto zerolag times within the statmap code. As such, once controls the window by setting the veto-window option in the [statmap] section. I hope this will make the plots suitable for closed box viewing. 

Example here:
https://sugar-jobs.phy.syr.edu/~ahnitz/projects/polish/r7/gw/html/single_triggers/