### PR TITLE
Add logging import to summaryplots module

### DIFF
--- a/pycbc/workflow/summaryplots.py
+++ b/pycbc/workflow/summaryplots.py
@@ -21,8 +21,9 @@
 #
 # =============================================================================
 #
-import os
 import itertools
+import logging
+import os
 import urllib
 
 from pycbc.workflow.core import Executable, Node, File, FileList, make_external_call


### PR DESCRIPTION
This PR adds a `import logging` to the `summaryplots` module. It was missing before but didn't fail in the workflow generator because `logging` was being imported elsewhere.