### PR TITLE
Fix ini file condition in template

### DIFF
--- a/pycbc/results/templates/files/file_default.html
+++ b/pycbc/results/templates/files/file_default.html
@@ -37,7 +37,7 @@
 
 <!--configuration files-->
 {% elif filename.endswith('.ini') %}
-    <pre>{{content}}</pre>
+    <pre>{{ open(path, 'rb').read() }}</pre>
 
 <!--html file fragments-->
 {% elif filename.endswith('.htmlf') %}


### PR DESCRIPTION
This PR makes it so the ini files are displayed on the summary pages as text.

An example: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/html_version_14/0._configuration/