### PR TITLE
fix misnamed variable in pycbc_plot_singles_vs_params

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_singles_vs_params
+++ b/bin/hdfcoinc/pycbc_plot_singles_vs_params
@@ -71,7 +71,7 @@ logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
 filter_func = None # placeholder for a general filter function for the triggers
 trigs = pycbc.io.SingleDetTriggers(opts.single_trig_file, opts.bank_file,
-                  opts.veto_file, opts.segment_name, filterfunc, opts.detector)
+                  opts.veto_file, opts.segment_name, filter_func, opts.detector)
 
 x = getattr(trigs, opts.x_var)
 y = getattr(trigs, opts.y_var)

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -177,6 +177,8 @@ class SingleDetTriggers(object):
             self.mask = np.logical_and(self.boolean_veto, self.filter_mask)
             logging.info('%i triggers remain after cut on %s',
                           len(self.trigs['end_time'][self.mask]), filter_func)
+        else:
+            self.mask = self.veto_mask
 
     @classmethod
     def get_param_names(cls):


### PR DESCRIPTION
There is a misnamed variable 'filter_func' that is causing pycbc_plot_singles to fail in current workflows.