### PR TITLE
Add versioning back into HDF workflow.

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -322,6 +322,9 @@ with open(ini_file_path, 'wb') as ini_fh:
 ini_file = wf.FileList([wf.File(ifos, '', workflow.analysis_time, file_url='file://'+ini_file_path)])
 single_layout(base, ini_file)
 
+# Create versioning information
+create_versioning_page(rdir['configuration'], container.cp)
+
 wf.make_results_web_page(finalize_workflow, os.path.join(os.getcwd(), rdir.base))
 
 container += workflow


### PR DESCRIPTION
Call to the versioning module was deleted from HDF workflow. This puts it back in.