### PR TITLE
add segments-method to analyze all single ifo time or coinc time

### DIFF
--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1056,6 +1056,9 @@ def get_analyzable_segments(workflow, out_dir, tags=[]):
     """
     from pycbc.events import segments_to_file
     logging.info('Entering generation of science segments')
+    segments_method = workflow.cp.get_opt_tags("workflow-segments", 
+                                      "segments-method", tags)
+    
     make_analysis_dir(out_dir)
     start_time = workflow.analysis_time[0]
     end_time = workflow.analysis_time[1]
@@ -1091,7 +1094,23 @@ def get_analyzable_segments(workflow, out_dir, tags=[]):
         seg_ok_path = os.path.abspath(os.path.join(out_dir, '%s-SCIENCE-OK.xml' % ifo))
         seg_files += [segments_to_file(sci_segs[ifo], seg_ok_path, 
                                           "SCIENCE_OK", ifo=ifo)]  
-                                                   
+
+    if segments_method == 'ALL_SINGLE_IFO_TIME':
+        pass
+    elif segments_method == 'COINC_TIME':
+        cum_segs = None
+        for ifo in sci_segs:
+            if cum_segs is not None:
+                cum_segs = (cum_segs & sci_segs[ifo]).coalesce() 
+            else:
+                cum_segs = sci_segs[ifo]
+                
+        for ifo in sci_segs:
+            sci_segs[ifo] = cum_segs 
+    else:
+        raise ValueError("Invalid segments-method, %s. Options are "
+                         "ALL_SINGLE_IFO_TIME and COINC_TIME" % segments_method)
+
     logging.info('Leaving generation of science segments')
     return sci_segs, data_segs, seg_files
     


### PR DESCRIPTION
Tom,

Here is the patch to add back the analyze coinc time only option. I'll let you and Ian decide if this is an ok state to merge to this function, even if it isn't perfect. 