### PR TITLE
don't interpolate n louder background, add 1 for IFAR

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -96,40 +96,32 @@ coinc_time_exc = coinc_time - veto_time
 
 logging.info("Making mapping from FAN to the combined statistic")
 back_stat = d.stat[back_locs]
-fanmap = coinc.calculate_fan_map(back_stat, d.decimation_factor[back_locs])       
-back_fan = fanmap(back_stat)
+fore_stat = d.stat[fore_locs]
+back_cnum, fnlouder = coinc.calculate_n_louder(back_stat, fore_stat, 
+                                               d.decimation_factor[back_locs])       
 
-fanmap_exc = coinc.calculate_fan_map(e.stat, e.decimation_factor)     
-back_fan_exc = fanmap_exc(e.stat)         
+back_cnum_exc, fnlouder_exc = coinc.calculate_n_louder(e.stat, fore_stat, 
+                                               e.decimation_factor)         
 
-f['background/fan'] = back_fan
-f['background/ifar'] = sec_to_year(background_time / back_fan)  
-f['background_exc/fan'] = back_fan_exc
-f['background_exc/ifar'] = sec_to_year(background_time_exc / back_fan_exc)
+print back_cnum.max(), back_cnum.min()
+f['background/ifar'] = sec_to_year(background_time / (back_cnum + 1))  
+f['background_exc/ifar'] = sec_to_year(background_time_exc / (back_cnum_exc + 1))
 
 f.attrs['background_time'] = background_time
 f.attrs['foreground_time'] = coinc_time
 f.attrs['background_time_exc'] = background_time_exc
 f.attrs['foreground_time_exc'] = coinc_time_exc
 
-logging.info("calculating ifar values")
-fore_stat = d.stat[fore_locs]
+logging.info("calculating ifar/fap values")
 
-fore_fan = fanmap(fore_stat)
-ifar = background_time / fore_fan
-
-fore_fan_exc = fanmap_exc(fore_stat)
-ifar_exc = background_time_exc / fore_fan_exc
-
-logging.info("calculating fap values")
-fap = 1 - numpy.exp(- coinc_time / ifar)
-fap_exc = 1 - numpy.exp(- coinc_time_exc / ifar_exc)
 if fore_locs.sum() > 0:
-    f['foreground/fan'] = fore_fan
+    ifar = background_time / (fnlouder + 1)
+    fap = 1 - numpy.exp(- coinc_time / ifar)
     f['foreground/ifar'] = sec_to_year(ifar)
     f['foreground/fap'] = fap
-   
-    f['foreground/fan_exc'] = fore_fan_exc
+
+    ifar_exc = background_time_exc / (fnlouder_exc + 1)
+    fap_exc = 1 - numpy.exp(- coinc_time_exc / ifar_exc)
     f['foreground/ifar_exc'] = sec_to_year(ifar_exc)
     f['foreground/fap_exc'] = fap_exc
 

--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -75,7 +75,6 @@ background_time = float(fb.attrs['background_time_exc'])
 coinc_time = float(fb.attrs['foreground_time_exc'])
 back_stat = fb['background_exc/stat'][:]
 dec_fac = fb['background_exc/decimation_factor'][:]
-fanmap_exc = coinc.calculate_fan_map(back_stat, dec_fac)
 
 f.attrs['background_time_exc'] = background_time
 f.attrs['foreground_time_exc'] = coinc_time
@@ -83,10 +82,9 @@ f.attrs['background_time'] = background_time
 f.attrs['foreground_time'] = coinc_time
 
 if len(zdata) > 0:
-    fore_fan = fanmap_exc(zdata.stat)
-    ifar_exc = background_time / fore_fan
+    back_cnum_exc, fnlouder_exc = coinc.calculate_n_louder(back_stat, zdata.stat, dec_fac)
+    ifar_exc = background_time / (fnlouder_exc + 1)
     fap_exc = 1 - numpy.exp(- coinc_time / ifar_exc)
-    f['foreground/fan_exc'] = fore_fan
     f['foreground/ifar_exc'] = sec_to_year(ifar_exc)
     f['foreground/fap_exc'] = fap_exc
     
@@ -94,7 +92,7 @@ if len(zdata) > 0:
     ftimes = (zdata.time1 + zdata.time2) / 2.0
     start, end = ftimes - args.veto_window, ftimes + args.veto_window
 
-    fan = numpy.zeros(len(ftimes), dtype=numpy.float32)
+    fnlouder = numpy.zeros(len(ftimes), dtype=numpy.float32)
     ifar = numpy.zeros(len(ftimes), dtype=numpy.float32)
     fap = numpy.zeros(len(ftimes), dtype=numpy.float32)
     
@@ -113,7 +111,7 @@ if len(zdata) > 0:
         # If the trigger is quiet enough, then don't calculate a separate 
         # background type, as it would not be significantly different
         if args.ranking_statistic_threshold and fstat < args.ranking_statistic_threshold:
-            fan[i] = fore_fan[i]
+            fnlouder[i] = fnlouder_exc[i]
             ifar[i] = ifar_exc[i]
             fap[i] = fap_exc[i]
             continue
@@ -123,13 +121,11 @@ if len(zdata) > 0:
         
         inj_stat = numpy.concatenate([ifdata.stat[v2], fidata.stat[v1], back_stat])
         inj_dec = numpy.concatenate([numpy.repeat(1, len(v1) + len(v2)), dec_fac])
-        fanmap = coinc.calculate_fan_map(inj_stat, inj_dec)
         
-        fan[i] = fanmap(fstat)
-        ifar[i] = background_time / fan[i]
+        back_cnum, fnlouder[i] = coinc.calculate_n_louder(inj_stat, fstat, inj_dec)
+        ifar[i] = background_time / (fnlouder[i] + 1)
         fap[i] = 1 - numpy.exp(- coinc_time / ifar[i])
 
-    f['foreground/fan'] = fan
     f['foreground/ifar'] = sec_to_year(ifar)
     f['foreground/fap'] = fap                                                
 logging.info("Done") 

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -27,8 +27,6 @@ if args.verbose:
 logging.info('Read in the data')
 f = h5py.File(args.trigger_file, 'r')
 
-print f.attrs['background_time'], f.attrs['foreground_time']
-
 try:
     cstat_fore = f['foreground/stat'][:]
     cstat_fore.sort()
@@ -42,11 +40,6 @@ cstat_back = f['background/stat'][:]
 back_sort = cstat_back.argsort()
 cstat_back = cstat_back[back_sort]
 far_back = 1.0 / back_ifar[back_sort]
-
-back_fan = f['background/fan'][:][back_sort]
-err_low = far_back * ((back_fan - numpy.sqrt(back_fan)) / back_fan) 
-err_low[err_low == 0] = 1e-100
-err_high = far_back * ((back_fan + numpy.sqrt(back_fan)) / back_fan)
 
 logging.info('Found %s background (inclusive zerolag) triggers' % len(cstat_back))
 
@@ -66,8 +59,7 @@ if not args.closed_box:
         pylab.fill_between(cstat_back, far_back, far_back / (1 - p),
                            linewidth=0, color=pylab.cm.YlOrRd(1.0/sig), alpha=0.3) 
         pylab.text(cstat_back[-1], (far_back / (1 - p))[-1], "$\sigma = %s$" % sig)
-        
-    #pylab.fill_between(cstat_back, err_low, err_high, linewidth=0, color='tan')
+
     pylab.scatter(cstat_back, far_back, color='black', marker='x', label='Open Box Background')
 
     if cstat_fore is not None:

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -27,15 +27,44 @@ coincident triggers.
 import numpy, logging, h5py
 from itertools import izip
 from scipy.interpolate import interp1d  
-   
-def calculate_fan_map(combined_stat, dec):
-    """ Return a function to map between false alarm number (FAN) and the
-    combined ranking statistic.
+
+def calculate_n_louder(bstat, fstat, dec):
+    """ Calculate for each foreground event the number of background events
+    that are louder than it.
+    
+    Parameters
+    ----------
+    bstat: numpy.ndarray
+        Array of the background statistic values
+    fstat: numpy.ndarray
+        Array of the foreground statitsic values
+    dec: numpy.ndarray
+        Array of the decimation factors for the background statistics
+    
+    Returns
+    ------- 
+    cum_back_num: numpy.ndarray
+        The cumulative array of background triggers 
+    fore_n_louder: numpy.ndarray
+        The number of background triggers above each foreground trigger
     """
-    stat_sorting = combined_stat.argsort()    
-    combined_stat = combined_stat[stat_sorting]
-    fan = dec[stat_sorting][::-1].cumsum()[::-1]    
-    return interp1d(combined_stat, fan, fill_value=1, bounds_error=False) 
+    sort = bstat.argsort()
+    unsort = sort.argsort()
+    bstat = bstat[sort]
+    dec = dec[sort]
+    
+    # calculate cumulative number of triggers louder than the trigger in 
+    # a given index. We need to subtract the decimation factor, as the cumsum
+    # includes itself in the first sum (it is inclusive of the first value)
+    n_louder = dec[::-1].cumsum()[::-1] - dec
+    
+    # Determine how many values are louder than the foreground ones
+    # We need to subtract one from the index, to be consistent with the definition
+    # of n_louder, as here we do want to include the background value at the
+    # found index
+    fore_n_louder = n_louder[numpy.searchsorted(bstat, fstat, side='left') - 1]
+    back_cum_num = n_louder[unsort]
+    return back_cum_num, fore_n_louder
 
 def timeslide_durations(start1, start2, end1, end2, timeslide_offsets):
     """ Find the coincident time for each timeslide.


### PR DESCRIPTION
Hi Tom,

I wanted to bring to your attention another change I'd like to get it, which should (I think) bring the algorithm for assigning IFAR and FAP in agreement with your presentation. 

An example result page after this change is here.
https://sugar-jobs.phy.syr.edu/~ahnitz/projects/test_inj/t6v7/gw/html/7._result/

And from master
https://sugar-jobs.phy.syr.edu/~ahnitz/projects/test_inj/t6/gw/html/7._result/

The main changes

Calculate the number of louder background triggers more correctly, instead of using an interpolate. Allow the number to be 0.
Add 1 to the n louder number when calculating IFAR, we could put your estimate FAR here, but I'm keeping the changes as small as possible first.