### PR TITLE
add IFAR plotting nodes to HDF workflow

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -151,7 +151,7 @@ for inj_file, tag, output_dir in zip([None]+inj_files, tags, output_dirs):
         final_bg_file =  wf.setup_interval_coinc(workflow, hdfbank, insps, 
                                        final_veto_file, final_veto_name,
                                        output_dir, tags=ctags)
-             
+
         censored_veto = wf.make_foreground_censored_veto(workflow, 
                                final_bg_file[0], final_veto_file[0], final_veto_name[0],
                                'closed_box', 'segments')      
@@ -162,8 +162,9 @@ for inj_file, tag, output_dir in zip([None]+inj_files, tags, output_dirs):
                                  closed_box=True, tags=bg_file.tags + ['closed'])
             if bg_file == final_bg_file[0]:
                 closed_snrifar = snrifar
-                
-        
+
+            ifar = wf.make_ifar_plot(workflow, bg_file, rdir['result'])
+
         snrifar = wf.make_snrifar_plot(workflow, final_bg_file[0],
                             rdir['result'], tags=final_bg_file[0].tags)
 

--- a/pycbc/workflow/ini_files/example_hdf_bns.ini
+++ b/pycbc/workflow/ini_files/example_hdf_bns.ini
@@ -72,6 +72,7 @@ page_foreground = ${which:pycbc_page_foreground}
 page_injections = ${which:pycbc_page_injtable}
 page_segplot = ${which:pycbc_page_segplot}
 page_segtable = ${which:pycbc_page_segtable}
+page_ifar = ${which:pycbc_page_ifar}
 hdf_trigger_merge = ${which:pycbc_coinc_mergetrigs}
 plot_snrchi = ${which:pycbc_page_snrchi}
 plot_coinc_snrchi = ${which:pycbc_page_coinc_snrchi}
@@ -181,6 +182,9 @@ num-coincs-to-write = 10
 [page_segplot]
 
 [page_segtable]
+
+[page_ifar]
+decimation-factor = ${coinc-full|decimation-factor}
 
 [plot_snrchi]
 [plot_coinc_snrchi]

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -161,6 +161,20 @@ def make_seg_plot(workflow, seg_files, out_dir, seg_names=None, tags=None):
     workflow += node
     return node.output_files[0]
 
+def make_ifar_plot(workflow, trigger_file, out_dir, tags=None):
+    """ Creates a node in the workflow for plotting cumlative histogram
+    of IFAR values.
+    """
+
+    if tags is None: tags = []
+    makedir(out_dir)
+    node = PlotExecutable(workflow.cp, 'page_ifar', ifos=workflow.ifos,
+                    out_dir=out_dir, tags=tags).create_node()
+    node.add_input_opt('--trigger-file', trigger_file)
+    node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
+    workflow += node
+    return node.output_files[0]
+
 def make_snrchi_plot(workflow, trig_files, veto_file, veto_name, 
                      out_dir, exclude=None, require=None, tags=[]):
     makedir(out_dir)    


### PR DESCRIPTION
This PR adds nodes for the `pycbc_page_ifar` plotting exe to the HDF workflow.

In the workflow it adds a IFAR node for each background level (123H, 12H, 1H).

The plots are stored in the Results tab of the summary page, ie. they are behind a `chmod 700` directory with the other "closed box" plots.