### PR TITLE
Disable getconf on MacOS

### DIFF
--- a/pycbc/opt.py
+++ b/pycbc/opt.py
@@ -25,7 +25,10 @@ import pycbc
 # info on hardware cache sizes
 _USE_SUBPROCESS = False
 HAVE_GETCONF = False
-if sys.version_info >= (2, 7):
+if sys.platform == 'darwin':
+    # Mac has getconf, but we can do nothing useful with it
+    HAVE_GETCONF = False
+elif sys.version_info >= (2, 7):
     import subprocess
     _USE_SUBPROCESS = True
     HAVE_GETCONF = True


### PR DESCRIPTION
Disable use of 'getconf' to find out cache information and such on a Mac, since it doesn't work.