### PR TITLE
Add script to upload events to gracedb

### DIFF
--- a/bin/pycbc_upload_xml_to_gracedb
+++ b/bin/pycbc_upload_xml_to_gracedb
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2015 Ian Harry
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+Take a coinc xml file containing multiple events and upload to gracedb.
+"""
+
+import os, json
+import argparse
+import logging
+from ligo.gracedb.rest import GraceDb
+
+from glue.ligolw import ligolw
+from glue.ligolw import table
+from glue.ligolw import lsctables
+from glue.ligolw import ilwd
+from glue.ligolw import utils as ligolw_utils
+from glue.ligolw.utils import process as ligolw_process
+
+class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
+    pass
+
+logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
+                    level=logging.INFO)
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--input-file', dest='input_file',
+                    required=True, type=str,
+                    help='Input LIGOLW XML file of coincidences.')
+parser.add_argument('--testing', action="store_true", default=False,
+                    help="Upload event to the TEST group of gracedb.")
+args = parser.parse_args()
+
+gracedb = GraceDb()
+
+lsctables.use_in(LIGOLWContentHandler)
+
+xmldoc = ligolw_utils.load_filename(args.input_file,
+                             contenthandler=LIGOLWContentHandler)
+
+coinc_table = table.get_table(xmldoc, lsctables.CoincTable.tableName)
+coinc_inspiral_table = table.get_table(xmldoc,
+                                       lsctables.CoincInspiralTable.tableName)
+coinc_event_map_table = table.get_table(xmldoc,
+                                        lsctables.CoincMapTable.tableName)
+
+sngl_inspiral_table = table.get_table(xmldoc,
+                                      lsctables.SnglInspiralTable.tableName)
+
+xmldoc.childNodes[-1].removeChild(sngl_inspiral_table)
+xmldoc.childNodes[-1].removeChild(coinc_event_map_table)
+xmldoc.childNodes[-1].removeChild(coinc_inspiral_table)
+xmldoc.childNodes[-1].removeChild(coinc_table)
+
+for event in coinc_table:
+    coinc_event_table_curr = lsctables.New(lsctables.CoincTable)
+    coinc_event_table_curr.append(event)
+    coinc_inspiral_table_curr = lsctables.New(lsctables.CoincInspiralTable)
+    coinc_event_map_table_curr = lsctables.New(lsctables.CoincMapTable)
+    sngl_inspiral_table_curr = lsctables.New(lsctables.SnglInspiralTable)
+
+    coinc_event_id = event.coinc_event_id
+    for coinc_insp in coinc_inspiral_table:
+        if coinc_insp.coinc_event_id == event.coinc_event_id:
+            coinc_inspiral_table_curr.append(coinc_insp)
+
+    sngl_ids = []
+    for coinc_map in coinc_event_map_table:
+        if coinc_map.coinc_event_id == event.coinc_event_id:
+            coinc_event_map_table_curr.append(coinc_map)
+            sngl_ids.append(coinc_map.event_id)
+
+    for sngl in sngl_inspiral_table:
+        if sngl.event_id in sngl_ids:
+            sngl_inspiral_table_curr.append(sngl)
+
+    xmldoc.childNodes[-1].appendChild(coinc_event_table_curr)
+    xmldoc.childNodes[-1].appendChild(coinc_inspiral_table_curr)
+    xmldoc.childNodes[-1].appendChild(coinc_event_map_table_curr)
+    xmldoc.childNodes[-1].appendChild(sngl_inspiral_table_curr)
+    ligolw_utils.write_filename(xmldoc, "tmp_coinc_xml_file.xml")
+    if args.testing:
+        r = gracedb.createEvent("Test", "pycbc", "tmp_coinc_xml_file.xml",
+                                "AllSky").json()
+    else:
+        r = gracedb.createEvent("CBC", "pycbc", "tmp_coinc_xml_file.xml",
+                                "AllSky").json()
+    logging.info("Uploaded event %s." %(r["graceid"]))
+    xmldoc.childNodes[-1].removeChild(coinc_event_table_curr)
+    xmldoc.childNodes[-1].removeChild(coinc_inspiral_table_curr)
+    xmldoc.childNodes[-1].removeChild(coinc_event_map_table_curr)
+    xmldoc.childNodes[-1].removeChild(sngl_inspiral_table_curr)

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -378,7 +378,8 @@ class ForegroundTriggers(object):
 
         sngl_col_names = ['snr', 'chisq', 'chisq_dof', 'bank_chisq',
                           'bank_chisq_dof', 'cont_chisq', 'cont_chisq_dof',
-                          'end_time']
+                          'end_time', 'template_duration', 'coa_phase',
+                          'sigmasq']
         sngl_col_vals = {}
         for name in sngl_col_names:
             sngl_col_vals[name] = self.get_snglfile_array_dict(name)
@@ -396,6 +397,8 @@ class ForegroundTriggers(object):
                 sngl_id = self.trig_id[ifo][idx]
                 event_id = lsctables.SnglInspiralID(sngl_id)
                 sngl = return_empty_sngl()
+                sngl.event_id = event_id
+                sngl.ifo = ifo
                 curr_sngl_file = self.sngl_files[ifo].h5file[ifo]
                 for name in sngl_col_names:
                     val = sngl_col_vals[name][ifo][idx]
@@ -407,6 +410,7 @@ class ForegroundTriggers(object):
                         sngl.mass1, sngl.mass2)
                 sngl.mchirp, junk = pnutils.mass1_mass2_to_mchirp_eta(
                         sngl.mass1, sngl.mass2)
+                sngl.eff_distance = (sngl.sigmasq)**0.5 / sngl.snr
                 sngl_combined_mchirp += sngl.mchirp
                 sngl_combined_mtot += sngl.mtotal
 

--- a/setup.py
+++ b/setup.py
@@ -363,6 +363,7 @@ setup (
                'bin/pycbc_run_sqlite',
                'bin/pycbc_inspinjfind',
                'bin/pycbc_write_results_page',
+               'bin/pycbc_upload_xml_to_gracedb',
                'bin/gstlal/pycbc_calculate_likelihood',
                'bin/gstlal/pycbc_combine_likelihood',
                'bin/gstlal/pycbc_compute_far_from_snr_chisq_histograms',


### PR DESCRIPTION
This adds a script to upload coinc XML files to gracedb. The process would then be: workflow runs as normal and produces a summary XML file. This XML file is only uploaded, by hand, with this script once the box is opened.

This also adds some small modifications to populate more fully the resulting coinc XML file before uploading it. The previously missing event_id (line 400) was a bug, and without it coinc XML files written in this way were invalid!