### PR TITLE
Template banks: fix failing unit test, clean up option parsing.

### DIFF
--- a/bin/pycbc_aligned_stoch_bank
+++ b/bin/pycbc_aligned_stoch_bank
@@ -26,7 +26,8 @@ import numpy
 import logging
 import pycbc
 import pycbc.version
-from pycbc import tmpltbank, pnutils, positive_float
+from pycbc import tmpltbank, pnutils
+from pycbc.types import positive_float
 import pycbc.psd
 import pycbc.strain
 

--- a/bin/pycbc_aligned_stoch_bank
+++ b/bin/pycbc_aligned_stoch_bank
@@ -26,7 +26,7 @@ import numpy
 import logging
 import pycbc
 import pycbc.version
-from pycbc import tmpltbank, pnutils
+from pycbc import tmpltbank, pnutils, positive_float
 import pycbc.psd
 import pycbc.strain
 
@@ -45,15 +45,10 @@ parser = argparse.ArgumentParser(description=_desc,
 parser.add_argument("--version", action="version", version=__version__)
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="verbose output")
-parser.add_argument("-O", "--output-file",
-                    help="Output file name.  REQUIRED.")
-parser.add_argument("-m", "--min-match", action="store", type=float,
-                    default=None, help=
-                    "Generate bank with specified minimum match.  REQUIRED.")
 parser.add_argument("-V", "--vary-fupper", action="store_true", default=False,
                     help="Use a variable upper frequency cutoff in laying "
                     "out the bank.  OPTIONAL.")
-parser.add_argument("--bank-fupper-step", type=float, default=10.,
+parser.add_argument("--bank-fupper-step", type=positive_float, default=10.,
                     help="Size of discrete frequency steps used when varying "
                     "the fupper. If --calculate-ethinca-metric and "
                     "--ethinca-freq-step are also given, the code will use "
@@ -80,6 +75,8 @@ parser.add_argument("--random-seed", action="store", type=int,
                     "physical space.  If given, the code should give the "
                     "same output when run with the same random seed.")
 
+tmpltbank.insert_base_bank_options(parser)
+
 # Insert the metric calculation options
 tmpltbank.insert_metric_calculation_options(parser)
 
@@ -104,11 +101,6 @@ else:
 log_format='%(asctime)s %(message)s'
 logging.basicConfig(format=log_format, level=log_level)
 
-# Sanity check options
-if not opts.output_file:
-    parser.error("Must supply --output-file")
-if not opts.min_match:
-    parser.error("Must supply --min-match")
 # delete defaults for redundant options if not varying fupper
 if not opts.vary_fupper:
     opts.bank_fupper_step = None

--- a/bin/pycbc_geom_aligned_2dstack
+++ b/bin/pycbc_geom_aligned_2dstack
@@ -71,10 +71,6 @@ parser.add_argument("-I", "--input-bank-file", action="store", type=str,\
                    default=None,\
                    help="ASCII file containing the input bank. "+\
                         "REQUIRED ARGUMENT.")
-parser.add_argument("-O", "--output-bank-file", action="store", type=str,\
-                   default=None,\
-                   help="ASCII file containing the output bank. "+\
-                        "REQUIRED ARGUMENT.")
 parser.add_argument("--metric-evals-file", action="store", type=str,\
                    default=None,\
                    help="ASCII file containing the metric eigenvalues. "+\
@@ -87,9 +83,6 @@ parser.add_argument("--cov-evecs-file", action="store", type=str,\
                    default=None,\
                    help="ASCII file containing the covariance eigenvectors. "+\
                         "REQUIRED ARGUMENT.")
-parser.add_argument("--min-match", action="store", type=float,\
-                  default=None, help="Minimum match to generate bank with."+\
-                                     "REQUIRED ARGUMENT.")
 parser.add_argument("--stack-distance", action="store", type=float,\
                   default=0.2, help="Minimum metric spacing before we stack"+\
                                     "OPTIONAL")
@@ -111,6 +104,7 @@ parser.add_argument("--random-seed", action="store", type=int,\
                             If this is used the code should give the same
                             output if run with the same random seed.""")
 
+pycbc.tmpltbank.insert_base_bank_options(parser)
 
 # Insert the mass range options
 pycbc.tmpltbank.insert_mass_range_option_group(parser)
@@ -130,11 +124,7 @@ if not opts.pn_order:
     parser.error("Must supply --pn-order")
 if not opts.input_bank_file:
     parser.error("Must supply --input-bank-file")
-if not opts.min_match:
-    parser.error("Must supply --min-match")
 opts.max_mismatch = 1 - opts.min_match
-if not opts.output_bank_file:
-    parser.error("Must supply --output-bank-file")
 if not opts.metric_evals_file:
     parser.error("Must supply --metric-evals-file")
 if not opts.metric_evecs_file:
@@ -209,7 +199,7 @@ maxBHspin = opts.max_bh_spin_mag
 
 # Here we start looping over bank
 temp_number = 0
-outFile = opts.output_bank_file
+outFile = opts.output_file
 outPointer = open(outFile,'w')
 outPointer2 = open(outFile+'.reject','w')
 outPointer3 = open(outFile+'.depths','w')

--- a/bin/pycbc_geom_aligned_bank
+++ b/bin/pycbc_geom_aligned_bank
@@ -68,16 +68,11 @@ parser = argparse.ArgumentParser(description=_desc,
 
 # Begin with code specific options
 parser.add_argument('--version', action='version', version=__version__)
-parser.add_argument("-V", "--verbose", action="store_true", default=False,\
+parser.add_argument("-V", "--verbose", action="store_true", default=False,
                     help="verbose output")
-parser.add_argument("-O", "--output-file",  help="Output file name. "+\
-                                               "REQUIRED ARGUMENT.")
-parser.add_argument("-L", "--log-path", action="store", type=str,\
-                   default=None,\
-                   help="Directory to store condor logs. REQUIRED ARGUMENT")
-parser.add_argument("-m", "--min-match", action="store", type=float,\
-                  default=None, help="Minimum match to generate bank with. "+\
-                                      "REQUIRED ARGUMENT")
+parser.add_argument("-L", "--log-path", action="store", required=True, type=str,
+                    default=None,
+                    help="Directory to store condor logs. REQUIRED ARGUMENT")
 parser.add_argument("-s", "--stack-distance", action="store", type=float,\
                   default=0.2, help="Minimum metric spacing before we "+\
                                "stack.")
@@ -105,6 +100,8 @@ parser.add_argument("--print-chi-points", action="store", default=None,
                     "using pycbc_tmpltbank_to_chi_params. This will be "
                     "written to FILENAME. If this argument is not given, no "
                     "chi points file will be written.")
+
+pycbc.tmpltbank.insert_base_bank_options(parser)
 
 # Insert the metric calculation options
 metric_opts = pycbc.tmpltbank.insert_metric_calculation_options(parser)
@@ -142,14 +139,7 @@ else:
 log_format='%(asctime)s %(message)s'
 logging.basicConfig(format=log_format, level=log_level)
 
-# Sanity check options
-if not opts.output_file:
-    parser.error("Must supply --output-file")
-if not opts.min_match:
-    parser.error("Must supply --min-match")
 opts.max_mismatch = 1 - opts.min_match
-if not opts.log_path:
-    parser.error("Must supply --log-path")
 if not opts.write_metric:
     warn_message = "--write-metric is required by this code. Enabling it."
     logging.warn(warn_message)
@@ -409,7 +399,7 @@ numBanks = int((len(newV1s) - 0.5)//opts.split_bank_num) + 1
 for i in xrange(numBanks):
     node = pipeline.CondorDAGNode(job)
     node.add_var_opt('input-bank-file','split_banks/split_bank_%05d.dat'%(i))
-    node.add_var_opt('output-bank-file','output_banks/output_bank_%05d.dat'%(i))
+    node.add_var_opt('output-file','output_banks/output_bank_%05d.dat'%(i))
     cat_node.add_parent(node)
     dag.add_node(node)
 

--- a/bin/pycbc_geom_nonspinbank
+++ b/bin/pycbc_geom_nonspinbank
@@ -49,9 +49,6 @@ parser = argparse.ArgumentParser(
 parser.add_argument('--version', action='version', version=__version__)
 parser.add_argument("-V", "--verbose", action="store_true", default=False,
                     help="verbose output")
-parser.add_argument("-m", "--min-match", action="store", type=float,
-                    default=None, help=
-                    "Generate bank with specified minimum match.  REQUIRED.")
 parser.add_argument("--random-seed", action="store", type=int,
                     default=None,
                     help="""Random seed to use when calling numpy.random
@@ -60,8 +57,8 @@ parser.add_argument("--random-seed", action="store", type=int,
                             physical space.  
                             If given, the code should give the same output 
                             when run with the same random seed.""")
-parser.add_argument("-O", "--output-file",
-                    help="Output file name.  REQUIRED.")
+
+tmpltbank.insert_base_bank_options(parser)
 
 # Insert the metric calculation options
 tmpltbank.insert_metric_calculation_options(parser)
@@ -86,11 +83,6 @@ else:
     log_level = logging.WARN
 logging.basicConfig(format='%(asctime)s %(message)s', level=log_level)
 
-# Sanity check options
-if not opts.output_file:
-    parser.error("Must supply --output-file")
-if not opts.min_match:
-    parser.error("Must supply --min-match")
 opts.max_mismatch = 1 - opts.min_match
 tmpltbank.verify_metric_calculation_options(opts, parser)
 metricParams=tmpltbank.metricParameters.from_argparse(opts)

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -28,6 +28,7 @@
 import subprocess, os, sys, tempfile
 import logging
 import signal
+import argparse
 
 
 def init_logging(verbose=False):
@@ -54,6 +55,34 @@ def init_logging(verbose=False):
     else:
         initial_level = logging.WARN
     logging.basicConfig(format='%(asctime)s %(message)s', level=initial_level)
+
+def positive_float(s):
+    """
+    Ensures given argument is a positive real number. To be used as type in
+    argparse arguments.
+    """
+    err_msg = "must be a positive number, not %r" % s
+    try:
+        value = float(s)
+    except ValueError, e:
+        raise argparse.ArgumentTypeError(err_msg)
+    if value <= 0:
+        raise argparse.ArgumentTypeError(err_msg)
+    return value
+
+def nonnegative_float(s):
+    """
+    Ensures given argument is a positive real number, or zero. To be used as
+    type in argparse arguments.
+    """
+    err_msg = "must be either positive or zero, not %r" % s
+    try:
+        value = float(s)
+    except ValueError, e:
+        raise argparse.ArgumentTypeError(err_msg)
+    if value < 0:
+        raise argparse.ArgumentTypeError(err_msg)
+    return value
 
 
 # Check for optional components of the PyCBC Package

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -28,7 +28,6 @@
 import subprocess, os, sys, tempfile
 import logging
 import signal
-import argparse
 
 
 def init_logging(verbose=False):
@@ -55,34 +54,6 @@ def init_logging(verbose=False):
     else:
         initial_level = logging.WARN
     logging.basicConfig(format='%(asctime)s %(message)s', level=initial_level)
-
-def positive_float(s):
-    """
-    Ensures given argument is a positive real number. To be used as type in
-    argparse arguments.
-    """
-    err_msg = "must be a positive number, not %r" % s
-    try:
-        value = float(s)
-    except ValueError, e:
-        raise argparse.ArgumentTypeError(err_msg)
-    if value <= 0:
-        raise argparse.ArgumentTypeError(err_msg)
-    return value
-
-def nonnegative_float(s):
-    """
-    Ensures given argument is a positive real number, or zero. To be used as
-    type in argparse arguments.
-    """
-    err_msg = "must be either positive or zero, not %r" % s
-    try:
-        value = float(s)
-    except ValueError, e:
-        raise argparse.ArgumentTypeError(err_msg)
-    if value < 0:
-        raise argparse.ArgumentTypeError(err_msg)
-    return value
 
 
 # Check for optional components of the PyCBC Package

--- a/pycbc/tmpltbank/option_utils.py
+++ b/pycbc/tmpltbank/option_utils.py
@@ -18,8 +18,9 @@ import argparse
 import logging
 import textwrap
 from pycbc.tmpltbank.lambda_mapping import *
-from pycbc import pnutils, positive_float, nonnegative_float
+from pycbc import pnutils
 from pycbc.tmpltbank.em_progenitors import load_ns_sequence
+from pycbc.types import positive_float, nonnegative_float
 
 class IndentedHelpFormatterWithNL(argparse.ArgumentDefaultsHelpFormatter):
     """

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -16,7 +16,6 @@
 """
 This modules contains extensions for use with argparse
 """
-import logging
 import copy
 import argparse
 from collections import defaultdict
@@ -309,3 +308,33 @@ def convert_to_process_params_dict(opt):
                         new_val.append(':'.join([key, str(val[key])]))
             setattr(opt, arg, new_val)
     return vars(opt)
+
+def positive_float(s):
+    """
+    Ensure argument is a positive real number and return it as float.
+
+    To be used as type in argparse arguments.
+    """
+    err_msg = "must be a positive number, not %r" % s
+    try:
+        value = float(s)
+    except ValueError, e:
+        raise argparse.ArgumentTypeError(err_msg)
+    if value <= 0:
+        raise argparse.ArgumentTypeError(err_msg)
+    return value
+
+def nonnegative_float(s):
+    """
+    Ensure argument is a positive real number or zero and return it as float.
+
+    To be used as type in argparse arguments.
+    """
+    err_msg = "must be either positive or zero, not %r" % s
+    try:
+        value = float(s)
+    except ValueError, e:
+        raise argparse.ArgumentTypeError(err_msg)
+    if value < 0:
+        raise argparse.ArgumentTypeError(err_msg)
+    return value


### PR DESCRIPTION
Hi Ian, this fixes failures in tmpltbank unit tests. While I was at it, I went around and did some cleanup which is now possible thanks to argparse:

* Made some of the required options actually required. This also leads to shorter explicit checks.
* Introduced checks for correct ranges of some numerical arguments.
* Moved --min-match and --output-file options to a common insert_*() style function for all bank scripts.
* Fixed a case where an invalid option combination was caught, but not reported.

I tested this by running one of the pycbc_geom_nonspinbank examples and the output is unchanged.