### PR TITLE
Display ini file in well on summary page

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -318,6 +318,8 @@ wf.makedir(base)
 ini_file_path = os.path.join(base, 'configuration.ini')
 with open(ini_file_path, 'wb') as ini_fh:
     container.cp.write(ini_fh)
+ini_file = wf.FileList([wf.File(ifos, '', workflow.analysis_time, file_url='file://'+ini_file_path)])
+single_layout(base, ini_file)
 
 wf.make_results_web_page(finalize_workflow, os.path.join(os.getcwd(), rdir.base))
 


### PR DESCRIPTION
This PR makes it so that on the Configuration summary page for the HDF workflow the ini file is shown in the well.

You no longer have to click an accordion.

An example: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/html_version_16/0._configuration/