### PR TITLE
Add expand/collapse all button

### DIFF
--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -42,12 +42,12 @@ $(function () {
             active = false;
             $('.panel-collapse').collapse('show');
             $('.panel-title').attr('data-toggle', '');
-            $(this).text('Enable accordion behavior');
+            $(this).text('Collapse All');
         } else {
             active = true;
             $('.panel-collapse').collapse('hide');
             $('.panel-title').attr('data-toggle', 'collapse');
-            $(this).text('Disable accordion behavior');
+            $(this).text('Expand All');
         }
     });
     
@@ -168,40 +168,38 @@ $(function () {
                         <!-- loop over files in directory -->
                         <h1>Additional Files</h1>
                             The following files were also found in this directory:
-
-                            <!-- accordion group -->
-                            <div class="panel-group" id="accordion">
+                            <div class="row" style="padding:15px">
+                                <button id="collapse-init" class="btn btn-xs btn-primary">Expand All</button>
+                            </div>
                             {% for file in dir.files %}
 
-                                <!-- get config file and slug -->
+                                <!-- get config file -->
                                 {% set cp = get_embedded_config(file.path) %}
-                                {% set slug = file.filename().replace('.', '_') %}
 
                                 <!-- do not show well.html -->
                                 {% if not file.filename() == 'well.html' %}
-
-                                    <!-- accordion panel -->
+                                <div class="panel-group" id="accordion">
+                                    {% set i = i + 1 %}
                                     <div class="panel panel-default">
                                         <div class="panel-heading">
-                                            <h4 class="panel-title" data-toggle="collapse" href="#{{slug}}">
+                                            <h4 class="panel-title" data-toggle="collapse" data-target="#collapse{{i}}">
                                                 {% if cp.check_option(file.filename(), 'title') %}
-                                                    <a href='#'>B{{i}}. {{cp.get(file.filename(), 'title')}}</a>
+                                                    B{{i}}. {{cp.get(file.filename(), 'title')}}
                                                 {% else %}
-                                                    <a href='#'>B{{i}}. {{file.filename()}}</a>
+                                                    B{{i}}. {{file.filename()}}
                                                 {% endif %}
                                             </h4>
                                         </div>
-                                        {% set i = i + 1 %}
-                                        <div id="{{slug}}" class="panel-collapse collapse">
-                                             <div class="panel-body">
-                                                 {{file.render()}}
-                                             </div>
+                                        <div id="collapse{{i}}" class="panel-collapse collapse">
+                                            <div class="panel-body">
+                                                {{file.render()}}
+                                            </div>
                                         </div>
                                     </div>
+                                </div>
                                 {% endif %}
 
                             {% endfor %}
-</div>
                     </div>
                 </div>
                 {% endif %}
@@ -212,11 +210,6 @@ $(function () {
 </div>
 
 <footer>
-
-<button id="collapse-init" class="btn btn-primary">
-    Disable accordion behavior
-</button>
-
     <div class="container-fluid">
         <div class="footer-custom">
             <a href="{{dot_dot_str}}sitemap/index.html">Sitemap</a>

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -31,6 +31,33 @@
         }
     </style>
 
+    <!-- add expand all js -->
+<script>
+$(function () {
+
+    var active = true;
+
+    $('#collapse-init').click(function () {
+        if (active) {
+            active = false;
+            $('.panel-collapse').collapse('show');
+            $('.panel-title').attr('data-toggle', '');
+            $(this).text('Enable accordion behavior');
+        } else {
+            active = true;
+            $('.panel-collapse').collapse('hide');
+            $('.panel-title').attr('data-toggle', 'collapse');
+            $(this).text('Disable accordion behavior');
+        }
+    });
+    
+    $('#accordion').on('show.bs.collapse', function () {
+        if (active) $('#accordion .in').collapse('hide');
+    });
+
+});
+</script>
+
     <!-- title -->
     <title>{{analysis_title}}</title>
 
@@ -141,6 +168,9 @@
                         <!-- loop over files in directory -->
                         <h1>Additional Files</h1>
                             The following files were also found in this directory:
+
+                            <!-- accordion group -->
+                            <div class="panel-group" id="accordion">
                             {% for file in dir.files %}
 
                                 <!-- get config file and slug -->
@@ -150,38 +180,28 @@
                                 <!-- do not show well.html -->
                                 {% if not file.filename() == 'well.html' %}
 
-                                    <!-- accordion -->
-                                    <div class="panel-group" id="accordion-{{slug}}">
-                                        <div class="panel panel-default">
-
-                                            <!-- accordion title -->
-                                            <div class="panel-heading collapsed" data-toggle="collapse" data-parent="#accordion" href="#{{slug}}">
-                                                <h4 class="panel-title">
+                                    <!-- accordion panel -->
+                                    <div class="panel panel-default">
+                                        <div class="panel-heading">
+                                            <h4 class="panel-title" data-toggle="collapse" href="#{{slug}}">
                                                 {% if cp.check_option(file.filename(), 'title') %}
                                                     <a href='#'>B{{i}}. {{cp.get(file.filename(), 'title')}}</a>
                                                 {% else %}
                                                     <a href='#'>B{{i}}. {{file.filename()}}</a>
                                                 {% endif %}
-                                                </h4>
-                                            </div>
-
-                                            <!-- increment -->
-                                            {% set i = i + 1 %}
-
-                                            <!-- accordion content -->
-                                            <div id="{{slug}}" class="panel-collapse collapse">
-                                                <div class="panel-body">
-                                                    {{file.render()}}
-                                                </div>
-                                            </div>
-
+                                            </h4>
+                                        </div>
+                                        {% set i = i + 1 %}
+                                        <div id="{{slug}}" class="panel-collapse collapse">
+                                             <div class="panel-body">
+                                                 {{file.render()}}
+                                             </div>
                                         </div>
                                     </div>
-
                                 {% endif %}
 
                             {% endfor %}
-
+</div>
                     </div>
                 </div>
                 {% endif %}
@@ -192,6 +212,11 @@
 </div>
 
 <footer>
+
+<button id="collapse-init" class="btn btn-primary">
+    Disable accordion behavior
+</button>
+
     <div class="container-fluid">
         <div class="footer-custom">
             <a href="{{dot_dot_str}}sitemap/index.html">Sitemap</a>

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -32,31 +32,31 @@
     </style>
 
     <!-- add expand all js -->
-<script>
-$(function () {
+    <script>
+        $(function () {
 
-    var active = true;
+            var active = true;
 
-    $('#collapse-init').click(function () {
-        if (active) {
-            active = false;
-            $('.panel-collapse').collapse('show');
-            $('.panel-title').attr('data-toggle', '');
-            $(this).text('Collapse All');
-        } else {
-            active = true;
-            $('.panel-collapse').collapse('hide');
-            $('.panel-title').attr('data-toggle', 'collapse');
-            $(this).text('Expand All');
-        }
-    });
+            $('#collapse-init').click(function () {
+                if (active) {
+                    active = false;
+                    $('.panel-collapse').collapse('show');
+                    $('.panel-title').attr('data-toggle', '');
+                    $(this).text('Collapse All');
+                } else {
+                    active = true;
+                    $('.panel-collapse').collapse('hide');
+                    $('.panel-title').attr('data-toggle', 'collapse');
+                    $(this).text('Expand All');
+                }
+            });
     
-    $('#accordion').on('show.bs.collapse', function () {
-        if (active) $('#accordion .in').collapse('hide');
-    });
+            $('#accordion').on('show.bs.collapse', function () {
+                if (active) $('#accordion .in').collapse('hide');
+            });
 
-});
-</script>
+        });
+    </script>
 
     <!-- title -->
     <title>{{analysis_title}}</title>

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -178,25 +178,25 @@
 
                                 <!-- do not show well.html -->
                                 {% if not file.filename() == 'well.html' %}
-                                <div class="panel-group" id="accordion">
-                                    {% set i = i + 1 %}
-                                    <div class="panel panel-default">
-                                        <div class="panel-heading">
-                                            <h4 class="panel-title" data-toggle="collapse" data-target="#collapse{{i}}">
-                                                {% if cp.check_option(file.filename(), 'title') %}
-                                                    B{{i}}. {{cp.get(file.filename(), 'title')}}
-                                                {% else %}
-                                                    B{{i}}. {{file.filename()}}
-                                                {% endif %}
-                                            </h4>
-                                        </div>
-                                        <div id="collapse{{i}}" class="panel-collapse collapse">
+                                    <div class="panel-group" id="accordion">
+                                        <div class="panel panel-default">
+                                            <div class="panel-heading">
+                                                <h4 class="panel-title" data-toggle="collapse" data-target="#collapse{{i}}">
+                                                    {% if cp.check_option(file.filename(), 'title') %}
+                                                        B{{i}}. {{cp.get(file.filename(), 'title')}}
+                                                    {% else %}
+                                                        B{{i}}. {{file.filename()}}
+                                                    {% endif %}
+                                                </h4>
+                                            </div>
+                                            <div id="collapse{{i}}" class="panel-collapse collapse">
                                             <div class="panel-body">
-                                                {{file.render()}}
+                                                    {{file.render()}}
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
-                                </div>
+                                    {% set i = i + 1 %}
                                 {% endif %}
 
                             {% endfor %}

--- a/pycbc/results/templates/wells/two_column.html
+++ b/pycbc/results/templates/wells/two_column.html
@@ -6,11 +6,11 @@
 
     <!-- display formatted files -->
     {% for filelist in filelists %}
-        <div class="row" style="padding-left:10px;">
+        <div class="row">
 
             <!-- two file case -->
             {% if len(filelist) == 2 %}
-                <div class="col-md-6">
+                <div class="col-md-6" style="padding-top:20px;">
                 {% if filelist[0] != None %}
                     {% raw %}
                     {% set cp = get_embedded_config('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}') %}
@@ -22,7 +22,7 @@
                 {% endif %}
                 </div>
                 {% set i = i + 1 %}
-                <div class="col-md-6">
+                <div class="col-md-6" style="padding-top:20px;">
                 {% if filelist[1] != None %}
                     {% raw %}
                     {% set cp = get_embedded_config('{% endraw %}{{dir}}/{{filelist[1].name}}{% raw %}') %}
@@ -37,7 +37,7 @@
 
             <!-- one file case -->
             {% if len(filelist) == 1 %}
-                <div class="col-md-12" style="padding-top:10px;">
+                <div class="col-md-12" style="padding-top:20px;">
                     {% raw %}
                     {% set cp = get_embedded_config('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}') %}
                         {% if cp.has_option('{% endraw %}{{filelist[0].name}}{% raw %}', 'title') %}


### PR DESCRIPTION
This PR adds an expand/collapse all as the title states.

It also fixes the padding in the template `well.html`.

An example of the button is here: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/html_version_2/coincident_triggers/