### PR TITLE
Allow pycbc_page_foreground to write in xml format

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -168,7 +168,14 @@ for inj_file, tag, output_dir in zip([None]+inj_files, tags, output_dirs):
                             rdir['result'], tags=final_bg_file[0].tags)
 
         table = wf.make_foreground_table(workflow, final_bg_file[0], 
-                            hdfbank[0], tag, rdir['result'])
+                            hdfbank[0], tag, rdir['result'], singles=insps,
+                            extension='.html', tags=["html"])
+        fore_xmlall = wf.make_foreground_table(workflow, final_bg_file[0],
+                            hdfbank[0], tag, rdir['result'], singles=insps,
+                            extension='.xml', tags=["xmlall"])
+        fore_xmlloudest = wf.make_foreground_table(workflow, final_bg_file[0],
+                            hdfbank[0], tag, rdir['result'], singles=insps,
+                            extension='.xml', tags=["xmlloudest"])
         single_layout(rdir['result'], [snrifar, table])
 
         snrchi = wf.make_snrchi_plot(workflow, insps, censored_veto, 

--- a/bin/hdfcoinc/pycbc_page_foreground
+++ b/bin/hdfcoinc/pycbc_page_foreground
@@ -7,56 +7,73 @@ parser = argparse.ArgumentParser()
 # General required options
 parser.add_argument('--trigger-file')
 parser.add_argument('--bank-file')
+parser.add_argument('--single-detector-triggers', nargs='+', default=None)
 parser.add_argument('--verbose', action='count')
 parser.add_argument('--output-file')
 parser.add_argument('--foreground-tag')
+parser.add_argument('--num-coincs-to-write', type=int)
 args = parser.parse_args()
 
 import h5py, numpy, logging, pycbc.results, pycbc.results.followup
 from pycbc.pnutils import mass1_mass2_to_mchirp_eta
+from pycbc.io import hdf
 
 if args.verbose:
     log_level = logging.INFO
     logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
+
+if args.output_file.endswith('.xml') or args.output_file.endswith('.xml.gz'):
+    if args.single_detector_triggers is None:
+        err_msg = "If creating xml files must provide the single detector "
+        err_msg += "trigger lists with --single-detector-triggers."
+        raise ValueError(err_msg)
     
-logging.info('Read in the foreground data')
-f = h5py.File(args.trigger_file, 'r')
-ifar = f['foreground/ifar'][:]
-sorting = ifar.argsort()[::-1]
-ifar = ifar[sorting]
-ifar_exc = f['foreground/ifar_exc'][:][sorting]
-fap = f['foreground/fap'][:][sorting]
-fap_exc = f['foreground/fap_exc'][:][sorting]
-stat = f['foreground/stat'][:][sorting]
-time1 = f['foreground/time1'][:][sorting]
-time2 = f['foreground/time2'][:][sorting]
-template_id = f['foreground/template_id'][:][sorting].astype(numpy.uint32)
-trigid1 = f['foreground/trigger_id1'][:][sorting].astype(numpy.uint32)
-trigid2 = f['foreground/trigger_id2'][:][sorting].astype(numpy.uint32)
+fortrigs = hdf.ForegroundTriggers(args.trigger_file, args.bank_file,
+                       sngl_files=args.single_detector_triggers,
+                       n_loudest=args.num_coincs_to_write)
 
-logging.info('Found %s foreground triggers' % len(stat))
+if args.output_file.endswith('.html'):
+    ifar = fortrigs.get_coincfile_array('ifar')
+    ifar_exc = fortrigs.get_coincfile_array('ifar_exc') 
+    fap = fortrigs.get_coincfile_array('fap')
+    fap_exc = fortrigs.get_coincfile_array('fap_exc')
+    stat = fortrigs.get_coincfile_array('stat')
+    time1 = fortrigs.get_coincfile_array('time1')
+    time2 = fortrigs.get_coincfile_array('time2')
 
-logging.info('Read in the template bank data to get template parameters')
-f = h5py.File(args.bank_file, 'r')
-mass1 = f['mass1'][:][template_id]
-mass2 = f['mass2'][:][template_id]
-spin1z = f['spin1z'][:][template_id]
-spin2z = f['spin2z'][:][template_id]
+    mass1 = fortrigs.get_bankfile_array('mass1')
+    mass2 = fortrigs.get_bankfile_array('mass2')
+    spin1z = fortrigs.get_bankfile_array('spin1z')
+    spin2z = fortrigs.get_bankfile_array('spin2z')
 
-mchirp, eta = mass1_mass2_to_mchirp_eta(mass1, mass2)
+    mchirp, eta = mass1_mass2_to_mchirp_eta(mass1, mass2)
 
-columns = [ifar_exc, ifar, fap_exc, fap, stat,  time1,
-           (time2-time1)*1000, mchirp, mass1, mass2, spin1z, spin2z]
-names = ['IFAR with Rem. (YR)', 'IFAR (YR)', 'FAP with Rem.', 'FAP', 'Combined NewSNR', 'End Time', 
-         'Time Diff. (ms)', 'mchirp', 'm1', 'm2',
-         's1z', 's2z']
-format_strings = ['#.###E0', '#.###E0', '#.##E0', '#.##E0', '##.###',
-                  None, '##.##', '##.##', '##.##',
-                  '##.##', '##.##', '##.##']
+    columns = [ifar_exc, ifar, fap_exc, fap, stat,  time1,
+               (time2-time1)*1000, mchirp, mass1, mass2, spin1z, spin2z]
+    names = ['IFAR with Rem. (YR)', 'IFAR (YR)', 'FAP with Rem.', 'FAP',
+             'Combined NewSNR', 'End Time', 'Time Diff. (ms)', 'mchirp', 'm1',
+             'm2', 's1z', 's2z']
+    format_strings = ['#.###E0', '#.###E0', '#.##E0', '#.##E0', '##.###',
+                      None, '##.##', '##.##', '##.##',
+                      '##.##', '##.##', '##.##']
 
-logging.info('Making table of foreground triggers')
-html_table = pycbc.results.table(columns, names, 
-                                 format_strings=format_strings, page_size=10)
+    if args.single_detector_triggers:
+        single_snr = fortrigs.get_snglfile_array_dict('snr')
+        single_chisq = fortrigs.get_snglfile_array_dict('chisq')
 
-f = open(args.output_file, 'w')
-f.write(html_table)
+        columns.extend([single_snr[ifo] for ifo in single_snr.keys()])
+        names.extend(["SNR in %s" %(ifo) for ifo in single_snr.keys()])
+        format_strings.extend(["##.##" for ifo in single_snr.keys()])
+        columns.extend([single_chisq[ifo] for ifo in single_chisq.keys()])
+        names.extend(["Chisq in %s" %(ifo) for ifo in single_chisq.keys()])
+        format_strings.extend(["##.##" for ifo in single_chisq.keys()])
+
+    logging.info('Making table of foreground triggers')
+    html_table = pycbc.results.table(columns, names, 
+                                   format_strings=format_strings, page_size=10)
+
+    f = open(args.output_file, 'w')
+    f.write(html_table)
+elif args.output_file.endswith('.xml') or args.output_file.endswith('.xml.gz'):
+    fortrigs.to_coinc_xml_object(args.output_file)
+

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -168,29 +168,12 @@ class ForegroundTriggers(object):
         self._trig_ids = {}
         # FIXME: There is no clear mapping from trig_id to ifo. This is bad!!!
         #        for now a hack is in place.
+        ifo1 = self.coinc_file.h5file.attrs['detector_1']
+        ifo2 = self.coinc_file.h5file.attrs['detector_2']
         trigid1 = self.get_coincfile_array('trigger_id1')
         trigid2 = self.get_coincfile_array('trigger_id2')
-        for ifo, file in self.sngl_files.items():
-            try:
-                ifo = file.h5file.keys()[0]
-                fs = file.h5file
-                if (fs[ifo]['template_id'][:][trigid1] ==\
-                                                       self.template_id).all():
-                    self._trig_ids[ifo] = trigid1
-                else:
-                    raise IndexError()
-            except IndexError:
-                # Trig1 doesn't fit, try trigid2
-                try:
-                    if (fs[ifo]['template_id'][:][trigid2] ==\
-                                                       self.template_id).all():
-                        self._trig_ids[ifo] = trigid2
-                    else:
-                        raise IndexError()
-                except IndexError:
-                     # Neither fit, fail
-                    err_msg = "Cannot match id1 or id2 to the single triggers."
-                    raise ValueError(err_msg)
+        self._trig_ids[ifo1] = trigid1
+        self._trig_ids[ifo2] = trigid2
         return self._trig_ids
 
     def get_coincfile_array(self, variable):
@@ -277,13 +260,11 @@ class ForegroundTriggers(object):
             coinc_id = lsctables.CoincID(idx)
 
             # Set up sngls
-            # FIXME: Need to do this to set up mapping from trigid1 to ifo
-            self.trig_id            
             # FIXME: As two-ifo is hardcoded loop over all ifos
             sngl_combined_mchirp = 0
             sngl_combined_mtot = 0
             for ifo in ifos:
-                sngl_id = self._trig_ids[ifo][idx]
+                sngl_id = self.trig_id[ifo][idx]
                 event_id = lsctables.SnglInspiralID(sngl_id)
                 sngl = return_empty_sngl()
                 curr_sngl_file = self.sngl_files[ifo].h5file[ifo]

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -6,9 +6,23 @@ import h5py
 import numpy as np
 import logging
 
+from lal import LIGOTimeGPS
+
+from glue.ligolw import ligolw
+from glue.ligolw import table
+from glue.ligolw import lsctables
+from glue.ligolw import ilwd
+from glue.ligolw import utils as ligolw_utils
+from glue.ligolw.utils import process as ligolw_process
+
+from pycbc import version as pycbc_version
+from pycbc.tmpltbank import return_search_summary
+from pycbc.tmpltbank import return_empty_sngl
+from pycbc import pnutils
+
 class FileData(object):
 
-    def __init__(self, fname, group, columnlist=None, filter_func=None):
+    def __init__(self, fname, group=None, columnlist=None, filter_func=None):
         '''
         Parameters
         ----------
@@ -21,9 +35,14 @@ class FileData(object):
             of the class instance derived from columns: ex. 'self.snr < 6.5'
         '''
         if not fname: raise RuntimeError("Didn't get a file!")
-        if not group: raise RuntimeError("Didn't get a group!")
         self.fname = fname
         self.h5file = h5py.File(fname, "r")
+        if group is None:           
+            if len(self.h5file.keys()) == 1:
+                group = self.h5file.keys()[0]
+            else:
+                raise RuntimeError("Didn't get a group!")
+        self.group_key = group
         self.group = self.h5file[group]
         self.columns = columnlist if columnlist is not None \
                        else self.group.keys()
@@ -67,14 +86,11 @@ class FileData(object):
         numpy array
             Values from the dataset, filtered if requested
         '''
-        try:
-            vals = self.group[col]
-            if self.filter_func:
-                return vals[self.mask]
-            else:
-                return vals[:]
-        except KeyError:  # if the column doesn't exist, as happens for zero triggers
-            return np.array([])  # this may or may not have the right effect
+        vals = self.group[col]
+        if self.filter_func:
+            return vals[self.mask]
+        else:
+            return vals[:]
 
 class DataFromFiles(object):
 
@@ -111,3 +127,219 @@ class DataFromFiles(object):
         logging.info('- got %i values' % sum(len(v) for v in vals))
         return np.concatenate(vals)
 
+class ForegroundTriggers(object):
+    # FIXME: A lot of this is hardcoded to expect two ifos
+    def __init__(self, coinc_file, bank_file, sngl_files=None, n_loudest=None):
+        self.coinc_file = FileData(coinc_file, group='foreground')
+        self.sngl_files = {}
+        if sngl_files is not None:
+            for file in sngl_files:
+                curr_dat = FileData(file)
+                curr_ifo = curr_dat.group_key
+                self.sngl_files[curr_ifo] = curr_dat
+        self.bank_file = h5py.File(bank_file, "r")
+        self.n_loudest = n_loudest
+
+        self._sort_arr = None
+        self._template_id = None
+        self._trig_ids = None
+
+    @property
+    def sort_arr(self):
+        if self._sort_arr is None:
+            ifar = self.coinc_file.get_column('ifar')
+            sorting = ifar.argsort()[::-1]
+            if self.n_loudest:
+                sorting = sorting[:self.n_loudest]
+            self._sort_arr = sorting
+        return self._sort_arr
+
+    @property
+    def template_id(self):
+        if self._template_id is None:
+            template_id = self.get_coincfile_array('template_id')
+            self._template_id = template_id
+        return self._template_id
+
+    @property
+    def trig_id(self):
+        if self._trig_ids is not None:
+            return self._trig_ids
+        self._trig_ids = {}
+        # FIXME: There is no clear mapping from trig_id to ifo. This is bad!!!
+        #        for now a hack is in place.
+        trigid1 = self.get_coincfile_array('trigger_id1')
+        trigid2 = self.get_coincfile_array('trigger_id2')
+        for ifo, file in self.sngl_files.items():
+            try:
+                ifo = file.h5file.keys()[0]
+                fs = file.h5file
+                if (fs[ifo]['template_id'][:][trigid1] ==\
+                                                       self.template_id).all():
+                    self._trig_ids[ifo] = trigid1
+                else:
+                    raise IndexError()
+            except IndexError:
+                # Trig1 doesn't fit, try trigid2
+                try:
+                    if (fs[ifo]['template_id'][:][trigid2] ==\
+                                                       self.template_id).all():
+                        self._trig_ids[ifo] = trigid2
+                    else:
+                        raise IndexError()
+                except IndexError:
+                     # Neither fit, fail
+                    err_msg = "Cannot match id1 or id2 to the single triggers."
+                    raise ValueError(err_msg)
+        return self._trig_ids
+
+    def get_coincfile_array(self, variable):
+        return self.coinc_file.get_column(variable)[self.sort_arr]
+
+    def get_bankfile_array(self, variable):
+        return self.bank_file[variable][:][self.template_id]
+
+    def get_snglfile_array_dict(self, variable):
+        return_dict = {}
+        for ifo in self.sngl_files.keys():
+            curr = self.sngl_files[ifo].get_column(variable)[self.trig_id[ifo]]
+            return_dict[ifo] = curr
+        return return_dict
+
+    def to_coinc_xml_object(self, file_name):
+        # FIXME: This function will only work with two ifos!!
+
+        outdoc = ligolw.Document()
+        outdoc.appendChild(ligolw.LIGO_LW())
+
+        ifos = [ifo for ifo in self.sngl_files.keys()]
+        proc_id = ligolw_process.register_to_xmldoc(outdoc, 'pycbc',
+                     {}, ifos=ifos, comment='', version=pycbc_version.git_hash,
+                     cvs_repository='pycbc/'+pycbc_version.git_branch,
+                     cvs_entry_time=pycbc_version.date).process_id
+
+        search_summ_table = lsctables.New(lsctables.SearchSummaryTable)
+        coinc_h5file = self.coinc_file.h5file
+        start_time = coinc_h5file['segments']['coinc']['start'][:].min()
+        end_time = coinc_h5file['segments']['coinc']['end'][:].max()
+        num_trigs = len(self.sort_arr)
+        search_summary = return_search_summary(start_time, end_time,
+                                                 num_trigs, ifos)
+        search_summ_table.append(search_summary)
+        outdoc.childNodes[0].appendChild(search_summ_table)
+
+        sngl_inspiral_table = lsctables.New(lsctables.SnglInspiralTable)
+        coinc_def_table = lsctables.New(lsctables.CoincDefTable)
+        coinc_event_table = lsctables.New(lsctables.CoincTable)
+        coinc_inspiral_table = lsctables.New(lsctables.CoincInspiralTable)
+        coinc_event_map_table = lsctables.New(lsctables.CoincMapTable)
+        time_slide_table = lsctables.New(lsctables.TimeSlideTable)
+        
+        # Set up time_slide table
+        time_slide_id = lsctables.TimeSlideID(0)
+        for ifo in ifos:
+            time_slide_row = lsctables.TimeSlide()
+            time_slide_row.instrument = ifo
+            time_slide_row.time_slide_id = time_slide_id
+            time_slide_row.offset = 0
+            time_slide_row.process_id = proc_id
+            time_slide_table.append(time_slide_row)
+
+        # Set up coinc_definer table
+        coinc_def_id = lsctables.CoincDefID(0)
+        coinc_def_row = lsctables.CoincDef()
+        coinc_def_row.search = "inspiral"
+        coinc_def_row.description = "sngl_inspiral-sngl_inspiral coincidences"
+        coinc_def_row.coinc_def_id = coinc_def_id
+        coinc_def_row.search_coinc_type = 0
+        coinc_def_table.append(coinc_def_row)
+
+        bank_col_names = ['mass1', 'mass2', 'spin1z', 'spin2z']
+        bank_col_vals = {}
+        for name in bank_col_names:
+            bank_col_vals[name] = self.get_bankfile_array(name)
+
+        coinc_event_names = ['ifar','time1','fap', 'stat']
+        coinc_event_vals = {}
+        for name in coinc_event_names:
+            coinc_event_vals[name] = self.get_coincfile_array(name)
+        
+        sngl_col_names = ['snr', 'chisq', 'chisq_dof', 'bank_chisq',
+                          'bank_chisq_dof', 'cont_chisq', 'cont_chisq_dof',
+                          'end_time']
+        sngl_col_vals = {}
+        for name in sngl_col_names:
+            sngl_col_vals[name] = self.get_snglfile_array_dict(name)
+
+        for idx, coinc_idx in enumerate(self.sort_arr):
+            # Set up IDs and mapping values
+            curr_tmplt_id = self.template_id[idx]
+            coinc_id = lsctables.CoincID(idx)
+
+            # Set up sngls
+            # FIXME: Need to do this to set up mapping from trigid1 to ifo
+            self.trig_id            
+            # FIXME: As two-ifo is hardcoded loop over all ifos
+            sngl_combined_mchirp = 0
+            sngl_combined_mtot = 0
+            for ifo in ifos:
+                sngl_id = self._trig_ids[ifo][idx]
+                event_id = lsctables.SnglInspiralID(sngl_id)
+                sngl = return_empty_sngl()
+                curr_sngl_file = self.sngl_files[ifo].h5file[ifo]
+                for name in sngl_col_names:
+                    val = sngl_col_vals[name][ifo][idx]
+                    setattr(sngl, name, val)
+                for name in bank_col_names:
+                    val = bank_col_vals[name][idx]
+                    setattr(sngl, name, val)
+                sngl.mtotal, sngl.eta = pnutils.mass1_mass2_to_mtotal_eta(
+                        sngl.mass1, sngl.mass2)
+                sngl.mchirp, junk = pnutils.mass1_mass2_to_mchirp_eta(
+                        sngl.mass1, sngl.mass2)
+                sngl_combined_mchirp += sngl.mchirp
+                sngl_combined_mtot += sngl.mtotal
+
+                sngl_inspiral_table.append(sngl)
+
+                # Set up coinc_map entry
+                coinc_map_row = lsctables.CoincMap()
+                coinc_map_row.table_name = 'sngl_inspiral'
+                coinc_map_row.coinc_event_id = coinc_id
+                coinc_map_row.event_id = event_id
+                coinc_event_map_table.append(coinc_map_row)
+
+            sngl_combined_mchirp = sngl_combined_mchirp / len(ifos)
+            sngl_combined_mtot = sngl_combined_mtot / len(ifos)
+                
+            # Set up coinc inspiral and coinc event tables
+            coinc_event_row = lsctables.Coinc()
+            coinc_inspiral_row = lsctables.CoincInspiral()
+            coinc_event_row.coinc_def_id = coinc_def_id
+            coinc_event_row.nevents = len(ifos)
+            coinc_event_row.instruments = ','.join(ifos)
+            coinc_inspiral_row.set_ifos(ifos)
+            coinc_event_row.time_slide_id = time_slide_id
+            coinc_event_row.process_id = proc_id
+            coinc_event_row.coinc_event_id = coinc_id
+            coinc_inspiral_row.coinc_event_id = coinc_id
+            coinc_inspiral_row.mchirp = sngl_combined_mchirp
+            coinc_inspiral_row.mass = sngl_combined_mtot
+            coinc_inspiral_row.set_end(\
+                                   LIGOTimeGPS(coinc_event_vals['time1'][idx]))
+            coinc_inspiral_row.snr = coinc_event_vals['stat'][idx]
+            coinc_inspiral_row.false_alarm_rate = coinc_event_vals['fap'][idx]
+            coinc_inspiral_row.combined_far = 1./coinc_event_vals['ifar'][idx]
+            coinc_event_row.likelihood = 0.
+            coinc_inspiral_row.minimum_duration = 0.
+            coinc_event_table.append(coinc_event_row)
+            coinc_inspiral_table.append(coinc_inspiral_row)
+
+        outdoc.childNodes[0].appendChild(coinc_def_table)
+        outdoc.childNodes[0].appendChild(coinc_event_table)
+        outdoc.childNodes[0].appendChild(coinc_event_map_table)
+        outdoc.childNodes[0].appendChild(time_slide_table)
+        outdoc.childNodes[0].appendChild(coinc_inspiral_table)
+        outdoc.childNodes[0].appendChild(sngl_inspiral_table)
+
+        ligolw_utils.write_filename(outdoc, file_name)

--- a/pycbc/workflow/ini_files/example_hdf_bns.ini
+++ b/pycbc/workflow/ini_files/example_hdf_bns.ini
@@ -171,6 +171,11 @@ ranking-statistic-threshold=8.7
 injection-window = 1.0
 
 [page_foreground]
+[page_foreground-html]
+[page_foreground-xmlall]
+[page_foreground-xmlloudest]
+num-coincs-to-write = 10
+
 [plot_snrifar]
 
 [page_segplot]

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -74,14 +74,17 @@ def make_segments_plot(workflow, seg_files, out_dir, tags=[]):
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow += node
         
-def make_foreground_table(workflow, trig_file, bank_file, ftag, out_dir, tags=[]):
+def make_foreground_table(workflow, trig_file, bank_file, ftag, out_dir, 
+                          singles=None, extension='.html', tags=[]):
     makedir(out_dir)
     node = PlotExecutable(workflow.cp, 'page_foreground', ifos=workflow.ifos,
                     out_dir=out_dir, tags=tags).create_node()
     node.add_input_opt('--bank-file', bank_file)
     node.add_opt('--foreground-tag', ftag)
     node.add_input_opt('--trigger-file', trig_file)
-    node.new_output_file_opt(bank_file.segment, '.html', '--output-file')
+    if singles is not None:
+        node.add_input_list_opt('--single-detector-triggers', singles)
+    node.new_output_file_opt(bank_file.segment, extension, '--output-file')
     workflow += node
     return node.output_files[0]
 

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -75,7 +75,9 @@ def make_segments_plot(workflow, seg_files, out_dir, tags=[]):
     workflow += node
         
 def make_foreground_table(workflow, trig_file, bank_file, ftag, out_dir, 
-                          singles=None, extension='.html', tags=[]):
+                          singles=None, extension='.html', tags=None):
+    if tags is None:
+        tags = []
     makedir(out_dir)
     node = PlotExecutable(workflow.cp, 'page_foreground', ifos=workflow.ifos,
                     out_dir=out_dir, tags=tags).create_node()


### PR DESCRIPTION
At the face-to-face it was requested by the PE group that we upload the loudest N events to gracedb after box opening. The first step in doing this is to allow the ability to write foreground triggers in XML format.

This patch addresses that by allowing pycbc_page_foreground to be able to write in XML or HD5 format. I have verified that an example HDF5 output is unchanged by this patch. This also allows the single-detector files to be read in and some additional data produced to html in this. Single-detector trigger files are mandatory for XML writing, but currently optional for html.

This is implemented by adding a new class in io/hdf.py to handle the set of files comprising our coincident output.

The next step will be to add this to the workflow generator and then to add a post-box opening script that will upload the triggers after the box has been opened.