### PR TITLE
fix frame-type option

### DIFF
--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -222,7 +222,7 @@ def insert_strain_option_group(parser, gps_times=True):
 
     #Use datafind to get frame files 
     data_reading_group.add_argument("--frame-type",
-                            type=str, nargs="+",
+                            type=str,
                             help="(optional), replaces frame-files. Use datafind "
                                  "to get the needed frame file(s) of this type.")
 


### PR DESCRIPTION
As reported by Chris, the frame-type option is currently broken. This patch fixes it, so now you can provide a frame type to pycbc_inspiral in lieu of frame files and it will figure out where they are on its own.