### PR TITLE
minor plot tweaks

### DIFF
--- a/bin/hdfcoinc/pycbc_page_foreground
+++ b/bin/hdfcoinc/pycbc_page_foreground
@@ -50,7 +50,7 @@ if args.output_file.endswith('.html'):
 
     columns = [ifar_exc, ifar, fap_exc, fap, stat,  time1,
                (time2-time1)*1000, mchirp, mass1, mass2, spin1z, spin2z]
-    names = ['IFAR with Rem. (YR)', 'IFAR (YR)', 'FAP with Rem.', 'FAP',
+    names = ['Exc. IFAR (YR)', 'Inc. IFAR (YR)', 'Exc. FAP.', 'Inc. FAP',
              'Combined NewSNR', 'End Time', 'Time Diff. (ms)', 'mchirp', 'm1',
              'm2', 's1z', 's2z']
     format_strings = ['#.###E0', '#.###E0', '#.##E0', '#.##E0', '##.###',
@@ -60,12 +60,13 @@ if args.output_file.endswith('.html'):
     if args.single_detector_triggers:
         single_snr = fortrigs.get_snglfile_array_dict('snr')
         single_chisq = fortrigs.get_snglfile_array_dict('chisq')
+        single_chisq_dof = fortrigs.get_snglfile_array_dict('chisq_dof')
 
         columns.extend([single_snr[ifo] for ifo in single_snr.keys()])
-        names.extend(["SNR in %s" %(ifo) for ifo in single_snr.keys()])
+        names.extend(["%s SNR" %(ifo) for ifo in single_snr.keys()])
         format_strings.extend(["##.##" for ifo in single_snr.keys()])
-        columns.extend([single_chisq[ifo] for ifo in single_chisq.keys()])
-        names.extend(["Chisq in %s" %(ifo) for ifo in single_chisq.keys()])
+        columns.extend([single_chisq[ifo] / (single_chisq_dof[ifo] * 2 - 2) for ifo in single_chisq.keys()])
+        names.extend(["%s Red. Chisq" %(ifo) for ifo in single_chisq.keys()])
         format_strings.extend(["##.##" for ifo in single_chisq.keys()])
 
     logging.info('Making table of foreground triggers')

--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -17,6 +17,8 @@ parser.add_argument('--dynamic', action='store_true', default=False)
 parser.add_argument('--gradient-far', action='store_true',
                     help='Show far of found injections as a gradient')
 parser.add_argument('--output-file')
+parser.add_argument('--missed-on-top', action='store_true',
+                    help="Make the missed injections be plotted on top of the found ones")
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 args = parser.parse_args()
 
@@ -62,6 +64,8 @@ labels={'mchirp': 'Chirp Mass',
 # missed = missed[dvals[args.distance_type][missed] < dvals[args.distance_type][found].max() * 1.1]
 
 fig = plot.figure()
+zmissed = args.missed_on_top
+zfound = not args.missed_on_top
 
 if not args.gradient_far:
     color = numpy.zeros(len(found))
@@ -71,19 +75,19 @@ if not args.gradient_far:
     color[hundred] = 0.5
     color[thousand] = 1.0
     mpoints = plot.scatter(vals[args.axis_type][missed], dvals[args.distance_type][missed], 
-                           marker='x', color='black', label='missed')
+                           marker='x', color='black', label='missed', zorder=zmissed)
     points = plot.scatter(vals[args.axis_type][found], dvals[args.distance_type][found], 
                            c=color, linewidth=0, vmin=0, vmax=1,
-                           marker='o', label='found')
+                           marker='o', label='found', zorder=zfound)
     caption = ("Found and missed injections: Black x's are missed injections. "
               "Blue circles are found with IFAR < 100 years, green are < 1000 years, and "
               "red are found with IFAR >=1000 years. ")
 else:
     mpoints = plot.scatter(vals[args.axis_type][missed], dvals[args.distance_type][missed], 
-                           marker='x', color='red', label='missed')
+                           marker='x', color='red', label='missed', zorder=zmissed)
     points = plot.scatter(vals[args.axis_type][found], dvals[args.distance_type][found], 
                            c=1.0 / ifar_found, linewidth=0, norm=matplotlib.colors.LogNorm(),
-                           marker='o', label='found')
+                           marker='o', label='found', zorder=zfound)
     caption = ("Found and missed injections: Red x's are missed injections. "
                "Circles are found injections. The color indicates the value of "
                "the false alarm rate" )

--- a/pycbc/workflow/ini_files/example_hdf_bns.ini
+++ b/pycbc/workflow/ini_files/example_hdf_bns.ini
@@ -364,6 +364,13 @@ log-distance=
 axis-type=mchirp
 log-distance=
 gradient-far=
+
+[plot_foundmissed-mchirp_static_gradm&plot_foundmissed-all_mchirp_static_gradm&plot_foundmissed-summarym]
+axis-type=mchirp
+log-distance=
+gradient-far=
+missed-on-top=
+
 [plot_foundmissed-chirpdistmchirp_static_grad&plot_foundmissed-all_chirpdistmchirp_static_grad]
 axis-type=mchirp
 distance-type=chirp_distance


### PR DESCRIPTION
1. Add option to pycbc_page_foundmissed to plot the missed injections on top
2. modify the example bns ini file to include this plot in the summary page
3. display the reduced chisq in the foreground table