### PR TITLE
add example single template version of pycbc inspiral

### DIFF
--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+import sys, logging, argparse, numpy, itertools, pycbc
+from pycbc import vetoes, psd, waveform, version, strain, scheme, fft, filter, events
+from pycbc.types import zeros, float32, complex64, TimeSeries
+
+parser = argparse.ArgumentParser(usage='',
+    description="Single template gravitational-wave followup")
+parser.add_argument('--version', action='version', 
+                    version=pycbc.version.git_verbose_msg)
+parser.add_argument('--output-file')
+parser.add_argument("-V", "--verbose", action="store_true", 
+                  help="print extra debugging information", default=False )
+parser.add_argument("--low-frequency-cutoff", type=float,
+                  help="The low frequency cutoff to use for filtering (Hz)")
+parser.add_argument("--chisq-bins", default=0, type=int, help=
+                    "Number of frequency bins to use for power chisq.")
+parser.add_argument("--psd-recalculate-segments", type=int, 
+                    help="Number of segments to use before recalculating the PSD", default=0)
+parser.add_argument("--approximant", type=str,
+                  help="The name of the approximant to use for filtering. ")
+parser.add_argument("--mass1", type=float)
+parser.add_argument("--mass2", type=float)
+parser.add_argument("--spin1z", type=float, default=0)
+parser.add_argument("--spin2z", type=float, default=0)
+parser.add_argument("--order", type=int,
+                  help="The integer half-PN order at which to generate"
+                       " the approximant. Default is -1 which indicates to use"
+                       " approximant defined default.", default=-1, 
+                       choices = numpy.arange(-1, 9, 1))
+parser.add_argument("--taper-template", choices=["start","end","startend"],
+                    help="For time-domain approximants, taper the start and/or"
+                    " end of the waveform before FFTing.")
+
+# Add options groups
+psd.insert_psd_option_group(parser)
+strain.insert_strain_option_group(parser)
+strain.StrainSegments.insert_segment_option_group(parser)
+scheme.insert_processing_option_group(parser)
+fft.insert_fft_option_group(parser)
+opt = parser.parse_args()
+
+# Check that the values returned for the options make sense
+psd.verify_psd_options(opt, parser)
+strain.verify_strain_options(opt, parser)
+strain.StrainSegments.verify_segment_options(opt, parser)
+scheme.verify_processing_options(opt, parser)
+fft.verify_fft_options(opt,parser)
+pycbc.init_logging(opt.verbose)
+
+def associate_psd(strain_segments, gwstrain, segments, nsegs, flen, delta_f, flow):
+    logging.info("Computing noise PSD")
+    def grouper(n, iterable):
+        args = [iter(iterable)] * n
+        return list([e for e in t if e != None] for t in itertools.izip_longest(*args))
+
+    nsegs = nsegs if nsegs != 0 else len(strain_segments.full_segment_slices)
+    groups = grouper(nsegs, strain_segments.full_segment_slices)
+    if len(groups[-1]) != len(groups[0]):
+        logging.warn('PSD recalculation does not divide equally among analysis'
+                     'segments. Make sure that this is what you want')
+
+    psds = []
+    for psegs in groups:
+        strain_part = gwstrain[psegs[0].start:psegs[-1].stop]
+        ppsd = psd.from_cli(opt, flen, delta_f, flow, strain_part, pycbc.DYN_RANGE_FAC)
+        psds.append(ppsd)
+        for seg in segments:
+            if seg.seg_slice in psegs:
+                seg.psd = ppsd.astype(float32)
+    return psds
+
+ctx = scheme.from_cli(opt)
+gwstrain = strain.from_cli(opt, pycbc.DYN_RANGE_FAC)
+strain_segments = strain.StrainSegments.from_cli(opt, gwstrain)
+
+with ctx:
+    fft.from_cli(opt)
+    flow = opt.low_frequency_cutoff
+    flen = strain_segments.freq_len
+    delta_f = strain_segments.delta_f
+
+    logging.info("Making frequency-domain data segments")
+    segments = strain_segments.fourier_segments()
+    
+    logging.info("Calculating the PSDs")
+    psds = associate_psd(strain_segments, gwstrain, segments, 
+                         opt.psd_recalculate_segments, 
+                         flen, delta_f, flow)
+
+    logging.info("Making template: %s" % opt.approximant)
+    template = waveform.get_waveform_filter(zeros(flen, dtype=complex64), 
+                                    approximant=opt.approximant,
+                                    mass1=opt.mass1, mass2=opt.mass2,
+                                    spin1z=opt.spin1z, spin2z=opt.spin2z,
+                                    taper=opt.taper_template, 
+                                    f_lower=flow, delta_f=delta_f,
+                                    delta_t=gwstrain.delta_t)
+                                    
+    for s_num, stilde in enumerate(segments):
+        logging.info("Filtering segment %s" % s_num)
+        snr, corr, norm = filter.matched_filter_core(template, stilde, 
+                                    psd=stilde.psd,
+                                    low_frequency_cutoff=flow)
+        snr *= norm
+        logging.info("calculating chisq")
+        chisq = vetoes.power_chisq(template, stilde, opt.chisq_bins, stilde.psd, 
+                                    low_frequency_cutoff = flow)
+        chisq /= opt.chisq_bins * 2 - 2   
+        newsnr = TimeSeries(events.newsnr(abs(snr).numpy(), chisq.numpy()), 
+                            delta_t=snr.delta_t, epoch=snr.start_time)
+        #import pylab # example plot segment by segment
+        #pylab.plot(snr.sample_times.numpy(), abs(snr).numpy(), label='SNR')
+        #pylab.plot(chisq.sample_times.numpy(), chisq.numpy(), label='CHISQ')
+        #pylab.plot(newsnr.sample_times.numpy(), newsnr.numpy(), label='NewSNR')
+        #pylab.show()
+logging.info("Finished")

--- a/setup.py
+++ b/setup.py
@@ -342,6 +342,7 @@ setup (
                'bin/pycbc_banksim',
                'bin/pycbc_faithsim',
                'bin/pycbc_inspiral',
+               'bin/pycbc_single_template',
                'bin/pycbc_multi_inspiral',
                'bin/pycbc_make_banksim',
                'bin/pycbc_splitbank',


### PR DESCRIPTION
This adds a single template version of pycbc inspiral. It doesn't save anything nor produce any result plots at this point, but is available as base so it can be modified to do so in the near future. 

Here is an example 

```
pycbc_single_template \
--approximant SPAtmplt \
--mass1 1.4 \
--mass2 1.4 \
--low-frequency-cutoff 40 \
--sample-rate 4096 \
--chisq-bins 64 \
--psd-estimation median \
--psd-segment-length 16 \
--psd-segment-stride 8 \
--gps-start-time 100000000 \
--gps-end-time   100002016 \
--strain-high-pass 30 \
--pad-data 8 \
--channel-name H1:FAKE-STRAIN \
--fake-strain iLIGOModel \
--fake-strain-seed=1 \
--segment-length 512 \
--segment-start-pad 64 \
--segment-end-pad 16 \
--processing-scheme cpu:16 \
--fftw-measure-level 0 \
--output test.hdf \
--verbose 
