### PR TITLE
coalesce start/end times before doing indices_within_times function

### DIFF
--- a/pycbc/events/veto.py
+++ b/pycbc/events/veto.py
@@ -119,6 +119,9 @@ def indices_within_times(times, start, end):
     indices: numpy.ndarray
         Array of indices into times
     """
+    # coalesce the start/end segments
+    start, end = segments_to_start_end(start_end_to_segments(start, end).coalesce())
+
     tsort = times.argsort()
     times_sorted = times[tsort]
     left = numpy.searchsorted(times_sorted, start)


### PR DESCRIPTION
Hopefully, this will help reduce some memory consumption when using indices_within_times and the start/end times given are overlapping. 