### PR TITLE
Statmap reorg

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -40,9 +40,13 @@ ft1, ft2 = d.time1[fore_locs], d.time2[fore_locs]
 vt = (ft1 + ft2) / 2.0
 veto_start, veto_end = vt - args.veto_window, vt + args.veto_window
 veto_time = abs(veto.start_end_to_segments(veto_start, veto_end).coalesce())  
+
 v1 = veto.indices_within_times(d.time1, veto_start, veto_end) 
-v2 = veto.indices_within_times(d.time2, veto_start, veto_end) 
-e = d.remove(v1).remove(v2)
+e = d.remove(v1).
+
+v2 = veto.indices_within_times(e.time2, veto_start, veto_end) 
+e = e.remove(v2)
+
 logging.info("Clustering coinc triggers (exclusive of zerolag)")
 e = e.cluster(attrs['timeslide_interval'], args.cluster_window)
 

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -27,11 +27,11 @@ args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 
 logging.info("Loading coinc triggers")    
-d, attrs, seg = coinc.load_coincs(args.coinc_files)   
+d = coinc.load_coincs(args.coinc_files)   
 logging.info("We have %s triggers" % len(d.stat))
 
 logging.info("Clustering coinc triggers (inclusive of zerolag)")
-d = d.cluster(attrs['timeslide_interval'], args.cluster_window)
+d = d.cluster(args.cluster_window)
 
 fore_locs = d.timeslide_id == 0
 logging.info("%s clustered foreground triggers" % fore_locs.sum())
@@ -48,18 +48,18 @@ v2 = veto.indices_within_times(e.time2, veto_start, veto_end)
 e = e.remove(v2)
 
 logging.info("Clustering coinc triggers (exclusive of zerolag)")
-e = e.cluster(attrs['timeslide_interval'], args.cluster_window)
+e = e.cluster(args.cluster_window)
 
 logging.info("Dumping foreground triggers")
 f = h5py.File(args.output_file, "w")
-f.attrs['detector_1'] = attrs['detector_1']
-f.attrs['detector_2'] = attrs['detector_2']
-f.attrs['timeslide_interval'] = attrs['timeslide_interval']
+f.attrs['detector_1'] = d.attrs['detector_1']
+f.attrs['detector_2'] = d.attrs['detector_2']
+f.attrs['timeslide_interval'] = d.attrs['timeslide_interval']
 
 # Copy over the segment for coincs and singles
-for key in seg.keys():
-    f['segments/%s/start' % key] = seg[key]['start'][:]
-    f['segments/%s/end' % key] = seg[key]['end'][:]
+for key in d.seg.keys():
+    f['segments/%s/start' % key] = d.seg[key]['start'][:]
+    f['segments/%s/end' % key] = d.seg[key]['end'][:]
 
 f['segments/foreground_veto/start'] = veto_start
 f['segments/foreground_veto/end'] = veto_end
@@ -83,16 +83,16 @@ logging.info("Dumping background triggers (exclusive of zerolag)")
 for k in e.data:
     f['background_exc/' + k] = e.data[k]
 
-maxtime = max(attrs['foreground_time1'], attrs['foreground_time2'])
-mintime = min(attrs['foreground_time1'], attrs['foreground_time2'])
+maxtime = max(d.attrs['foreground_time1'], d.attrs['foreground_time2'])
+mintime = min(d.attrs['foreground_time1'], d.attrs['foreground_time2'])
 
 maxtime_exc = maxtime - veto_time
 mintime_exc = mintime - veto_time
 
-background_time = int(maxtime / attrs['timeslide_interval']) * mintime
-coinc_time = float(attrs['coinc_time'])
+background_time = int(maxtime / d.attrs['timeslide_interval']) * mintime
+coinc_time = float(d.attrs['coinc_time'])
 
-background_time_exc = int(maxtime_exc / attrs['timeslide_interval']) * mintime_exc
+background_time_exc = int(maxtime_exc / d.attrs['timeslide_interval']) * mintime_exc
 coinc_time_exc = coinc_time - veto_time
 
 logging.info("Making mapping from FAN to the combined statistic")

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -6,7 +6,7 @@ with producing the combined foreground and background triggers
 """
 import argparse, h5py, logging, itertools, numpy
 from pycbc.events import veto, coinc
-import pycbc.version, pycbc.pnutils
+import pycbc.version, pycbc.pnutils, pycbc.io
 
 def sec_to_year(sec):
     return sec / (3.15569e7)
@@ -27,15 +27,9 @@ args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 
 logging.info("Loading coinc triggers")    
-d = coinc.load_coincs(args.coinc_files)   
+d = pycbc.io.StatmapData(files=args.coinc_files)   
 logging.info("We have %s triggers" % len(d.stat))
-
-logging.info("Clustering coinc triggers (inclusive of zerolag)")
-d = d.cluster(args.cluster_window)
-
 fore_locs = d.timeslide_id == 0
-logging.info("%s clustered foreground triggers" % fore_locs.sum())
-
 ft1, ft2 = d.time1[fore_locs], d.time2[fore_locs]
 vt = (ft1 + ft2) / 2.0
 veto_start, veto_end = vt - args.veto_window, vt + args.veto_window
@@ -46,6 +40,11 @@ e = d.remove(v1)
 
 v2 = veto.indices_within_times(e.time2, veto_start, veto_end) 
 e = e.remove(v2)
+
+logging.info("Clustering coinc triggers (inclusive of zerolag)")
+d = d.cluster(args.cluster_window)
+fore_locs = d.timeslide_id == 0
+logging.info("%s clustered foreground triggers" % fore_locs.sum())
 
 logging.info("Clustering coinc triggers (exclusive of zerolag)")
 e = e.cluster(args.cluster_window)

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -5,96 +5,8 @@ by pycbc_coinc_findtrigs to generated a mapping between SNR and FAP, along
 with producing the combined foreground and background triggers
 """
 import argparse, h5py, logging, itertools, numpy
-from scipy.interpolate import interp1d  
 from pycbc.events import veto, coinc
 import pycbc.version, pycbc.pnutils
-
-def apply_bank_statistic(data, name, bank_file):
-    if name == 'mchirp_bin':
-        bank = h5py.File(bank_file)
-        b = [0, 1, 2, 3, 4]
-        data = mchirp_bin(data, bank, b)           
-    return data
-    
-def mchirp_bin(data, bank, bins):
-    logging.info("applying mchirp binning")
-    r = []
-    mc, et = pycbc.pnutils.mass1_mass2_to_mchirp_eta(bank['mass1'][:], bank['mass2'][:])
-    for i in range(len(bins)-1):
-        loc = numpy.where(numpy.logical_and(mc > bins[i], mc <= bins[i+1]))[0]
-        d = data.select(numpy.in1d(data.template_id, loc))
-        if len(d) > 0:
-            d = d.cluster()
-            fan = calculate_fan_map(d.stat, d.decimation_factor)(d.stat)
-            d.data['stat'] = 1.0 / fan
-        r.append(ArrayData(d.interval, d.window, data=d.data))
-    return numpy.sum(r)            
-
-class ArrayData(object):
-    def __init__(self, interval, window, data=None, files=None, groups=None):
-        self.data = data
-        self.interval = interval
-        self.window = window
-        
-        if files:
-            self.data = {}
-            for g in groups:
-                self.data[g] = []
-            
-            for f in files:
-                for g in groups:
-                    d = h5py.File(f)
-                    if g in d:
-                        self.data[g].append(d[g][:])
-                    d.close()
-                    
-            for k in self.data:
-                self.data[k] = numpy.concatenate(self.data[k])
-
-        for k in self.data:
-            setattr(self, k, self.data[k])
-
-    def __len__(self):
-        return len(self.data[self.data.keys()[0]])
-
-    def __add__(self, other):
-        data = {}
-        for k in self.data:
-            data[k] = numpy.concatenate([self.data[k], other.data[k]])
-        return ArrayData(self.interval, self.window, data=data)
-
-    def select(self, idx):
-        data = {}
-        for k in self.data:
-            data[k] = self.data[k][idx]
-        return ArrayData(self.interval, self.window, data=data)
-   
-    def remove(self, idx):
-        data = {}
-        for k in self.data:
-            data[k] = numpy.delete(self.data[k], idx)
-        return ArrayData(self.interval, self.window, data=data)
-
-    def cluster(self):
-        cid = coinc.cluster_coincs(self.stat, self.time1, self.time2,
-                                 self.timeslide_id, self.interval, self.window)
-        return self.select(cid) 
-         
-def load_coincs(coinc_files, window):
-    columns = ['stat', 'time1', 'time2', 'trigger_id1', 'trigger_id2', 
-               'template_id', 'decimation_factor', 'timeslide_id']
-    f = h5py.File(coinc_files[0])
-    d = ArrayData(f.attrs['timeslide_interval'], window, files=coinc_files, groups=columns)
-    return (d, dict(f.attrs), f['segments'])
-           
-def calculate_fan_map(combined_stat, dec):
-    """ Return a function to map between false alarm number (FAN) and the
-    combined ranking statistic.
-    """
-    stat_sorting = combined_stat.argsort()    
-    combined_stat = combined_stat[stat_sorting]
-    fan = dec[stat_sorting][::-1].cumsum()[::-1]    
-    return interp1d(combined_stat, fan, fill_value=1, bounds_error=False) 
 
 def sec_to_year(sec):
     return sec / (3.15569e7)
@@ -110,18 +22,16 @@ parser.add_argument('--cluster-window', type=float,
          help='Size in seconds to maximize coinc triggers')
 parser.add_argument('--veto-window', type=float, 
          help='window around each zerolag trigger to window out')
-parser.add_argument('--cross-bank-statistic', default=None)
 parser.add_argument('--output-file')
-parser.add_argument('--bank-file')
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 
 logging.info("Loading coinc triggers")    
-d, attrs, seg = load_coincs(args.coinc_files, args.cluster_window)   
+d, attrs, seg = coinc.load_coincs(args.coinc_files)   
 logging.info("We have %s triggers" % len(d.stat))
 
 logging.info("Clustering coinc triggers (inclusive of zerolag)")
-d = apply_bank_statistic(d, args.cross_bank_statistic, args.bank_file).cluster()
+d = d.cluster(attrs['timeslide_interval'], args.cluster_window)
 
 fore_locs = d.timeslide_id == 0
 logging.info("%s clustered foreground triggers" % fore_locs.sum())
@@ -134,7 +44,7 @@ v1 = veto.indices_within_times(d.time1, veto_start, veto_end)
 v2 = veto.indices_within_times(d.time2, veto_start, veto_end) 
 e = d.remove(v1).remove(v2)
 logging.info("Clustering coinc triggers (exclusive of zerolag)")
-e = apply_bank_statistic(e, args.cross_bank_statistic, args.bank_file).cluster()
+e = e.cluster(attrs['timeslide_interval'], args.cluster_window)
 
 logging.info("Dumping foreground triggers")
 f = h5py.File(args.output_file, "w")
@@ -153,8 +63,6 @@ f['segments/foreground_veto/end'] = veto_end
 if fore_locs.sum() > 0:
     for k in d.data:
         f['foreground/' + k] = d.data[k][fore_locs]
-
-
 
 back_locs = d.timeslide_id != 0
 
@@ -185,10 +93,10 @@ coinc_time_exc = coinc_time - veto_time
 
 logging.info("Making mapping from FAN to the combined statistic")
 back_stat = d.stat[back_locs]
-fanmap = calculate_fan_map(back_stat, d.decimation_factor[back_locs])       
+fanmap = coinc.calculate_fan_map(back_stat, d.decimation_factor[back_locs])       
 back_fan = fanmap(back_stat)
 
-fanmap_exc = calculate_fan_map(e.stat, e.decimation_factor)     
+fanmap_exc = coinc.calculate_fan_map(e.stat, e.decimation_factor)     
 back_fan_exc = fanmap_exc(e.stat)         
 
 f['background/fan'] = back_fan
@@ -217,7 +125,7 @@ if fore_locs.sum() > 0:
     f['foreground/fan'] = fore_fan
     f['foreground/ifar'] = sec_to_year(ifar)
     f['foreground/fap'] = fap
-    
+   
     f['foreground/fan_exc'] = fore_fan_exc
     f['foreground/ifar_exc'] = sec_to_year(ifar_exc)
     f['foreground/fap_exc'] = fap_exc

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -123,8 +123,8 @@ fore_fan_exc = fanmap_exc(fore_stat)
 ifar_exc = background_time_exc / fore_fan_exc
 
 logging.info("calculating fap values")
-fap = numpy.clip(coinc_time/ifar, 0, 1)
-fap_exc = numpy.clip(coinc_time_exc/ifar_exc, 0, 1)
+fap = 1 - numpy.exp(- coinc_time / ifar)
+fap_exc = 1 - numpy.exp(- coinc_time_exc / ifar_exc)
 if fore_locs.sum() > 0:
     f['foreground/fan'] = fore_fan
     f['foreground/ifar'] = sec_to_year(ifar)

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -42,7 +42,7 @@ veto_start, veto_end = vt - args.veto_window, vt + args.veto_window
 veto_time = abs(veto.start_end_to_segments(veto_start, veto_end).coalesce())  
 
 v1 = veto.indices_within_times(d.time1, veto_start, veto_end) 
-e = d.remove(v1).
+e = d.remove(v1)
 
 v2 = veto.indices_within_times(e.time2, veto_start, veto_end) 
 e = e.remove(v2)

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -4,39 +4,61 @@ The program combines coincident output files generated
 by pycbc_coinc_findtrigs to generated a mapping between SNR and FAP, along
 with producing the combined foreground and background triggers
 """
-import argparse, h5py, logging, itertools, copy
+import argparse, h5py, logging, itertools, copy, numpy
 from scipy.interpolate import interp1d  
-from pycbc.future import numpy
-from itertools import izip
 from pycbc.events import veto, coinc
 import pycbc.version
-    
-def load_coincs(coinc_files):
-    stat, time1, time2, timeslide_id, template_id, decimation_factor, i1, i2 = [], [], [], [], [], [], [], []
-    for cfile in coinc_files:
-        try:
-            logging.info('reading %s' % cfile)
-            f = h5py.File(cfile, "r")
-            stat.append(f['stat'][:])
-            time1.append(f['time1'][:])
-            time2.append(f['time2'][:])
-            i1.append(f['trigger_id1'][:])
-            i2.append(f['trigger_id2'][:])
-            timeslide_id.append(f['timeslide_id'][:])
-            template_id.append(f['template_id'][:])
-            decimation_factor.append(f['decimation_factor'][:])
-            attr = dict(f.attrs)
-            
-        except:
-            continue
-    return (numpy.concatenate(stat), numpy.concatenate(time1),
-           numpy.concatenate(time2), numpy.concatenate(timeslide_id),
-           numpy.concatenate(template_id), numpy.concatenate(decimation_factor),
-           numpy.concatenate(i1), numpy.concatenate(i2), attr, 
-           f['segments/coinc/start'][:], f['segments/coinc/end'][:],
-           f['segments']
-           )
 
+def choose_bank_statistic(name):
+    pass
+    
+class BankStatistic(object):
+    pass
+    
+class MassBins(BankStatistic):
+    pass
+
+class ArrayData(object):
+    def __init__(self, data=None, files=None, groups=None):
+        if data:
+            self.data = data
+        elif files:
+            self.data = {}
+            for g in groups:
+                self.data[g] = []
+            
+            for f in files:
+                for g in groups:
+                    d = h5py.File(f)
+                    if g in d:
+                        self.data[g].append(d[g][:])
+                    d.close()
+                    
+            for k in self.data:
+                self.data[k] = numpy.concatenate(self.data[k])
+
+        for k in self.data:
+            setattr(self, k, self.data[k])
+
+    def select(self, idx):
+        data = {}
+        for k in self.data:
+            data[k] = self.data[k][idx]
+        return ArrayData(data)
+   
+    def remove(self, idx):
+        data = {}
+        for k in self.data:
+            data[k] = numpy.delete(self.data[k], idx)
+        return ArrayData(data)
+        
+def load_coincs(coinc_files):
+    columns = ['stat', 'time1', 'time2', 'trigger_id1', 'trigger_id2', 
+               'template_id', 'decimation_factor', 'timeslide_id']
+    f = h5py.File(coinc_files[0])
+    return (ArrayData(files=coinc_files, groups=columns), dict(f.attrs), 
+           f['segments/coinc/start'][:], f['segments/coinc/end'][:], f['segments'])
+           
 def calculate_fan_map(combined_stat, dec):
     """ Return a function to map between false alarm number (FAN) and the
     combined ranking statistic.
@@ -51,60 +73,46 @@ def sec_to_year(sec):
 
 parser = argparse.ArgumentParser()
 # General required options
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
-parser.add_argument('--coinc-files', nargs='+', help='List of coincidence files used to calculate the FAP, FAR, etc.')
+parser.add_argument('--version', action='version', 
+         version=pycbc.version.git_verbose_msg)
+parser.add_argument('--coinc-files', nargs='+', 
+         help='List of coincidence files used to calculate the FAP, FAR, etc.')
 parser.add_argument('--verbose', action='count')
-parser.add_argument('--cluster-window', type=float, help='Size in seconds to maximize coinc triggers')
-parser.add_argument('--veto-window', type=float, help='window around each zerolag trigger to window out')
+parser.add_argument('--cluster-window', type=float, 
+         help='Size in seconds to maximize coinc triggers')
+parser.add_argument('--veto-window', type=float, 
+         help='window around each zerolag trigger to window out')
 parser.add_argument('--output-file')
 args = parser.parse_args()
-
-if args.verbose:
-    log_level = logging.INFO
-    logging.basicConfig(format='%(asctime)s : %(message)s', 
-                            level=log_level)
+pycbc.init_logging(args.verbose)
 
 logging.info("Loading coinc triggers")    
-stat, t1, t2, sid, tid, dec, i1, i2, attrs, start, end, seg = load_coincs(args.coinc_files)   
-logging.info("We have %s triggers" % len(stat))
-
-unclustered_fore_locs = numpy.where((sid == 0))[0]
-logging.info('%s unclustered foreground triggers' % len(unclustered_fore_locs))  
+d, attrs, start, end, seg = load_coincs(args.coinc_files)   
+logging.info("We have %s triggers" % len(d.stat))
 
 logging.info("Clustering coinc triggers (inclusive of zerolag)")
-cid = coinc.cluster_coincs(stat, t1, t2, sid, 
-                     attrs['timeslide_interval'], 
-                     args.cluster_window)
-stat_i, t1_i, t2_i, sid_i, tid_i, dec_i, i1_i, i2_i = stat[cid], t1[cid], t2[cid], sid[cid], tid[cid], dec[cid], i1[cid], i2[cid]
+d = d.select(coinc.cluster_coincs(d.stat, d.time1, d.time2, d.timeslide_id, 
+                     attrs['timeslide_interval'], args.cluster_window))
 
-ft1, ft2 = t1[unclustered_fore_locs], t2[unclustered_fore_locs]
+fore_locs = d.timeslide_id == 0
+logging.info("%s clustered foreground triggers" % fore_locs.sum())
+
+ft1, ft2 = d.time1[fore_locs], d.time2[fore_locs]
 vt = (ft1 + ft2) / 2.0
 veto_start, veto_end = vt - args.veto_window, vt + args.veto_window
-v1 = veto.indices_within_times(t1, veto_start, veto_end) 
-v2 = veto.indices_within_times(t2, veto_start, veto_end) 
-vidx = numpy.unique(numpy.concatenate([v1, v2]))
-vi = numpy.zeros(len(t1), dtype=numpy.bool)
-vi[:] = True
-vi[vidx] = False
-
 veto_time = abs(veto.start_end_to_segments(veto_start, veto_end).coalesce())  
-
+v1 = veto.indices_within_times(d.time1, veto_start, veto_end) 
+v2 = veto.indices_within_times(d.time2, veto_start, veto_end) 
+e = d.remove(v1).remove(v2)
 logging.info("Clustering coinc triggers (exclusive of zerolag)")
-cid = coinc.cluster_coincs(stat[vi], t1[vi], t2[vi], sid[vi], 
-                     attrs['timeslide_interval'], 
-                     args.cluster_window)
-stat_e, t1_e, t2_e, sid_e, tid_e, dec_e, i1_e, i2_e = stat[vi][cid], t1[vi][cid], t2[vi][cid], sid[vi][cid], tid[vi][cid], dec[vi][cid], i1[vi][cid], i2[vi][cid]
+e = e.select(coinc.cluster_coincs(e.stat, e.time1, e.time2, e.timeslide_id, 
+                     attrs['timeslide_interval'], args.cluster_window))
 
 logging.info("Dumping foreground triggers")
 f = h5py.File(args.output_file, "w")
-
 f.attrs['detector_1'] = attrs['detector_1']
 f.attrs['detector_2'] = attrs['detector_2']
 f.attrs['timeslide_interval'] = attrs['timeslide_interval']
-
-
-fore_locs = (sid_i == 0)
-logging.info("%s clustered foreground triggers" % fore_locs.sum())
 
 # Copy over the segment for coincs and singles
 for key in seg.keys():
@@ -115,89 +123,75 @@ f['segments/foreground_veto/start'] = veto_start
 f['segments/foreground_veto/end'] = veto_end
 
 if fore_locs.sum() > 0:
-    f['foreground/stat'] = stat_i[fore_locs]
-    f['foreground/time1'] = t1_i[fore_locs]
-    f['foreground/time2'] = t2_i[fore_locs]
-    f['foreground/trigger_id1'] = i1_i[fore_locs]
-    f['foreground/trigger_id2'] = i2_i[fore_locs]
-    f['foreground/template_id'] = tid_i[fore_locs]
+    for k in d.data:
+        f['foreground/' + k] = d.data[k][fore_locs]
 
-back_locs = numpy.where((sid_i != 0))[0]
 
-if len(back_locs) > 0:
-    logging.info("Dumping background triggers (inclusive of zerolag)")
-    f['background/stat'] = stat_i[back_locs]
-    f['background/time1'] = t1_i[back_locs]
-    f['background/time2'] = t2_i[back_locs]
-    f['background/trigger_id1'] = i1_i[back_locs]
-    f['background/trigger_id2'] = i2_i[back_locs]
-    f['background/timeslide_id'] = sid_i[back_locs]
-    f['background/template_id'] = tid_i[back_locs]
-    f['background/decimation_factor'] = dec_i[back_locs]
 
-    logging.info("Dumping background triggers (exclusive of zerolag)")      
-    f['background_exc/stat'] = stat_e
-    f['background_exc/time1'] = t1_e
-    f['background_exc/time2'] = t2_e
-    f['background_exc/trigger_id1'] = i1_e
-    f['background_exc/trigger_id2'] = i2_e
-    f['background_exc/timeslide_id'] = sid_e
-    f['background_exc/template_id'] = tid_e
-    f['background_exc/decimation_factor'] = dec_e
-    
-    maxtime = max(attrs['foreground_time1'], attrs['foreground_time2'])
-    mintime = min(attrs['foreground_time1'], attrs['foreground_time2'])
-    
-    maxtime_exc = maxtime - veto_time
-    mintime_exc = mintime - veto_time
-    
-    background_time = int(maxtime / attrs['timeslide_interval']) * mintime
-    coinc_time = float(attrs['coinc_time'])
-    
-    background_time_exc = int(maxtime_exc / attrs['timeslide_interval']) * mintime_exc
-    coinc_time_exc = coinc_time - veto_time
-    
-    logging.info("Making mapping from FAN to the combined statistic")
-    back_stat = stat_i[back_locs]
-    fanmap = calculate_fan_map(back_stat, dec_i[back_locs])       
-    back_fan = fanmap(back_stat)
+back_locs = d.timeslide_id != 0
 
-    fanmap_exc = calculate_fan_map(stat_e, dec_e)     
-    back_fan_exc = fanmap_exc(stat_e)         
-    
-    f['background/fan'] = back_fan
-    f['background/ifar'] = sec_to_year(background_time / back_fan)
-    
-    f['background_exc/fan'] = back_fan_exc
-    f['background_exc/ifar'] = sec_to_year(background_time_exc / back_fan_exc)
-
-    f.attrs['background_time'] = background_time
-    f.attrs['foreground_time'] = coinc_time
-    f.attrs['background_time_exc'] = background_time_exc
-    f.attrs['foreground_time_exc'] = coinc_time_exc
-    
-    logging.info("calculating ifar values")
-    fore_stat = stat_i[fore_locs]
-    
-    fore_fan = fanmap(fore_stat)
-    ifar = background_time / fore_fan
-    
-    fore_fan_exc = fanmap_exc(fore_stat)
-    ifar_exc = background_time_exc / fore_fan_exc
-
-    logging.info("calculating fap values")
-    fap = numpy.clip(coinc_time/ifar, 0, 1)
-    fap_exc = numpy.clip(coinc_time_exc/ifar_exc, 0, 1)
-    if fore_locs.sum() > 0:
-        f['foreground/fan'] = fore_fan
-        f['foreground/ifar'] = sec_to_year(ifar)
-        f['foreground/fap'] = fap
-        
-        f['foreground/fan_exc'] = fore_fan_exc
-        f['foreground/ifar_exc'] = sec_to_year(ifar_exc)
-        f['foreground/fap_exc'] = fap_exc
-else:
+if (back_locs.sum()) == 0:
     logging.warn("There were no background events, so we could not assign "
                  "any statistic values")
-logging.info("Done") 
+    exit()
+    
+logging.info("Dumping background triggers (inclusive of zerolag)")
+for k in d.data:
+    f['background/' + k] = d.data[k][back_locs]
+    
+logging.info("Dumping background triggers (exclusive of zerolag)")   
+for k in e.data:
+    f['background_exc/' + k] = e.data[k]
 
+maxtime = max(attrs['foreground_time1'], attrs['foreground_time2'])
+mintime = min(attrs['foreground_time1'], attrs['foreground_time2'])
+
+maxtime_exc = maxtime - veto_time
+mintime_exc = mintime - veto_time
+
+background_time = int(maxtime / attrs['timeslide_interval']) * mintime
+coinc_time = float(attrs['coinc_time'])
+
+background_time_exc = int(maxtime_exc / attrs['timeslide_interval']) * mintime_exc
+coinc_time_exc = coinc_time - veto_time
+
+logging.info("Making mapping from FAN to the combined statistic")
+back_stat = d.stat[back_locs]
+fanmap = calculate_fan_map(back_stat, d.decimation_factor[back_locs])       
+back_fan = fanmap(back_stat)
+
+fanmap_exc = calculate_fan_map(e.stat, e.decimation_factor)     
+back_fan_exc = fanmap_exc(e.stat)         
+
+f['background/fan'] = back_fan
+f['background/ifar'] = sec_to_year(background_time / back_fan)  
+f['background_exc/fan'] = back_fan_exc
+f['background_exc/ifar'] = sec_to_year(background_time_exc / back_fan_exc)
+
+f.attrs['background_time'] = background_time
+f.attrs['foreground_time'] = coinc_time
+f.attrs['background_time_exc'] = background_time_exc
+f.attrs['foreground_time_exc'] = coinc_time_exc
+
+logging.info("calculating ifar values")
+fore_stat = d.stat[fore_locs]
+
+fore_fan = fanmap(fore_stat)
+ifar = background_time / fore_fan
+
+fore_fan_exc = fanmap_exc(fore_stat)
+ifar_exc = background_time_exc / fore_fan_exc
+
+logging.info("calculating fap values")
+fap = numpy.clip(coinc_time/ifar, 0, 1)
+fap_exc = numpy.clip(coinc_time_exc/ifar_exc, 0, 1)
+if fore_locs.sum() > 0:
+    f['foreground/fan'] = fore_fan
+    f['foreground/ifar'] = sec_to_year(ifar)
+    f['foreground/fap'] = fap
+    
+    f['foreground/fan_exc'] = fore_fan_exc
+    f['foreground/ifar_exc'] = sec_to_year(ifar_exc)
+    f['foreground/fap_exc'] = fap_exc
+
+logging.info("Done") 

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -18,10 +18,10 @@ parser.add_argument('--version', action='version',
 parser.add_argument('--coinc-files', nargs='+', 
          help='List of coincidence files used to calculate the FAP, FAR, etc.')
 parser.add_argument('--verbose', action='count')
-parser.add_argument('--cluster-window', type=float, 
-         help='Size in seconds to maximize coinc triggers')
-parser.add_argument('--veto-window', type=float, 
-         help='window around each zerolag trigger to window out')
+parser.add_argument('--cluster-window', type=float, default=10,
+         help='Length of time window in seconds to cluster coinc events, [default=10s]')
+parser.add_argument('--veto-window', type=float, default=.1,
+         help='Time around each zerolag trigger to window out, [default=.1s]')
 parser.add_argument('--output-file')
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -4,25 +4,39 @@ The program combines coincident output files generated
 by pycbc_coinc_findtrigs to generated a mapping between SNR and FAP, along
 with producing the combined foreground and background triggers
 """
-import argparse, h5py, logging, itertools, copy, numpy
+import argparse, h5py, logging, itertools, numpy
 from scipy.interpolate import interp1d  
 from pycbc.events import veto, coinc
-import pycbc.version
+import pycbc.version, pycbc.pnutils
 
-def choose_bank_statistic(name):
-    pass
+def apply_bank_statistic(data, name, bank_file):
+    if name == 'mchirp_bin':
+        bank = h5py.File(bank_file)
+        b = [0, 1, 2, 3, 4]
+        data = mchirp_bin(data, bank, b)           
+    return data
     
-class BankStatistic(object):
-    pass
-    
-class MassBins(BankStatistic):
-    pass
+def mchirp_bin(data, bank, bins):
+    logging.info("applying mchirp binning")
+    r = []
+    mc, et = pycbc.pnutils.mass1_mass2_to_mchirp_eta(bank['mass1'][:], bank['mass2'][:])
+    for i in range(len(bins)-1):
+        loc = numpy.where(numpy.logical_and(mc > bins[i], mc <= bins[i+1]))[0]
+        d = data.select(numpy.in1d(data.template_id, loc))
+        if len(d) > 0:
+            d = d.cluster()
+            fan = calculate_fan_map(d.stat, d.decimation_factor)(d.stat)
+            d.data['stat'] = 1.0 / fan
+        r.append(ArrayData(d.interval, d.window, data=d.data))
+    return numpy.sum(r)            
 
 class ArrayData(object):
-    def __init__(self, data=None, files=None, groups=None):
-        if data:
-            self.data = data
-        elif files:
+    def __init__(self, interval, window, data=None, files=None, groups=None):
+        self.data = data
+        self.interval = interval
+        self.window = window
+        
+        if files:
             self.data = {}
             for g in groups:
                 self.data[g] = []
@@ -40,24 +54,38 @@ class ArrayData(object):
         for k in self.data:
             setattr(self, k, self.data[k])
 
+    def __len__(self):
+        return len(self.data[self.data.keys()[0]])
+
+    def __add__(self, other):
+        data = {}
+        for k in self.data:
+            data[k] = numpy.concatenate([self.data[k], other.data[k]])
+        return ArrayData(self.interval, self.window, data=data)
+
     def select(self, idx):
         data = {}
         for k in self.data:
             data[k] = self.data[k][idx]
-        return ArrayData(data)
+        return ArrayData(self.interval, self.window, data=data)
    
     def remove(self, idx):
         data = {}
         for k in self.data:
             data[k] = numpy.delete(self.data[k], idx)
-        return ArrayData(data)
-        
-def load_coincs(coinc_files):
+        return ArrayData(self.interval, self.window, data=data)
+
+    def cluster(self):
+        cid = coinc.cluster_coincs(self.stat, self.time1, self.time2,
+                                 self.timeslide_id, self.interval, self.window)
+        return self.select(cid) 
+         
+def load_coincs(coinc_files, window):
     columns = ['stat', 'time1', 'time2', 'trigger_id1', 'trigger_id2', 
                'template_id', 'decimation_factor', 'timeslide_id']
     f = h5py.File(coinc_files[0])
-    return (ArrayData(files=coinc_files, groups=columns), dict(f.attrs), 
-           f['segments/coinc/start'][:], f['segments/coinc/end'][:], f['segments'])
+    d = ArrayData(f.attrs['timeslide_interval'], window, files=coinc_files, groups=columns)
+    return (d, dict(f.attrs), f['segments'])
            
 def calculate_fan_map(combined_stat, dec):
     """ Return a function to map between false alarm number (FAN) and the
@@ -82,17 +110,18 @@ parser.add_argument('--cluster-window', type=float,
          help='Size in seconds to maximize coinc triggers')
 parser.add_argument('--veto-window', type=float, 
          help='window around each zerolag trigger to window out')
+parser.add_argument('--cross-bank-statistic', default=None)
 parser.add_argument('--output-file')
+parser.add_argument('--bank-file')
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 
 logging.info("Loading coinc triggers")    
-d, attrs, start, end, seg = load_coincs(args.coinc_files)   
+d, attrs, seg = load_coincs(args.coinc_files, args.cluster_window)   
 logging.info("We have %s triggers" % len(d.stat))
 
 logging.info("Clustering coinc triggers (inclusive of zerolag)")
-d = d.select(coinc.cluster_coincs(d.stat, d.time1, d.time2, d.timeslide_id, 
-                     attrs['timeslide_interval'], args.cluster_window))
+d = apply_bank_statistic(d, args.cross_bank_statistic, args.bank_file).cluster()
 
 fore_locs = d.timeslide_id == 0
 logging.info("%s clustered foreground triggers" % fore_locs.sum())
@@ -105,8 +134,7 @@ v1 = veto.indices_within_times(d.time1, veto_start, veto_end)
 v2 = veto.indices_within_times(d.time2, veto_start, veto_end) 
 e = d.remove(v1).remove(v2)
 logging.info("Clustering coinc triggers (exclusive of zerolag)")
-e = e.select(coinc.cluster_coincs(e.stat, e.time1, e.time2, e.timeslide_id, 
-                     attrs['timeslide_interval'], args.cluster_window))
+e = apply_bank_statistic(e, args.cross_bank_statistic, args.bank_file).cluster()
 
 logging.info("Dumping foreground triggers")
 f = h5py.File(args.output_file, "w")

--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -11,24 +11,85 @@ from itertools import izip
 from pycbc.events import veto, coinc
 import pycbc.version
 
-def load_coincs(coinc_files):
-    cols = ['stat', 'time1', 'time2', 'trigger_id1', 'trigger_id2', 
-            'timeslide_id', 'template_id', 'decimation_factor']
-    data = {}
-    for key in cols:
-        data[key] = []   
-    for cfile in coinc_files:
-        try:
-            logging.info('reading %s' % cfile)
-            f = h5py.File(cfile, "r")
-            for key in data:
-                data[key].append(f[key][:])        
-        except:
-            continue            
-    for key in data:
-        data[key] = numpy.concatenate(data[key])              
-    return data, dict(f.attrs), f['segments/coinc/start'][:], f['segments/coinc/end'][:], f['segments']
+def apply_bank_statistic(data, name, bank_file):
+    bank = h5py.File(bank_file)
+    if name == 'mchirp_bin':
+        b = [0, 1, 2, 3, 4]
+        data = mchirp_bin(data, bank, b)           
+    return data
+    
+def mchirp_bin(data, bank, bins):
+    logging.info("applying mchirp binning")
+    r = []
+    mc, et = pycbc.pnutils.mass1_mass2_to_mchirp_eta(bank['mass1'][:], bank['mass2'][:])
+    for i in range(len(bins)-1):
+        loc = numpy.where(numpy.logical_and(mc > bins[i], mc <= bins[i+1]))[0]
+        d = data.select(numpy.in1d(data.template_id, loc))
+        if len(d) > 0:
+            d = d.cluster()
+            fan = calculate_fan_map(d.stat, d.decimation_factor)(d.stat)
+            d.data['stat'] = 1.0 / fan
+        r.append(ArrayData(d.interval, d.window, data=d.data))
+    return numpy.sum(r)            
 
+class ArrayData(object):
+    def __init__(self, interval, window, data=None, files=None, groups=None):
+        self.data = data
+        self.interval = interval
+        self.window = window
+        
+        if files:
+            self.data = {}
+            for g in groups:
+                self.data[g] = []
+            
+            for f in files:
+                d = h5py.File(f)
+                print f
+                print numpy.where(d['time1'][:] == 0)[0]
+                for g in groups:
+                    if g in d:
+                        self.data[g].append(d[g][:])
+                    
+            for k in self.data:
+                self.data[k] = numpy.concatenate(self.data[k])
+
+        for k in self.data:
+            setattr(self, k, self.data[k])
+
+    def __len__(self):
+        return len(self.data[self.data.keys()[0]])
+
+    def __add__(self, other):
+        data = {}
+        for k in self.data:
+            data[k] = numpy.concatenate([self.data[k], other.data[k]])
+        return ArrayData(self.interval, self.window, data=data)
+
+    def select(self, idx):
+        data = {}
+        for k in self.data:
+            data[k] = self.data[k][idx]
+        return ArrayData(self.interval, self.window, data=data)
+   
+    def remove(self, idx):
+        data = {}
+        for k in self.data:
+            data[k] = numpy.delete(self.data[k], idx)
+        return ArrayData(self.interval, self.window, data=data)
+
+    def cluster(self):
+        cid = coinc.cluster_coincs(self.stat, self.time1, self.time2,
+                                 self.timeslide_id, self.interval, self.window)
+        return self.select(cid) 
+         
+def load_coincs(coinc_files, window):
+    columns = ['stat', 'time1', 'time2', 'trigger_id1', 'trigger_id2', 
+               'template_id', 'decimation_factor', 'timeslide_id']
+    f = h5py.File(coinc_files[0])
+    d = ArrayData(f.attrs['timeslide_interval'], window, files=coinc_files, groups=columns)
+    return (d, dict(f.attrs), f['segments'])
+           
 def calculate_fan_map(combined_stat, dec):
     """ Return a function to map between false alarm number (FAN) and the
     combined ranking statistic.
@@ -70,20 +131,17 @@ if args.verbose:
     logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
 
 logging.info("Loading coinc zerolag triggers")    
-zdata, attrs, start, end, seg = load_coincs(args.zero_lag_coincs)   
-interval = attrs['timeslide_interval']
-zcid = coinc.cluster_coincs(zdata['stat'], zdata['time1'], zdata['time2'], 
-                          zdata['timeslide_id'], interval, args.cluster_window)
+zdata, attrs, seg = load_coincs(args.zero_lag_coincs, args.cluster_window)   
+print zdata.time1, zdata.time2
+print numpy.where(zdata.time1 == 0)[0]
+
+zdata = zdata.cluster()
                      
 logging.info("Loading coinc full inj triggers")    
-fidata, _, _, _, _ = load_coincs(args.mixed_coincs_full_inj)   
-ficid = coinc.cluster_coincs(fidata['stat'], fidata['time1'], fidata['time2'], 
-                         fidata['timeslide_id'], interval, args.cluster_window)
+fidata = load_coincs(args.mixed_coincs_full_inj, args.cluster_window)[0].cluster()
                      
 logging.info("Loading coinc inj full triggers")    
-izdata, _, _, _, _ = load_coincs(args.mixed_coincs_inj_full)   
-ifcid = coinc.cluster_coincs(izdata['stat'], izdata['time1'], izdata['time2'], 
-                         izdata['timeslide_id'], interval, args.cluster_window)
+ifdata = load_coincs(args.mixed_coincs_inj_full, args.cluster_window)[0].cluster() 
 
 f = h5py.File(args.output_file, "w")
 
@@ -95,16 +153,15 @@ f.attrs['timeslide_interval'] = attrs['timeslide_interval']
 for key in seg.keys():
     f['segments/%s/start' % key] = seg[key]['start'][:]
     f['segments/%s/end' % key] = seg[key]['end'][:]
-
+    
 logging.info('writing zero lag triggers')
-
-if len(zdata['stat']) > 0:
-    for key in zdata:
-        f['foreground/%s' % key] = zdata[key][zcid]
-        
+if len(zdata) > 0:
+    for key in zdata.data:
+        f['foreground/%s' % key] = zdata.data[key]
 
 logging.info('calculating statistics excluding zerolag')
 fb = h5py.File(args.full_data_background, "r")
+
 background_time = float(fb.attrs['background_time_exc'])
 coinc_time = float(fb.attrs['foreground_time_exc'])
 back_stat = fb['background_exc/stat'][:]
@@ -116,9 +173,8 @@ f.attrs['foreground_time_exc'] = coinc_time
 f.attrs['background_time'] = background_time
 f.attrs['foreground_time'] = coinc_time
 
-if len(zdata['stat']) > 0:
-    
-    fore_fan = fanmap_exc(zdata['stat'][zcid])
+if len(zdata) > 0:
+    fore_fan = fanmap_exc(zdata.stat)
     ifar_exc = background_time / fore_fan
     fap_exc = numpy.clip(coinc_time / ifar_exc, 0, 1)
     f['foreground/fan_exc'] = fore_fan
@@ -126,10 +182,9 @@ if len(zdata['stat']) > 0:
     f['foreground/fap_exc'] = fap_exc
     
     logging.info('calculating injection backgrounds')
-    ftimes = (zdata['time1'][zcid] + zdata['time2'][zcid]) / 2
-    fstats = zdata['stat'][zcid]
+    ftimes = (zdata.time1 + zdata.time2) / 2.0
     start, end = ftimes - args.veto_window, ftimes + args.veto_window
-    
+    print ftimes
     fan = numpy.zeros(len(ftimes), dtype=numpy.float32)
     ifar = numpy.zeros(len(ftimes), dtype=numpy.float32)
     fap = numpy.zeros(len(ftimes), dtype=numpy.float32)
@@ -137,37 +192,39 @@ if len(zdata['stat']) > 0:
     # We are relying on the injection data set to be the first one, 
     # this is determined
     # by the argument order to pycbc_coinc_findtrigs
-    ifstat = izdata['stat'][ifcid]
-    if_time = izdata['time1'][ifcid]
-    ifsort = if_time.argsort()
-    ifsorted = if_time[ifsort]
+    ifsort = ifdata.time1.argsort()
+    ifsorted = ifdata.time1[ifsort]
     if_start, if_end = numpy.searchsorted(ifsorted, start), numpy.searchsorted(ifsorted, end)
     
-    fistat = fidata['stat'][ficid]
-    fi_time = fidata['time1'][ficid]
-    fisort = fi_time.argsort()
-    fisorted = fi_time[fisort]
+    print ifsorted, start
+    fisort = fidata.time1.argsort()
+    fisorted = fidata.time1[fisort]
     fi_start, fi_end = numpy.searchsorted(fisorted, start), numpy.searchsorted(fisorted, end)
-    
-    for i, fstat in enumerate(fstats):
+    #print start, end
+    #print fisorted
+    for i, fstat in enumerate(zdata.stat):
         # If the trigger is quiet enough, then don't calculate a separate 
         # background type, as it would not be significantly different
         if args.ranking_statistic_threshold and fstat < args.ranking_statistic_threshold:
             fan[i] = fore_fan[i]
             ifar[i] = ifar_exc[i]
-            fap[i] = fap_exc[i]    
+            fap[i] = fap_exc[i]
+            continue
             
         v1 = fisort[fi_start[i]:fi_end[i]]
         v2 = ifsort[if_start[i]:if_end[i]]
         
-        inj_stat = numpy.concatenate([ifstat[v2], fistat[v1], back_stat])
+        inj_stat = numpy.concatenate([ifdata.stat[v2], fidata.stat[v1], back_stat])
         inj_dec = numpy.concatenate([numpy.repeat(1, len(v1) + len(v2)), dec_fac])
         fanmap = calculate_fan_map(inj_stat, inj_dec)
         
         fan[i] = fanmap(fstat)
         ifar[i] = background_time / fan[i]
         fap[i] = numpy.clip(coinc_time / ifar[i], 0, 1)
-
+        
+        #print len(v1), len(v2)
+        print  fstat, ifar[i], ifar_exc[i]
+        
     f['foreground/fan'] = fan
     f['foreground/ifar'] = sec_to_year(ifar)
     f['foreground/fap'] = fap                                                

--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -17,8 +17,8 @@ parser = argparse.ArgumentParser()
 # General required options
 parser.add_argument('--verbose', action='count')
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
-parser.add_argument('--cluster-window', type=float, 
-                    help='Size in seconds to maximize coinc triggers')
+parser.add_argument('--cluster-window', type=float, default=10,
+         help='Length of time window in seconds to cluster coinc events, [default=10s]')
 parser.add_argument('--zero-lag-coincs', nargs='+',
                     help="Files containing the injection zerolag coincidences")
 parser.add_argument('--mixed-coincs-inj-full', nargs='+',
@@ -29,8 +29,8 @@ parser.add_argument('--mixed-coincs-full-inj', nargs='+',
                          "time slides")
 parser.add_argument('--full-data-background', 
                     help='background file from full data for use in analyzing injection coincs')
-parser.add_argument('--veto-window', type=float, 
-                    help='window around each zerolag trigger to window out')
+parser.add_argument('--veto-window', type=float, default=.1,
+         help='Time around each zerolag trigger to window out, [default=.1s]')
 parser.add_argument("--ranking-statistic-threshold", type=float,
                     help="Minimum value of the ranking statistic to calculate"
                          " a unique inclusive background.")

--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -5,99 +5,10 @@ by pycbc_coinc_findtrigs to generated a mapping between SNR and FAP, along
 with producing the combined foreground and background triggers
 """
 import argparse, h5py, logging, itertools, copy
-from scipy.interpolate import interp1d  
 from pycbc.future import numpy
 from itertools import izip
 from pycbc.events import veto, coinc
 import pycbc.version
-
-def apply_bank_statistic(data, name, bank_file):
-    bank = h5py.File(bank_file)
-    if name == 'mchirp_bin':
-        b = [0, 1, 2, 3, 4]
-        data = mchirp_bin(data, bank, b)           
-    return data
-    
-def mchirp_bin(data, bank, bins):
-    logging.info("applying mchirp binning")
-    r = []
-    mc, et = pycbc.pnutils.mass1_mass2_to_mchirp_eta(bank['mass1'][:], bank['mass2'][:])
-    for i in range(len(bins)-1):
-        loc = numpy.where(numpy.logical_and(mc > bins[i], mc <= bins[i+1]))[0]
-        d = data.select(numpy.in1d(data.template_id, loc))
-        if len(d) > 0:
-            d = d.cluster()
-            fan = calculate_fan_map(d.stat, d.decimation_factor)(d.stat)
-            d.data['stat'] = 1.0 / fan
-        r.append(ArrayData(d.interval, d.window, data=d.data))
-    return numpy.sum(r)            
-
-class ArrayData(object):
-    def __init__(self, interval, window, data=None, files=None, groups=None):
-        self.data = data
-        self.interval = interval
-        self.window = window
-        
-        if files:
-            self.data = {}
-            for g in groups:
-                self.data[g] = []
-            
-            for f in files:
-                d = h5py.File(f)
-                print f
-                print numpy.where(d['time1'][:] == 0)[0]
-                for g in groups:
-                    if g in d:
-                        self.data[g].append(d[g][:])
-                    
-            for k in self.data:
-                self.data[k] = numpy.concatenate(self.data[k])
-
-        for k in self.data:
-            setattr(self, k, self.data[k])
-
-    def __len__(self):
-        return len(self.data[self.data.keys()[0]])
-
-    def __add__(self, other):
-        data = {}
-        for k in self.data:
-            data[k] = numpy.concatenate([self.data[k], other.data[k]])
-        return ArrayData(self.interval, self.window, data=data)
-
-    def select(self, idx):
-        data = {}
-        for k in self.data:
-            data[k] = self.data[k][idx]
-        return ArrayData(self.interval, self.window, data=data)
-   
-    def remove(self, idx):
-        data = {}
-        for k in self.data:
-            data[k] = numpy.delete(self.data[k], idx)
-        return ArrayData(self.interval, self.window, data=data)
-
-    def cluster(self):
-        cid = coinc.cluster_coincs(self.stat, self.time1, self.time2,
-                                 self.timeslide_id, self.interval, self.window)
-        return self.select(cid) 
-         
-def load_coincs(coinc_files, window):
-    columns = ['stat', 'time1', 'time2', 'trigger_id1', 'trigger_id2', 
-               'template_id', 'decimation_factor', 'timeslide_id']
-    f = h5py.File(coinc_files[0])
-    d = ArrayData(f.attrs['timeslide_interval'], window, files=coinc_files, groups=columns)
-    return (d, dict(f.attrs), f['segments'])
-           
-def calculate_fan_map(combined_stat, dec):
-    """ Return a function to map between false alarm number (FAN) and the
-    combined ranking statistic.
-    """
-    stat_sorting = combined_stat.argsort()    
-    combined_stat = combined_stat[stat_sorting]
-    fan = dec[stat_sorting][::-1].cumsum()[::-1]    
-    return interp1d(combined_stat, fan, fill_value=1, bounds_error=False) 
 
 def sec_to_year(sec):
     return sec / (3.15569e7)
@@ -131,23 +42,22 @@ if args.verbose:
     logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
 
 logging.info("Loading coinc zerolag triggers")    
-zdata, attrs, seg = load_coincs(args.zero_lag_coincs, args.cluster_window)   
-print zdata.time1, zdata.time2
-print numpy.where(zdata.time1 == 0)[0]
-
-zdata = zdata.cluster()
+zdata, attrs, seg = coinc.load_coincs(args.zero_lag_coincs)   
+interval = attrs['timeslide_interval']
+window = args.cluster_window
+zdata = zdata.cluster(interval, window)
                      
 logging.info("Loading coinc full inj triggers")    
-fidata = load_coincs(args.mixed_coincs_full_inj, args.cluster_window)[0].cluster()
+fidata = coinc.load_coincs(args.mixed_coincs_full_inj)[0].cluster(interval, window)
                      
 logging.info("Loading coinc inj full triggers")    
-ifdata = load_coincs(args.mixed_coincs_inj_full, args.cluster_window)[0].cluster() 
+ifdata = coinc.load_coincs(args.mixed_coincs_inj_full)[0].cluster(interval, window)
 
 f = h5py.File(args.output_file, "w")
 
 f.attrs['detector_1'] = attrs['detector_1']
 f.attrs['detector_2'] = attrs['detector_2']
-f.attrs['timeslide_interval'] = attrs['timeslide_interval']
+f.attrs['timeslide_interval'] = interval
 
 # Copy over the segment for coincs and singles
 for key in seg.keys():
@@ -166,7 +76,7 @@ background_time = float(fb.attrs['background_time_exc'])
 coinc_time = float(fb.attrs['foreground_time_exc'])
 back_stat = fb['background_exc/stat'][:]
 dec_fac = fb['background_exc/decimation_factor'][:]
-fanmap_exc = calculate_fan_map(back_stat, dec_fac)
+fanmap_exc = coinc.calculate_fan_map(back_stat, dec_fac)
 
 f.attrs['background_time_exc'] = background_time
 f.attrs['foreground_time_exc'] = coinc_time
@@ -184,7 +94,7 @@ if len(zdata) > 0:
     logging.info('calculating injection backgrounds')
     ftimes = (zdata.time1 + zdata.time2) / 2.0
     start, end = ftimes - args.veto_window, ftimes + args.veto_window
-    print ftimes
+
     fan = numpy.zeros(len(ftimes), dtype=numpy.float32)
     ifar = numpy.zeros(len(ftimes), dtype=numpy.float32)
     fap = numpy.zeros(len(ftimes), dtype=numpy.float32)
@@ -196,12 +106,10 @@ if len(zdata) > 0:
     ifsorted = ifdata.time1[ifsort]
     if_start, if_end = numpy.searchsorted(ifsorted, start), numpy.searchsorted(ifsorted, end)
     
-    print ifsorted, start
     fisort = fidata.time1.argsort()
     fisorted = fidata.time1[fisort]
     fi_start, fi_end = numpy.searchsorted(fisorted, start), numpy.searchsorted(fisorted, end)
-    #print start, end
-    #print fisorted
+
     for i, fstat in enumerate(zdata.stat):
         # If the trigger is quiet enough, then don't calculate a separate 
         # background type, as it would not be significantly different
@@ -216,15 +124,12 @@ if len(zdata) > 0:
         
         inj_stat = numpy.concatenate([ifdata.stat[v2], fidata.stat[v1], back_stat])
         inj_dec = numpy.concatenate([numpy.repeat(1, len(v1) + len(v2)), dec_fac])
-        fanmap = calculate_fan_map(inj_stat, inj_dec)
+        fanmap = coinc.calculate_fan_map(inj_stat, inj_dec)
         
         fan[i] = fanmap(fstat)
         ifar[i] = background_time / fan[i]
         fap[i] = numpy.clip(coinc_time / ifar[i], 0, 1)
-        
-        #print len(v1), len(v2)
-        print  fstat, ifar[i], ifar_exc[i]
-        
+
     f['foreground/fan'] = fan
     f['foreground/ifar'] = sec_to_year(ifar)
     f['foreground/fap'] = fap                                                

--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -4,7 +4,7 @@ The program combines coincident output files generated
 by pycbc_coinc_findtrigs to generated a mapping between SNR and FAP, along
 with producing the combined foreground and background triggers
 """
-import argparse, h5py, logging, itertools, copy
+import argparse, h5py, logging, itertools, copy, pycbc.io
 from pycbc.future import numpy
 from itertools import izip
 from pycbc.events import veto, coinc
@@ -43,14 +43,14 @@ if args.verbose:
 
 logging.info("Loading coinc zerolag triggers")    
 window = args.cluster_window
-zdata = coinc.load_coincs(args.zero_lag_coincs)   
+zdata = pycbc.io.StatmapData(files=args.zero_lag_coincs)   
 zdata = zdata.cluster(window)
                      
 logging.info("Loading coinc full inj triggers")    
-fidata = coinc.load_coincs(args.mixed_coincs_full_inj).cluster(window)
+fidata = pycbc.io.StatmapData(files=args.mixed_coincs_full_inj).cluster(window)
                      
 logging.info("Loading coinc inj full triggers")    
-ifdata = coinc.load_coincs(args.mixed_coincs_inj_full).cluster(window)
+ifdata = pycbc.io.StatmapData(files=args.mixed_coincs_inj_full).cluster(window)
 
 f = h5py.File(args.output_file, "w")
 

--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -86,7 +86,7 @@ f.attrs['foreground_time'] = coinc_time
 if len(zdata) > 0:
     fore_fan = fanmap_exc(zdata.stat)
     ifar_exc = background_time / fore_fan
-    fap_exc = numpy.clip(coinc_time / ifar_exc, 0, 1)
+    fap_exc = 1 - numpy.exp(- coinc_time / ifar_exc)
     f['foreground/fan_exc'] = fore_fan
     f['foreground/ifar_exc'] = sec_to_year(ifar_exc)
     f['foreground/fap_exc'] = fap_exc
@@ -128,7 +128,7 @@ if len(zdata) > 0:
         
         fan[i] = fanmap(fstat)
         ifar[i] = background_time / fan[i]
-        fap[i] = numpy.clip(coinc_time / ifar[i], 0, 1)
+        fap[i] = 1 - numpy.exp(- coinc_time / ifar[i])
 
     f['foreground/fan'] = fan
     f['foreground/ifar'] = sec_to_year(ifar)

--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -42,27 +42,26 @@ if args.verbose:
     logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
 
 logging.info("Loading coinc zerolag triggers")    
-zdata, attrs, seg = coinc.load_coincs(args.zero_lag_coincs)   
-interval = attrs['timeslide_interval']
 window = args.cluster_window
-zdata = zdata.cluster(interval, window)
+zdata = coinc.load_coincs(args.zero_lag_coincs)   
+zdata = zdata.cluster(window)
                      
 logging.info("Loading coinc full inj triggers")    
-fidata = coinc.load_coincs(args.mixed_coincs_full_inj)[0].cluster(interval, window)
+fidata = coinc.load_coincs(args.mixed_coincs_full_inj).cluster(window)
                      
 logging.info("Loading coinc inj full triggers")    
-ifdata = coinc.load_coincs(args.mixed_coincs_inj_full)[0].cluster(interval, window)
+ifdata = coinc.load_coincs(args.mixed_coincs_inj_full).cluster(window)
 
 f = h5py.File(args.output_file, "w")
 
-f.attrs['detector_1'] = attrs['detector_1']
-f.attrs['detector_2'] = attrs['detector_2']
-f.attrs['timeslide_interval'] = interval
+f.attrs['detector_1'] = zdata.attrs['detector_1']
+f.attrs['detector_2'] = zdata.attrs['detector_2']
+f.attrs['timeslide_interval'] = zdata.attrs['timeslide_interval']
 
 # Copy over the segment for coincs and singles
-for key in seg.keys():
-    f['segments/%s/start' % key] = seg[key]['start'][:]
-    f['segments/%s/end' % key] = seg[key]['end'][:]
+for key in zdata.seg.keys():
+    f['segments/%s/start' % key] = zdata.seg[key]['start'][:]
+    f['segments/%s/end' % key] = zdata.seg[key]['end'][:]
     
 logging.info('writing zero lag triggers')
 if len(zdata) > 0:

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -27,39 +27,6 @@ coincident triggers.
 import numpy, logging, h5py
 from itertools import izip
 from scipy.interpolate import interp1d  
-
-def load_coincs(coinc_files):
-    import pycbc.io
-    class StatmapData(pycbc.io.DictArray):
-        def __init__(self, data=None, seg=None, attrs=None,
-                           files=None, groups=None):
-            super(StatmapData, self).__init__(data=data, files=files, groups=groups)
-            
-            if data:
-                self.seg=seg
-                self.attrs=attrs
-            elif files:
-                f = h5py.File(files[0], "r")
-                self.seg = f['segments']
-                self.attrs = f.attrs
-    
-        def _return(self, data):
-            return self.__class__(data=data, 
-                                  attrs=self.attrs, 
-                                  seg=self.seg)
-    
-        def cluster(self, window):
-            """ Cluster the dict array, assuming it has the relevant Coinc colums,
-            time1, time2, stat, and timeslide_id
-            """
-            interval = self.attrs['timeslide_interval']
-            cid = cluster_coincs(self.stat, self.time1, self.time2,
-                                     self.timeslide_id, interval, window)
-            return self.select(cid) 
-
-    columns = ['stat', 'time1', 'time2', 'trigger_id1', 'trigger_id2', 
-               'template_id', 'decimation_factor', 'timeslide_id']
-    return StatmapData(files=coinc_files, groups=columns)
    
 def calculate_fan_map(combined_stat, dec):
     """ Return a function to map between false alarm number (FAN) and the

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -31,22 +31,22 @@ from scipy.interpolate import interp1d
 def load_coincs(coinc_files):
     import pycbc.io
     class StatmapData(pycbc.io.DictArray):
-        def __init__(self, data=None, segments=None, attrs=None,
+        def __init__(self, data=None, seg=None, attrs=None,
                            files=None, groups=None):
-            super().__init__(self, data=data, files=files, groups=groups)
+            super(StatmapData, self).__init__(data=data, files=files, groups=groups)
             
             if data:
-                self.segments=segments
+                self.seg=seg
                 self.attrs=attrs
             elif files:
                 f = h5py.File(files[0], "r")
-                self.segments = f['segments']
+                self.seg = f['segments']
                 self.attrs = f.attrs
     
-        def _return(self, data)
+        def _return(self, data):
             return self.__class__(data=data, 
                                   attrs=self.attrs, 
-                                  segments=self.segments)
+                                  seg=self.seg)
     
         def cluster(self, window):
             """ Cluster the dict array, assuming it has the relevant Coinc colums,

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -167,10 +167,40 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window):
     left = numpy.searchsorted(time, time - window)
     right = numpy.searchsorted(time, time + window)
     logging.info('done sorting')
-    indices = []
-    for i, (l, r) in enumerate(izip(left, right)):
-        if stat[l:r].argmax() + l == i:
-            indices += [i]
+    indices = numpy.zeros(len(left), dtype=numpy.uint32)
+    
+    # i is the index we are inspecting, j is the next one to save
+    i = 0
+    j = 0
+    while i < len(left):
+        l = left[i]
+        r = right[i]
+        
+        # If there are no other points to compare it is obviosly the max
+        if (r - l) == 1:
+            indices[j] = i
+            j += 1
+            i += 1            
+            continue            
+        
+        # Find the location of the maximum within the time interval around i
+        max_loc = stat[l:r].argmax() + l 
+        
+        # If this point is the max, we can skip to the right boundary
+        if max_loc == i:
+            indices[j] = i
+            i = r
+            j += 1
+        
+        # If the max is later than i, we can skip to it
+        elif max_loc > i:
+            i = max_loc 
+            
+        elif max_loc < i:
+            i += 1
+
+    indices = indices[:j]
+            
     logging.info('done clustering coinc triggers: %s triggers remaining' % len(indices))
-    return time_sorting[numpy.array(indices)]
+    return time_sorting[indices]
 

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -60,7 +60,7 @@ class DictArray(object):
         for k in self.data:
             setattr(self, k, self.data[k])
 
-    def _return(self, data)
+    def _return(self, data):
         return self.__class__(data=data)
 
     def __len__(self):

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -60,6 +60,9 @@ class DictArray(object):
         for k in self.data:
             setattr(self, k, self.data[k])
 
+    def _return(self, data)
+        return self.__class__(data=data)
+
     def __len__(self):
         return len(self.data[self.data.keys()[0]])
 
@@ -67,7 +70,7 @@ class DictArray(object):
         data = {}
         for k in self.data:
             data[k] = np.concatenate([self.data[k], other.data[k]])
-        return self.__class__(data=data)
+        return self._return(data=data)
 
     def select(self, idx):
         """ Return a new DictArray containing only the indexed values
@@ -75,7 +78,7 @@ class DictArray(object):
         data = {}
         for k in self.data:
             data[k] = self.data[k][idx]
-        return self.__class__(data=data)
+        return self._return(data=data)
    
     def remove(self, idx):
         """ Return a new DictArray that does not contain the indexed values
@@ -83,7 +86,7 @@ class DictArray(object):
         data = {}
         for k in self.data:
             data[k] = np.delete(self.data[k], idx)
-        return self.__class__(data=data)
+        return self._return(data=data)
 
 class FileData(object):
 


### PR DESCRIPTION
Consolidate functionality that was duplicated in both pycbc_coinc_statmap and pycbc_coinc_statmap_inj into pycbc/events/coinc.py. This adds a generic dictionary array class as well that I've put into io/hdf.py. At some point when we have time, we might want to see if it makes sense to consolidate some of these classes, but at the moment, I can see reasons for each. Also, I added a speed up / minor memory reduction in the clustering algorithm.