### PR TITLE
Allowing more chisq choices in plotting codes

### DIFF
--- a/bin/hdfcoinc/pycbc_page_coinc_snrchi
+++ b/bin/hdfcoinc/pycbc_page_coinc_snrchi
@@ -3,6 +3,7 @@ import numpy, h5py, argparse, matplotlib
 from matplotlib import colors
 matplotlib.use('Agg')
 import pylab, pycbc.results
+from pycbc.io import get_chisq_from_file_choice, chisq_choices
 
 def snr_from_chisq(chisq, newsnr, q=6.):
     snr = numpy.zeros(len(chisq)) + float(newsnr)
@@ -20,7 +21,7 @@ parser.add_argument('--coinc-statistic-file', help='HDF format statistic file')
 parser.add_argument('--single-trigger-file', help='Single detector triggers files from the zero lag run')
 parser.add_argument('--newsnr-contours', nargs='*', help="List of newsnr values to draw contours at.", default=[])
 parser.add_argument('--background-front', action='store_true', default=False)
-parser.add_argument('--chisq-choice', choices=['traditional','max_cont_trad'],
+parser.add_argument('--chisq-choice', choices=chisq_choices,
                     default='traditional',
                     help='Which chisquared to plot. Default=traditional')
 parser.add_argument('--output-file')
@@ -38,29 +39,12 @@ f = h5py.File(args.single_trigger_file)
 ifo = f.keys()[0]
 f = f[ifo]
 tid = b_tids[ifo][:]
-snr = f['snr'][:][tid]
+bkg_snr = f['snr'][:][tid]
 
-if args.chisq_choice in ['traditional','max_cont_trad']:
-    trad_chisq = f['chisq'][:][tid]
-    chisq_not_calc = trad_chisq == 0
-    trad_chisq_dof = f['chisq_dof'][:][tid]
-    trad_chisq /= (trad_chisq_dof * 2 - 2)
-    # deal badly with triggers where chisq was not calculated and set to 0
-    trad_chisq[chisq_not_calc] = 0.1
-if args.chisq_choice in ['max_cont_trad']:
-    cont_chisq = f['cont_chisq'][:][tid]
-    cont_chisq_dof = f['cont_chisq_dof'][:][tid]
-    cont_chisq /= cont_chisq_dof
-if args.chisq_choice == 'traditional':
-    chisq = trad_chisq
-elif args.chisq_choice == 'max_cont_trad':
-    chisq = numpy.maximum(trad_chisq, cont_chisq)
-else:
-    err_msg="Do not recognized --chisq-choice %s" %(args.chisq_choice,)
-    raise ValueError(err_msg)
+bkg_chisq = get_chisq_from_file_choice(f, args.chisq_choice)[tid]
 
 fig = pylab.figure()
-pylab.scatter(snr, chisq, marker='o', color='black',
+pylab.scatter(bkg_snr, bkg_chisq, marker='o', color='black',
               linewidth=0, s=2.0, label='background', 
               zorder=args.background_front)
 
@@ -75,28 +59,16 @@ eff_dist = f['injections'][eff_map[ifo]][:][inj_idx]
 
 f = h5py.File(args.single_injection_file)[ifo]
 tid = inj_tids[ifo][:]
-snr = f['snr'][:][tid]
+inj_snr = f['snr'][:][tid]
 
-if args.chisq_choice in ['traditional','max_cont_trad']:
-    trad_chisq = f['chisq'][:][tid]
-    chisq_not_calc = trad_chisq == 0
-    trad_chisq_dof = f['chisq_dof'][:][tid]
-    trad_chisq /= (trad_chisq_dof * 2 - 2)
-    trad_chisq[chisq_not_calc] = 0.1
-if args.chisq_choice in ['max_cont_trad']:
-    cont_chisq = f['cont_chisq'][:][tid]
-    cont_chisq_dof = f['cont_chisq_dof'][:][tid]
-    cont_chisq /= cont_chisq_dof
-if args.chisq_choice == 'traditional':
-    chisq = trad_chisq
-elif args.chisq_choice == 'max_cont_trad':
-    chisq = numpy.maximum(trad_chisq, cont_chisq)
+inj_chisq = get_chisq_from_file_choice(f, args.chisq_choice)[tid]
 
-pylab.scatter(snr, chisq, c=eff_dist, norm=colors.LogNorm(), 
+pylab.scatter(inj_snr, inj_chisq, c=eff_dist, norm=colors.LogNorm(),
               marker='^', linewidth=0, label="Injections", 
               zorder= not args.background_front)
     
-r = numpy.logspace(numpy.log(chisq.min()*0.9), numpy.log(chisq.max()*1.1), 200)   
+r = numpy.logspace(numpy.log(min(bkg_chisq.min(), inj_chisq.min())*0.9),
+                   numpy.log(max(bkg_chisq.max(), inj_chisq.max())*1.1), 200)
 for cval in args.newsnr_contours:
     snrv = snr_from_chisq(r, cval)
     pylab.plot(snrv, r, '--', color='grey', linewidth=1)
@@ -109,11 +81,13 @@ cb.set_label('Effective Distance (Mpc)', size='large')
 pylab.title('%s Coincident Triggers' % ifo, size='large')
 pylab.xlabel('SNR', size='large')
 pylab.ylabel('Reduced $\chi^2$', size='large')
-pylab.xlim(snr.min()*0.9, snr.max()*1.4)
-pylab.ylim(chisq.min()*0.7, chisq.max()*1.4)
+pylab.xlim(min(inj_snr.min(),bkg_snr.min())*0.9,
+           max(inj_snr.max(),bkg_snr.max())*1.4)
+pylab.ylim(min(bkg_chisq.min(), inj_chisq.min())*0.7,
+           max(bkg_chisq.max(), inj_chisq.max())*1.4)
 pylab.legend(loc='lower right', prop={'size': 12})
 pylab.grid(which='major', ls='solid', alpha=0.7, linewidth=.5)
 pylab.grid(which='minor', ls='solid', alpha=0.7, linewidth=.1)
 pycbc.results.save_fig_with_metadata(fig, args.output_file, 
-                                     title='%s background with injections %s' % (ifo.upper(), 'behind' if args.background_front else 'ontop'), 
+                                     title='%s %s chisq vs SNR. Background with injections %s' % (ifo.upper(), args.chisq_choice, 'behind' if args.background_front else 'ontop'), 
                                      caption='')

--- a/bin/hdfcoinc/pycbc_page_snrchi
+++ b/bin/hdfcoinc/pycbc_page_snrchi
@@ -3,6 +3,7 @@ import numpy, h5py, argparse, matplotlib, sys
 matplotlib.use('Agg')
 import pylab, pycbc.results, pycbc.version
 from pycbc.events import veto
+from pycbc.io import get_chisq_from_file_choice, chisq_choices
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--trigger-file', help='Single ifo trigger file')
@@ -13,7 +14,7 @@ parser.add_argument('--segment-name', default=None, type=str,
 parser.add_argument('--min-snr', type=float, help='Optional, Minimum SNR to plot')
 parser.add_argument('--output-file')
 parser.add_argument('--newsnr-contours', nargs='*', help="List of newsnr values to draw contours at.", default=[])
-parser.add_argument('--chisq-choice', choices=['traditional','max_cont_trad'],
+parser.add_argument('--chisq-choice', choices=chisq_choices,
                     default='traditional',
                     help='Which chisquared to plot. Default=traditional')
 args = parser.parse_args()
@@ -22,25 +23,7 @@ f = h5py.File(args.trigger_file, 'r')
 ifo = f.keys()[0]
 f = f[ifo]
 snr = f['snr'][:]
-
-if args.chisq_choice in ['traditional','max_cont_trad']:
-    trad_chisq = f['chisq'][:]
-    # We now need to handle the case where chisq is not actually calculated
-    # 0 is used as a sentinel value
-    l = trad_chisq == 0
-    trad_chisq_dof = f['chisq_dof'][:]
-    trad_chisq /= (trad_chisq_dof * 2 - 2)
-if args.chisq_choice in ['max_cont_trad']:
-    cont_chisq = f['cont_chisq'][:]
-    cont_chisq_dof = f['cont_chisq_dof'][:]
-    cont_chisq /= cont_chisq_dof
-if args.chisq_choice == 'traditional':
-    chisq = trad_chisq
-elif args.chisq_choice == 'max_cont_trad':
-    chisq = numpy.maximum(trad_chisq, cont_chisq)
-else:
-    err_msg="Do not recognized --chisq-choice %s" %(args.chisq_choice,)
-    raise ValueError(err_msg)
+chisq = get_chisq_from_file_choice(f, args.chisq_choice)
 
 def snr_from_chisq(chisq, newsnr, q=6.):
     snr = numpy.zeros(len(chisq)) + float(newsnr)
@@ -88,8 +71,9 @@ cb.set_label('Trigger Density')
 pylab.xlabel('Signal-to-Noise Ratio')
 pylab.ylabel('Reduced $\\chi^2$')
 pycbc.results.save_fig_with_metadata(fig, args.output_file, 
-     title="%s :SNR vs Reduced Chisq" % ifo, 
-     caption="Distribution of SNR and Chisq for single detector triggers: "
-             "Black lines show contours of constant NewSNR.",
+     title="%s :SNR vs Reduced %s Chisq" % (ifo, args.chisq_choice),
+     caption="Distribution of SNR and %s Chisq for single detector triggers: "
+             "Black lines show contours of constant NewSNR." \
+              %(args.chisq_choice,),
      cmd=' '.join(sys.argv),
      fig_kwds={'dpi':300})

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -324,3 +324,45 @@ class ForegroundTriggers(object):
         outdoc.childNodes[0].appendChild(sngl_inspiral_table)
 
         ligolw_utils.write_filename(outdoc, file_name)
+
+chisq_choices = ['traditional', 'cont', 'bank', 'max_cont_trad',
+                 'max_bank_cont', 'max_bank_trad', 'max_bank_cont_trad']
+
+def get_chisq_from_file_choice(hdfile, chisq_choice):
+    f = hdfile
+    if chisq_choice in ['traditional','max_cont_trad', 'max_bank_trad',
+                             'max_bank_cont_trad']:
+        trad_chisq = f['chisq'][:]
+        # We now need to handle the case where chisq is not actually calculated
+        # 0 is used as a sentinel value
+        l = trad_chisq == 0
+        trad_chisq_dof = f['chisq_dof'][:]
+        trad_chisq /= (trad_chisq_dof * 2 - 2)
+    if chisq_choice in ['cont', 'max_cont_trad', 'max_bank_cont',
+                             'max_bank_cont_trad']:
+        cont_chisq = f['cont_chisq'][:]
+        cont_chisq_dof = f['cont_chisq_dof'][:]
+        cont_chisq /= cont_chisq_dof
+    if chisq_choice in ['bank', 'max_bank_cont', 'max_bank_trad',
+                             'max_bank_cont_trad']:
+        bank_chisq = f['bank_chisq'][:]
+        bank_chisq_dof = f['bank_chisq_dof'][:]
+        bank_chisq /= bank_chisq_dof
+    if chisq_choice == 'traditional':
+        chisq = trad_chisq
+    elif chisq_choice == 'cont':
+        chisq = cont_chisq
+    elif chisq_choice == 'bank':
+        chisq = bank_chisq
+    elif chisq_choice == 'max_cont_trad':
+        chisq = np.maximum(trad_chisq, cont_chisq)
+    elif chisq_choice == 'max_bank_cont':
+        chisq = np.maximum(bank_chisq, cont_chisq)
+    elif chisq_choice == 'max_bank_trad':
+        chisq = np.maximum(bank_chisq, trad_chisq)
+    elif chisq_choice == 'max_bank_cont_trad':
+        chisq = np.maximum(np.maximum(bank_chisq, cont_chisq), trad_chisq)
+    else:
+        err_msg="Do not recognized --chisq-choice %s" %(args.chisq_choice,)
+        raise ValueError(err_msg)
+    return chisq


### PR DESCRIPTION
This commit allows for plotting any of the three chisqs (or combinations thereof) in the two chisq plotting codes. It also includes some cosmetic fixes to ensure that the axis limits are sane and to put the chisq type in the file metadata for the webpage.

Here's an example of this plotting *all* the chisqs (our webserver still seems to have problems, be patient):

https://galahad.aei.mpg.de/~spxiwh/LVC/ER7/analyses/BBH_alignedspin/run17/3._single_triggers/

I'm not sure if io/hdf.py is the right place for the chisq choices code block. Any suggestions for a better home, or is this okay?

(With all 3 chisqs the L1 performance actually seems quite good for these short duration templates! We need to figure out how to better discriminate in H1 though).