### PR TITLE
tmpltbank: use default flags for An^* lattice

### DIFF
--- a/pycbc/tmpltbank/lattice_utils.py
+++ b/pycbc/tmpltbank/lattice_utils.py
@@ -136,7 +136,12 @@ def generate_anstar_3d_lattice(maxv1, minv1, maxv2, minv2, maxv3, minv3, \
     a.data[2,2] = 1
     lalpulsar.SetTilingLatticeAndMetric(tiling, lalpulsar.TILING_LATTICE_ANSTAR,
                                         a, mindist)
-    iterator = lalpulsar.CreateLatticeTilingIterator(tiling, 3, lalpulsar.TILING_ORDER_POSITIVE)
+    try:
+        iterator = lalpulsar.CreateLatticeTilingIterator(tiling, 3)
+    except TypeError:
+        # old versions of lalpulsar required the flags argument
+        # (set to 0 for defaults)
+        iterator = lalpulsar.CreateLatticeTilingIterator(tiling, 3, 0)
 
     vs1 = []
     vs2 = []


### PR DESCRIPTION
LALPulsar flag constants have been renamed a few times recently, which broke PyCBC (currently broken with the latest lalsuite master). Karl suggested simply setting the flags to 0 to get the default behavior instead.