### PR TITLE
Add sitemap to orange.html and remove numbering in navbar

### DIFF
--- a/bin/pycbc_make_html_page
+++ b/bin/pycbc_make_html_page
@@ -24,7 +24,7 @@ import shutil
 import zipfile
 from glue import segments
 from jinja2 import Environment, FileSystemLoader
-from pycbc.results.render import get_embedded_config, setup_template_render
+from pycbc.results.render import get_embedded_config, render_workflow_html_template, setup_template_render
 from pycbc.workflow import segment
 
 def examine_dir(cwd):
@@ -62,6 +62,13 @@ def examine_dir(cwd):
             nondirs.append(name)
 
     return cwd, dirs, nondirs
+
+def render_sitemap_page(output_path, dirs):
+    """
+    Creates sitemap page.
+    """
+    dirs.sort(key=lambda x: x.path)
+    render_workflow_html_template(output_path, 'sitemap.html', dirs)
 
 class Directory():
     """
@@ -216,6 +223,24 @@ for cwd in dirs:
 for cwd in dirs:
     for file in cwd.files:
         shutil.copy(file.path, opts.output_path+'/'+cwd.path+'/'+file.filename())
+
+# make sitemap page
+sitemap_dir = '/sitemap'
+if not os.path.exists(opts.plots_dir+sitemap_dir):
+    os.makedirs(opts.plots_dir+sitemap_dir)
+render_sitemap_page(opts.plots_dir+sitemap_dir+'/well.html', dirs)
+cwd = Directory(opts.plots_dir+sitemap_dir, opts.plots_dir)
+context = {'analysis_title'    : analysis_title,
+           'analysis_subtitle' : analysis_subtitle,
+           'dirs_0'            : dirs_0,
+           'dir'               : cwd,
+           'dot_dot_str'       : cwd.level() * '../',
+           'plots_dir'         : opts.plots_dir}
+output = template.render(context)
+if not os.path.exists(opts.output_path+cwd.path):
+    os.makedirs(opts.output_path+cwd.path)
+with open(opts.output_path+cwd.path+'/index.html', "wb") as fp:
+    fp.write(output)
 
 # copy css, js, and font files to html directory
 cssDir       = pycbc.results.__path__[0] + '/static/css/'

--- a/pycbc/results/static/css/pycbc/orange.css
+++ b/pycbc/results/static/css/pycbc/orange.css
@@ -81,3 +81,6 @@ font-size:16px;
     color:#000000;
 }
 
+.footer-custom {
+    padding : 25px;
+}

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -88,28 +88,20 @@
       <ul class="nav navbar-nav">
 
         <!-- always have a button to the top-level directory -->
-        <li class="active"><a href="{{dot_dot_str}}">{{i}}. Summary</a></li>
-
-        <!-- increment -->
-        {% set i = i + 1 %}
+        <li class="active"><a href="{{dot_dot_str}}">Summary</a></li>
 
         <!-- display top-level directories -->
         {% for dir0 in dirs_0 %}
         <li class="dropdown ">
-            <a href="#" id="drop1" data-toggle="dropdown" class="dropdown-toggle" role="button">{{i}}. {{dir0.title()}}<b class="caret"></b></a>
+            <a href="#" id="drop1" data-toggle="dropdown" class="dropdown-toggle" role="button">{{dir0.title()}}<b class="caret"></b></a>
             <ul role="menu" class="dropdown-menu" aria-labelledby="drop1">
-                <li role="presentation"><a href="{{dot_dot_str}}{{dir0.name()}}" role="menuitem">{{i}}.0. Summary</a></li>
+                <li role="presentation"><a href="{{dot_dot_str}}{{dir0.name()}}" role="menuitem">Summary</a></li>
                 <li class="divider"></li>
 
                 <!-- set subsection counter integer -->
-                {% set j = 1 %}
                 {% for subdir in dir0.subdirs %}
-                    <li role="presentation"><a href="{{dot_dot_str}}.{{subdir.path}}" role="menuitem">{{i}}.{{j}}. {{subdir.title()}}</a></li>
-                    {% set j = j + 1 %}
+                    <li role="presentation"><a href="{{dot_dot_str}}.{{subdir.path}}" role="menuitem">{{subdir.title()}}</a></li>
                 {% endfor %}
-
-                <!-- increment -->
-                {% set i = i + 1 %}
 
             </ul>
         </li>

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -199,5 +199,13 @@
      </div>
 </div>
 
+<footer>
+    <div class="container-fluid">
+        <div class="footer-custom">
+            <a href="{{dot_dot_str}}sitemap/index.html">Sitemap</a>
+        </div>
+    </div>
+</footer>
+
 </body>
 </html>

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -154,33 +154,39 @@
                                 <!-- get config file and slug -->
                                 {% set cp = get_embedded_config(file.path) %}
                                 {% set slug = file.filename().replace('.', '_') %}
-                                <!-- accordion -->
-                                <div class="panel-group" id="accordion-{{slug}}">
-                                    <div class="panel panel-default">
 
-                                        <!-- accordion title -->
-                                        <div class="panel-heading collapsed" data-toggle="collapse" data-parent="#accordion" href="#{{slug}}">
-                                            <h4 class="panel-title">
-                                            {% if cp.check_option(file.filename(), 'title') %}
-                                                <a href='#'>B{{i}}. {{cp.get(file.filename(), 'title')}}</a>
-                                            {% else %}
-                                                <a href='#'>B{{i}}. {{file.filename()}}</a>
-                                            {% endif %}
-                                            </h4>
-                                        </div>
+                                <!-- do not show well.html -->
+                                {% if not file.filename() == 'well.html' %}
 
-                                        <!-- increment -->
-                                        {% set i = i + 1 %}
+                                    <!-- accordion -->
+                                    <div class="panel-group" id="accordion-{{slug}}">
+                                        <div class="panel panel-default">
 
-                                        <!-- accordion content -->
-                                        <div id="{{slug}}" class="panel-collapse collapse">
-                                            <div class="panel-body">
-                                                {{file.render()}}
+                                            <!-- accordion title -->
+                                            <div class="panel-heading collapsed" data-toggle="collapse" data-parent="#accordion" href="#{{slug}}">
+                                                <h4 class="panel-title">
+                                                {% if cp.check_option(file.filename(), 'title') %}
+                                                    <a href='#'>B{{i}}. {{cp.get(file.filename(), 'title')}}</a>
+                                                {% else %}
+                                                    <a href='#'>B{{i}}. {{file.filename()}}</a>
+                                                {% endif %}
+                                                </h4>
                                             </div>
-                                        </div>
 
+                                            <!-- increment -->
+                                            {% set i = i + 1 %}
+
+                                            <!-- accordion content -->
+                                            <div id="{{slug}}" class="panel-collapse collapse">
+                                                <div class="panel-body">
+                                                    {{file.render()}}
+                                                </div>
+                                            </div>
+
+                                        </div>
                                     </div>
-                                </div>
+
+                                {% endif %}
 
                             {% endfor %}
 

--- a/pycbc/results/templates/wells/sitemap.html
+++ b/pycbc/results/templates/wells/sitemap.html
@@ -1,0 +1,10 @@
+<!-- hold images inside a well -->
+<div class="scaffold well">
+
+    <div class="list-group">
+        {% for path in filelists %}
+            <a href="../{{path.path}}" class="list-group-item">{% if path.path %}{{path.path}}{% else %}/{% endif %}</a>
+        {% endfor %}
+    </div>
+
+</div>

--- a/pycbc/results/templates/wells/two_column.html
+++ b/pycbc/results/templates/wells/two_column.html
@@ -15,7 +15,7 @@
                     {% raw %}
                     {% set cp = get_embedded_config('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}') %}
                         {% if cp.has_option('{% endraw %}{{filelist[0].name}}{% raw %}', 'title') %}
-                            <p class="text-center"><b>{% endraw %}A{{i}}. {% raw %}{{cp.get('{% endraw %}{{filelist[0].name}}{% raw %}', 'title')}}</b></p>
+                            <p class="text-center" style="font-size:18px;"><b>{% endraw %}A{{i}}. {% raw %}{{cp.get('{% endraw %}{{filelist[0].name}}{% raw %}', 'title')}}</b></p>
                         {% endif %}
                         {{ setup_template_render('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}' , '') }}
                     {% endraw %}
@@ -27,7 +27,7 @@
                     {% raw %}
                     {% set cp = get_embedded_config('{% endraw %}{{dir}}/{{filelist[1].name}}{% raw %}') %}
                         {% if cp.has_option('{% endraw %}{{filelist[1].name}}{% raw %}', 'title') %}
-                           <p class="text-center"><b>{% endraw %}A{{i}}. {% raw %}{{cp.get('{% endraw %}{{filelist[1].name}}{% raw %}', 'title')}}</b></p>
+                           <p class="text-center" style="font-size:18px;"><b>{% endraw %}A{{i}}. {% raw %}{{cp.get('{% endraw %}{{filelist[1].name}}{% raw %}', 'title')}}</b></p>
                         {% endif %}
                         {{ setup_template_render('{% endraw %}{{dir}}/{{filelist[1].name}}{% raw %}' , '') }}
                     {% endraw %}
@@ -41,7 +41,7 @@
                     {% raw %}
                     {% set cp = get_embedded_config('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}') %}
                         {% if cp.has_option('{% endraw %}{{filelist[0].name}}{% raw %}', 'title') %}
-                            <p class="text-center"><b>{% endraw %}A{{i}}. {% raw %}{{cp.get('{% endraw %}{{filelist[0].name}}{% raw %}', 'title')}}</b></p>
+                            <p class="text-center" style="font-size:18px;"><b>{% endraw %}A{{i}}. {% raw %}{{cp.get('{% endraw %}{{filelist[0].name}}{% raw %}', 'title')}}</b></p>
                         {% endif %}
                         {{ setup_template_render('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}' , '') }}
                     {% endraw %}


### PR DESCRIPTION
This PR:
  * Removes numbering in navbar. This can be done by the workflow generator.
  * Adds a sitemap page at `/sitemap`. The link to the sitemap is in the `<footer>` tag.
  * Title are bigger and some more padding.

An example of this PR is here: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/html_version_2/