### PR TITLE
Remote workflows

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -23,6 +23,7 @@ from pycbc import vetoes, psd, waveform, events, strain, scheme, fft, DYN_RANGE_
 from pycbc.filter import MatchedFilterControl, make_frequency_series
 from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, complex64
 import pycbc.fft.fftw, pycbc.version
+import pycbc.opt as pycbc_opt
 
 parser = argparse.ArgumentParser(usage='',
     description="Find single detector gravitational-wave triggers.")
@@ -140,6 +141,7 @@ strain.insert_strain_option_group(parser)
 strain.StrainSegments.insert_segment_option_group(parser)
 scheme.insert_processing_option_group(parser)
 fft.insert_fft_option_group(parser)
+pycbc_opt.insert_optimization_option_group(parser)
 
 opt = parser.parse_args()
 
@@ -149,7 +151,7 @@ strain.verify_strain_options(opt, parser)
 strain.StrainSegments.verify_segment_options(opt, parser)
 scheme.verify_processing_options(opt, parser)
 fft.verify_fft_options(opt,parser)
-
+pycbc_opt.verify_optimization_options(opt, parser)
 
 def associate_psd(strain_segments, gwstrain, segments, nsegs, flen, delta_f, flow):
     logging.info("Computing noise PSD")

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -16,7 +16,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import os,sys
+import sys
 import logging, argparse, numpy, itertools
 import pycbc
 from pycbc import vetoes, psd, waveform, events, strain, scheme, fft, DYN_RANGE_FAC
@@ -133,13 +133,6 @@ parser.add_argument("--keep-loudest-interval", type=float,
 parser.add_argument("--keep-loudest-num", type=int, 
                     help="Number of triggers to keep from each maximization interval")
 parser.add_argument("--gpu-callback-method", default='none')
-parser.add_argument("--cpu-affinity", help="""
-                    A set of CPUs on which to run, specified in a format suitable
-                    to pass to taskset.""")
-parser.add_argument("--cpu-affinity-from-env", help="""
-                    The name of an enivornment variable containing a set
-                    of CPUs on which to run,  specified in a format suitable
-                    to pass to taskset.""")
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -182,41 +175,6 @@ def associate_psd(strain_segments, gwstrain, segments, nsegs, flen, delta_f, flo
 
 
 pycbc.init_logging(opt.verbose)
-
-# Pin to specified CPUs if requested
-requested_cpus = None
-
-if opt.cpu_affinity_from_env is not None:
-    if opt.cpu_affinity is not None:
-        logging.error("Both --cpu_affinity_from_env and --cpu_affinity specified")
-        sys.exit(1)
-
-    requested_cpus = os.environ.get(opt.cpu_affinity_from_env)
-
-    if requested_cpus is None:
-        logging.error("CPU affinity requested from environment variable %s "
-                      "but this variable is not defined" % opt.cpu_affinity_from_env)
-        sys.exit(1)
-
-    if requested_cpus == '':
-        logging.error("CPU affinity requested from environment variable %s "
-                      "but this variable is empty" % opt.cpu_affinity_from_env)
-        sys.exit(1)
-
-if requested_cpus is None:
-    requested_cpus = opt.cpu_affinity
-
-if requested_cpus is not None:
-    command = 'taskset -pc %s %d' % (requested_cpus, os.getpid())
-    retcode = os.system(command)
-
-    if retcode != 0:
-        logging.error('taskset command <%s> failed with return code %d' % \
-                      (command, retcode))
-        sys,exit(1)
-
-    logging.info("Pinned to CPUs %s " % requested_cpus)
-
 
 ctx = scheme.from_cli(opt)
 gwstrain = strain.from_cli(opt, DYN_RANGE_FAC)

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -16,7 +16,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import sys
+import os,sys
 import logging, argparse, numpy, itertools
 import pycbc
 from pycbc import vetoes, psd, waveform, events, strain, scheme, fft, DYN_RANGE_FAC
@@ -133,6 +133,13 @@ parser.add_argument("--keep-loudest-interval", type=float,
 parser.add_argument("--keep-loudest-num", type=int, 
                     help="Number of triggers to keep from each maximization interval")
 parser.add_argument("--gpu-callback-method", default='none')
+parser.add_argument("--cpu-affinity", help="""
+                    A set of CPUs on which to run, specified in a format suitable
+                    to pass to taskset.""")
+parser.add_argument("--cpu-affinity-from-env", help="""
+                    The name of an enivornment variable containing a set
+                    of CPUs on which to run,  specified in a format suitable
+                    to pass to taskset.""")
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -175,6 +182,41 @@ def associate_psd(strain_segments, gwstrain, segments, nsegs, flen, delta_f, flo
 
 
 pycbc.init_logging(opt.verbose)
+
+# Pin to specified CPUs if requested
+requested_cpus = None
+
+if opt.cpu_affinity_from_env is not None:
+    if opt.cpu_affinity is not None:
+        logging.error("Both --cpu_affinity_from_env and --cpu_affinity specified")
+        sys.exit(1)
+
+    requested_cpus = os.environ.get(opt.cpu_affinity_from_env)
+
+    if requested_cpus is None:
+        logging.error("CPU affinity requested from environment variable %s "
+                      "but this variable is not defined" % opt.cpu_affinity_from_env)
+        sys.exit(1)
+
+    if requested_cpus == '':
+        logging.error("CPU affinity requested from environment variable %s "
+                      "but this variable is empty" % opt.cpu_affinity_from_env)
+        sys.exit(1)
+
+if requested_cpus is None:
+    requested_cpus = opt.cpu_affinity
+
+if requested_cpus is not None:
+    command = 'taskset -pc %s %d' % (requested_cpus, os.getpid())
+    retcode = os.system(command)
+
+    if retcode != 0:
+        logging.error('taskset command <%s> failed with return code %d' % \
+                      (command, retcode))
+        sys,exit(1)
+
+    logging.info("Pinned to CPUs %s " % requested_cpus)
+
 
 ctx = scheme.from_cli(opt)
 gwstrain = strain.from_cli(opt, DYN_RANGE_FAC)

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -140,6 +140,13 @@ parser.add_argument("--cpu-affinity-from-env", help="""
                     The name of an enivornment variable containing a set
                     of CPUs on which to run,  specified in a format suitable
                     to pass to taskset.""")
+parser.add_argument("--per-process-cache", action="store_true",
+                    default=False,
+                    help="""If given, each process will use a separate directory
+                         for scipy.weave compilation.  This is slower, but safer if
+                         several instances may be starting on the same machine at
+                         the same time.""")
+
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -217,6 +224,15 @@ if requested_cpus is not None:
 
     logging.info("Pinned to CPUs %s " % requested_cpus)
 
+
+# Check whether to use a private directory for scipy.weave
+if opt.per_process_cache:
+    # PYTHONCOMPILED is initially set in pycbc.__init__
+    new_dir = os.path.join(os.environ['PYTHONCOMPILED'],
+                           str(os.getpid()))
+    print "Setting cache to %s " % new_dir
+    os.environ['PYTHONCOMPILED'] = new_dir
+    os.makedirs(new_dir)
 
 ctx = scheme.from_cli(opt)
 gwstrain = strain.from_cli(opt, DYN_RANGE_FAC)

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -23,7 +23,8 @@ from pycbc import vetoes, psd, waveform, events, strain, scheme, fft, DYN_RANGE_
 from pycbc.filter import MatchedFilterControl, make_frequency_series
 from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, complex64
 import pycbc.fft.fftw, pycbc.version
-import pycbc.opt as pycbc_opt
+import pycbc.opt
+import pycbc.weave
 
 parser = argparse.ArgumentParser(usage='',
     description="Find single detector gravitational-wave triggers.")
@@ -141,7 +142,8 @@ strain.insert_strain_option_group(parser)
 strain.StrainSegments.insert_segment_option_group(parser)
 scheme.insert_processing_option_group(parser)
 fft.insert_fft_option_group(parser)
-pycbc_opt.insert_optimization_option_group(parser)
+pycbc.opt.insert_optimization_option_group(parser)
+pycbc.weave.insert_weave_option_group(parser)
 
 opt = parser.parse_args()
 
@@ -151,7 +153,8 @@ strain.verify_strain_options(opt, parser)
 strain.StrainSegments.verify_segment_options(opt, parser)
 scheme.verify_processing_options(opt, parser)
 fft.verify_fft_options(opt,parser)
-pycbc_opt.verify_optimization_options(opt, parser)
+pycbc.opt.verify_optimization_options(opt, parser)
+pycbc.weave.verify_weave_options(opt, parser)
 
 def associate_psd(strain_segments, gwstrain, segments, nsegs, flen, delta_f, flow):
     logging.info("Computing noise PSD")

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -140,13 +140,6 @@ parser.add_argument("--cpu-affinity-from-env", help="""
                     The name of an enivornment variable containing a set
                     of CPUs on which to run,  specified in a format suitable
                     to pass to taskset.""")
-parser.add_argument("--per-process-cache", action="store_true",
-                    default=False,
-                    help="""If given, each process will use a separate directory
-                         for scipy.weave compilation.  This is slower, but safer if
-                         several instances may be starting on the same machine at
-                         the same time.""")
-
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -224,15 +217,6 @@ if requested_cpus is not None:
 
     logging.info("Pinned to CPUs %s " % requested_cpus)
 
-
-# Check whether to use a private directory for scipy.weave
-if opt.per_process_cache:
-    # PYTHONCOMPILED is initially set in pycbc.__init__
-    new_dir = os.path.join(os.environ['PYTHONCOMPILED'],
-                           str(os.getpid()))
-    print "Setting cache to %s " % new_dir
-    os.environ['PYTHONCOMPILED'] = new_dir
-    os.makedirs(new_dir)
 
 ctx = scheme.from_cli(opt)
 gwstrain = strain.from_cli(opt, DYN_RANGE_FAC)

--- a/pycbc/opt.py
+++ b/pycbc/opt.py
@@ -184,6 +184,6 @@ def verify_optimization_options(opt, parser):
         if retcode != 0:
             logging.error('taskset command <%s> failed with return code %d' % \
                           (command, retcode))
-            sys,exit(1)
+            sys.exit(1)
 
         logging.info("Pinned to CPUs %s " % requested_cpus)

--- a/pycbc/weave.py
+++ b/pycbc/weave.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2015 Larne Pekowsky
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+This module provides methods for controlling scipy.weave
+"""
+import os, sys
+import logging
+import shutil, atexit, signal
+
+
+def insert_weave_option_group(parser):
+    """
+    Adds the options used to specify weave options.
+    
+    Parameters
+    ----------
+    parser : object
+        OptionParser instance
+    """
+    optimization_group = parser.add_argument_group("Options for controlling "
+                                   "scipy.weave")
+    
+    optimization_group.add_argument("--per-process-weave-cache",
+                    action="store_true",
+                    default=False,
+                    help="""If given, each process will use a separate directory
+                         for scipy.weave compilation.  This is slower, but safer if
+                         several instances may be starting on the same machine at
+                         the same time.""")
+
+    optimization_group.add_argument("--clear-weave-cache-at-start", 
+                    action="store_true",
+                    default=False,
+                    help="If given, delete the contents of the weave cache "
+                         "when the process starts")
+
+    optimization_group.add_argument("--clear-weave-cache-at-end", 
+                    action="store_true",
+                    default=False,
+                    help="If given, delete the contents of the weave cache "
+                         "when the process exits")
+
+
+def _clear_weave_cache():
+    """Deletes the weave cache specified in os.environ['PYTHONCOMPILED']"""
+
+    cache_dir = os.environ['PYTHONCOMPILED']
+    if os.path.exists(cache_dir):
+        shutil.rmtree(cache_dir)
+    logging.info("Cleared weave cache %s" % cache_dir)
+
+
+def verify_weave_options(opt, parser):
+    """Parses the CLI options, verifies that they are consistent and 
+    reasonable, and acts on them if they are
+
+    Parameters
+    ----------
+    opt : object
+        Result of parsing the CLI with OptionParser, or any object with the
+        required attributes 
+    parser : object
+        OptionParser instance.
+    """
+
+    # PYTHONCOMPILED is initially set in pycbc.__init__
+    cache_dir = os.environ['PYTHONCOMPILED']
+
+    # Check whether to use a private directory for scipy.weave
+    if opt.per_process_weave_cache:
+        cache_dir = os.path.join(cache_dir, str(os.getpid()))
+        os.environ['PYTHONCOMPILED'] = cache_dir
+        logging.info("Setting weave cache to %s" % cache_dir)
+
+    if not os.path.exists(cache_dir):
+        try:
+            os.makedirs(cache_dir)
+        except:
+            logging.error("Unable to create weave cache %s" % cache_dir)
+            sys.exit(1)
+        
+    if opt.clear_weave_cache_at_start:
+        _clear_weave_cache()
+        os.makedirs(cache_dir)
+
+    if opt.clear_weave_cache_at_end:
+        atexit.register(_clear_weave_cache)
+        signal.signal(signal.SIGTERM, _clear_weave_cache)
+
+
+


### PR DESCRIPTION
This adds two features to pycbc_inspiral inspired by recent testing on Stampede:
  * Processor affinity
  * Per-process caches for scipy.weave

Affinity is controllable by two new flags, --cpu-affinity which takes a list of processor ids and --cpu-affinity-from-env which takes the name of an environment variable, which should contain a list of processor ids.  The second is needed to use pycbc_inspiral with pegasus-mpi-cluster.

The per-process cache is enabled by setting --per-process-cache, which will append /(current pid) to the existing cache directory.  This will incur a performance penalty as each process will have to recompile the kernels, but it avoids a potential race condition that can cause one or more processes to fail.