### PR TITLE
Add ability to specify backup gsiftp datafind server

### DIFF
--- a/docs/workflow/datafind.rst
+++ b/docs/workflow/datafind.rst
@@ -88,6 +88,7 @@ When using any of the AT_RUNTIME sub-modules the following other configuration o
 
 * datafind-X1-frame-type = NAME - REQUIRED. Where X1 is replaced by the ifo name for each ifo. The NAME should be the full frame type, which is used when querying the database.
 * datafind-ligo-datafind-server = URL - OPTIONAL. If provided use this server when querying for frames. If not provided, which is recommended for most applications, then the LIGO_DATAFIND_SERVER environment variable will be used to determine this.
+* datafind-backup-datafind-server = URL - OPTIONAL. This option is only available when using AT_RUNTIME_SINGLE_FRAMES or AT_RUNTIME_MULTIPLE_FRAMES. If given it will query a second datafind server (ie. a remote server) using gsiftp urltypes. This will then allow frames to be associated with both a file:// and gsiftp:// url, in the case that your local site is missing a frame file, or the file is not accessible, pegasus will copy the file from gsiftp://. **NOTE** This will not catch the case that the frame file is available at the **start** of a workflow but goes missing later. Pegasus can copy **all** frame files around at the start of the workflow, but you may not want this (remove symlink option from the basic_pegasus.conf if you want this).
 
 When using the PREGENERATED sub-module the following configuartion options apply in the [workflow-datafind] section:
 


### PR DESCRIPTION
Josh, I'm not sure who to assign this to with Alex on thesis-writing duty. As this was requested by Cardiff folk maybe we can assign to one of them? For now I am assigning you.

This was a feature request from the Cardiff folk at the recent face-to-face. Specifically, you can now specify a backup datafind server for PyCBC workflows. The primary server is used for frames in the case that it finds all the frames it expects to, the backup server is only used if frames are missing on the local server. The backup server is only asked for gsiftp urls (though we could change this if there is a use-case for that) and the frame files will be *copied* to the local machine.

This allows us to run analyses when a specific local file server or node goes down (for that you need to be using the check-frames-exist option) or a site is just missing some files. Frame files are deleted along with other temporary products on workflow completion.

I have tested this on Cardiff's Raven cluster and pulled in missing ER6 L1 recalibrated data alongside present H1 Gaussian noise. I also tested by making it look like a frame was not present locally and the new code recognized this, removed the local url and fell back to the gsiftp url.

A strange pegasus thing: If I supply 3 urls for a file, pegasus will expect all to be valid or it will fail. It does not fall back on a gsiftp url if the file url is not present. It would be nice if this were possible, maybe I am missing some magic config option to do this.

Cheers
Ian