### PR TITLE
remove duplicate files and add segments plot on summary page

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -263,6 +263,9 @@ seg_summ_file = multi_segments_to_file(seg_list, filename, names, ifos)
 # make segment table for summary page
 seg_summ_table = wf.make_seg_table(workflow, [seg_summ_file], zip_names,
                         rdir['analysis_time/segments'], ['SUMMARY'])
+veto_summ_table = wf.make_seg_table(workflow, cum_veto_files + final_veto_file,
+                        veto_data_seg_names + veto_triggers_seg_names,
+                        rdir['analysis_time/segments'], ['VETO_SUMMARY'])
 
 # make segment plot for summary page
 seg_summ_plot = wf.make_seg_plot(workflow, [seg_summ_file],
@@ -290,7 +293,7 @@ if len(inj_files) > 0:
     inj_summ = list(grouper(inj + sen, 2))
                             
 # make full summary
-summ = [(seg_summ_plot,)] + [(seg_summ_table,)] + \
+summ = [(seg_summ_plot,)] + [(seg_summ_table, veto_summ_table)] + \
        det_summ + hist_summ + [(closed_snrifar,)] + inj_summ
 for row in summ:
     for f in row:

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -262,13 +262,12 @@ seg_summ_file = multi_segments_to_file(seg_list, filename, names, ifos)
 
 # make segment table for summary page
 seg_summ_table = wf.make_seg_table(workflow, [seg_summ_file], zip_names,
-                                       rdir['analysis_time/segments'], ['SUMMARY'])
+                        rdir['analysis_time/segments'], ['SUMMARY'])
 
 # make segment plot for summary page
-seg_summ_plot = wf.make_seg_plot(workflow, [seg_summ_file] + cum_veto_files + final_veto_file,
-                                 rdir['analysis_time/segments'],
-                                 science_seg_names, veto_data_seg_names,
-                                 veto_triggers_seg_names, ['SUMMARY'])
+seg_summ_plot = wf.make_seg_plot(workflow, [seg_summ_file],
+                        rdir['analysis_time/segments'],
+                        data_seg_names + science_seg_names, ['SUMMARY'])
 
 # Make combined injection plots
 inj_summ = []

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -240,12 +240,18 @@ wf.make_segments_plot(workflow, full_segs,
 wf.make_segments_plot(workflow, science_seg_file,
                  rdir['analysis_time/segments'], tags=['SCIENCE_MINUS_CAT1'])
 
+# FIXME: move to ini file
+data_seg_names = ['DATA', 'ANALYZABLE_DATA']
+science_seg_names = ['TRIGGERS_PRODUCED']
+veto_data_seg_names = ['CUMULATIVE_CAT_1H']
+veto_triggers_seg_names = ['CUMULATIVE_CAT_12H', 'CUMULATIVE_CAT_123H']
+
 # write segment summary XML file
 seg_list = []
 names = []
 ifos = []
 zip_seglists = [data_segs, science_segs, insp_segs]
-zip_names = ['DATA', 'ANALYZABLE_DATA', 'TRIGGERS_PRODUCED']
+zip_names = data_seg_names + science_seg_names
 for segment_list,segment_name in zip(zip_seglists, zip_names):
     for ifo in workflow.ifos:
         seg_list.append(segment_list[ifo])
@@ -257,6 +263,12 @@ seg_summ_file = multi_segments_to_file(seg_list, filename, names, ifos)
 # make segment table for summary page
 seg_summ_table = wf.make_seg_table(workflow, [seg_summ_file], zip_names,
                                        rdir['analysis_time/segments'], ['SUMMARY'])
+
+# make segment plot for summary page
+seg_summ_plot = wf.make_seg_plot(workflow, [seg_summ_file] + cum_veto_files + final_veto_file,
+                                 rdir['analysis_time/segments'],
+                                 science_seg_names, veto_data_seg_names,
+                                 veto_triggers_seg_names, ['SUMMARY'])
 
 # Make combined injection plots
 inj_summ = []
@@ -279,7 +291,8 @@ if len(inj_files) > 0:
     inj_summ = list(grouper(inj + sen, 2))
                             
 # make full summary
-summ = [(seg_summ_table, )] + det_summ + hist_summ + [(closed_snrifar,)] + inj_summ
+summ = [(seg_summ_plot,)] + [(seg_summ_table,)] + \
+       det_summ + hist_summ + [(closed_snrifar,)] + inj_summ
 for row in summ:
     for f in row:
         if f is None:

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -114,6 +114,7 @@ ifos = ['H1', 'L1']
 
 # loop over segment XML files
 i = 0
+seg_list = []
 for segment_file in opts.segment_files:
 
     # read segment definer table
@@ -127,14 +128,11 @@ for segment_file in opts.segment_files:
             for key in seg_dict.keys():
 
                 # if IFO:SEGMENT_NAME exists then plot it
-                segs = []
                 if key.startswith(ifo+':'+segment_name):
                     segs = seg_dict[key]
 
                     # increment y position of bits
-                    y = i + .05
-                    i += 1
-                    print i
+                    y = ifos.index(ifo) + .05
 
                 else:
                     continue
@@ -161,11 +159,12 @@ for segment_file in opts.segment_files:
                 smin = start.min() if len(start) and start.min() < smin else smin
                 smax = end.max() if len(end) and end.max() > smax else smax
 
-                # add name to list
-                names += [(ifo+':'+segment_name, total, y + h + .1)]
-
                 # get patches for plotting rectangles
                 patches = plot_segs(start, end, y=y, h=h)
+
+                # add name to list
+                names += [ifo+':'+segment_name]
+                seg_list += [patches]
 
                 # loop over patches to draw rectangles
                 for j, p in enumerate(patches):
@@ -175,12 +174,8 @@ for segment_file in opts.segment_files:
                     else:
                         mpld3.plugins.connect(fig, Tooltip(p, [l], css=css))
 
-# put a text label for each segment on the plot
-for name, total, h in names:
-     pylab.text(smin, h, "%s: %s" % (name, total))
-
 # format the plot
-pylab.ylim(0, h + 0.2)
+pylab.ylim(0, len(ifos) * (h + 0.2))
 pylab.xlim(smin, smax)
 pylab.xlabel('GPS Time (s)')
 
@@ -189,6 +184,10 @@ mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fontsize=14, fmt='10f'))
 mpld3.plugins.connect(fig, mpld3.plugins.BoxZoom())
 mpld3.plugins.connect(fig, MPLSlide())
 mpld3.plugins.connect(fig, mpld3.plugins.Reset())
+legend =  mpld3.plugins.InteractiveLegendPlugin(seg_list,
+                                                names,
+                                                alpha_unsel=0.0)
+mpld3.plugins.connect(fig, legend)
 
 # save the plot as an interactive HTML
 mpld3.save_html(fig, open(opts.output_file, 'w'))

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -163,6 +163,6 @@ fig_kwds = {}
 caption = "Text."
 pycbc.results.save_fig_with_metadata(fig, opts.output_file,
                      fig_kwds=fig_kwds,
-                     title='Segments',
+                     title='Segments Timeseries',
                      cmd=' '.join(sys.argv),
                      caption=caption)

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -16,8 +16,12 @@ from pycbc.workflow import fromsegmentxml
 parser = argparse.ArgumentParser()
 parser.add_argument('--segment-files', type=str, nargs="+",
                         help='XML files with a segment definer table to read.')
-parser.add_argument('--segment-names', type=str, nargs="+", required=False,
-                        help='Names of segments in the segment definer table.')
+parser.add_argument('--science-segment-names', type=str, nargs="+", required=False,
+                        help='Names of science segments in the segment definer table.')
+parser.add_argument('--veto-data-segment-names', type=str, nargs="+", required=False,
+                        help='Names of segments for vetoing data in the segment definer table.')
+parser.add_argument('--veto-trigger-segment-names', type=str, nargs="+", required=False,
+                        help='Names of segments for vetoing triggers in the segment definer table.')
 parser.add_argument('--output-file', type=str,
                         help='Path of the output HTML file.')
 opts = parser.parse_args()
@@ -41,62 +45,7 @@ def timestr(s):
     t += "%ss " % s
     return t
 
-def get_name(segment_file):
-    """ Reads a segment file and returns the first name in the segment_definer
-    table.
-    """
-
-    from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
-    from glue import segments
-    from glue.segments import segment, segmentlist
-    # dummy class needed for loading LIGOLW files
-    class KF(ligolw.LIGOLWContentHandler):
-        pass
-    lsctables.use_in(KF)
-    indoc = ligolw_utils.load_filename(segment_file, False, contenthandler=KF)
-    n = table.get_table(indoc, 'segment_definer')[0]
-    return "%s:%s:%s" % (n.ifos, n.name, n.version)
-
-def plot_segs(start, end, color=None, y=0, h=1):
-    """ Returns the patches for making rectangles in matplotlib.
-    """
-    from itertools import cycle
-    patches = []
-    if not hasattr(plot_segs, 'colors'):
-        plot_segs.colors = cycle(['red', 'blue', 'green', 'yellow', 'cyan', 'violet'])
-        
-    if color is None:
-        color = plot_segs.colors.next()
-        
-    for s, e in zip(start, end):
-        ax = pylab.gca()
-        patch = Rectangle((s, y), (e-s), h, facecolor=color)
-        ax.add_patch(patch)
-        patches += [patch]
-        
-    return patches
-
-# Define some CSS to control our custom labels
-css = """
-    table
-    {
-      border-collapse: collapse;
     }
-    th
-    {
-      background-color: #cccccc;
-    }
-    td
-    {
-      background-color: #ffffff;
-    }
-    table, th, td
-    {
-      font-family:Arial, Helvetica, sans-serif;
-      border: 1px solid black;
-      text-align: right;
-    }
-"""
 
 # make a figure
 mpld3.plugins.DEFAULT_PLUGINS = []

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -65,7 +65,7 @@ ifos = ['H1', 'L1']
 line_collections = []
 
 # create a figure
-fig, ax = plt.subplots()
+fig, ax = plt.subplots(figsize=(16,9))
 
 # loop over segment XML files
 i = 0
@@ -159,6 +159,9 @@ mpld3.plugins.connect(fig, interactive_legend)
 pylab.ylim(0, len(ifos) * (h + 0.2))
 pylab.xlim(smin, smax)
 pylab.xlabel('GPS Time (s)')
+
+# add whitespace for the legend
+fig.subplots_adjust(left=0.1, right=0.7, top=0.9, bottom=0.1)
 
 # add plugins to the plot
 mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fontsize=14, fmt='10f'))

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -151,10 +151,10 @@ for segment_file in opts.segment_files:
                 line_collections.append(sub_line_collections)
 
 # add interactive legend
-#interactive_legend = mpld3.plugins.InteractiveLegendPlugin(line_collections,
-#                                                     names,
-#                                                     alpha_unsel=0.1)
-#mpld3.plugins.connect(fig, interactive_legend)
+interactive_legend = mpld3.plugins.InteractiveLegendPlugin(line_collections,
+                                                     names,
+                                                     alpha_unsel=0.1)
+mpld3.plugins.connect(fig, interactive_legend)
 
 # format the plot
 pylab.ylim(0, len(ifos) * (h + 0.2))

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -10,7 +10,7 @@ import itertools, datetime, time
 import sys
 from matplotlib.patches import Rectangle
 from pycbc.results.color import ifo_color
-from pycbc.results.mpld3_utils import MPLSlide, Tooltip
+from pycbc.results.mpld3_utils import MPLSlide, LineTooltip
 from pycbc.workflow import fromsegmentxml
 
 # parse command line
@@ -142,7 +142,10 @@ for segment_file in opts.segment_files:
                     """ % (segment_name, s, e, e-s)
 
                     # add tooltip for segment
-                    mpld3.plugins.connect(fig, mpld3.plugins.LineHTMLTooltip(l[0], label))
+                    if len(line_collections) < 1:
+                        mpld3.plugins.connect(fig, mpld3.plugins.LineHTMLTooltip(l[0], label))
+                    else:
+                        mpld3.plugins.connect(fig, LineTooltip(l[0], label))
 
                 # add name to list
                 names += [ifo+':'+segment_name]
@@ -162,7 +165,7 @@ pylab.xlim(smin, smax)
 pylab.xlabel('GPS Time (s)')
 
 # add whitespace for the legend
-fig.subplots_adjust(left=0.1, right=0.7, top=0.9, bottom=0.1)
+fig.subplots_adjust(left=0.0, right=0.6, top=0.9, bottom=0.1)
 
 # add plugins to the plot
 mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fontsize=14, fmt='10f'))

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -20,7 +20,7 @@ parser.add_argument('--science-segment-names', type=str, nargs="+", required=Fal
                         help='Names of science segments in the segment definer table.')
 parser.add_argument('--veto-data-segment-names', type=str, nargs="+", required=False,
                         help='Names of segments for vetoing data in the segment definer table.')
-parser.add_argument('--veto-trigger-segment-names', type=str, nargs="+", required=False,
+parser.add_argument('--veto-triggers-segment-names', type=str, nargs="+", required=False,
                         help='Names of segments for vetoing triggers in the segment definer table.')
 parser.add_argument('--output-file', type=str,
                         help='Path of the output HTML file.')
@@ -45,8 +45,6 @@ def timestr(s):
     t += "%ss " % s
     return t
 
-    }
-
 # make a figure
 mpld3.plugins.DEFAULT_PLUGINS = []
 fig = pylab.figure(figsize=[10, 5])
@@ -63,7 +61,7 @@ h = .7
 #FIXME: set IFO list
 ifos = ['H1', 'L1']
 
-
+# an empty list for holding lists of matplotlib objects for the interactive legend
 line_collections = []
 
 # create a figure
@@ -73,19 +71,30 @@ fig, ax = plt.subplots()
 i = 0
 seg_list = []
 s = []
+segment_groups = {'science' : opts.science_segment_names,
+                  'veto_data' : opts.veto_data_segment_names,
+                  'veto_triggers' : opts.veto_triggers_segment_names,
+}
+segment_names = []
+if opts.science_segment_names:
+    segment_names += opts.science_segment_names
+if opts.veto_data_segment_names:
+    segment_names += opts.veto_data_segment_names
+if opts.veto_triggers_segment_names:
+    segment_names += opts.veto_triggers_segment_names
 for segment_file in opts.segment_files:
 
     # read segment definer table
     seg_dict = fromsegmentxml(open(segment_file, 'rb'), return_dict=True)
 
     # loop over segment names
-    for segment_name in opts.segment_names:
+    for segment_name in segment_names:
 
         # get segments
         for ifo in ifos:
             for key in seg_dict.keys():
 
-                # if IFO:SEGMENT_NAME exists then plot it
+                # FIXME: if IFO:SEGMENT_NAME exists then plot it
                 if key.startswith(ifo+':'+segment_name):
                     segs = seg_dict[key]
 
@@ -111,8 +120,15 @@ for segment_file in opts.segment_files:
 
                 # plot segments
                 sub_line_collections = []
+                color = None
+                if segment_name in segment_groups['science']:
+                    color = ifo_color(ifo)
+                elif segment_name in segment_groups['veto_data']:
+                    color = 'black'
+                elif segment_name in segment_groups['veto_triggers']:
+                    color = 'blue'
                 for s,e in zip(start, end):
-                    l = ax.plot([s,e], [y,y], '-', lw=60, color=ifo_color(ifo), alpha=0.1)
+                    l = ax.plot([s,e], [y,y], '-', lw=120, color=color, alpha=0.1)
                     sub_line_collections += l
 
                     # set HTML table string
@@ -130,6 +146,7 @@ for segment_file in opts.segment_files:
                 # add name to list
                 names += [ifo+':'+segment_name]
 
+                # add list of lines to list
                 line_collections.append(sub_line_collections)
 
 # add interactive legend

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+""" Make interactive visualization of segments
+"""
+
+import argparse, pycbc.version
+import matplotlib; matplotlib.use('Agg')
+import numpy, pylab, pycbc.events, mpld3, mpld3.plugins
+import itertools, datetime, time
+from matplotlib.patches import Rectangle
+from pycbc.results.mpld3_utils import MPLSlide, Tooltip
+
+# parse command line
+parser = argparse.ArgumentParser()
+parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
+parser.add_argument('--segment-files', nargs='+', help="List of segment files to plot")
+parser.add_argument('--output-file', help="output html file")
+args = parser.parse_args()
+
+def timestr(s):
+    """ Takes seconds and returns a human-readable string for the amount
+    of time.
+    """
+
+    t = ""
+    s = int(s)
+    d = s / 86400
+    t += "%sd " % d if d else ""
+    s -= d * 86400
+    h = s / 3600
+    t += "%sh " % h if h else ""
+    s -= h * 3600
+    m = s / 60
+    t += "%sm " % m if m else ""
+    s -= m * 60
+    t += "%ss " % s
+    return t
+
+def get_name(segment_file):
+    """ Reads a segment file and returns the first name in the segment_definer
+    table.
+    """
+
+    from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
+    from glue import segments
+    from glue.segments import segment, segmentlist
+    # dummy class needed for loading LIGOLW files
+    class KF(ligolw.LIGOLWContentHandler):
+        pass
+    lsctables.use_in(KF)
+    indoc = ligolw_utils.load_filename(segment_file, False, contenthandler=KF)
+    n = table.get_table(indoc, 'segment_definer')[0]
+    return "%s:%s:%s" % (n.ifos, n.name, n.version)
+
+def plot_segs(start, end, color=None, y=0, h=1):
+    """ Returns the patches for making rectangles in matplotlib.
+    """
+    from itertools import cycle
+    patches = []
+    if not hasattr(plot_segs, 'colors'):
+        plot_segs.colors = cycle(['red', 'blue', 'green', 'yellow', 'cyan', 'violet'])
+        
+    if color is None:
+        color = plot_segs.colors.next()
+        
+    for s, e in zip(start, end):
+        ax = pylab.gca()
+        patch = Rectangle((s, y), (e-s), h, facecolor=color)
+        ax.add_patch(patch)
+        patches += [patch]
+        
+    return patches
+
+# Define some CSS to control our custom labels
+css = """
+    table
+    {
+      border-collapse: collapse;
+    }
+    th
+    {
+      background-color: #cccccc;
+    }
+    td
+    {
+      background-color: #ffffff;
+    }
+    table, th, td
+    {
+      font-family:Arial, Helvetica, sans-serif;
+      border: 1px solid black;
+      text-align: right;
+    }
+"""
+
+# make a figure
+mpld3.plugins.DEFAULT_PLUGINS = []
+fig = pylab.figure(figsize=[10, 5])
+
+# an empty list for holding segment names
+names = []
+
+# limits to accept GPS times
+smin, smax = numpy.inf, -numpy.inf
+
+# loop over segment XML files
+for i, seg_file in enumerate(args.segment_files):
+
+    # increment y position of bits
+    y = i + .05
+
+    # set height of bits
+    h = .7
+
+    # FIXME: only looks at first entry in seg_definer table
+    # get name of segment
+    name = get_name(seg_file)
+
+    # get a start time and end time array
+    start, end = pycbc.events.start_end_from_segments(seg_file)
+
+    # get an array for the duration of each segment
+    dur = end - start
+
+    # total amount of time for segment
+    total = timestr(abs(pycbc.events.start_end_to_segments(start, end).coalesce()))
+
+    # set HTML table string
+    label = """<table>
+             <tr><th>Start</th><td>%.0f</td></tr>
+             <tr><th>End</th><td>%.0f</td></tr>
+             <tr><th>Duration</th><td>%s</td></tr>
+      </table>
+    """
+
+    # get the start and end of the timeseries
+    smin = start.min() if len(start) and start.min() < smin else smin
+    smax = end.max() if len(end) and end.max() > smax else smax
+
+    # add name to list
+    names += [(name, total, y + h + .1)]
+
+    # get patches for plotting rectangles
+    patches = plot_segs(start, end, y=y, h=h)
+
+    # loop over patches to draw rectangles
+    for i, p in enumerate(patches):
+        l = label % (start[i], end[i], timestr(dur[i]))
+        if i == 0:
+            mpld3.plugins.connect(fig, mpld3.plugins.PointHTMLTooltip(p, [l], css=css))
+        else:
+            mpld3.plugins.connect(fig, Tooltip(p, [l], css=css))
+
+# put a text label for each segment on the plot
+for name, total, h in names:
+     pylab.text(smin, h, "%s: %s" % (name, total))
+
+# format the plot
+pylab.ylim(0, h + 0.2)
+pylab.xlim(smin, smax)
+pylab.xlabel('GPS Time (s)')
+
+# format the plot
+mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fontsize=14, fmt='10f'))
+mpld3.plugins.connect(fig, mpld3.plugins.BoxZoom())
+mpld3.plugins.connect(fig, MPLSlide())
+mpld3.plugins.connect(fig, mpld3.plugins.Reset())
+
+# save the plot as an interactive HTML
+mpld3.save_html(fig, open(args.output_file, 'w'))

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import numpy, pylab, pycbc.events, mpld3, mpld3.plugins
 import itertools, datetime, time
 import sys
+from itertools import cycle
 from matplotlib.patches import Rectangle
 from pycbc.results.color import ifo_color
 from pycbc.results.mpld3_utils import MPLSlide, LineTooltip
@@ -17,12 +18,8 @@ from pycbc.workflow import fromsegmentxml
 parser = argparse.ArgumentParser()
 parser.add_argument('--segment-files', type=str, nargs="+",
                         help='XML files with a segment definer table to read.')
-parser.add_argument('--science-segment-names', type=str, nargs="+", required=False,
-                        help='Names of science segments in the segment definer table.')
-parser.add_argument('--veto-data-segment-names', type=str, nargs="+", required=False,
-                        help='Names of segments for vetoing data in the segment definer table.')
-parser.add_argument('--veto-triggers-segment-names', type=str, nargs="+", required=False,
-                        help='Names of segments for vetoing triggers in the segment definer table.')
+parser.add_argument('--segment-names', type=str, nargs="+", required=False,
+                        help='Names of segments in the segment definer table.')
 parser.add_argument('--output-file', type=str,
                         help='Path of the output HTML file.')
 opts = parser.parse_args()
@@ -45,6 +42,9 @@ def timestr(s):
     s -= m * 60
     t += "%ss " % s
     return t
+
+# set colors
+color_cycle = cycle(['red', 'blue', 'green', 'yellow', 'cyan', 'violet'])
 
 # make a figure
 mpld3.plugins.DEFAULT_PLUGINS = []
@@ -72,24 +72,16 @@ fig, ax = plt.subplots(figsize=(16,9))
 i = 0
 seg_list = []
 s = []
-segment_groups = {'science' : opts.science_segment_names,
-                  'veto_data' : opts.veto_data_segment_names,
-                  'veto_triggers' : opts.veto_triggers_segment_names,
-}
-segment_names = []
-if opts.science_segment_names:
-    segment_names += opts.science_segment_names
-if opts.veto_data_segment_names:
-    segment_names += opts.veto_data_segment_names
-if opts.veto_triggers_segment_names:
-    segment_names += opts.veto_triggers_segment_names
 for segment_file in opts.segment_files:
 
     # read segment definer table
     seg_dict = fromsegmentxml(open(segment_file, 'rb'), return_dict=True)
 
     # loop over segment names
-    for segment_name in segment_names:
+    for segment_name in opts.segment_names:
+
+        # get new color for this segment name
+        color = color_cycle.next()
 
         # get segments
         for ifo in ifos:
@@ -121,13 +113,6 @@ for segment_file in opts.segment_files:
 
                 # plot segments
                 sub_line_collections = []
-                color = None
-                if segment_name in segment_groups['science']:
-                    color = ifo_color(ifo)
-                elif segment_name in segment_groups['veto_data']:
-                    color = 'black'
-                elif segment_name in segment_groups['veto_triggers']:
-                    color = 'blue'
                 for s,e in zip(start, end):
                     l = ax.plot([s,e], [y,y], '-', lw=120, color=color, alpha=0.1)
                     sub_line_collections += l

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -8,13 +8,17 @@ import numpy, pylab, pycbc.events, mpld3, mpld3.plugins
 import itertools, datetime, time
 from matplotlib.patches import Rectangle
 from pycbc.results.mpld3_utils import MPLSlide, Tooltip
+from pycbc.workflow import fromsegmentxml
 
 # parse command line
 parser = argparse.ArgumentParser()
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
-parser.add_argument('--segment-files', nargs='+', help="List of segment files to plot")
-parser.add_argument('--output-file', help="output html file")
-args = parser.parse_args()
+parser.add_argument('--segment-files', type=str, nargs="+",
+                        help='XML files with a segment definer table to read.')
+parser.add_argument('--segment-names', type=str, nargs="+", required=False,
+                        help='Names of segments in the segment definer table.')
+parser.add_argument('--output-file', type=str,
+                        help='Path of the output HTML file.')
+opts = parser.parse_args()
 
 def timestr(s):
     """ Takes seconds and returns a human-readable string for the amount
@@ -99,56 +103,77 @@ fig = pylab.figure(figsize=[10, 5])
 # an empty list for holding segment names
 names = []
 
-# limits to accept GPS times
+# default x-axis limits
 smin, smax = numpy.inf, -numpy.inf
 
+# set height of rectangles
+h = .7
+
+#FIXME: set IFO list
+ifos = ['H1', 'L1']
+
 # loop over segment XML files
-for i, seg_file in enumerate(args.segment_files):
+i = 0
+for segment_file in opts.segment_files:
 
-    # increment y position of bits
-    y = i + .05
+    # read segment definer table
+    seg_dict = fromsegmentxml(open(segment_file, 'rb'), return_dict=True)
 
-    # set height of bits
-    h = .7
+    # loop over segment names
+    for segment_name in opts.segment_names:
 
-    # FIXME: only looks at first entry in seg_definer table
-    # get name of segment
-    name = get_name(seg_file)
+        # get segments
+        for ifo in ifos:
+            for key in seg_dict.keys():
 
-    # get a start time and end time array
-    start, end = pycbc.events.start_end_from_segments(seg_file)
+                # if IFO:SEGMENT_NAME exists then plot it
+                segs = []
+                if key.startswith(ifo+':'+segment_name):
+                    segs = seg_dict[key]
 
-    # get an array for the duration of each segment
-    dur = end - start
+                    # increment y position of bits
+                    y = i + .05
+                    i += 1
+                    print i
 
-    # total amount of time for segment
-    total = timestr(abs(pycbc.events.start_end_to_segments(start, end).coalesce()))
+                else:
+                    continue
 
-    # set HTML table string
-    label = """<table>
-             <tr><th>Start</th><td>%.0f</td></tr>
-             <tr><th>End</th><td>%.0f</td></tr>
-             <tr><th>Duration</th><td>%s</td></tr>
-      </table>
-    """
+                # get a start time and end time array
+                start = numpy.array([float(seg[0]) for seg in segs])
+                end = numpy.array([float(seg[1]) for seg in segs])
 
-    # get the start and end of the timeseries
-    smin = start.min() if len(start) and start.min() < smin else smin
-    smax = end.max() if len(end) and end.max() > smax else smax
+                # get an array for the duration of each segment
+                dur = end - start
 
-    # add name to list
-    names += [(name, total, y + h + .1)]
+                # total amount of time for segment
+                total = timestr(abs(pycbc.events.start_end_to_segments(start, end).coalesce()))
 
-    # get patches for plotting rectangles
-    patches = plot_segs(start, end, y=y, h=h)
+                # set HTML table string
+                label = """<table>
+                         <tr><th>Start</th><td>%.0f</td></tr>
+                         <tr><th>End</th><td>%.0f</td></tr>
+                         <tr><th>Duration</th><td>%s</td></tr>
+                     </table>
+                """
 
-    # loop over patches to draw rectangles
-    for i, p in enumerate(patches):
-        l = label % (start[i], end[i], timestr(dur[i]))
-        if i == 0:
-            mpld3.plugins.connect(fig, mpld3.plugins.PointHTMLTooltip(p, [l], css=css))
-        else:
-            mpld3.plugins.connect(fig, Tooltip(p, [l], css=css))
+                # get the start and end of the timeseries
+                smin = start.min() if len(start) and start.min() < smin else smin
+                smax = end.max() if len(end) and end.max() > smax else smax
+
+                # add name to list
+                names += [(ifo+':'+segment_name, total, y + h + .1)]
+
+                # get patches for plotting rectangles
+                patches = plot_segs(start, end, y=y, h=h)
+
+                # loop over patches to draw rectangles
+                for j, p in enumerate(patches):
+                    l = label % (start[j], end[j], timestr(dur[j]))
+                    if i == 0:
+                        mpld3.plugins.connect(fig, mpld3.plugins.PointHTMLTooltip(p, [l], css=css))
+                    else:
+                        mpld3.plugins.connect(fig, Tooltip(p, [l], css=css))
 
 # put a text label for each segment on the plot
 for name, total, h in names:
@@ -166,4 +191,4 @@ mpld3.plugins.connect(fig, MPLSlide())
 mpld3.plugins.connect(fig, mpld3.plugins.Reset())
 
 # save the plot as an interactive HTML
-mpld3.save_html(fig, open(args.output_file, 'w'))
+mpld3.save_html(fig, open(opts.output_file, 'w'))

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -10,6 +10,7 @@ import itertools, datetime, time
 import sys
 from itertools import cycle
 from matplotlib.patches import Rectangle
+from pycbc.events.veto import get_segment_definer_comments
 from pycbc.results.color import ifo_color
 from pycbc.results.mpld3_utils import MPLSlide, LineTooltip
 from pycbc.workflow import fromsegmentxml
@@ -62,6 +63,9 @@ h = .7
 #FIXME: set IFO list
 ifos = ['H1', 'L1']
 
+# set caption beginning
+caption = "This plots shows each segment. Shown are: "
+
 # an empty list for holding lists of matplotlib objects for the interactive legend
 line_collections = []
 
@@ -76,6 +80,9 @@ for segment_file in opts.segment_files:
 
     # read segment definer table
     seg_dict = fromsegmentxml(open(segment_file, 'rb'), return_dict=True)
+
+    # read comments from segment definer table
+    comment_dict = get_segment_definer_comments(open(segment_file, 'rb'))
 
     # loop over segment names
     for segment_name in opts.segment_names:
@@ -97,15 +104,18 @@ for segment_file in opts.segment_files:
                 else:
                     continue
 
+                # put comment in caption
+                caption += segment_name
+                if comment_dict[key] != None:
+                    caption += " ("+comment_dict[key]+")"
+                caption += " "
+
                 # get a start time and end time array
                 start = numpy.array([float(seg[0]) for seg in segs])
                 end = numpy.array([float(seg[1]) for seg in segs])
 
                 # get an array for the duration of each segment
                 dur = end - start
-
-                # total amount of time for segment
-                total = timestr(abs(pycbc.events.start_end_to_segments(start, end).coalesce()))
 
                 # get the start and end of the timeseries
                 smin = start.min() if len(start) and start.min() < smin else smin
@@ -160,7 +170,6 @@ mpld3.plugins.connect(fig, mpld3.plugins.Reset())
 
 # save the plot as an interactive HTML
 fig_kwds = {}
-caption = "Text."
 pycbc.results.save_fig_with_metadata(fig, opts.output_file,
                      fig_kwds=fig_kwds,
                      title='Segments Timeseries',

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -7,6 +7,7 @@ import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy, pylab, pycbc.events, mpld3, mpld3.plugins
 import itertools, datetime, time
+import sys
 from matplotlib.patches import Rectangle
 from pycbc.results.color import ifo_color
 from pycbc.results.mpld3_utils import MPLSlide, Tooltip
@@ -150,10 +151,10 @@ for segment_file in opts.segment_files:
                 line_collections.append(sub_line_collections)
 
 # add interactive legend
-interactive_legend = mpld3.plugins.InteractiveLegendPlugin(line_collections,
-                                                     names,
-                                                     alpha_unsel=0.1)
-mpld3.plugins.connect(fig, interactive_legend)
+#interactive_legend = mpld3.plugins.InteractiveLegendPlugin(line_collections,
+#                                                     names,
+#                                                     alpha_unsel=0.1)
+#mpld3.plugins.connect(fig, interactive_legend)
 
 # format the plot
 pylab.ylim(0, len(ifos) * (h + 0.2))
@@ -170,4 +171,10 @@ mpld3.plugins.connect(fig, MPLSlide())
 mpld3.plugins.connect(fig, mpld3.plugins.Reset())
 
 # save the plot as an interactive HTML
-mpld3.save_html(fig, open(opts.output_file, 'w'))
+fig_kwds = {}
+caption = "Text."
+pycbc.results.save_fig_with_metadata(fig, opts.output_file,
+                     fig_kwds=fig_kwds,
+                     title='Segments',
+                     cmd=' '.join(sys.argv),
+                     caption=caption)

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -1,6 +1,20 @@
-#!/usr/bin/env python
-""" Make interactive visualization of segments
-"""
+#!/usr/bin/python
+
+# Copyright (C) 2015 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import argparse, pycbc.version
 import matplotlib; matplotlib.use('Agg')
@@ -49,7 +63,7 @@ color_cycle = cycle(['red', 'blue', 'green', 'yellow', 'cyan', 'violet'])
 
 # make a figure
 mpld3.plugins.DEFAULT_PLUGINS = []
-fig = pylab.figure(figsize=[10, 5])
+fig = pylab.figure(figsize=[10, 3])
 
 # an empty list for holding segment names
 names = []

--- a/bin/hdfcoinc/pycbc_page_segplot
+++ b/bin/hdfcoinc/pycbc_page_segplot
@@ -4,9 +4,11 @@
 
 import argparse, pycbc.version
 import matplotlib; matplotlib.use('Agg')
+import matplotlib.pyplot as plt
 import numpy, pylab, pycbc.events, mpld3, mpld3.plugins
 import itertools, datetime, time
 from matplotlib.patches import Rectangle
+from pycbc.results.color import ifo_color
 from pycbc.results.mpld3_utils import MPLSlide, Tooltip
 from pycbc.workflow import fromsegmentxml
 
@@ -112,9 +114,16 @@ h = .7
 #FIXME: set IFO list
 ifos = ['H1', 'L1']
 
+
+line_collections = []
+
+# create a figure
+fig, ax = plt.subplots()
+
 # loop over segment XML files
 i = 0
 seg_list = []
+s = []
 for segment_file in opts.segment_files:
 
     # read segment definer table
@@ -132,7 +141,7 @@ for segment_file in opts.segment_files:
                     segs = seg_dict[key]
 
                     # increment y position of bits
-                    y = ifos.index(ifo) + .05
+                    y = ifos.index(ifo) + 0.33
 
                 else:
                     continue
@@ -147,47 +156,49 @@ for segment_file in opts.segment_files:
                 # total amount of time for segment
                 total = timestr(abs(pycbc.events.start_end_to_segments(start, end).coalesce()))
 
-                # set HTML table string
-                label = """<table>
-                         <tr><th>Start</th><td>%.0f</td></tr>
-                         <tr><th>End</th><td>%.0f</td></tr>
-                         <tr><th>Duration</th><td>%s</td></tr>
-                     </table>
-                """
-
                 # get the start and end of the timeseries
                 smin = start.min() if len(start) and start.min() < smin else smin
                 smax = end.max() if len(end) and end.max() > smax else smax
 
-                # get patches for plotting rectangles
-                patches = plot_segs(start, end, y=y, h=h)
+                # plot segments
+                sub_line_collections = []
+                for s,e in zip(start, end):
+                    l = ax.plot([s,e], [y,y], '-', lw=60, color=ifo_color(ifo), alpha=0.1)
+                    sub_line_collections += l
+
+                    # set HTML table string
+                    label = """<table>
+                             <tr><th>Segment Name</th><td>%s</td></tr>
+                             <tr><th>Start</th><td>%.0f</td></tr>
+                             <tr><th>End</th><td>%.0f</td></tr>
+                             <tr><th>Duration</th><td>%s</td></tr>
+                         </table>
+                    """ % (segment_name, s, e, e-s)
+
+                    # add tooltip for segment
+                    mpld3.plugins.connect(fig, mpld3.plugins.LineHTMLTooltip(l[0], label))
 
                 # add name to list
                 names += [ifo+':'+segment_name]
-                seg_list += [patches]
 
-                # loop over patches to draw rectangles
-                for j, p in enumerate(patches):
-                    l = label % (start[j], end[j], timestr(dur[j]))
-                    if i == 0:
-                        mpld3.plugins.connect(fig, mpld3.plugins.PointHTMLTooltip(p, [l], css=css))
-                    else:
-                        mpld3.plugins.connect(fig, Tooltip(p, [l], css=css))
+                line_collections.append(sub_line_collections)
+
+# add interactive legend
+interactive_legend = mpld3.plugins.InteractiveLegendPlugin(line_collections,
+                                                     names,
+                                                     alpha_unsel=0.1)
+mpld3.plugins.connect(fig, interactive_legend)
 
 # format the plot
 pylab.ylim(0, len(ifos) * (h + 0.2))
 pylab.xlim(smin, smax)
 pylab.xlabel('GPS Time (s)')
 
-# format the plot
+# add plugins to the plot
 mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fontsize=14, fmt='10f'))
 mpld3.plugins.connect(fig, mpld3.plugins.BoxZoom())
 mpld3.plugins.connect(fig, MPLSlide())
 mpld3.plugins.connect(fig, mpld3.plugins.Reset())
-legend =  mpld3.plugins.InteractiveLegendPlugin(seg_list,
-                                                names,
-                                                alpha_unsel=0.0)
-mpld3.plugins.connect(fig, legend)
 
 # save the plot as an interactive HTML
 mpld3.save_html(fig, open(opts.output_file, 'w'))

--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -126,6 +126,6 @@ fig_kwds = {}
 html_table = pycbc.results.table(vals, keys, page_size=10)
 save_fig_with_metadata(str(html_table), opts.output_file,
                      fig_kwds=fig_kwds,
-                     title='Segments',
+                     title='Segments Table',
                      cmd=' '.join(sys.argv),
                      caption=caption)

--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -26,33 +26,9 @@ from glue.ligolw import ligolw
 from glue.ligolw import lsctables
 from glue.ligolw import table
 from glue.ligolw import utils
+from pycbc.events.veto import get_segment_definer_comments
 from pycbc.results import save_fig_with_metadata
 from pycbc.workflow import fromsegmentxml
-
-class ContentHandler(ligolw.LIGOLWContentHandler):
-    pass
-lsctables.use_in(ContentHandler)
-
-def get_segment_definer_comments(xml_file):
-    """ Returns a dict with the comment column as the value for each segment.
-    """
-
-    # read segment definer table
-    xmldoc, digest = utils.load_fileobj(xml_file,
-                                        gz=xml_file.name.endswith(".gz"),
-                                        contenthandler=ContentHandler)
-    seg_def_table = table.get_table(xmldoc,
-                                    lsctables.SegmentDefTable.tableName)
-
-    # put comment column into a dict
-    comment_dict = {}
-    for seg_def in seg_def_table:
-        full_channel_name = ':'.join([str(seg_def.ifos),
-                                      str(seg_def.name),
-                                      str(seg_def.version)])
-        comment_dict[full_channel_name] = seg_def.comment
-
-    return comment_dict
 
 # parse command line
 parser = argparse.ArgumentParser()

--- a/bin/pycbc_make_html_page
+++ b/bin/pycbc_make_html_page
@@ -186,6 +186,7 @@ env = Environment(loader=FileSystemLoader(input_path))
 env.globals.update(setup_template_render=setup_template_render)
 env.globals.update(get_embedded_config=get_embedded_config)
 env.globals.update(path_exists=os.path.exists)
+env.globals.update(list=list)
 template = env.get_template(input_template)
 
 # find all subdirs and the top-level subdirs

--- a/pycbc/events/veto.py
+++ b/pycbc/events/veto.py
@@ -255,4 +255,27 @@ def indices_outside_segments(times, segment_files, ifo=None, segment_name=None):
                                          ifo=ifo, segment_name=segment_name)
     indices = numpy.arange(0, len(times))
     return numpy.delete(indices, exclude), segs
-    
+
+def get_segment_definer_comments(xml_file):
+    """ Returns a dict with the comment column as the value for each segment.
+    """
+
+    from glue.ligolw.ligolw import LIGOLWContentHandler as h
+    lsctables.use_in(h)
+
+    # read segment definer table
+    xmldoc, digest = ligolw_utils.load_fileobj(xml_file,
+                                        gz=xml_file.name.endswith(".gz"),
+                                        contenthandler=h)
+    seg_def_table = table.get_table(xmldoc,
+                                    lsctables.SegmentDefTable.tableName)
+
+    # put comment column into a dict
+    comment_dict = {}
+    for seg_def in seg_def_table:
+        full_channel_name = ':'.join([str(seg_def.ifos),
+                                      str(seg_def.name),
+                                      str(seg_def.version)])
+        comment_dict[full_channel_name] = seg_def.comment
+
+    return comment_dict

--- a/pycbc/future.py
+++ b/pycbc/future.py
@@ -355,3 +355,479 @@ def _nearest_real_complex_idx(fro, to, which):
     if which == 'complex':
         mask = ~mask
     return order[np.where(mask)[0][0]]
+
+"""A parser for HTML and XHTML."""
+
+# This file is based on sgmllib.py, but the API is slightly different.
+
+# XXX There should be a way to distinguish between PCDATA (parsed
+# character data -- the normal case), RCDATA (replaceable character
+# data -- only char and entity references and end tags are special)
+# and CDATA (character data -- only end tags are special).
+
+
+import markupbase
+import re
+
+# Regular expressions used for parsing
+
+interesting_normal = re.compile('[&<]')
+incomplete = re.compile('&[a-zA-Z#]')
+
+entityref = re.compile('&([a-zA-Z][-.a-zA-Z0-9]*)[^a-zA-Z0-9]')
+charref = re.compile('&#(?:[0-9]+|[xX][0-9a-fA-F]+)[^0-9a-fA-F]')
+
+starttagopen = re.compile('<[a-zA-Z]')
+piclose = re.compile('>')
+commentclose = re.compile(r'--\s*>')
+
+# see http://www.w3.org/TR/html5/tokenization.html#tag-open-state
+# and http://www.w3.org/TR/html5/tokenization.html#tag-name-state
+# note: if you change tagfind/attrfind remember to update locatestarttagend too
+tagfind = re.compile('([a-zA-Z][^\t\n\r\f />\x00]*)(?:\s|/(?!>))*')
+# this regex is currently unused, but left for backward compatibility
+tagfind_tolerant = re.compile('[a-zA-Z][^\t\n\r\f />\x00]*')
+
+attrfind = re.compile(
+    r'((?<=[\'"\s/])[^\s/>][^\s/=>]*)(\s*=+\s*'
+    r'(\'[^\']*\'|"[^"]*"|(?![\'"])[^>\s]*))?(?:\s|/(?!>))*')
+
+locatestarttagend = re.compile(r"""
+  <[a-zA-Z][^\t\n\r\f />\x00]*       # tag name
+  (?:[\s/]*                          # optional whitespace before attribute name
+    (?:(?<=['"\s/])[^\s/>][^\s/=>]*  # attribute name
+      (?:\s*=+\s*                    # value indicator
+        (?:'[^']*'                   # LITA-enclosed value
+          |"[^"]*"                   # LIT-enclosed value
+          |(?!['"])[^>\s]*           # bare value
+         )
+       )?(?:\s|/(?!>))*
+     )*
+   )?
+  \s*                                # trailing whitespace
+""", re.VERBOSE)
+endendtag = re.compile('>')
+# the HTML 5 spec, section 8.1.2.2, doesn't allow spaces between
+# </ and the tag name, so maybe this should be fixed
+endtagfind = re.compile('</\s*([a-zA-Z][-.a-zA-Z0-9:_]*)\s*>')
+
+
+class HTMLParseError(Exception):
+    """Exception raised for all parse errors."""
+
+    def __init__(self, msg, position=(None, None)):
+        assert msg
+        self.msg = msg
+        self.lineno = position[0]
+        self.offset = position[1]
+
+    def __str__(self):
+        result = self.msg
+        if self.lineno is not None:
+            result = result + ", at line %d" % self.lineno
+        if self.offset is not None:
+            result = result + ", column %d" % (self.offset + 1)
+        return result
+
+
+class HTMLParser(markupbase.ParserBase):
+    """Find tags and other markup and call handler functions.
+
+    Usage:
+        p = HTMLParser()
+        p.feed(data)
+        ...
+        p.close()
+
+    Start tags are handled by calling self.handle_starttag() or
+    self.handle_startendtag(); end tags by self.handle_endtag().  The
+    data between tags is passed from the parser to the derived class
+    by calling self.handle_data() with the data as argument (the data
+    may be split up in arbitrary chunks).  Entity references are
+    passed by calling self.handle_entityref() with the entity
+    reference as the argument.  Numeric character references are
+    passed to self.handle_charref() with the string containing the
+    reference as the argument.
+    """
+
+    CDATA_CONTENT_ELEMENTS = ("script", "style")
+
+
+    def __init__(self):
+        """Initialize and reset this instance."""
+        self.reset()
+
+    def reset(self):
+        """Reset this instance.  Loses all unprocessed data."""
+        self.rawdata = ''
+        self.lasttag = '???'
+        self.interesting = interesting_normal
+        self.cdata_elem = None
+        markupbase.ParserBase.reset(self)
+
+    def feed(self, data):
+        r"""Feed data to the parser.
+
+        Call this as often as you want, with as little or as much text
+        as you want (may include '\n').
+        """
+        self.rawdata = self.rawdata + data
+        self.goahead(0)
+
+    def close(self):
+        """Handle any buffered data."""
+        self.goahead(1)
+
+    def error(self, message):
+        raise HTMLParseError(message, self.getpos())
+
+    __starttag_text = None
+
+    def get_starttag_text(self):
+        """Return full source of start tag: '<...>'."""
+        return self.__starttag_text
+
+    def set_cdata_mode(self, elem):
+        self.cdata_elem = elem.lower()
+        self.interesting = re.compile(r'</\s*%s\s*>' % self.cdata_elem, re.I)
+
+    def clear_cdata_mode(self):
+        self.interesting = interesting_normal
+        self.cdata_elem = None
+
+    # Internal -- handle data as far as reasonable.  May leave state
+    # and data to be processed by a subsequent call.  If 'end' is
+    # true, force handling all data as if followed by EOF marker.
+    def goahead(self, end):
+        rawdata = self.rawdata
+        i = 0
+        n = len(rawdata)
+        while i < n:
+            match = self.interesting.search(rawdata, i) # < or &
+            if match:
+                j = match.start()
+            else:
+                if self.cdata_elem:
+                    break
+                j = n
+            if i < j: self.handle_data(rawdata[i:j])
+            i = self.updatepos(i, j)
+            if i == n: break
+            startswith = rawdata.startswith
+            if startswith('<', i):
+                if starttagopen.match(rawdata, i): # < + letter
+                    k = self.parse_starttag(i)
+                elif startswith("</", i):
+                    k = self.parse_endtag(i)
+                elif startswith("<!--", i):
+                    k = self.parse_comment(i)
+                elif startswith("<?", i):
+                    k = self.parse_pi(i)
+                elif startswith("<!", i):
+                    k = self.parse_html_declaration(i)
+                elif (i + 1) < n:
+                    self.handle_data("<")
+                    k = i + 1
+                else:
+                    break
+                if k < 0:
+                    if not end:
+                        break
+                    k = rawdata.find('>', i + 1)
+                    if k < 0:
+                        k = rawdata.find('<', i + 1)
+                        if k < 0:
+                            k = i + 1
+                    else:
+                        k += 1
+                    self.handle_data(rawdata[i:k])
+                i = self.updatepos(i, k)
+            elif startswith("&#", i):
+                match = charref.match(rawdata, i)
+                if match:
+                    name = match.group()[2:-1]
+                    self.handle_charref(name)
+                    k = match.end()
+                    if not startswith(';', k-1):
+                        k = k - 1
+                    i = self.updatepos(i, k)
+                    continue
+                else:
+                    if ";" in rawdata[i:]:  # bail by consuming '&#'
+                        self.handle_data(rawdata[i:i+2])
+                        i = self.updatepos(i, i+2)
+                    break
+            elif startswith('&', i):
+                match = entityref.match(rawdata, i)
+                if match:
+                    name = match.group(1)
+                    self.handle_entityref(name)
+                    k = match.end()
+                    if not startswith(';', k-1):
+                        k = k - 1
+                    i = self.updatepos(i, k)
+                    continue
+                match = incomplete.match(rawdata, i)
+                if match:
+                    # match.group() will contain at least 2 chars
+                    if end and match.group() == rawdata[i:]:
+                        self.error("EOF in middle of entity or char ref")
+                    # incomplete
+                    break
+                elif (i + 1) < n:
+                    # not the end of the buffer, and can't be confused
+                    # with some other construct
+                    self.handle_data("&")
+                    i = self.updatepos(i, i + 1)
+                else:
+                    break
+            else:
+                assert 0, "interesting.search() lied"
+        # end while
+        if end and i < n and not self.cdata_elem:
+            self.handle_data(rawdata[i:n])
+            i = self.updatepos(i, n)
+        self.rawdata = rawdata[i:]
+
+    # Internal -- parse html declarations, return length or -1 if not terminated
+    # See w3.org/TR/html5/tokenization.html#markup-declaration-open-state
+    # See also parse_declaration in _markupbase
+    def parse_html_declaration(self, i):
+        rawdata = self.rawdata
+        if rawdata[i:i+2] != '<!':
+            self.error('unexpected call to parse_html_declaration()')
+        if rawdata[i:i+4] == '<!--':
+            # this case is actually already handled in goahead()
+            return self.parse_comment(i)
+        elif rawdata[i:i+3] == '<![':
+            return self.parse_marked_section(i)
+        elif rawdata[i:i+9].lower() == '<!doctype':
+            # find the closing >
+            gtpos = rawdata.find('>', i+9)
+            if gtpos == -1:
+                return -1
+            self.handle_decl(rawdata[i+2:gtpos])
+            return gtpos+1
+        else:
+            return self.parse_bogus_comment(i)
+
+    # Internal -- parse bogus comment, return length or -1 if not terminated
+    # see http://www.w3.org/TR/html5/tokenization.html#bogus-comment-state
+    def parse_bogus_comment(self, i, report=1):
+        rawdata = self.rawdata
+        if rawdata[i:i+2] not in ('<!', '</'):
+            self.error('unexpected call to parse_comment()')
+        pos = rawdata.find('>', i+2)
+        if pos == -1:
+            return -1
+        if report:
+            self.handle_comment(rawdata[i+2:pos])
+        return pos + 1
+
+    # Internal -- parse processing instr, return end or -1 if not terminated
+    def parse_pi(self, i):
+        rawdata = self.rawdata
+        assert rawdata[i:i+2] == '<?', 'unexpected call to parse_pi()'
+        match = piclose.search(rawdata, i+2) # >
+        if not match:
+            return -1
+        j = match.start()
+        self.handle_pi(rawdata[i+2: j])
+        j = match.end()
+        return j
+
+    # Internal -- handle starttag, return end or -1 if not terminated
+    def parse_starttag(self, i):
+        self.__starttag_text = None
+        endpos = self.check_for_whole_start_tag(i)
+        if endpos < 0:
+            return endpos
+        rawdata = self.rawdata
+        self.__starttag_text = rawdata[i:endpos]
+
+        # Now parse the data between i+1 and j into a tag and attrs
+        attrs = []
+        match = tagfind.match(rawdata, i+1)
+        assert match, 'unexpected call to parse_starttag()'
+        k = match.end()
+        self.lasttag = tag = match.group(1).lower()
+
+        while k < endpos:
+            m = attrfind.match(rawdata, k)
+            if not m:
+                break
+            attrname, rest, attrvalue = m.group(1, 2, 3)
+            if not rest:
+                attrvalue = None
+            elif attrvalue[:1] == '\'' == attrvalue[-1:] or \
+                 attrvalue[:1] == '"' == attrvalue[-1:]:
+                attrvalue = attrvalue[1:-1]
+            if attrvalue:
+                attrvalue = self.unescape(attrvalue)
+            attrs.append((attrname.lower(), attrvalue))
+            k = m.end()
+
+        end = rawdata[k:endpos].strip()
+        if end not in (">", "/>"):
+            lineno, offset = self.getpos()
+            if "\n" in self.__starttag_text:
+                lineno = lineno + self.__starttag_text.count("\n")
+                offset = len(self.__starttag_text) \
+                         - self.__starttag_text.rfind("\n")
+            else:
+                offset = offset + len(self.__starttag_text)
+            self.handle_data(rawdata[i:endpos])
+            return endpos
+        if end.endswith('/>'):
+            # XHTML-style empty tag: <span attr="value" />
+            self.handle_startendtag(tag, attrs)
+        else:
+            self.handle_starttag(tag, attrs)
+            if tag in self.CDATA_CONTENT_ELEMENTS:
+                self.set_cdata_mode(tag)
+        return endpos
+
+    # Internal -- check to see if we have a complete starttag; return end
+    # or -1 if incomplete.
+    def check_for_whole_start_tag(self, i):
+        rawdata = self.rawdata
+        m = locatestarttagend.match(rawdata, i)
+        if m:
+            j = m.end()
+            next = rawdata[j:j+1]
+            if next == ">":
+                return j + 1
+            if next == "/":
+                if rawdata.startswith("/>", j):
+                    return j + 2
+                if rawdata.startswith("/", j):
+                    # buffer boundary
+                    return -1
+                # else bogus input
+                self.updatepos(i, j + 1)
+                self.error("malformed empty start tag")
+            if next == "":
+                # end of input
+                return -1
+            if next in ("abcdefghijklmnopqrstuvwxyz=/"
+                        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"):
+                # end of input in or before attribute value, or we have the
+                # '/' from a '/>' ending
+                return -1
+            if j > i:
+                return j
+            else:
+                return i + 1
+        raise AssertionError("we should not get here!")
+
+    # Internal -- parse endtag, return end or -1 if incomplete
+    def parse_endtag(self, i):
+        rawdata = self.rawdata
+        assert rawdata[i:i+2] == "</", "unexpected call to parse_endtag"
+        match = endendtag.search(rawdata, i+1) # >
+        if not match:
+            return -1
+        gtpos = match.end()
+        match = endtagfind.match(rawdata, i) # </ + tag + >
+        if not match:
+            if self.cdata_elem is not None:
+                self.handle_data(rawdata[i:gtpos])
+                return gtpos
+            # find the name: w3.org/TR/html5/tokenization.html#tag-name-state
+            namematch = tagfind.match(rawdata, i+2)
+            if not namematch:
+                # w3.org/TR/html5/tokenization.html#end-tag-open-state
+                if rawdata[i:i+3] == '</>':
+                    return i+3
+                else:
+                    return self.parse_bogus_comment(i)
+            tagname = namematch.group(1).lower()
+            # consume and ignore other stuff between the name and the >
+            # Note: this is not 100% correct, since we might have things like
+            # </tag attr=">">, but looking for > after tha name should cover
+            # most of the cases and is much simpler
+            gtpos = rawdata.find('>', namematch.end())
+            self.handle_endtag(tagname)
+            return gtpos+1
+
+        elem = match.group(1).lower() # script or style
+        if self.cdata_elem is not None:
+            if elem != self.cdata_elem:
+                self.handle_data(rawdata[i:gtpos])
+                return gtpos
+
+        self.handle_endtag(elem)
+        self.clear_cdata_mode()
+        return gtpos
+
+    # Overridable -- finish processing of start+end tag: <tag.../>
+    def handle_startendtag(self, tag, attrs):
+        self.handle_starttag(tag, attrs)
+        self.handle_endtag(tag)
+
+    # Overridable -- handle start tag
+    def handle_starttag(self, tag, attrs):
+        pass
+
+    # Overridable -- handle end tag
+    def handle_endtag(self, tag):
+        pass
+
+    # Overridable -- handle character reference
+    def handle_charref(self, name):
+        pass
+
+    # Overridable -- handle entity reference
+    def handle_entityref(self, name):
+        pass
+
+    # Overridable -- handle data
+    def handle_data(self, data):
+        pass
+
+    # Overridable -- handle comment
+    def handle_comment(self, data):
+        pass
+
+    # Overridable -- handle declaration
+    def handle_decl(self, decl):
+        pass
+
+    # Overridable -- handle processing instruction
+    def handle_pi(self, data):
+        pass
+
+    def unknown_decl(self, data):
+        pass
+
+    # Internal -- helper to remove special character quoting
+    entitydefs = None
+    def unescape(self, s):
+        if '&' not in s:
+            return s
+        def replaceEntities(s):
+            s = s.groups()[0]
+            try:
+                if s[0] == "#":
+                    s = s[1:]
+                    if s[0] in ['x','X']:
+                        c = int(s[1:], 16)
+                    else:
+                        c = int(s)
+                    return unichr(c)
+            except ValueError:
+                return '&#'+s+';'
+            else:
+                # Cannot use name2codepoint directly, because HTMLParser supports apos,
+                # which is not part of HTML 4
+                import htmlentitydefs
+                if HTMLParser.entitydefs is None:
+                    entitydefs = HTMLParser.entitydefs = {'apos':u"'"}
+                    for k, v in htmlentitydefs.name2codepoint.iteritems():
+                        entitydefs[k] = unichr(v)
+                try:
+                    return self.entitydefs[s]
+                except KeyError:
+                    return '&'+s+';'
+
+        return re.sub(r"&(#?[xX]?(?:[0-9a-fA-F]+|\w{1,8}));", replaceEntities, s)

--- a/pycbc/results/metadata.py
+++ b/pycbc/results/metadata.py
@@ -3,7 +3,8 @@ This Module contains generic utility functions for creating plots within
 PyCBC. 
 """
 import os.path, pycbc.version
-import ConfigParser, HTMLParser
+import ConfigParser
+from pycbc.future import HTMLParser
 from xml.sax.saxutils import escape, unescape
 
 escape_table = {
@@ -21,10 +22,10 @@ def html_escape(text):
     """ Sanitize text for html parsing """
     return escape(text, escape_table)
 
-class MetaParser(HTMLParser.HTMLParser):
+class MetaParser(HTMLParser):
     def __init__(self):
         self.metadata = {}
-        HTMLParser.HTMLParser.__init__(self)
+        HTMLParser.__init__(self)
 
     def handle_data(self, data):
         pass

--- a/pycbc/results/mpld3_utils.py
+++ b/pycbc/results/mpld3_utils.py
@@ -114,3 +114,8 @@ class Tooltip(mpld3.plugins.PointHTMLTooltip):
     def __init__(self, points, labels=None,
                  hoffset=0, voffset=10, css=None):
         super(Tooltip, self).__init__(points, labels, hoffset, voffset, "")
+
+class LineTooltip(mpld3.plugins.LineHTMLTooltip):
+    JAVASCRIPT = ""
+    def __init__(self, line, label=None, hoffset=0, voffset=10, css=None):
+        super(LineTooltip, self).__init__(line, label, hoffset, voffset, "")

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -35,6 +35,11 @@ def render_workflow_html_template(filename, subtemplate, filelists):
 
     dir = os.path.dirname(filename)
 
+    try:
+        filenames = [f.name for filelist in filelists for f in filelist if f != None]
+    except TypeError:
+        filenames = []
+
     # render subtemplate
     subtemplate_dir = pycbc.results.__path__[0] + '/templates/wells'
     env = Environment(loader=FileSystemLoader(subtemplate_dir))
@@ -47,7 +52,8 @@ def render_workflow_html_template(filename, subtemplate, filelists):
     output = subtemplate.render(context)
 
     # save as html page
-    kwds = {'render-function' : 'render_tmplt'}
+    kwds = {'render-function' : 'render_tmplt',
+            'filenames' : ','.join(filenames)}
     save_html_with_metadata(str(output), filename, None, kwds)
 
 def get_embedded_config(filename):

--- a/pycbc/results/templates/files/file_default.html
+++ b/pycbc/results/templates/files/file_default.html
@@ -4,9 +4,7 @@
 
 <!--html file condition-->
 {% elif filename.endswith('html') %}
-    {% if path_exists(path) %}
-        {{ open(path, 'rb').read() }}
-    {% endif %}
+    {{ open(path, 'rb').read() }}
 
 <!--segment XML file condition-->
 {% elif ( filename.endswith('xml') or filename.endswith('xml.gz') ) and content %}

--- a/pycbc/results/templates/files/file_default.html
+++ b/pycbc/results/templates/files/file_default.html
@@ -4,8 +4,9 @@
 
 <!--html file condition-->
 {% elif filename.endswith('html') %}
-    <!-- <iframe height=100% width=100% frameborder=0 src="{{filename}}"><iframe> -->
-    {{ open(path, 'rb').read() }}
+    {% if path_exists(path) %}
+        {{ open(path, 'rb').read() }}
+    {% endif %}
 
 <!--segment XML file condition-->
 {% elif ( filename.endswith('xml') or filename.endswith('xml.gz') ) and content %}

--- a/pycbc/results/templates/files/file_default.html
+++ b/pycbc/results/templates/files/file_default.html
@@ -4,7 +4,8 @@
 
 <!--html file condition-->
 {% elif filename.endswith('html') %}
-    {% include 'file_iframe.html' %}
+    <!-- <iframe height=100% width=100% frameborder=0 src="{{filename}}"><iframe> -->
+    {{ open(path, 'rb').read() }}
 
 <!--segment XML file condition-->
 {% elif ( filename.endswith('xml') or filename.endswith('xml.gz') ) and content %}

--- a/pycbc/results/templates/files/file_default.html
+++ b/pycbc/results/templates/files/file_default.html
@@ -4,7 +4,7 @@
 
 <!--html file condition-->
 {% elif filename.endswith('html') %}
-    {{ open(path, 'rb').read() }}
+    {% include 'file_iframe.html' %}
 
 <!--segment XML file condition-->
 {% elif ( filename.endswith('xml') or filename.endswith('xml.gz') ) and content %}

--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -153,9 +153,15 @@
                 <!-- set file counter integer -->
                 {% set i = 1 %}
 
-                <!-- include well if it exists -->
-                {% if path_exists(plots_dir+dir.path+'/well.html') %}
-                   {{ setup_template_render(plots_dir+dir.path+'/well.html', None) }}
+                <!-- include well if it exists and check meta-data if well renders any files inside it -->
+                {% set well_path = plots_dir+dir.path+'/well.html' %}
+                {% if path_exists(well_path) %}
+                    {{ setup_template_render(well_path, None) }}
+                    {% if get_embedded_config(well_path).has_option('well.html', 'filenames') %}
+                        {% set well_filenames = get_embedded_config(well_path).get('well.html', 'filenames').split(',') %}
+                    {% else %}
+                        {% set well_filenames = [] %}
+                    {% endif %}
                 {% endif %}
 
                 <hr class="row-divider">
@@ -178,7 +184,7 @@
                                     {% set cp = get_embedded_config(file.path) %}
 
                                     <!-- do not show well.html -->
-                                    {% if not file.filename() == 'well.html' %}
+                                    {% if not file.filename() == 'well.html' and file.filename() not in well_filenames %}
                                         <div class="panel-group" id="accordion">
                                             <div class="panel panel-default">
                                                 <div class="panel-heading">

--- a/pycbc/results/templates/wells/two_column.html
+++ b/pycbc/results/templates/wells/two_column.html
@@ -19,7 +19,7 @@
                             {% endif %}
                             {{ setup_template_render('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}' , '') }}
                     {% endif %}
-                    {% endraw %}
+                {% endraw %}
                 </div>
                 {% set i = i + 1 %}
                 <div class="col-md-6" style="padding-top:20px;">

--- a/pycbc/results/templates/wells/two_column.html
+++ b/pycbc/results/templates/wells/two_column.html
@@ -25,7 +25,7 @@
                 <div class="col-md-6" style="padding-top:20px;">
                 {% if filelist[1] != None %}
                     {% raw %}
-                    {% if path_exists('{% endraw %}{{dir}}/{{filelist[0].name}}{% raw %}') %}
+                    {% if path_exists('{% endraw %}{{dir}}/{{filelist[1].name}}{% raw %}') %}
                         {% set cp = get_embedded_config('{% endraw %}{{dir}}/{{filelist[1].name}}{% raw %}') %}
                             {% if cp.has_option('{% endraw %}{{filelist[1].name}}{% raw %}', 'title') %}
                                 <p class="text-center" style="font-size:18px;"><b>{% endraw %}A{{i}}. {% raw %}{{cp.get('{% endraw %}{{filelist[1].name}}{% raw %}', 'title')}}</b></p>

--- a/pycbc/workflow/ini_files/example_hdf_bns.ini
+++ b/pycbc/workflow/ini_files/example_hdf_bns.ini
@@ -70,6 +70,7 @@ plot_snrifar = ${which:pycbc_page_snrifar}
 plot_singles = ${which:pycbc_plot_singles_vs_params}
 page_foreground = ${which:pycbc_page_foreground}
 page_injections = ${which:pycbc_page_injtable}
+page_segplot = ${which:pycbc_page_segplot}
 page_segtable = ${which:pycbc_page_segtable}
 hdf_trigger_merge = ${which:pycbc_coinc_mergetrigs}
 plot_snrchi = ${which:pycbc_page_snrchi}
@@ -171,6 +172,8 @@ injection-window = 1.0
 
 [page_foreground]
 [plot_snrifar]
+
+[page_segplot]
 
 [page_segtable]
 

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -141,6 +141,28 @@ def make_seg_table(workflow, seg_files, seg_names, out_dir, tags=None):
     workflow += node
     return node.output_files[0]
 
+def make_seg_plot(workflow, seg_files, out_dir, science_seg_names=None,
+                            veto_data_seg_names=None,
+                            veto_triggers_seg_names=None, tags=None):
+    """ Creates a node in the workflow for plotting science, and veto segments.
+    """
+
+    seg_files = list(seg_files)
+    if tags is None: tags = []
+    makedir(out_dir)
+    node = PlotExecutable(workflow.cp, 'page_segplot', ifos=workflow.ifos,
+                    out_dir=out_dir, tags=tags).create_node()
+    node.add_input_list_opt('--segment-files', seg_files)
+    if len(science_seg_names):
+        node.add_opt('--science-segment-names', ' '.join(science_seg_names))
+    if len(veto_data_seg_names):
+        node.add_opt('--veto-data-segment-names', ' '.join(veto_data_seg_names))
+    if len(veto_triggers_seg_names):
+        node.add_opt('--veto-triggers-segment-names', ' '.join(veto_triggers_seg_names))
+    node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
+    workflow += node
+    return node.output_files[0]
+
 def make_snrchi_plot(workflow, trig_files, veto_file, veto_name, 
                      out_dir, exclude=None, require=None, tags=[]):
     makedir(out_dir)    

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -141,9 +141,7 @@ def make_seg_table(workflow, seg_files, seg_names, out_dir, tags=None):
     workflow += node
     return node.output_files[0]
 
-def make_seg_plot(workflow, seg_files, out_dir, science_seg_names=None,
-                            veto_data_seg_names=None,
-                            veto_triggers_seg_names=None, tags=None):
+def make_seg_plot(workflow, seg_files, out_dir, seg_names=None, tags=None):
     """ Creates a node in the workflow for plotting science, and veto segments.
     """
 
@@ -153,12 +151,7 @@ def make_seg_plot(workflow, seg_files, out_dir, science_seg_names=None,
     node = PlotExecutable(workflow.cp, 'page_segplot', ifos=workflow.ifos,
                     out_dir=out_dir, tags=tags).create_node()
     node.add_input_list_opt('--segment-files', seg_files)
-    if len(science_seg_names):
-        node.add_opt('--science-segment-names', ' '.join(science_seg_names))
-    if len(veto_data_seg_names):
-        node.add_opt('--veto-data-segment-names', ' '.join(veto_data_seg_names))
-    if len(veto_triggers_seg_names):
-        node.add_opt('--veto-triggers-segment-names', ' '.join(veto_triggers_seg_names))
+    node.add_opt('--segment-names', ' '.join(seg_names))
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow += node
     return node.output_files[0]

--- a/setup.py
+++ b/setup.py
@@ -390,6 +390,7 @@ setup (
                'bin/hdfcoinc/pycbc_page_snrchi',
                'bin/hdfcoinc/pycbc_page_segments',
                'bin/hdfcoinc/pycbc_page_segtable',
+               'bin/hdfcoinc/pycbc_page_segplot',
                'bin/hdfcoinc/pycbc_plot_psd_file',
                'bin/hdfcoinc/pycbc_plot_range',
                'bin/hdfcoinc/pycbc_foreground_censor',


### PR DESCRIPTION
This PR:
  * If a file is rendered in the `well.html` for `orange.html`, then it is not added to the additional files section.
  * Added `get_segment_definer_comments` to `pycbc.events.veto`, this function returns a dict of the comments in the segment definer table.
  * Adds an executable `pycbc_page_segplot` that plots segments for each IFO.
  * Adds veto table to summary page.
  * Adds HTMLParser from Python 2.7 to `pycbc.future`. This was needed because the 2.6 version does not handle `<script>` tags.

Can see an example of segment tables and plots on summary page here: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/html_version_13/