### PR TITLE
Preserve directory permissions in pycbc_make_html_page

### DIFF
--- a/bin/pycbc_make_html_page
+++ b/bin/pycbc_make_html_page
@@ -214,9 +214,12 @@ for cwd in dirs:
                'plots_dir'         : opts.plots_dir}
     output = template.render(context)
 
-    # save html page
+    # if directory does not exist make it and copy directory permissions
     if not os.path.exists(opts.output_path+cwd.path):
         os.makedirs(opts.output_path+cwd.path)
+        shutil.copymode(opts.plots_dir+cwd.path, opts.output_path+'/'+cwd.path)
+
+    # save html page
     with open(opts.output_path+cwd.path+'/index.html', "wb") as fp:
         fp.write(output)
 


### PR DESCRIPTION
This PR includes the python line to copy the permission bits for a directory.

This is relevant because in some workflow generators (ie. `pycbc_make_hdf_workflow`) the results section has been `chmod 700` so that others cannot view it. This keeps "things inside the box" and when you want the box opened, all you should have to do is `chmod 777`.

An example is here: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/html_version_15/

Section 3 was `chmod 700` to not be viewable same as the `pycbc_make_hdf_workflow`.