### PR TITLE
Show the and of times triggers were produced and background levels

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -249,18 +249,17 @@ wf.make_segments_plot(workflow, science_seg_file,
                  rdir['analysis_time/segments'], tags=['SCIENCE_MINUS_CAT1'])
 
 # get data segments to write to segment summary XML file
-seg_summ_names   = ['DATA', 'ANALYZABLE_DATA', 'TRIGGERS_PRODUCED']
+seg_summ_names    = ['DATA', 'ANALYZABLE_DATA', 'TRIGGERS_PRODUCED']
 seg_summ_seglists = [data_segs, science_segs, insp_segs]
 
-# get other segments to write to segment summary XML file
-veto_summ_names  = ['DATA-ANALYZABLE_DATA']
-veto_summ_names  += ['ANALYZABLE_DATA-TRIGGERS_PRODUCED']
-veto_summ_seglists = [data_segs.coalesce() - science_segs.coalesce()]
-veto_summ_seglists += [science_segs.coalesce() - insp_segs.coalesce()]
+# declare comparasion segments for table on summary page
+veto_summ_names = ['TRIGGERS_PRODUCED&CUMULATIVE_CAT_1H',
+                   'TRIGGERS_PRODUCED&CUMULATIVE_CAT_12H',
+                   'TRIGGERS_PRODUCED&CUMULATIVE_CAT_123H']
 
 # write segment summary XML file
-seg_list = [], names = [], ifos = []
-for segment_list,segment_name in zip(seg_summ_seglists+veto_summ_seglists, seg_summ_names+veto_summ_names):
+seg_list = []; names = []; ifos = []
+for segment_list,segment_name in zip(seg_summ_seglists, seg_summ_names):
     for ifo in workflow.ifos:
         seg_list.append(segment_list[ifo])
         names.append(segment_name)
@@ -271,8 +270,10 @@ seg_summ_file = multi_segments_to_file(seg_list, filename, names, ifos)
 # make segment table for summary page
 seg_summ_table = wf.make_seg_table(workflow, [seg_summ_file], seg_summ_names,
                         rdir['analysis_time/segments'], ['SUMMARY'])
-veto_summ_table = wf.make_seg_table(workflow, [seg_summ_file], veto_summ_names,
-                        rdir['analysis_time/segments'], ['VETO_SUMMARY'])
+veto_summ_table = wf.make_seg_table(workflow,
+                        [seg_summ_file] + final_veto_file + cum_veto_files,
+                        veto_summ_names, rdir['analysis_time/segments'],
+                        ['VETO_SUMMARY'])
 
 # make segment plot for summary page
 seg_summ_plot = wf.make_seg_plot(workflow, [seg_summ_file],

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -248,19 +248,19 @@ wf.make_segments_plot(workflow, full_segs,
 wf.make_segments_plot(workflow, science_seg_file,
                  rdir['analysis_time/segments'], tags=['SCIENCE_MINUS_CAT1'])
 
-# FIXME: move to ini file
-data_seg_names = ['DATA', 'ANALYZABLE_DATA']
-science_seg_names = ['TRIGGERS_PRODUCED']
-veto_data_seg_names = ['CUMULATIVE_CAT_1H']
-veto_triggers_seg_names = ['CUMULATIVE_CAT_12H', 'CUMULATIVE_CAT_123H']
+# get data segments to write to segment summary XML file
+seg_summ_names   = ['DATA', 'ANALYZABLE_DATA', 'TRIGGERS_PRODUCED']
+seg_summ_seglists = [data_segs, science_segs, insp_segs]
+
+# get other segments to write to segment summary XML file
+veto_summ_names  = ['DATA-ANALYZABLE_DATA']
+veto_summ_names  += ['ANALYZABLE_DATA-TRIGGERS_PRODUCED']
+veto_summ_seglists = [data_segs.coalesce() - science_segs.coalesce()]
+veto_summ_seglists += [science_segs.coalesce() - insp_segs.coalesce()]
 
 # write segment summary XML file
-seg_list = []
-names = []
-ifos = []
-zip_seglists = [data_segs, science_segs, insp_segs]
-zip_names = data_seg_names + science_seg_names
-for segment_list,segment_name in zip(zip_seglists, zip_names):
+seg_list = [], names = [], ifos = []
+for segment_list,segment_name in zip(seg_summ_seglists+veto_summ_seglists, seg_summ_names+veto_summ_names):
     for ifo in workflow.ifos:
         seg_list.append(segment_list[ifo])
         names.append(segment_name)
@@ -269,16 +269,15 @@ filename = 'segments/'+''.join(workflow.ifos)+'-WORKFLOW_SEGMENT_SUMMARY.xml'
 seg_summ_file = multi_segments_to_file(seg_list, filename, names, ifos)
 
 # make segment table for summary page
-seg_summ_table = wf.make_seg_table(workflow, [seg_summ_file], zip_names,
+seg_summ_table = wf.make_seg_table(workflow, [seg_summ_file], seg_summ_names,
                         rdir['analysis_time/segments'], ['SUMMARY'])
-veto_summ_table = wf.make_seg_table(workflow, cum_veto_files + final_veto_file,
-                        veto_data_seg_names + veto_triggers_seg_names,
+veto_summ_table = wf.make_seg_table(workflow, [seg_summ_file], veto_summ_names,
                         rdir['analysis_time/segments'], ['VETO_SUMMARY'])
 
 # make segment plot for summary page
 seg_summ_plot = wf.make_seg_plot(workflow, [seg_summ_file],
                         rdir['analysis_time/segments'],
-                        data_seg_names + science_seg_names, ['SUMMARY'])
+                        seg_summ_names, ['SUMMARY'])
 
 # Make combined injection plots
 inj_summ = []

--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -68,7 +68,7 @@ for segment_file in opts.segment_files:
 # loop over segment names
 for segment_name in opts.segment_names:
 
-    # allow user to subtract find the and of two segments if they use a '&' on the command line
+    # allow user to find the and of two segments if they use a '&' on the command line
     names = segment_name.split('&')
     if len(names) > 2:
         logging.info('You can only compare two segments but was provided %s', segment_name)

--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -84,7 +84,7 @@ for segment_name in opts.segment_names:
         logging.info('Did not find a segment definition for %s', segment_name)
         continue
 
-    # get second segments for each IFO if subtracting two segments
+    # get second segments for each IFO if comparing two segments
     if len(names) == 2:
         segs_tmp = segments.segmentlistdict()
         for ifo in ifos:

--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -84,6 +84,9 @@ for segment_name in opts.segment_names:
         caption += " ("+comment_dict[key]+")"
     caption += " "
 
+    # coalesce segments
+    segs = segs.coalesce()
+
     # get length of time of segments in seconds
     h1_len = abs(segs['H1'])
     l1_len = abs(segs['L1'])

--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -68,7 +68,7 @@ for segment_file in opts.segment_files:
 # loop over segment names
 for segment_name in opts.segment_names:
 
-    # allow user to subtract two segments if they use a '-' on the command line
+    # allow user to subtract find the and of two segments if they use a '&' on the command line
     names = segment_name.split('&')
     if len(names) > 2:
         logging.info('You can only compare two segments but was provided %s', segment_name)

--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -56,42 +56,44 @@ caption = "This table shows the cumulative amount of time for each segment. Show
 ifos = ['H1', 'L1']
 
 # loop over segment files from command line
+seg_dict = {}
+comment_dict = {}
 for segment_file in opts.segment_files:
 
    # read segment definer table
-   seg_dict = fromsegmentxml(open(segment_file, 'rb'), return_dict=True) 
-   comment_dict = get_segment_definer_comments(open(segment_file, 'rb'))
+   seg_dict.update(fromsegmentxml(open(segment_file, 'rb'), return_dict=True))
+   comment_dict.update(get_segment_definer_comments(open(segment_file, 'rb')))
 
-   # loop over segment names
-   for segment_name in opts.segment_names:
+# loop over segment names
+for segment_name in opts.segment_names:
 
-       # get segments
-       segs = {}
-       for ifo in ifos:
-           for key in seg_dict.keys():
-               if key.startswith(ifo+':'+segment_name):
-                   segs[ifo] = seg_dict[key]
-       if not len(segs.keys()):
-           logging.info('Did not find a segment definition for %s',
-               segment_name)
-           continue
+    # get segments
+    segs = {}
+    for ifo in ifos:
+        for key in seg_dict.keys():
+            if key.startswith(ifo+':'+segment_name):
+                segs[ifo] = seg_dict[key]
+    if not len(segs.keys()):
+        logging.info('Did not find a segment definition for %s',
+            segment_name)
+        continue
 
-       # put comment in caption
-       caption += segment_name
-       if comment_dict[key] != None:
-           caption += " ("+comment_dict[key]+")"
-       caption += " "
+    # put comment in caption
+    caption += segment_name
+    if comment_dict[key] != None:
+        caption += " ("+comment_dict[key]+")"
+    caption += " "
 
-       # get length of time of segments in seconds
-       h1_len = abs(segs['H1'])
-       l1_len = abs(segs['L1'])
-       h1l1_len = abs( segs['H1'] & segs['L1'] )
+    # get length of time of segments in seconds
+    h1_len = abs(segs['H1'])
+    l1_len = abs(segs['L1'])
+    h1l1_len = abs( segs['H1'] & segs['L1'] )
 
-       # put values into columns
-       columns[0][1].append(segment_name)
-       columns[1][1].append(h1_len)
-       columns[2][1].append(l1_len)
-       columns[3][1].append(h1l1_len)
+    # put values into columns
+    columns[0][1].append(segment_name)
+    columns[1][1].append(h1_len)
+    columns[2][1].append(l1_len)
+    columns[3][1].append(h1l1_len)
 
 # cast columns into arrays
 keys = [numpy.array(key, dtype=type(key[0])) for key,_ in columns]

--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -60,9 +60,9 @@ seg_dict = {}
 comment_dict = {}
 for segment_file in opts.segment_files:
 
-   # read segment definer table
-   seg_dict.update(fromsegmentxml(open(segment_file, 'rb'), return_dict=True))
-   comment_dict.update(get_segment_definer_comments(open(segment_file, 'rb')))
+    # read segment definer table
+    seg_dict.update(fromsegmentxml(open(segment_file, 'rb'), return_dict=True))
+    comment_dict.update(get_segment_definer_comments(open(segment_file, 'rb')))
 
 # loop over segment names
 for segment_name in opts.segment_names:

--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -22,6 +22,7 @@ import logging
 import numpy
 import pycbc.results
 import sys
+from glue import segments
 from glue.ligolw import ligolw
 from glue.ligolw import lsctables
 from glue.ligolw import table
@@ -67,25 +68,41 @@ for segment_file in opts.segment_files:
 # loop over segment names
 for segment_name in opts.segment_names:
 
-    # get segments
-    segs = {}
+    # allow user to subtract two segments if they use a '-' on the command line
+    names = segment_name.split('&')
+    if len(names) > 2:
+        logging.info('You can only compare two segments but was provided %s', segment_name)
+        continue
+
+    # get segments for each IFO
+    segs = segments.segmentlistdict()
     for ifo in ifos:
         for key in seg_dict.keys():
-            if key.startswith(ifo+':'+segment_name):
+            if key.startswith(ifo+':'+names[0]):
                 segs[ifo] = seg_dict[key]
     if not len(segs.keys()):
-        logging.info('Did not find a segment definition for %s',
-            segment_name)
+        logging.info('Did not find a segment definition for %s', segment_name)
         continue
+
+    # get second segments for each IFO if subtracting two segments
+    if len(names) == 2:
+        segs_tmp = segments.segmentlistdict()
+        for ifo in ifos:
+            for key in seg_dict.keys():
+                if key.startswith(ifo+':'+names[1]):
+                    segs_tmp[ifo] = seg_dict[key]
+        if not len(segs.keys()):
+            logging.info('Did not find a segment definition for %s', segment_name)
+            continue
+
+        # find overlap
+        segs = segs.coalesce() & segs_tmp.coalesce()
 
     # put comment in caption
     caption += segment_name
     if comment_dict[key] != None:
         caption += " ("+comment_dict[key]+")"
     caption += " "
-
-    # coalesce segments
-    segs = segs.coalesce()
 
     # get length of time of segments in seconds
     h1_len = abs(segs['H1'])


### PR DESCRIPTION
This PR replaces the table on the summary page created with `pycbc_page_segtable` that only showed the cumulative amount of background level 1H, 12H, 123H time.

The table is replaced with one that shows the "and" of times when triggers were produced and the different background levels. This is better because it shows the amount of time that actually overlapped with the search.

Can see an example here: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/html_version_17/

The '&' (and) operation is handled by `pycbc_page_segtable` in this PR. The user can specify `SEG_NAME1&SEG_NAME2` on the command line to take the and.

An example command line on sugar is:
```
cd /home/cbiwer/projects/pycbc_test_tmplt_dev
pycbc_page_segtable --segment-files veto2_test/segments/H1L1-WORKFLOW_SEGMENT_SUMMARY.xml veto2_test/segments/H1L1-CUMULATIVE_CAT_123H_VETO_SEGMENTS.xml veto2_test/segments/H1L1-CUMULATIVE_CAT_1H_VETO_SEGMENTS.xml veto2_test/segments/H1L1-CUMULATIVE_CAT_12H_VETO_SEGMENTS.xml --segment-names "TRIGGERS_PRODUCED&CUMULATIVE_CAT_1H" "TRIGGERS_PRODUCED&CUMULATIVE_CAT_12H" "TRIGGERS_PRODUCED&CUMULATIVE_CAT_123H" --output-file veto2_test/results/1._analysis_time/1.1_segments/H1L1-PAGE_SEGTABLE_VETO_SUMMARY-962582415-604800.html
```