### PR TITLE
don't interpolate n louder background, add 1 for IFAR

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -96,40 +96,35 @@ coinc_time_exc = coinc_time - veto_time
 
 logging.info("Making mapping from FAN to the combined statistic")
 back_stat = d.stat[back_locs]
-fanmap = coinc.calculate_fan_map(back_stat, d.decimation_factor[back_locs])       
-back_fan = fanmap(back_stat)
+fore_stat = d.stat[fore_locs]
+back_cnum, fnlouder = coinc.calculate_n_louder(back_stat, fore_stat, 
+                                               d.decimation_factor[back_locs])       
 
-fanmap_exc = coinc.calculate_fan_map(e.stat, e.decimation_factor)     
-back_fan_exc = fanmap_exc(e.stat)         
+back_cnum_exc, fnlouder_exc = coinc.calculate_fan_map(e.stat, fore_stat, 
+                                               e.decimation_factor)         
 
-f['background/fan'] = back_fan
-f['background/ifar'] = sec_to_year(background_time / back_fan)  
-f['background_exc/fan'] = back_fan_exc
-f['background_exc/ifar'] = sec_to_year(background_time_exc / back_fan_exc)
+f['background/fan'] = back_cnum
+f['background/ifar'] = sec_to_year(background_time / back_cnum)  
+f['background_exc/fan'] = back_cnum_exc
+f['background_exc/ifar'] = sec_to_year(background_time_exc / back_cnum_exc)
 
 f.attrs['background_time'] = background_time
 f.attrs['foreground_time'] = coinc_time
 f.attrs['background_time_exc'] = background_time_exc
 f.attrs['foreground_time_exc'] = coinc_time_exc
 
-logging.info("calculating ifar values")
-fore_stat = d.stat[fore_locs]
+logging.info("calculating ifar/fap values")
 
-fore_fan = fanmap(fore_stat)
-ifar = background_time / fore_fan
-
-fore_fan_exc = fanmap_exc(fore_stat)
-ifar_exc = background_time_exc / fore_fan_exc
-
-logging.info("calculating fap values")
-fap = 1 - numpy.exp(- coinc_time / ifar)
-fap_exc = 1 - numpy.exp(- coinc_time_exc / ifar_exc)
 if fore_locs.sum() > 0:
-    f['foreground/fan'] = fore_fan
+    ifar = background_time / (fnlouder + 1)
+    fap = 1 - numpy.exp(- coinc_time / ifar)
+    f['foreground/fan'] = fnlouder
     f['foreground/ifar'] = sec_to_year(ifar)
     f['foreground/fap'] = fap
-   
-    f['foreground/fan_exc'] = fore_fan_exc
+
+    ifar_exc = background_time_exc / (fnloduer_exc + 1)
+    fap_exc = 1 - numpy.exp(- coinc_time_exc / ifar_exc)
+    f['foreground/fan_exc'] = fnlouder_exc
     f['foreground/ifar_exc'] = sec_to_year(ifar_exc)
     f['foreground/fap_exc'] = fap_exc
 

--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -75,7 +75,6 @@ background_time = float(fb.attrs['background_time_exc'])
 coinc_time = float(fb.attrs['foreground_time_exc'])
 back_stat = fb['background_exc/stat'][:]
 dec_fac = fb['background_exc/decimation_factor'][:]
-fanmap_exc = coinc.calculate_fan_map(back_stat, dec_fac)
 
 f.attrs['background_time_exc'] = background_time
 f.attrs['foreground_time_exc'] = coinc_time
@@ -83,10 +82,10 @@ f.attrs['background_time'] = background_time
 f.attrs['foreground_time'] = coinc_time
 
 if len(zdata) > 0:
-    fore_fan = fanmap_exc(zdata.stat)
-    ifar_exc = background_time / fore_fan
+    back_cnum_exc, fnlouder_exc = coinc.calculate_n_louder(back_stat, zdata.stat, dec_fac)
+    ifar_exc = background_time / (fnlouder_exc + 1)
     fap_exc = 1 - numpy.exp(- coinc_time / ifar_exc)
-    f['foreground/fan_exc'] = fore_fan
+    f['foreground/fan_exc'] = fnlouder_exc
     f['foreground/ifar_exc'] = sec_to_year(ifar_exc)
     f['foreground/fap_exc'] = fap_exc
     
@@ -94,7 +93,7 @@ if len(zdata) > 0:
     ftimes = (zdata.time1 + zdata.time2) / 2.0
     start, end = ftimes - args.veto_window, ftimes + args.veto_window
 
-    fan = numpy.zeros(len(ftimes), dtype=numpy.float32)
+    fnlouder = numpy.zeros(len(ftimes), dtype=numpy.float32)
     ifar = numpy.zeros(len(ftimes), dtype=numpy.float32)
     fap = numpy.zeros(len(ftimes), dtype=numpy.float32)
     
@@ -113,7 +112,7 @@ if len(zdata) > 0:
         # If the trigger is quiet enough, then don't calculate a separate 
         # background type, as it would not be significantly different
         if args.ranking_statistic_threshold and fstat < args.ranking_statistic_threshold:
-            fan[i] = fore_fan[i]
+            fnlouder[i] = fnlouder_exc[i]
             ifar[i] = ifar_exc[i]
             fap[i] = fap_exc[i]
             continue
@@ -123,10 +122,9 @@ if len(zdata) > 0:
         
         inj_stat = numpy.concatenate([ifdata.stat[v2], fidata.stat[v1], back_stat])
         inj_dec = numpy.concatenate([numpy.repeat(1, len(v1) + len(v2)), dec_fac])
-        fanmap = coinc.calculate_fan_map(inj_stat, inj_dec)
         
-        fan[i] = fanmap(fstat)
-        ifar[i] = background_time / fan[i]
+        back_cnum, fnlouder[i] = coinc.calculate_n_louder(inj_stat, fstat, inj_dec)
+        ifar[i] = background_time / (fnlouder[i] + 1)
         fap[i] = 1 - numpy.exp(- coinc_time / ifar[i])
 
     f['foreground/fan'] = fan

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -52,8 +52,16 @@ def calculate_n_louder(bstat, fstat, dec):
     unsort = sort.argsort()
     bstat = bstat[sort]
     dec = dec[sort]
+    
+    # calculate cumulative number of triggers louder than the trigger in 
+    # a given index. We need to subtract the decimation factor, as the cumsum
+    # includes itself in the first sum (it is inclusive of the first value)
     n_louder = dec[sort][::-1].cumsum()[::-1] - dec
-       
+    
+    # Determine how many values are louder than the foreground ones
+    # We need to subtract one from the index, to be consistent with the definition
+    # of n_louder, as here we do want to include the background value at the
+    # found index
     fore_n_louder = n_louder[numpy.searchsorted(bstat, fstat, side='left') - 1]
     back_cum_num = n_louder[unsort]
     return back_cum_num, fore_n_louder


### PR DESCRIPTION
Hi Tom,

I wanted to bring to your attention another change I'd like to get it, which should (I think) bring the algorithm for assigning IFAR and FAP in agreement with your presentation. I'm currently testing this patch, and I'll report when it passes my tests (regenerating the post-processing with sane looking plots and values). 

The main changes
 * Calculate the number of louder background triggers more correctly, instead of using an interpolate. Allow the number to be 0.
 * Add 1 to the n louder number when calculating IFAR, we could put your estimate FAR here, but I'm keeping the changes as small as possible first. 