### PR TITLE
Add segment table

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -240,38 +240,23 @@ wf.make_segments_plot(workflow, full_segs,
 wf.make_segments_plot(workflow, science_seg_file,
                  rdir['analysis_time/segments'], tags=['SCIENCE_MINUS_CAT1'])
 
-# organize segments in preparation to be written to file
+# write segment summary XML file
 seg_list = []
 names = []
 ifos = []
-for ifo in workflow.ifos:
-
-    # all times for calibrated data
-    seg_list.append(data_segs[ifo])
-    names.append('DATA')
-    ifos.append(ifo)
-
-    # all times for calibrated data minus segdb missing segments
-    seg_list.append(science_segs[ifo])
-    names.append('ANALYZABLE_DATA')
-    ifos.append(ifo)
-
-    # all times for calibrated data minus segdb missing segments minus small segments
-    seg_list.append(insp_data_segs[ifo])
-    names.append('READ_DATA')
-    ifos.append(ifo)
-
-    # all times for calibrated data minus segdb missing segments minus small segments minus padding
-    seg_list.append(insp_segs[ifo])
-    names.append('TRIGGERS_PRODUCED')
-    ifos.append(ifo)
-
-# write segment summary XML file
+zip_seglists = [data_segs, science_segs, insp_data_segs, insp_segs]
+zip_names = ['DATA', 'ANALYZABLE_DATA', 'READ_DATA', 'TRIGGERS_PRODUCED']
+for segment_list,segment_name in zip(zip_seglists, zip_names):
+    for ifo in workflow.ifos:
+        seg_list.append(segment_list[ifo])
+        names.append(segment_name)
+        ifos.append(ifo)
 filename = 'segments/'+''.join(workflow.ifos)+'-WORKFLOW_SEGMENT_SUMMARY.xml'
 seg_summ_file = multi_segments_to_file(seg_list, filename, names, ifos)
 
 # make segment table for summary page
-seg_summ_table = wf.make_seg_table(workflow, [seg_summ_file], names, rdir.base)
+seg_summ_table = wf.make_seg_table(workflow, [seg_summ_file], zip_names,
+                                       rdir.base, ['SUMMARY'])
 
 # Make combined injection plots
 inj_summ = []

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -284,7 +284,7 @@ if len(inj_files) > 0:
                      "The limit is exactly one, skipping generation")
                             
 # make full summary
-summ = [(seg_summ_table,)] + det_summ + hist_summ + [(closed_snrifar,)] + inj_summ
+summ = [(seg_summ_table, )] + det_summ + hist_summ + [(closed_snrifar,)] + inj_summ
 for row in summ:
     for f in row:
         try:

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -256,7 +256,7 @@ seg_summ_file = multi_segments_to_file(seg_list, filename, names, ifos)
 
 # make segment table for summary page
 seg_summ_table = wf.make_seg_table(workflow, [seg_summ_file], zip_names,
-                                       rdir.base, ['SUMMARY'])
+                                       rdir['analysis_time/segments'], ['SUMMARY'])
 
 # Make combined injection plots
 inj_summ = []

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -329,18 +329,3 @@ for ifo in workflow.ifos:
 # write segment summary XML file
 filename = 'segments/'+''.join(workflow.ifos)+'-WORKFLOW_SEGMENT_SUMMARY.xml'
 seg_summ_file = multi_segments_to_file(seg_list, filename, names, ifos)
-
-exit()
-for ifo in ['H1', 'L1']:
-    print ifo, "data", "analyzable data", "analyzed", "triggers produced"
-    print ifo, abs(data_segs[ifo]), abs(science_segs[ifo]), abs(insp_data_segs[ifo].coalesce()), abs(insp_segs[ifo])
-
-print ("H1L1", abs(science_segs['H1'] & science_segs['L1']),
-               abs(data_segs['H1'] & data_segs['L1']),
-               abs(insp_data_segs['H1'].coalesce() & insp_data_segs['L1'].coalesce()),
-               abs(insp_segs['H1'].coalesce() & insp_segs['L1'].coalesce()),
-      )
-
-vsegs = wf.fromsegmentxml(open(final_veto_file[0].storage_path))
-print abs(insp_segs['H1'].coalesce() & insp_segs['L1'].coalesce() - vsegs)
-exit()

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -285,22 +285,6 @@ with open(ini_file_path, 'wb') as ini_fh:
 # Create versioning information
 create_versioning_page(rdir['configuration'], container.cp)
 
-wf.make_results_web_page(finalize_workflow, os.path.join(os.getcwd(), rdir.base))
-
-container += workflow
-container += finalize_workflow
-
-import Pegasus.DAX3 as dax
-dep = dax.Dependency(parent=workflow.as_job, child=finalize_workflow.as_job)
-container._adag.addDependency(dep)
-
-container.save()
-
-# Protect the open box results folder
-os.chmod(rdir['result'], 0700)
-
-logging.info("Written dax.")
-
 seg_list = []
 names = []
 ifos = []
@@ -329,3 +313,19 @@ for ifo in workflow.ifos:
 # write segment summary XML file
 filename = 'segments/'+''.join(workflow.ifos)+'-WORKFLOW_SEGMENT_SUMMARY.xml'
 seg_summ_file = multi_segments_to_file(seg_list, filename, names, ifos)
+
+wf.make_results_web_page(finalize_workflow, os.path.join(os.getcwd(), rdir.base))
+
+container += workflow
+container += finalize_workflow
+
+import Pegasus.DAX3 as dax
+dep = dax.Dependency(parent=workflow.as_job, child=finalize_workflow.as_job)
+container._adag.addDependency(dep)
+
+container.save()
+
+# Protect the open box results folder
+os.chmod(rdir['result'], 0700)
+
+logging.info("Written dax.")

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -244,8 +244,8 @@ wf.make_segments_plot(workflow, science_seg_file,
 seg_list = []
 names = []
 ifos = []
-zip_seglists = [data_segs, science_segs, insp_data_segs, insp_segs]
-zip_names = ['DATA', 'ANALYZABLE_DATA', 'READ_DATA', 'TRIGGERS_PRODUCED']
+zip_seglists = [data_segs, science_segs, insp_segs]
+zip_names = ['DATA', 'ANALYZABLE_DATA', 'TRIGGERS_PRODUCED']
 for segment_list,segment_name in zip(zip_seglists, zip_names):
     for ifo in workflow.ifos:
         seg_list.append(segment_list[ifo])

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -210,15 +210,15 @@ for inj_file, tag, output_dir in zip([None]+inj_files, tags, output_dirs):
                                       final_bg_file[0], trig_insp,
                                       rdir['injections/%s' % tag], tags=[tag])
    
-full_segs, psd_files = [], []                                 
+full_segs, psd_files, insp_segs, insp_data_segs = [], [], {}, {}                            
 for ifo, files in zip(*ind_insps.categorize_by_attr('ifo')):
     name = 'INSPIRAL_SEGMENTS'
     fname = 'segments/%s-' % ifo + name + '.xml'
-    fsegs = glue.segments.segmentlist([f.segment for f in files])
-    full_segs.append(pycbc.events.segments_to_file(fsegs, fname, name, ifo=ifo))
+    insp_segs[ifo] = glue.segments.segmentlist([f.segment for f in files])
+    full_segs.append(pycbc.events.segments_to_file(insp_segs[ifo], fname, name, ifo=ifo))
 
-    segs = glue.segments.segmentlist([f.metadata['data_seg'] for f in files])
-    data_seg = pycbc.events.segments_to_file(segs,
+    insp_data_segs[ifo] = glue.segments.segmentlist([f.metadata['data_seg'] for f in files])
+    data_seg = pycbc.events.segments_to_file(insp_data_segs[ifo],
                    'segments/%s-INSP_DATA.xml' % ifo, 'INSPIRAL_DATA', ifo=ifo)
 
     psd_files += [wf.make_psd_file(workflow, datafind_files.find_output_with_ifo(ifo), 
@@ -238,6 +238,21 @@ wf.make_segments_plot(workflow, full_segs,
                  rdir['analysis_time/segments'], tags=['INSPIRAL_SEGMENTS'])
 wf.make_segments_plot(workflow, science_seg_file,
                  rdir['analysis_time/segments'], tags=['SCIENCE_MINUS_CAT1'])
+
+for ifo in ['H1', 'L1']:
+    print ifo, "data", "analyzable data", "analyzed", "triggers produced"
+    print ifo, abs(data_segs[ifo]), abs(science_segs[ifo]), abs(insp_data_segs[ifo].coalesce()), abs(insp_segs[ifo])
+
+print ("H1L1", abs(science_segs['H1'] & science_segs['L1']), 
+               abs(data_segs['H1'] & data_segs['L1']),
+               abs(insp_data_segs['H1'].coalesce() & insp_data_segs['L1'].coalesce()),
+               abs(insp_segs['H1'].coalesce() & insp_segs['L1'].coalesce()),
+      )
+
+vsegs = wf.fromsegmentxml(open(final_veto_file[0].storage_path))
+print abs(insp_segs['H1'].coalesce() & insp_segs['L1'].coalesce() - vsegs) 
+exit()
+
 
 # Make combined injection plots
 inj_summ = []

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -240,51 +240,7 @@ wf.make_segments_plot(workflow, full_segs,
 wf.make_segments_plot(workflow, science_seg_file,
                  rdir['analysis_time/segments'], tags=['SCIENCE_MINUS_CAT1'])
 
-# Make combined injection plots
-inj_summ = []
-if len(inj_files) > 0:
-    found_inj = wf.find_injections_in_hdf_coinc(workflow, inj_coincs,
-                            inj_files, censored_veto, 'closed_box',
-                            'allinj', tags=['ALLINJ'])                                                
-    sen = wf.make_sensitivity_plot(workflow, found_inj, rdir['search_sensitivity'], 
-                            require='all', tags=['ALLINJ'])
-    group_layout(rdir['search_sensitivity'], sen)
-    inj = wf.make_foundmissed_plot(workflow, found_inj, rdir['injections'],
-                            require='all', tags=['ALLINJ'])
-    group_layout(rdir['injections'], inj)
-
-    # Make summary page foundmissed and sensitivity plot    
-    sen = wf.make_sensitivity_plot(workflow, found_inj, 
-                rdir['search_sensitivity'], require='summ', tags=['ALLINJ'])
-    inj = wf.make_foundmissed_plot(workflow, found_inj, 
-                rdir['injections'], require='summ', tags=['ALLINJ'])
-                
-    if len(sen) == 1 and len(inj) == 1:
-        inj_summ = [(inj[0], sen[0])]
-    else:
-        logging.warn("Invalid number of summary foundmissed/sensitivity plots. "
-                     "The limit is exactly one, skipping generation")
-                            
-# make full summary
-summ = det_summ + hist_summ + [(closed_snrifar,)] + inj_summ 
-for row in summ:
-    for f in row:
-        try:
-            os.symlink(f.storage_path, os.path.join(rdir.base, f.name))
-        except OSError:
-            pass           
-layout(rdir.base, summ)
-
-# save global config file to results directory
-base = rdir['configuration']
-wf.makedir(base)
-ini_file_path = os.path.join(base, 'configuration.ini')
-with open(ini_file_path, 'wb') as ini_fh:
-    container.cp.write(ini_fh)
-
-# Create versioning information
-create_versioning_page(rdir['configuration'], container.cp)
-
+# organize segments in preparation to be written to file
 seg_list = []
 names = []
 ifos = []
@@ -313,6 +269,51 @@ for ifo in workflow.ifos:
 # write segment summary XML file
 filename = 'segments/'+''.join(workflow.ifos)+'-WORKFLOW_SEGMENT_SUMMARY.xml'
 seg_summ_file = multi_segments_to_file(seg_list, filename, names, ifos)
+
+# make segment table for summary page
+seg_summ = wf.make_seg_table(workflow, [seg_summ_file], names, rdir.base)
+
+# Make combined injection plots
+inj_summ = []
+if len(inj_files) > 0:
+    found_inj = wf.find_injections_in_hdf_coinc(workflow, inj_coincs,
+                            inj_files, censored_veto, 'closed_box',
+                            'allinj', tags=['ALLINJ'])
+    sen = wf.make_sensitivity_plot(workflow, found_inj, rdir['search_sensitivity'],
+                            require='all', tags=['ALLINJ'])
+    group_layout(rdir['search_sensitivity'], sen)
+    inj = wf.make_foundmissed_plot(workflow, found_inj, rdir['injections'],
+                            require='all', tags=['ALLINJ'])
+    group_layout(rdir['injections'], inj)
+
+    # Make summary page foundmissed and sensitivity plot    
+    sen = wf.make_sensitivity_plot(workflow, found_inj, 
+                rdir['search_sensitivity'], require='summ', tags=['ALLINJ'])
+    inj = wf.make_foundmissed_plot(workflow, found_inj, 
+                rdir['injections'], require='summ', tags=['ALLINJ'])
+                
+    if len(sen) == 1 and len(inj) == 1:
+        inj_summ = [(inj[0], sen[0])]
+    else:
+        logging.warn("Invalid number of summary foundmissed/sensitivity plots. "
+                     "The limit is exactly one, skipping generation")
+                            
+# make full summary
+summ = [(seg_summ,)] + det_summ + hist_summ + [(closed_snrifar,)] + inj_summ
+for row in summ:
+    for f in row:
+        try:
+            os.symlink(f.storage_path, os.path.join(rdir.base, f.name))
+        except OSError:
+            pass           
+layout(rdir.base, summ)
+
+# save global config file to results directory
+base = rdir['configuration']
+wf.makedir(base)
+ini_file_path = os.path.join(base, 'configuration.ini')
+with open(ini_file_path, 'wb') as ini_fh:
+    container.cp.write(ini_fh)
 
 wf.make_results_web_page(finalize_workflow, os.path.join(os.getcwd(), rdir.base))
 

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -97,7 +97,7 @@ rdir = SectionNumber('results', ['configuration',
                                  ])
 
 # Get segments and find where the data is
-science_segs, science_seg_file = wf.get_analyzable_segments(workflow, "segments")
+science_segs, data_segs, science_seg_file = wf.get_analyzable_segments(workflow, "segments")
 datafind_files, science_segs = wf.setup_datafind_workflow(workflow, 
                                          science_segs, "datafind", science_seg_file)
 

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -21,6 +21,7 @@ generate post-processing and plots.
 """
 import pycbc, pycbc.version, pycbc.events, pycbc.workflow as wf
 import os, argparse, ConfigParser, logging, glue.segments, numpy
+from pycbc.events.veto import multi_segments_to_file
 from pycbc.results import create_versioning_page 
 from pycbc.results.render import render_workflow_html_template
 from itertools import izip_longest
@@ -239,21 +240,6 @@ wf.make_segments_plot(workflow, full_segs,
 wf.make_segments_plot(workflow, science_seg_file,
                  rdir['analysis_time/segments'], tags=['SCIENCE_MINUS_CAT1'])
 
-for ifo in ['H1', 'L1']:
-    print ifo, "data", "analyzable data", "analyzed", "triggers produced"
-    print ifo, abs(data_segs[ifo]), abs(science_segs[ifo]), abs(insp_data_segs[ifo].coalesce()), abs(insp_segs[ifo])
-
-print ("H1L1", abs(science_segs['H1'] & science_segs['L1']), 
-               abs(data_segs['H1'] & data_segs['L1']),
-               abs(insp_data_segs['H1'].coalesce() & insp_data_segs['L1'].coalesce()),
-               abs(insp_segs['H1'].coalesce() & insp_segs['L1'].coalesce()),
-      )
-
-vsegs = wf.fromsegmentxml(open(final_veto_file[0].storage_path))
-print abs(insp_segs['H1'].coalesce() & insp_segs['L1'].coalesce() - vsegs) 
-exit()
-
-
 # Make combined injection plots
 inj_summ = []
 if len(inj_files) > 0:
@@ -314,3 +300,47 @@ container.save()
 os.chmod(rdir['result'], 0700)
 
 logging.info("Written dax.")
+
+seg_list = []
+names = []
+ifos = []
+for ifo in workflow.ifos:
+
+    # all times for calibrated data
+    seg_list.append(data_segs[ifo])
+    names.append('DATA')
+    ifos.append(ifo)
+
+    # all times for calibrated data minus segdb missing segments
+    seg_list.append(science_segs[ifo])
+    names.append('ANALYZABLE_DATA')
+    ifos.append(ifo)
+
+    # all times for calibrated data minus segdb missing segments minus small segments
+    seg_list.append(insp_data_segs[ifo])
+    names.append('READ_DATA')
+    ifos.append(ifo)
+
+    # all times for calibrated data minus segdb missing segments minus small segments minus padding
+    seg_list.append(insp_segs[ifo])
+    names.append('TRIGGERS_PRODUCED')
+    ifos.append(ifo)
+
+# write segment summary XML file
+filename = 'segments/'+''.join(workflow.ifos)+'-WORKFLOW_SEGMENT_SUMMARY.xml'
+seg_summ_file = multi_segments_to_file(seg_list, filename, names, ifos)
+
+exit()
+for ifo in ['H1', 'L1']:
+    print ifo, "data", "analyzable data", "analyzed", "triggers produced"
+    print ifo, abs(data_segs[ifo]), abs(science_segs[ifo]), abs(insp_data_segs[ifo].coalesce()), abs(insp_segs[ifo])
+
+print ("H1L1", abs(science_segs['H1'] & science_segs['L1']),
+               abs(data_segs['H1'] & data_segs['L1']),
+               abs(insp_data_segs['H1'].coalesce() & insp_data_segs['L1'].coalesce()),
+               abs(insp_segs['H1'].coalesce() & insp_segs['L1'].coalesce()),
+      )
+
+vsegs = wf.fromsegmentxml(open(final_veto_file[0].storage_path))
+print abs(insp_segs['H1'].coalesce() & insp_segs['L1'].coalesce() - vsegs)
+exit()

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -271,7 +271,7 @@ filename = 'segments/'+''.join(workflow.ifos)+'-WORKFLOW_SEGMENT_SUMMARY.xml'
 seg_summ_file = multi_segments_to_file(seg_list, filename, names, ifos)
 
 # make segment table for summary page
-seg_summ = wf.make_seg_table(workflow, [seg_summ_file], names, rdir.base)
+seg_summ_table = wf.make_seg_table(workflow, [seg_summ_file], names, rdir.base)
 
 # Make combined injection plots
 inj_summ = []
@@ -299,7 +299,7 @@ if len(inj_files) > 0:
                      "The limit is exactly one, skipping generation")
                             
 # make full summary
-summ = [(seg_summ,)] + det_summ + hist_summ + [(closed_snrifar,)] + inj_summ
+summ = [(seg_summ_table,)] + det_summ + hist_summ + [(closed_snrifar,)] + inj_summ
 for row in summ:
     for f in row:
         try:

--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -1,7 +1,24 @@
 #!/usr/bin/python
 
+# Copyright (C) 2015 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 import argparse
 import h5py
+import logging
 import numpy
 import pycbc.results
 import sys
@@ -17,13 +34,16 @@ parser.add_argument('--output-file', type=str,
                         help='Path of the output HTML file.')
 opts = parser.parse_args()
 
+# setup log
+logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
+                    level=logging.INFO,datefmt='%I:%M:%S')
+
 # set column names
 columns = (('Name', []),
            ('H1 Time (s)', []),
            ('L1 Time (s)', []),
            ('H1L1 Time (s)', []),
 )
-
 
 # loop over segment files from command line
 for segment_file in opts.segment_files:
@@ -36,9 +56,12 @@ for segment_file in opts.segment_files:
 
        # get segments
        try:
-           h1_segs = seg_dict['H1:'+segment_name+':None']
-           l1_segs = seg_dict['L1:'+segment_name+':None']
+           version = 'None'
+           h1_segs = seg_dict['H1:'+segment_name+':'+version]
+           l1_segs = seg_dict['L1:'+segment_name+':'+version]
        except KeyError:
+           logging.info('Did not find a segment definition for %s:%s',
+               segment_name, version)
            continue
 
        # get length of time of segments in seconds
@@ -46,18 +69,18 @@ for segment_file in opts.segment_files:
        l1_len = abs(l1_segs)
        h1l1_len = abs( h1_segs & l1_segs )
 
-       # put into columns
+       # put values into columns
        columns[0][1].append(segment_name)
        columns[1][1].append(h1_len)
        columns[2][1].append(l1_len)
        columns[3][1].append(h1l1_len)
 
-# put columns and values into arrays
-keys = numpy.array([key for key,_ in columns])
-vals = numpy.array([val for _,val in columns])
+# cast columns into arrays
+keys = [numpy.array(key, dtype=type(key[0])) for key,_ in columns]
+vals = [numpy.array(val, dtype=type(val[0])) for _,val in columns]
 
 # write HTML table
-html_table = pycbc.results.table(keys, vals, page_size=20)
+html_table = pycbc.results.table(vals, keys, page_size=20)
 fp = open(opts.output_file, 'w')
 fp.write(html_table)
 fp.close()

--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -22,7 +22,37 @@ import logging
 import numpy
 import pycbc.results
 import sys
+from glue.ligolw import ligolw
+from glue.ligolw import lsctables
+from glue.ligolw import table
+from glue.ligolw import utils
+from pycbc.results import save_fig_with_metadata
 from pycbc.workflow import fromsegmentxml
+
+class ContentHandler(ligolw.LIGOLWContentHandler):
+    pass
+lsctables.use_in(ContentHandler)
+
+def get_segment_definer_comments(xml_file):
+    """ Returns a dict with the comment column as the value for each segment.
+    """
+
+    # read segment definer table
+    xmldoc, digest = utils.load_fileobj(xml_file,
+                                        gz=xml_file.name.endswith(".gz"),
+                                        contenthandler=ContentHandler)
+    seg_def_table = table.get_table(xmldoc,
+                                    lsctables.SegmentDefTable.tableName)
+
+    # put comment column into a dict
+    comment_dict = {}
+    for seg_def in seg_def_table:
+        full_channel_name = ':'.join([str(seg_def.ifos),
+                                      str(seg_def.name),
+                                      str(seg_def.version)])
+        comment_dict[full_channel_name] = seg_def.comment
+
+    return comment_dict
 
 # parse command line
 parser = argparse.ArgumentParser()
@@ -44,30 +74,39 @@ columns = (('Name', []),
            ('L1 Time (s)', []),
            ('H1L1 Time (s)', []),
 )
+caption = "This table shows the cumulative amount of time for each segment. Shown are: "
+
+# FIXME: set IFO list
+ifos = ['H1', 'L1']
 
 # loop over segment files from command line
 for segment_file in opts.segment_files:
 
    # read segment definer table
    seg_dict = fromsegmentxml(open(segment_file, 'rb'), return_dict=True) 
+   comment_dict = get_segment_definer_comments(open(segment_file, 'rb'))
 
    # loop over segment names
    for segment_name in opts.segment_names:
 
        # get segments
-       try:
-           version = 'None'
-           h1_segs = seg_dict['H1:'+segment_name+':'+version]
-           l1_segs = seg_dict['L1:'+segment_name+':'+version]
-       except KeyError:
-           logging.info('Did not find a segment definition for %s:%s',
-               segment_name, version)
+       segs = {}
+       for ifo in ifos:
+           for key in seg_dict.keys():
+               if key.startswith(ifo+':'+segment_name):
+                   segs[ifo] = seg_dict[key]
+                   caption += segment_name
+                   if comment_dict[key] != None:
+                       caption += " ("+comment_dict[key]+")"
+       if not len(segs.keys()):
+           logging.info('Did not find a segment definition for %s',
+               segment_name)
            continue
 
        # get length of time of segments in seconds
-       h1_len = abs(h1_segs)
-       l1_len = abs(l1_segs)
-       h1l1_len = abs( h1_segs & l1_segs )
+       h1_len = abs(segs['H1'])
+       l1_len = abs(segs['L1'])
+       h1l1_len = abs( segs['H1'] & segs['L1'] )
 
        # put values into columns
        columns[0][1].append(segment_name)
@@ -80,7 +119,10 @@ keys = [numpy.array(key, dtype=type(key[0])) for key,_ in columns]
 vals = [numpy.array(val, dtype=type(val[0])) for _,val in columns]
 
 # write HTML table
-html_table = pycbc.results.table(vals, keys, page_size=20)
-fp = open(opts.output_file, 'w')
-fp.write(html_table)
-fp.close()
+fig_kwds = {}
+html_table = pycbc.results.table(vals, keys, page_size=10)
+save_fig_with_metadata(str(html_table), opts.output_file,
+                     fig_kwds=fig_kwds,
+                     title='Segments',
+                     cmd=' '.join(sys.argv),
+                     caption=caption)

--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+
+import argparse
+import h5py
+import numpy
+import pycbc.results
+import sys
+from pycbc.workflow import fromsegmentxml
+
+# parse command line
+parser = argparse.ArgumentParser()
+parser.add_argument('--segment-files', type=str, nargs="+",
+                        help='XML files with a segment definer table to read.')
+parser.add_argument('--segment-names', type=str, nargs="+", required=False,
+                        help='Names of segments in the segment definer table.')
+parser.add_argument('--output-file', type=str,
+                        help='Path of the output HTML file.')
+opts = parser.parse_args()
+
+# set column names
+columns = (('Name', []),
+           ('H1 Time (s)', []),
+           ('L1 Time (s)', []),
+           ('H1L1 Time (s)', []),
+)
+
+
+# loop over segment files from command line
+for segment_file in opts.segment_files:
+
+   # read segment definer table
+   seg_dict = fromsegmentxml(open(segment_file, 'rb'), return_dict=True) 
+
+   # loop over segment names
+   for segment_name in opts.segment_names:
+
+       # get segments
+       try:
+           h1_segs = seg_dict['H1:'+segment_name+':None']
+           l1_segs = seg_dict['L1:'+segment_name+':None']
+       except KeyError:
+           continue
+
+       # get length of time of segments in seconds
+       h1_len = abs(h1_segs)
+       l1_len = abs(l1_segs)
+       h1l1_len = abs( h1_segs & l1_segs )
+
+       # put into columns
+       columns[0][1].append(segment_name)
+       columns[1][1].append(h1_len)
+       columns[2][1].append(l1_len)
+       columns[3][1].append(h1l1_len)
+
+# put columns and values into arrays
+keys = numpy.array([key for key,_ in columns])
+vals = numpy.array([val for _,val in columns])
+
+# write HTML table
+html_table = pycbc.results.table(keys, vals, page_size=20)
+fp = open(opts.output_file, 'w')
+fp.write(html_table)
+fp.close()

--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -95,13 +95,16 @@ for segment_file in opts.segment_files:
            for key in seg_dict.keys():
                if key.startswith(ifo+':'+segment_name):
                    segs[ifo] = seg_dict[key]
-                   caption += segment_name
-                   if comment_dict[key] != None:
-                       caption += " ("+comment_dict[key]+")"
        if not len(segs.keys()):
            logging.info('Did not find a segment definition for %s',
                segment_name)
            continue
+
+       # put comment in caption
+       caption += segment_name
+       if comment_dict[key] != None:
+           caption += " ("+comment_dict[key]+")"
+       caption += " "
 
        # get length of time of segments in seconds
        h1_len = abs(segs['H1'])

--- a/bin/pycbc_make_html_page
+++ b/bin/pycbc_make_html_page
@@ -222,7 +222,10 @@ for cwd in dirs:
 # copy all files to html directory
 for cwd in dirs:
     for file in cwd.files:
-        shutil.copy(file.path, opts.output_path+'/'+cwd.path+'/'+file.filename())
+        try:
+            shutil.copy2(file.path, opts.output_path+'/'+cwd.path+'/'+file.filename())
+        except IOError:
+            pass
 
 # make sitemap page
 sitemap_dir = '/sitemap'

--- a/pycbc/opt.py
+++ b/pycbc/opt.py
@@ -25,7 +25,10 @@ import pycbc
 # info on hardware cache sizes
 _USE_SUBPROCESS = False
 HAVE_GETCONF = False
-if sys.version_info >= (2, 7):
+if sys.platform == 'darwin':
+    # Mac has getconf, but we can do nothing useful with it
+    HAVE_GETCONF = False
+elif sys.version_info >= (2, 7):
     import subprocess
     _USE_SUBPROCESS = True
     HAVE_GETCONF = True

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -39,6 +39,7 @@ def render_workflow_html_template(filename, subtemplate, filelists):
     subtemplate_dir = pycbc.results.__path__[0] + '/templates/wells'
     env = Environment(loader=FileSystemLoader(subtemplate_dir))
     env.globals.update(get_embedded_config=get_embedded_config)
+    env.globals.update(path_exists=os.path.exists)
     env.globals.update(len=len)
     subtemplate = env.get_template(subtemplate)
     context = {'filelists' : filelists,
@@ -124,8 +125,11 @@ def render_default(path, cp):
     template_dir = pycbc.results.__path__[0] + '/templates/files'
     env = Environment(loader=FileSystemLoader(template_dir))
     env.globals.update(abs=abs)
+    env.globals.update(open=open)
+    env.globals.update(path_exists=os.path.exists)
     template = env.get_template('file_default.html')
-    context = {'filename' : filename,
+    context = {'path'     : path,
+               'filename' : filename,
                'slug'     : slug,
                'cp'       : cp,
                'content'  : content}
@@ -175,6 +179,7 @@ def render_text(path, cp):
     template_dir = pycbc.results.__path__[0] + '/templates/files'
     env = Environment(loader=FileSystemLoader(template_dir))
     env.globals.update(abs=abs)
+    env.globals.update(path_exists=os.path.exists)
     template = env.get_template('file_pre.html')
     context = {'filename' : filename,
                'slug'     : slug,
@@ -213,6 +218,7 @@ def render_tmplt(path, cp):
     env = Environment(loader=FileSystemLoader(template_dir))
     env.globals.update(setup_template_render=setup_template_render)
     env.globals.update(get_embedded_config=get_embedded_config)
+    env.globals.update(path_exists=os.path.exists)
     template = env.get_template(filename)
     context = {'filename' : filename,
                'slug'     : slug,

--- a/pycbc/results/templates/files/file_default.html
+++ b/pycbc/results/templates/files/file_default.html
@@ -4,7 +4,7 @@
 
 <!--html file condition-->
 {% elif filename.endswith('html') %}
-    <iframe width=100% frameborder="0" src="{{filename}}"></iframe>
+    {{ open(path, 'rb').read() }}
 
 <!--segment XML file condition-->
 {% elif ( filename.endswith('xml') or filename.endswith('xml.gz') ) and content %}

--- a/pycbc/results/templates/files/file_default.html
+++ b/pycbc/results/templates/files/file_default.html
@@ -4,9 +4,7 @@
 
 <!--html file condition-->
 {% elif filename.endswith('html') %}
-<div  class="embed-responsive embed-responsive-16by9">
-    <iframe class="embed-responsive-item" src="{{filename}}"></iframe>
-</div>
+    <iframe width=100% frameborder="0" src="{{filename}}"></iframe>
 
 <!--segment XML file condition-->
 {% elif ( filename.endswith('xml') or filename.endswith('xml.gz') ) and content %}
@@ -44,6 +42,7 @@
 <!--html file fragments-->
 {% elif filename.endswith('.htmlf') %}
     <pre>{{content}}</pre>
+
 <!--catch-all condition-->
 {% else %}
     <p>Unsupported file extension.</p>

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -172,33 +172,35 @@
                                 <button id="collapse-init" class="btn btn-xs btn-primary">Expand All</button>
                             </div>
                             {% for file in dir.files %}
+                                {% if path_exists(file.path) %}
 
-                                <!-- get config file -->
-                                {% set cp = get_embedded_config(file.path) %}
+                                    <!-- get config file -->
+                                    {% set cp = get_embedded_config(file.path) %}
 
-                                <!-- do not show well.html -->
-                                {% if not file.filename() == 'well.html' %}
-                                    <div class="panel-group" id="accordion">
-                                        <div class="panel panel-default">
-                                            <div class="panel-heading">
-                                                <h4 class="panel-title" data-toggle="collapse" data-target="#collapse{{i}}">
-                                                    {% if cp.check_option(file.filename(), 'title') %}
-                                                        B{{i}}. {{cp.get(file.filename(), 'title')}}
-                                                    {% else %}
-                                                        B{{i}}. {{file.filename()}}
-                                                    {% endif %}
-                                                </h4>
-                                            </div>
-                                            <div id="collapse{{i}}" class="panel-collapse collapse">
-                                            <div class="panel-body">
-                                                    {{file.render()}}
+                                    <!-- do not show well.html -->
+                                    {% if not file.filename() == 'well.html' %}
+                                        <div class="panel-group" id="accordion">
+                                            <div class="panel panel-default">
+                                                <div class="panel-heading">
+                                                    <h4 class="panel-title" data-toggle="collapse" data-target="#collapse{{i}}">
+                                                        {% if cp.check_option(file.filename(), 'title') %}
+                                                            B{{i}}. {{cp.get(file.filename(), 'title')}}
+                                                        {% else %}
+                                                            B{{i}}. {{file.filename()}}
+                                                        {% endif %}
+                                                    </h4>
+                                                </div>
+                                                <div id="collapse{{i}}" class="panel-collapse collapse">
+                                                    <div class="panel-body">
+                                                        {{file.render()}}
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    {% set i = i + 1 %}
-                                {% endif %}
+                                        {% set i = i + 1 %}
+                                    {% endif %}
 
+                                {% endif %}
                             {% endfor %}
                     </div>
                 </div>

--- a/pycbc/results/templates/wells/two_column.html
+++ b/pycbc/results/templates/wells/two_column.html
@@ -11,25 +11,27 @@
             <!-- two file case -->
             {% if len(filelist) == 2 %}
                 <div class="col-md-6" style="padding-top:20px;">
-                {% if filelist[0] != None %}
-                    {% raw %}
-                    {% set cp = get_embedded_config('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}') %}
-                        {% if cp.has_option('{% endraw %}{{filelist[0].name}}{% raw %}', 'title') %}
-                            <p class="text-center" style="font-size:18px;"><b>{% endraw %}A{{i}}. {% raw %}{{cp.get('{% endraw %}{{filelist[0].name}}{% raw %}', 'title')}}</b></p>
-                        {% endif %}
-                        {{ setup_template_render('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}' , '') }}
+                {% raw %}
+                    {% if path_exists('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}') %}
+                        {% set cp = get_embedded_config('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}') %}
+                            {% if cp.has_option('{% endraw %}{{filelist[0].name}}{% raw %}', 'title') %}
+                                <p class="text-center" style="font-size:18px;"><b>{% endraw %}A{{i}}. {% raw %}{{cp.get('{% endraw %}{{filelist[0].name}}{% raw %}', 'title')}}</b></p>
+                            {% endif %}
+                            {{ setup_template_render('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}' , '') }}
+                    {% endif %}
                     {% endraw %}
-                {% endif %}
                 </div>
                 {% set i = i + 1 %}
                 <div class="col-md-6" style="padding-top:20px;">
                 {% if filelist[1] != None %}
                     {% raw %}
-                    {% set cp = get_embedded_config('{% endraw %}{{dir}}/{{filelist[1].name}}{% raw %}') %}
-                        {% if cp.has_option('{% endraw %}{{filelist[1].name}}{% raw %}', 'title') %}
-                           <p class="text-center" style="font-size:18px;"><b>{% endraw %}A{{i}}. {% raw %}{{cp.get('{% endraw %}{{filelist[1].name}}{% raw %}', 'title')}}</b></p>
-                        {% endif %}
-                        {{ setup_template_render('{% endraw %}{{dir}}/{{filelist[1].name}}{% raw %}' , '') }}
+                    {% if path_exists('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}') %}
+                        {% set cp = get_embedded_config('{% endraw %}{{dir}}/{{filelist[1].name}}{% raw %}') %}
+                            {% if cp.has_option('{% endraw %}{{filelist[1].name}}{% raw %}', 'title') %}
+                                <p class="text-center" style="font-size:18px;"><b>{% endraw %}A{{i}}. {% raw %}{{cp.get('{% endraw %}{{filelist[1].name}}{% raw %}', 'title')}}</b></p>
+                            {% endif %}
+                            {{ setup_template_render('{% endraw %}{{dir}}/{{filelist[1].name}}{% raw %}' , '') }}
+                    {% endif %}
                     {% endraw %}
                 {% endif %}
                 </div>
@@ -39,11 +41,13 @@
             {% if len(filelist) == 1 %}
                 <div class="col-md-12" style="padding-top:20px;">
                     {% raw %}
-                    {% set cp = get_embedded_config('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}') %}
-                        {% if cp.has_option('{% endraw %}{{filelist[0].name}}{% raw %}', 'title') %}
-                            <p class="text-center" style="font-size:18px;"><b>{% endraw %}A{{i}}. {% raw %}{{cp.get('{% endraw %}{{filelist[0].name}}{% raw %}', 'title')}}</b></p>
-                        {% endif %}
-                        {{ setup_template_render('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}' , '') }}
+                    {% if path_exists('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}') %}
+                        {% set cp = get_embedded_config('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}') %}
+                            {% if cp.has_option('{% endraw %}{{filelist[0].name}}{% raw %}', 'title') %}
+                                <p class="text-center" style="font-size:18px;"><b>{% endraw %}A{{i}}. {% raw %}{{cp.get('{% endraw %}{{filelist[0].name}}{% raw %}', 'title')}}</b></p>
+                            {% endif %}
+                            {{ setup_template_render('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}' , '') }}
+                    {% endif %}
                     {% endraw %}
                 </div>
             {% endif %}

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -462,7 +462,8 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
             if not overwrite_options:
                 if option in self.options(section):
                     raise ValueError('Option exists in both original ' + \
-                                  'ConfigParser and input list: %s' %(option,))
+                                  'ConfigParser section [%s] and ' %(section,) + \
+                                  'input list: %s' %(option,))
             self.set(section,option,value)
 
 

--- a/pycbc/workflow/ini_files/example_hdf_bns.ini
+++ b/pycbc/workflow/ini_files/example_hdf_bns.ini
@@ -80,6 +80,7 @@ plot_snrifar = ${which:pycbc_page_snrifar}
 plot_singles = ${which:pycbc_plot_singles_vs_params}
 page_foreground = ${which:pycbc_page_foreground}
 page_injections = ${which:pycbc_page_injtable}
+page_segtable = ${which:pycbc_page_segtable}
 hdf_trigger_merge = ${which:pycbc_coinc_mergetrigs}
 plot_snrchi = ${which:pycbc_page_snrchi}
 plot_coinc_snrchi = ${which:pycbc_page_coinc_snrchi}
@@ -180,6 +181,8 @@ injection-window = 1.0
 
 [page_foreground]
 [plot_snrifar]
+
+[page_segtable]
 
 [plot_snrchi]
 [plot_coinc_snrchi]

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -139,8 +139,7 @@ def make_seg_table(workflow, seg_files, seg_names, out_dir, tags=None):
     node.add_opt('--segment-names', ' '.join(seg_names))
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow += node
-    files = FileList(node.output_files)
-    return files[0]
+    return node.output_files[0]
 
 def make_snrchi_plot(workflow, trig_files, veto_file, veto_name, 
                      out_dir, exclude=None, require=None, tags=[]):

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -126,6 +126,9 @@ def make_inj_table(workflow, inj_file, out_dir, tags=[]):
     workflow += node   
 
 def make_seg_table(workflow, seg_files, seg_names, out_dir, tags=None):
+    """ Creates a node in the workflow for writing the segment summary
+    table. Returns a File instances for the output file.
+    """
     seg_files = list(seg_files)
     seg_names = list(seg_names)
     if tags is None: tags = []

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -125,6 +125,20 @@ def make_inj_table(workflow, inj_file, out_dir, tags=[]):
     node.new_output_file_opt(inj_file.segment, '.html', '--output-file')
     workflow += node   
 
+def make_seg_table(workflow, seg_files, seg_names, out_dir, tags=None):
+    seg_files = list(seg_files)
+    seg_names = list(seg_names)
+    if tags is None: tags = []
+    makedir(out_dir)
+    node = PlotExecutable(workflow.cp, 'page_segtable', ifos=workflow.ifos,
+                    out_dir=out_dir, tags=tags).create_node()
+    node.add_input_list_opt('--segment-files', seg_files)
+    node.add_opt('--segment-names', ' '.join(seg_names))
+    node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
+    workflow += node
+    files = FileList(node.output_files)
+    return files[0]
+
 def make_snrchi_plot(workflow, trig_files, veto_file, veto_name, 
                      out_dir, exclude=None, require=None, tags=[]):
     makedir(out_dir)    

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1153,7 +1153,7 @@ def get_cumulative_veto_group_files(workflow, option, out_dir, tags=[]):
                         file_url=url, tags=[segment_name])
                         
         cum_seg_files += [get_cumulative_segs(workflow, seg_file,  categories,
-              cat_files, out_dir, execute_now=False, segment_name=segment_name)]
+              cat_files, out_dir, execute_now=True, segment_name=segment_name)]
         names.append(segment_name)
               
     return cum_seg_files, names, cat_files

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1048,6 +1048,8 @@ def get_analyzable_segments(workflow, out_dir, tags=[]):
     --------
     segs : glue.segments.segmentlist instance
         The segment list specifying the analyzable times
+    data_segs : glue.segments.segmentlist
+        The segment list specifying the time where data exists
     seg_files : workflow.core.FileList instance
         The cumulative segment files from each ifo that determined the
         analyzable time.
@@ -1068,12 +1070,13 @@ def get_analyzable_segments(workflow, out_dir, tags=[]):
     
     veto_gen_job = create_segs_from_cats_job(workflow.cp, out_dir, 
                                              workflow.ifo_string) 
-    sci_segs = {}
+    sci_segs, data_segs = {}, {}
     seg_files = FileList()
     for ifo in workflow.ifos:
         sci_segs[ifo], sci_xml = get_science_segments(ifo, workflow.cp, 
                                                  start_time, end_time, out_dir) 
-        seg_files += [sci_xml]      
+        seg_files += [sci_xml]    
+        data_segs[ifo] = sci_sgs[ifo]  
         for category in cat_set:
             curr_veto_file = get_veto_segs(workflow, ifo, 
                                         cat_to_pipedown_cat(category), 
@@ -1084,13 +1087,13 @@ def get_analyzable_segments(workflow, out_dir, tags=[]):
             f.close()    
             sci_segs[ifo] -= cat_segs
             
-            seg_ok_path = os.path.abspath(os.path.join(out_dir, '%s-SCIENCE-OK.xml' % ifo))
-            seg_files += [segments_to_file(sci_segs[ifo], seg_ok_path, 
-                                          "SCIENCE_OK", ifo=ifo)]
-            
         sci_segs[ifo].coalesce()
+        seg_ok_path = os.path.abspath(os.path.join(out_dir, '%s-SCIENCE-OK.xml' % ifo))
+        seg_files += [segments_to_file(sci_segs[ifo], seg_ok_path, 
+                                          "SCIENCE_OK", ifo=ifo)]  
+                                                   
     logging.info('Leaving generation of science segments')
-    return sci_segs, seg_files
+    return sci_segs, data_segs, seg_files
     
 def get_cumulative_veto_group_files(workflow, option, out_dir, tags=[]):
     """

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1047,7 +1047,7 @@ def get_analyzable_segments(workflow, out_dir, tags=[]):
     Returns
     --------
     segs : glue.segments.segmentlist instance
-        The segment list specifying the analyzable times
+        The segment list specifying the times to analyze
     data_segs : glue.segments.segmentlist
         The segment list specifying the time where data exists
     seg_files : workflow.core.FileList instance
@@ -1076,7 +1076,7 @@ def get_analyzable_segments(workflow, out_dir, tags=[]):
         sci_segs[ifo], sci_xml = get_science_segments(ifo, workflow.cp, 
                                                  start_time, end_time, out_dir) 
         seg_files += [sci_xml]    
-        data_segs[ifo] = sci_sgs[ifo]  
+        data_segs[ifo] = sci_segs[ifo]  
         for category in cat_set:
             curr_veto_file = get_veto_segs(workflow, ifo, 
                                         cat_to_pipedown_cat(category), 

--- a/setup.py
+++ b/setup.py
@@ -389,6 +389,7 @@ setup (
                'bin/hdfcoinc/pycbc_coinc_hdfinjfind',
                'bin/hdfcoinc/pycbc_page_snrchi',
                'bin/hdfcoinc/pycbc_page_segments',
+               'bin/hdfcoinc/pycbc_page_segtable',
                'bin/hdfcoinc/pycbc_plot_psd_file',
                'bin/hdfcoinc/pycbc_plot_range',
                'bin/hdfcoinc/pycbc_foreground_censor',


### PR DESCRIPTION
This PR adds a HTML table to the summary pages that shows segment information.

The executable that creates the table is called `pycbc_page_segtable` and takes a list of segment files, a list of segment names, and the output filename as options.

Displayed in the table is the name (read from the `segment_definer` table), and the amount of time in each IFO and in H1L1 time. If there is anything in the `comments` column for that segment then it shows up in the comments. We should populate the `comments` columns with useful descriptions, that will require some tweaks to `toSegmentXml`.

Also in this PR HTML do not use iframes anymore, instead they are read directly see changes to `file_default.html'.

And there are now checks to see if the file exists before rendering it.

An example of the segment information table can be seen here: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/html_version_4/