### PR TITLE
Add --tries 3 to the arguments passed to pegasus-mpi-cluster

### DIFF
--- a/pycbc/workflow/pegasus_files/xsede_site_template.xml
+++ b/pycbc/workflow/pegasus_files/xsede_site_template.xml
@@ -26,6 +26,7 @@ xsi:schemaLocation="http://pegasus.isi.edu/schema/sitecatalog http://pegasus.isi
         </directory>
         <profile namespace="env" key="PEGASUS_HOME">$PEGASUS_HOME</profile>
         <profile namespace="pegasus" key="job.aggregator" >mpiexec</profile>
+        <profile namespace="pegasus" key="cluster.arguments" >--tries 3</profile>
         <profile namespace="globus" key="queue">development</profile>
         <profile namespace="globus" key="maxwalltime">1</profile>
         <profile namespace="globus" key="host_count">1</profile>
@@ -43,6 +44,7 @@ xsi:schemaLocation="http://pegasus.isi.edu/schema/sitecatalog http://pegasus.isi
         </directory>
         <profile namespace="env" key="PEGASUS_HOME">$PEGASUS_HOME</profile>
         <profile namespace="pegasus" key="job.aggregator" >mpiexec</profile>
+        <profile namespace="pegasus" key="cluster.arguments" >--tries 3</profile>
         <profile namespace="globus" key="queue">normal</profile>
         <profile namespace="globus" key="maxwalltime">30</profile>
         <profile namespace="globus" key="host_count">$HOSTS</profile>


### PR DESCRIPTION
This patch adds an additional argument to pegasus-mpi-cluster which tells it to retry each job it is managing up to three times.  In the case of transient failures this can avoid the overhead of rerunning the PMC job itself.

(Note that the argument name in the commit message is wrong, it is correct in the patch itself)