### PR TITLE
Fix syntax error

### DIFF
--- a/pycbc/sensitivity.py
+++ b/pycbc/sensitivity.py
@@ -166,8 +166,8 @@ def volume_montecarlo(found_d, missed_d, found_mchirp, missed_mchirp,
 
     # return MC integral and its standard deviation; variance of mc_sum scales
     # relative to sample variance by Ninj (Bienayme' rule)
-    vol, vol_err = mc_prefactor * mc_sum,
-                              mc_prefactor * (Ninj * mc_sample_variance) ** 0.5
+    vol = mc_prefactor * mc_sum
+    vol_err = mc_prefactor * (Ninj * mc_sample_variance) ** 0.5
     return vol, vol_err
 
 def volume_binned_pylal(f_dist, m_dist, bins=15):


### PR DESCRIPTION
There is a syntax error in pycbc/sensitivity.py .... 

I *think* I see what is trying to be done here, only the line break character, or brackets, is missing. However, I don't see any reason why this shouldn't be two lines. Fix attached.

Did the auto-build tests miss this?
