### PR TITLE
don't plot to 6 sigma in snrifar plot, not very useful

### DIFF
--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -61,7 +61,7 @@ fig = pylab.figure(1)
 pylab.scatter(cstat_back_exc, far_back_exc, color='grey', marker='x', label='Closed Box Background')
 
 if not args.closed_box:
-    for sig in [6, 5, 4, 3, 2, 1]:
+    for sig in [5, 4, 3, 2, 1]:
         p = p_from_sigma(sig)
         pylab.fill_between(cstat_back, far_back, far_back / (1 - p),
                            linewidth=0, color=pylab.cm.YlOrRd(1.0/sig), alpha=0.3) 


### PR DESCRIPTION
Remove the 6 sigma line from the snrifar plot. It is basically useless, and often is outside the plot boundaries. This also gives more room in the color gradient to see the other lines better. 