### PR TITLE
analyze triggers only from coincident time after cat2/3 vetoes

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -9,7 +9,7 @@ parser.add_argument("--verbose", action="count")
 parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
 parser.add_argument("--veto-files", nargs='*',
                     help="Optional veto file. Triggers within these times are ignored")
-parser_add_argument("--strict-coinc-time", action='store_true',
+parser.add_argument("--strict-coinc-time", action='store_true',
                     help="Optional, only allow coincidences between triggers that are "
                          "in coincident time after applying vetoes ")
 parser.add_argument('--segment-name', default=None, type=str,

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -9,6 +9,9 @@ parser.add_argument("--verbose", action="count")
 parser.add_argument("--version", action="version", version=pycbc.version.git_verbose_msg)
 parser.add_argument("--veto-files", nargs='*',
                     help="Optional veto file. Triggers within these times are ignored")
+parser_add_argument("--strict-coinc-time", action='store_true',
+                    help="Optional, only allow coincidences between triggers that are "
+                         "in coincident time after applying vetoes ")
 parser.add_argument('--segment-name', default=None, type=str,
                     help='Optional, name of segment list to use for vetoes')
 parser.add_argument("--trigger-files", nargs=2,
@@ -241,6 +244,12 @@ logging.info('Opening second trigger file: %s' % args.trigger_files[1])
 trigs1 = ReadByTemplate(args.trigger_files[1], 
                         args.template_bank, args.segment_name, args.veto_files)
 coinc_segs = (trigs0.segs & trigs1.segs).coalesce()
+
+if args.strict_coinc_time:
+    trigs0.segs = coinc_segs
+    trigs1.segs = coinc_segs
+    trigs0.valid = veto.segments_to_start_end(trigs0.segs)
+    trigs1.valid = veto.segments_to_start_end(trigs1.segs)
 
 rank_method = get_statistic(args.ranking_statistic, args.statistic_files)
 det0, det1 = detector.Detector(trigs0.ifo), detector.Detector(trigs1.ifo)

--- a/bin/hdfcoinc/pycbc_foreground_censor
+++ b/bin/hdfcoinc/pycbc_foreground_censor
@@ -14,6 +14,8 @@ parser.add_argument('--veto-file',
 parser.add_argument('--segment-name', 
                     help="Segment name to use from the input veto file")
 parser.add_argument('--output-file', help='Name of the output segment file')
+parser.add_argument('--strict-coinc-time', action='store_true',
+                    help="Veto any time that is vetoed in either detector")
 parser.add_argument('--output-segment-name',    
                     help="(optional), Name of output segment file list",
                     default="censor_foreground")
@@ -36,5 +38,10 @@ for ifo in [ifo1, ifo2]:
     fsegs += [(segs + vsegs).coalesce()]
     names += [args.output_segment_name]
     ifos += [ifo]
+
+if args.strict_coinc_time:
+    fsegs[0] = (fsegs[0] + fsegs[1]).coalesce()
+    fsegs[1] = fsegs[0]
+
 pycbc.events.multi_segments_to_file(fsegs, args.output_file, names, ifos)
 logging.info('done')

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -200,8 +200,8 @@ for inj_file, tag, output_dir in zip([None]+inj_files, tags, output_dirs):
                                         final_veto_file[0], final_veto_name[0],
                                         output_dir, tags = ctags)
         found_inj = wf.find_injections_in_hdf_coinc(workflow, wf.FileList([inj_coinc]),
-                                        wf.FileList([inj_file]), final_veto_file[0], 
-                                        final_veto_name[0],
+                                        wf.FileList([inj_file]), censored_veto, 
+                                        'closed_box',
                                         output_dir, tags=ctags)
         inj_coincs += [inj_coinc]                      
         wf.make_sensitivity_plot(workflow, found_inj, 


### PR DESCRIPTION
This rolls up a 3 changes related to censoring closed box results from possible signals.

I had done a test run that included a single injection in the foreground. This is trivial to do in case anyone is interested in testing that yourself. Just add

[inspiral-full_data]
injection-file=/path/to/injection/file/with/single/injection

to your ini file and make sure to remove '--filter-inj-only', etc. 

For reference, I had chosen initially chosen a time for the injection that just happened to be a time that was CAT3 vetoed in only one of the detectors. This had some unpleasant side effects that I address here. Namely, that it was quite obvious that the background was affected by the injection. 

1. Apply the censored veto file to the individual found missed injections.
 This was already done for the allinj results, but I forgot to do it for the individual ones instead.

2. Add an option to pycbc_coinc_findtrigs to only analyze triggers that originated from coincident time after applying CAT3 vetoes. 

The option is '--strict-coinc-time'. 

This should help with #176, where we wan to analyze only coinc time, but without the current loss in short coinc segments. The downside of course is that you don't save the cost of the inspiral analysis yet. This is needed a separate option however, because you also don't want to include time made non-coinc by application of a cat2/3 veto in one detector. 

3. Add the same '--strict-coinc-time' option to the foreground censor script itself, so that vetoes get applied to both detectors if there is one in either. The case where this matters is as before where there is a signal that is cat2/3 vetoed in only one detector. 

Single detector triggers with single injection (cat3 vetoed in other detector)
https://sugar-jobs.phy.syr.edu/~ahnitz/projects/test_inj/t2/gw/results/3._single_triggers/L1-PLOT_SNRCHI__FULL_DATA-962582415-604800.png

After applying these patches, verifying the injection was no longer obvious in the result page, I shifted the injection to a coincident time. For those interested, here is the result page.

https://sugar-jobs.phy.syr.edu/~ahnitz/projects/test_inj/t4/gw/html/

The key plot that I am happy to say seems to work.

![h1l1-plot_snrifar_full_data_full_cumulative_cat_123h-962582415-604800](https://cloud.githubusercontent.com/assets/2206534/9019737/970c0e44-37be-11e5-8e4a-de0a562f08f5.png)

Overall, it looks like the blinding procedure is working quite well despite a very loud injection. I will have some results for quieter injections for my section of the background review as well to show how that looks. 


