### PR TITLE
Add script and doc to generate single-column ASCII files that can be used by awgstream

### DIFF
--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -105,10 +105,9 @@ parser.add_argument('--approximant', type=str, required=True,
                   choices=td_approximants(),
                   help='Approximant to use for generating waveform.')
 parser.add_argument("--order", type=str, default='default',
+                  choices = pn_orders.keys(),
                   help='The integer half-PN order at which to generate \
-                  the approximant. Default is -1 which indicates to use \
-                  approximant defined by default.',
-                  choices = pn_orders.keys())
+                  the approximant.')
 parser.add_argument('--mass1', type=float, required=True,
                   help='First mass of the binary in solar masses.')
 parser.add_argument('--mass2', type=float, required=True,

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -215,7 +215,7 @@ sim.taper = opts.taper
 
 # construct waveform string that can be parsed by lalsimulation
 waveform_string = opts.approximant
-if not opts.order == -1:
+if not pn_orders[opts.order] == -1:
     waveform_string += opts.order
 sim.waveform = waveform_string
 

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -1,0 +1,414 @@
+#!/usr/bin/python
+
+# Copyright (C) 2015 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import argparse
+import glue
+from glue.ligolw import ilwd
+from glue.ligolw import ligolw
+from glue.ligolw import lsctables
+from glue.ligolw import utils
+import logging
+import numpy
+from pycbc import DYN_RANGE_FAC
+from pycbc import pnutils
+from pycbc import psd as _psd
+from pycbc import strain as _strain
+from pycbc.detector import Detector
+from pycbc.inject import InjectionSet
+from pycbc.filter import make_frequency_series
+from pycbc.filter import sigmasq
+from pycbc.types import Array, FrequencySeries, TimeSeries, zeros
+from pycbc.waveform import FilterBank, get_td_waveform, td_approximants, taper_timeseries
+import os
+import sys
+
+def _empty_row(obj):
+    """Create an empty sim_inspiral or sngl_inspiral row where the columns have
+    default values of 0.0 for a float, 0 for an int, '' for a string. The ilwd
+    columns have a default where the index is 0.
+    """
+
+    # check if sim_inspiral or sngl_inspiral
+    if obj == lsctables.SimInspiral:
+        row = lsctables.SimInspiral()
+        cols = lsctables.SimInspiralTable.validcolumns
+    else:
+        row = lsctables.SnglInspiral()
+        cols = lsctables.SnglInspiralTable.validcolumns
+
+    # populate columns with default values
+    for entry in cols.keys():
+        if cols[entry] in ['real_4','real_8']:
+            setattr(row,entry,0.)
+        elif cols[entry] == 'int_4s':
+            setattr(row,entry,0)
+        elif cols[entry] == 'lstring':
+            setattr(row,entry,'')
+        elif entry == 'process_id':
+            row.process_id = ilwd.ilwdchar("sim_inspiral:process_id:0")
+        elif entry == 'simulation_id':
+            row.simulation_id = ilwd.ilwdchar("sim_inspiral:simulation_id:0")
+        elif entry == 'event_id':
+            row.event_id = ilwd.ilwdchar("sngl_inspiral:event_id:0")
+        else:
+            raise ValueError("Column %s not recognized." %(entry) )
+
+    return row
+
+# map order integer to a string that can be parsed by lalsimulation
+pn_orders = {
+    'default'          : -1,
+    'zeroPN'           : 0,
+    'onePN'            : 2,
+    'onePointFivePN'   : 3,
+    'twoPN'            : 4,
+    'twoPointFivePN'   : 5,
+    'threePN'          : 6,
+    'threePointFivePN' : 7,
+    'pseudoFourPN'     : 8,
+}
+
+# command line usage
+parser = argparse.ArgumentParser(usage='pycbc_generate_hwinj [--options]',
+                  description="Generates a hardware injection waveform using \
+                  a time-domain waveform.")
+
+# IFO network options
+parser.add_argument('--network-snr', type=float, required=True,
+                  help='The network SNR of the injection.')
+
+# sky location options
+parser.add_argument('--ra', type=float, required=True,
+                  help='The right ascension of the injection in radians.')
+parser.add_argument('--dec', type=float, required=True,
+                  help='The declination of the injection in radians.')
+parser.add_argument('--polarization', type=float, required=True,
+                  help='The polarization of the injection.')
+
+# waveform parameter options
+parser.add_argument('--approximant', type=str, required=True,
+                  choices=td_approximants(),
+                  help='Approximant to use for generating waveform.')
+parser.add_argument("--order", type=str, default='default',
+                  help='The integer half-PN order at which to generate \
+                  the approximant. Default is -1 which indicates to use \
+                  approximant defined by default.',
+                  choices = pn_orders.keys())
+parser.add_argument('--mass1', type=float, required=True,
+                  help='First mass of the binary in solar masses.')
+parser.add_argument('--mass2', type=float, required=True,
+                  help='Second mass of the binary in solar masses.')
+parser.add_argument('--inclination', type=float, required=True,
+                  help='Inclination of the binary.')
+parser.add_argument('--taper',  required=True,
+                    choices=['TAPER_NONE', 'TAPER_START', 'TAPER_END', 'TAPER_STARTEND'],
+                    help='Taper the wavform before FFT.')
+
+# waveform spin parameter options
+parser.add_argument('--spin1z', type=float, default=0.0,
+                  help='Spin in z direction for mass1.')
+parser.add_argument('--spin1y', type=float, default=0.0,
+                  help='Spin in y direction for mass1.')
+parser.add_argument('--spin1x', type=float, default=0.0,
+                  help='Spin in x direction for mass1.')
+parser.add_argument('--spin2z', type=float, default=0.0,
+                  help='Spin in z direction for mass2.')
+parser.add_argument('--spin2y', type=float, default=0.0,
+                  help='Spin in y direction for mass2.')
+parser.add_argument('--spin2x', type=float, default=0.0,
+                  help='Spin in x direction for mass2.')
+
+# end time options
+parser.add_argument('--geocentric-end-time', type=float, required=True,
+                  help='The geocentric GPS end time of the injection.')
+
+# data conditioning options
+parser.add_argument('--low-frequency-cutoff', type=float, required=True,
+                  help='Frequency to begin generating the waveform in Hz.')
+
+# output options
+parser.add_argument('--h1', action='store_true',
+                  help='Output files for H1 waveform.')
+parser.add_argument('--l1', action='store_true',
+                  help='Output files for L1 waveform.')
+
+# add option groups
+_psd.insert_psd_option_group(parser)
+_strain.insert_strain_option_group(parser)
+_strain.StrainSegments.insert_segment_option_group(parser)
+
+# parse command line
+opts = parser.parse_args()
+
+# determine which IFOs to create injection for from command line
+ifos = []
+if opts.h1: 
+    ifos.append('H1')
+if opts.l1:
+    ifos.append('L1')
+
+# set an initial distance to generate waveform
+distance = 40.0
+
+# set network SNR to 0.0
+network_snr = 0.0
+
+# set upper frequency to integrate sigma squared to
+f_high = 1000.0
+
+# setup log
+logging_level = logging.DEBUG
+logging.basicConfig(format='%(asctime)s : %(message)s', level=logging_level)
+
+# create output XML file
+logging.info('Creating XML file')
+outdoc = ligolw.Document()
+outdoc.appendChild(ligolw.LIGO_LW())
+
+# create process table
+proc_id = utils.process.register_to_xmldoc(outdoc,
+                    sys.argv[0], opts.__dict__,
+                    comment="", ifos=[''.join(ifos)],
+                    version=glue.git_version.id,
+                    cvs_repository=glue.git_version.branch,
+                    cvs_entry_time=glue.git_version.date).process_id
+
+# create sim_inspiral table
+sim_table = lsctables.New(lsctables.SimInspiralTable,
+                            columns=lsctables.SimInspiralTable.validcolumns)
+outdoc.childNodes[0].appendChild(sim_table)
+
+# create sim_inspiral row for injection
+# and populate non-IFO-specific columns in XML output file
+sim = _empty_row(lsctables.SimInspiral)
+sim.f_lower = opts.low_frequency_cutoff
+sim.geocent_end_time = int(opts.geocentric_end_time)
+sim.geocent_end_time_ns = int(opts.geocentric_end_time % 1 * 1e9)
+sim.inclination = opts.inclination
+sim.latitude = opts.ra
+sim.longitude = opts.dec
+sim.mass1 = opts.mass1
+sim.mass2 = opts.mass2
+sim.mchirp, sim.eta = pnutils.mass1_mass2_to_mtotal_eta(sim.mass1, sim.mass2)
+sim.spin1z = opts.spin1z
+sim.spin1y = opts.spin1y
+sim.spin1x = opts.spin1x
+sim.spin2z = opts.spin2z
+sim.spin2y = opts.spin2y
+sim.spin2x = opts.spin2x
+sim.polarization = opts.polarization
+sim.taper = opts.taper
+
+# construct waveform string that can be parsed by lalsimulation
+waveform_string = opts.approximant
+if not opts.order == -1:
+    waveform_string += opts.order
+sim.waveform = waveform_string
+
+# create sngl_inspiral table
+sngl_table = lsctables.New(lsctables.SnglInspiralTable,
+                            columns=lsctables.SnglInspiralTable.validcolumns)
+outdoc.childNodes[0].appendChild(sngl_table)
+
+# create sngl_inspiral row for injection
+# and populate non-IFO-specific columns in XML output file
+sngl = _empty_row(lsctables.SnglInspiral)
+sngl.mass1 = opts.mass1
+sngl.mass2 = opts.mass2
+sngl.mchirp, sngl.eta = pnutils.mass1_mass2_to_mtotal_eta(sngl.mass1, sngl.mass2)
+sngl.mtotal = sngl.mass1 + sngl.mass2
+sngl.spin1z = opts.spin1z
+sngl.spin1y = opts.spin1y
+sngl.spin1x = opts.spin1x
+sngl.spin2z = opts.spin2z
+sngl.spin2y = opts.spin2y
+sngl.spin2x = opts.spin2x
+
+# generate waveform
+logging.info('Generating waveform at %.3fMpc', distance)
+h_plus, h_cross = get_td_waveform(approximant=opts.approximant,
+                    order=pn_orders[opts.order],
+                    mass1=opts.mass1,
+                    mass2=opts.mass2,
+                    spin1z=opts.spin1z, spin1y=opts.spin1y, spin1x=opts.spin1x,
+                    spin2z=opts.spin2z, spin2y=opts.spin2y, spin2x=opts.spin2x,
+                    inclination=opts.inclination,
+                    delta_t=1.0/opts.sample_rate,
+                    distance=distance,
+                    f_lower=opts.low_frequency_cutoff)
+
+# get strain timeseries
+data = _strain.from_cli(opts, DYN_RANGE_FAC)
+
+# generate PSD
+logging.info('Generating PSD')
+N = len(h_plus)
+n = N/2+1
+delta_f = 1.0 / N / h_plus.delta_t
+psd = _psd.from_cli(opts, n, delta_f, opts.low_frequency_cutoff,
+             strain=data, dyn_range_factor=DYN_RANGE_FAC)
+
+# loop over IFOs to calculate sigma
+for ifo in ifos:
+
+    # get Detector instance for IFO
+    det = Detector(ifo)
+
+    # get antenna pattern
+    f_plus, f_cross = det.antenna_pattern(opts.ra, opts.dec,
+                        opts.polarization, opts.geocentric_end_time)
+
+    # calculate strain
+    logging.info('Calculating strain for %s', ifo)
+    strain = f_plus * h_plus + f_cross * h_cross
+
+    # taper waveform
+    logging.info('Tapering strain for %s', ifo)
+    strain = taper_timeseries(strain, tapermethod=opts.taper)
+
+    # FFT strain
+    logging.info('FFT strain for %s', ifo)
+    strain_tilde = make_frequency_series(strain)
+
+    # calculate sigma-squared SNR
+    logging.info('Calculating sigma for %s', ifo)
+    sigma_squared = sigmasq(DYN_RANGE_FAC * strain_tilde, psd=psd, low_frequency_cutoff=opts.low_frequency_cutoff, high_frequency_cutoff=f_high)
+    logging.info('Sigma integrated from %.3f to %.3fHz for %s is %.3f', opts.low_frequency_cutoff, f_high, ifo, numpy.sqrt(sigma_squared))
+
+    # include sigma in network SNR calculation
+    network_snr += sigma_squared
+
+# distance scaling factor to get target snr
+network_snr = numpy.sqrt(network_snr)
+scale = network_snr / opts.network_snr
+
+# reset network SNR
+network_snr = 0.0
+
+# generate waveform
+logging.info('Generating waveform at %.3fMpc', scale*distance)
+h_plus, h_cross = get_td_waveform(approximant=opts.approximant,
+                    order=pn_orders[opts.order],
+                    mass1=opts.mass1,
+                    mass2=opts.mass2,
+                    spin1z=opts.spin1z, spin1y=opts.spin1y, spin1x=opts.spin1x,
+                    spin2z=opts.spin2z, spin2y=opts.spin2y, spin2x=opts.spin2x,
+                    inclination=opts.inclination,
+                    delta_t=1.0/opts.sample_rate,
+                    distance=scale*distance,
+                    f_lower=opts.low_frequency_cutoff)
+
+# loop over IFOs to calculate sigma
+for ifo in ifos:
+
+    # get Detector instance for IFO
+    det = Detector(ifo)
+
+    # get time delay to detector from center of the Earth
+    time_delay = det.time_delay_from_earth_center(opts.ra, opts.dec,
+                        opts.geocentric_end_time)
+    end_time = opts.geocentric_end_time + time_delay
+
+    # get antenna pattern
+    f_plus, f_cross = det.antenna_pattern(opts.ra, opts.dec,
+                        opts.polarization, opts.geocentric_end_time)
+
+    # calculate strain
+    logging.info('Calculating strain for %s', ifo)
+    strain = f_plus * h_plus + f_cross * h_cross
+
+    # taper waveform
+    logging.info('Tapering strain for %s', ifo)
+    strain = taper_timeseries(strain, tapermethod=opts.taper)
+
+    # FFT strain
+    logging.info('FFT strain for '+ifo+'...')
+    strain_tilde = make_frequency_series(strain)
+
+    # calculate sigma-squared SNR
+    logging.info('Calculating sigma for %s', ifo)
+    sigma_squared = sigmasq(DYN_RANGE_FAC * strain_tilde, psd=psd, low_frequency_cutoff=opts.low_frequency_cutoff, high_frequency_cutoff=f_high)
+    logging.info('Sigma integrated from %.3f to %.3fHz for %s is %.3f', opts.low_frequency_cutoff, f_high, ifo, numpy.sqrt(sigma_squared))
+
+    # populate IFO end time columns
+    setattr(sim, ifo[0].lower()+'_end_time', int(end_time))
+    setattr(sim, ifo[0].lower()+'_end_time_ns', int(end_time % 1 * 1e9))
+
+    # populate IFO distance columns
+    eff_distance = 2 * distance 
+    eff_distance /= ( 1 + numpy.cos( opts.inclination )**2 )**2 / 4 * f_plus**2 + numpy.cos( opts.inclination )**2 * f_cross**2
+    setattr(sim, 'eff_dist_'+ifo[0].lower(), eff_distance)
+    setattr(sim, 'distance', scale*distance)
+
+    # populate IFO end time columns
+    sngl.end_time = int(end_time)
+    sngl.end_time_ns = int(end_time % 1 * 1e9)
+
+    # include sigma in network SNR calculation
+    network_snr += sigma_squared
+
+# sanity check network SNR
+network_snr = numpy.sqrt(network_snr)
+if not abs(opts.network_snr / network_snr) - 1 < 0.1:
+    logging.warn('Exiting because network SNR is %f but requested %s', network_snr, opts.network_snr)
+else:
+    logging.info('Network SNR of injection is %.3f', network_snr)
+
+# figure out length of time series to inject waveform into
+pad_seconds = 5
+template_duration_seconds = int( len(strain) / opts.sample_rate ) + 1
+start_time = int(opts.geocentric_end_time) - template_duration_seconds - pad_seconds
+end_time = int(opts.geocentric_end_time) + 1 + pad_seconds
+num_samples = (end_time - start_time) * opts.sample_rate
+
+# save XML output file if it does not exist
+logging.info('Writing XML file')
+sim_table.append(sim)
+sngl_table.append(sngl)
+xml_filename = ''.join(ifos) + '-' + 'HWINJ_CBC' + '-' + str(start_time) + '-' + str(end_time-start_time) + '.xml.gz'
+if os.path.exists(xml_filename):
+    logging.warn('Filename %s already exists and will not be overwritten', txt_filename)
+    sys.exit()
+else:
+    utils.write_filename(outdoc, xml_filename, gz=xml_filename.endswith('gz'))
+
+# loop over IFOs for writing waveforms to file
+for ifo in ifos:
+
+    # create a time series of zeroes to inject waveform into
+    initial_array = numpy.zeros(num_samples, dtype=strain.dtype)
+    output = TimeSeries(initial_array, delta_t=1.0/opts.sample_rate, epoch=start_time, dtype=strain.dtype)
+
+    # inject waveform
+    injections = InjectionSet(xml_filename)
+    injections.apply(output, ifo)
+
+    # set output filename
+    txt_filename = ifo + '-' + 'HWINJ_CBC' + '-' + str(start_time) + '-' + str(end_time-start_time) + '.txt'
+
+    # check if filename does not exist
+    if os.path.exists(txt_filename):
+        logging.warn('Filename %s already exists and will not be overwritten', txt_filename)
+        sys.exit()
+
+    # save waveform as single column ASCII for awgstream to use
+    logging.info('Writing strain for %s', ifo)
+    numpy.savetxt(txt_filename, output)
+
+# finish
+logging.info('Done')

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -120,17 +120,17 @@ parser.add_argument('--taper',  required=True,
 
 # waveform spin parameter options
 parser.add_argument('--spin1z', type=float, default=0.0,
-                  help='Spin in z direction for mass1.')
+                  help='(optional) Spin in z direction for mass1.')
 parser.add_argument('--spin1y', type=float, default=0.0,
-                  help='Spin in y direction for mass1.')
+                  help='(optional) Spin in y direction for mass1.')
 parser.add_argument('--spin1x', type=float, default=0.0,
-                  help='Spin in x direction for mass1.')
+                  help='(optional) Spin in x direction for mass1.')
 parser.add_argument('--spin2z', type=float, default=0.0,
-                  help='Spin in z direction for mass2.')
+                  help='(optional) Spin in z direction for mass2.')
 parser.add_argument('--spin2y', type=float, default=0.0,
-                  help='Spin in y direction for mass2.')
+                  help='(optional) Spin in y direction for mass2.')
 parser.add_argument('--spin2x', type=float, default=0.0,
-                  help='Spin in x direction for mass2.')
+                  help='(optional) Spin in x direction for mass2.')
 
 # end time options
 parser.add_argument('--geocentric-end-time', type=float, required=True,
@@ -142,9 +142,9 @@ parser.add_argument('--low-frequency-cutoff', type=float, required=True,
 
 # output options
 parser.add_argument('--h1', action='store_true',
-                  help='Output files for H1 waveform.')
+                  help='(optional) Output files for H1 waveform.')
 parser.add_argument('--l1', action='store_true',
-                  help='Output files for L1 waveform.')
+                  help='(optional) Output files for L1 waveform.')
 
 # add option groups
 _psd.insert_psd_option_group(parser)

--- a/bin/hwinj/pycbc_plot_hwinj
+++ b/bin/hwinj/pycbc_plot_hwinj
@@ -1,0 +1,16 @@
+#! /usr/bin/python
+
+"""
+Simple script to plot a txt file created by a TimeSeries.
+"""
+
+import matplotlib.pyplot as plt
+import sys
+
+import numpy
+
+timeseries = numpy.loadtxt(sys.argv[1])
+samples = range(len(timeseries))
+
+plt.plot(samples, timeseries)
+plt.show()

--- a/docs/hwinj.rst
+++ b/docs/hwinj.rst
@@ -44,7 +44,7 @@ Here is a usage example for generating a CBC waveform using a design noise curve
 
   pycbc_generate_hwinj --approximant EOBNRv2 --order pseudoFourPN --mass1 1.4 --mass2 1.4 --inclination 0.0 --polarization 0.0 --ra 1.0 --dec 1.0 --taper TAPER_START --network-snr 28 --geocentric-end-time 1117982241 --low-frequency-cutoff 15.0 --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --h1 --l1 --fake-strain aLIGOZeroDetHighPower --psd-model aLIGOZeroDetHighPower --sample-rate 16384
 
-You can plot the ASCII waveform files with an X11 connection. Its reccommended this way so that the user may zoom in and inspect the waveform. For the example above one would do: ::
+You can plot the ASCII waveform files with an X11 connection. Its recommended this way so that the user may zoom in and inspect the waveform. For the example above one would do: ::
 
   pycbc_plot_hwinj H1-HWINJ_CBC-1117981890-357.txt
 

--- a/docs/hwinj.rst
+++ b/docs/hwinj.rst
@@ -6,61 +6,43 @@ Hardware injection waveform generation (``pycbc_generate_hwinj``)
 Introduction
 =====================================
 
-The executable ``pycbc_generate_hwinj`` is for generating waveforms to be
-used for hardware injections.
+The executable ``pycbc_generate_hwinj`` is for generating waveforms to be used for hardware injections.
 
-The procedure for generating a waveform is
+The procedure for generating a waveform is:
 
  * Generate the waveform using the parameters given on the command line.
- * Generate a PSD.
- * Calculate the time delay and antenna pattern for each detector.
- * Calculate sigma for each detector using the waveform and the PSD. Determine the network SNR.
+ * Generate a PSD that will be used for calculating sigma squared.
+ * Calculate the antenna pattern for each detector.
+ * Calculate sigma squared for each detector using the waveform and the PSD. We do this to determine the network SNR.
  * Rescale the waveform to the desired network SNR.
- * Write an XML file with the waveform parameters and an ASCII file with the h(t) timeseries.
+ * Write an XML file with the waveform parameters and single-column ASCII files that contain the h(t) timeseries.
 
-This executable uses the ``pycbc.waveform`` module to generate the waveforms that uses the lalsimulation ``lalsimulation.SimInspiralChooseTDWaveform`` routine to return the two h(t) polarizations.
+This executable uses the ``pycbc.waveform`` module to generate the waveforms. The ``pycbc.waveform`` module is calling lalsimulation routines to inject h(t).
 
-The command line options to ``pycbc_generate_hwinj`` are
+The waveform-specific command line options to ``pycbc_generate_hwinj`` are:
 
- * ``--approximant`` the waveform approximant to use
- * ``--mass1`` and ``--mass2`` the component masses of the binary
- * ``--gps-end-time`` the geocentric end time of the hardware injection
- * ``--network-snr`` the network SNR of the hardware injection, network SNR is 
- * ``--ifos`` a list of the interferometers to include in the hardware injection
- * ``--output-waveform-file`` a list of ASCII filenames that will have a single-column with the h(t) timeseries, the ordering of the IFOs must match `--ifos`
- * ``--output-xml-file`` an XML filename with a ``sim_inspiral`` and ``sngl_inspiral`` table for the injection
- * ``--psd-model`` or ``--psd-estimate`` if you want to use a model noise curve or estimate the noise curve from data, if you estimate the PSD then you will need to include the additional options found in the PSD option group (see ``pycbc_generate_hwinj --help``)
+ * ``--approximant`` the waveform approximant to use,
+ * ``--order`` the post-Newtonian order of the waveform,
+ * ``--inclination`` the inclination of the orbit,
+ * ``--polarization`` the polarization,
+ * ``--ra`` and ``--dec`` the RA and DEC of the waveform in radians,
+ * ``--taper`` tells when to taper the waveform,
+ * ``--mass1`` and ``--mass2`` the component masses of the binary,
+ * ``--geocentric-end-time`` the geocentric end time of the hardware injection,
+ * ``--network-snr`` the desired network SNR of the hardware injection,
+ * ``--sample-rate`` the sample rate to generate the ASCII waveforms, and
+ * ``--h1`` and ``--l1`` select what IFOs to generate the hardware injection.
 
 ==================================
 How to generate a single waveform
 ==================================
 
-Here is a usage example for generating a CBC waveform that could
-be used as a hardware injection. ::
+Here is a usage example for generating a CBC waveform using a design noise curve. ::
 
-    pycbc_generate_hwinj --approximant EOBNRv2 \
-                         --mass1 1.4 \
-                         --mass2 1.4 \
-                         --output-xml-file injection.xml.gz \
-                         --output-waveform-file h1_injection.txt l1_injection.txt \
-                         --gps-end-time 1117982141 \
-                         --ifos H1 L1 \
-                         --psd-model aLIGOZeroDetHighPower \
-                         --psd-output injection_psd.txt \
-                         --inclination 0.0 \
-                         --network-snr 8
+  GPS_START_TIME=1117982000
+  GPS_END_TIME=$(($GPS_START_TIME + 2048))
 
-You can generate a CBC waveform using data to estimate the PSD instead of a model.
-Here is a usage example. ::
+  pycbc_generate_hwinj --approximant EOBNRv2 --order pseudoFourPN --mass1 1.4 --mass2 1.4 --inclination 0.0 --polarization 0.0 --ra 1.0 --dec 1.0 --taper TAPER_START --network-snr 28 --geocentric-end-time 1117982241 --low-frequency-cutoff 15.0 --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --h1 --l1 --fake-strain aLIGOZeroDetHighPower --psd-model aLIGOZeroDetHighPower --sample-rate 16384
 
-    pycbc_generate_hwinj --approximant EOBNRv2 \
-                         --mass1 1.4 \
-                         --mass2 1.4 \
-                         --output-xml-file injection.xml.gz \
-                         --output-waveform-file h1_injection.txt l1_injection.txt \
-                         --gps-end-time 1117982141 \
-                         --ifos H1 L1 \
-                         --psd-model aLIGOZeroDetHighPower \
-                         --psd-output injection_psd.txt \
-                         --inclination 0.0 \
-                         --network-snr 8
+
+You can generate a CBC waveform using interferometer data to estimate the PSD instead of a model. Using the pycbc strain and psd options.

--- a/docs/hwinj.rst
+++ b/docs/hwinj.rst
@@ -37,12 +37,15 @@ The waveform-specific command line options to ``pycbc_generate_hwinj`` are:
 How to generate a single waveform
 ==================================
 
-Here is a usage example for generating a CBC waveform using a design noise curve. ::
+Here is a usage example for generating a CBC waveform using a design noise curve: ::
 
   GPS_START_TIME=1117982000
   GPS_END_TIME=$(($GPS_START_TIME + 2048))
 
   pycbc_generate_hwinj --approximant EOBNRv2 --order pseudoFourPN --mass1 1.4 --mass2 1.4 --inclination 0.0 --polarization 0.0 --ra 1.0 --dec 1.0 --taper TAPER_START --network-snr 28 --geocentric-end-time 1117982241 --low-frequency-cutoff 15.0 --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --h1 --l1 --fake-strain aLIGOZeroDetHighPower --psd-model aLIGOZeroDetHighPower --sample-rate 16384
 
+You can plot the ASCII waveform files with an X11 connection. Its reccommended this way so that the user may zoom in and inspect the waveform. For the example above one would do: ::
+
+  pycbc_plot_hwinj H1-HWINJ_CBC-1117981890-357.txt
 
 You can generate a CBC waveform using interferometer data to estimate the PSD instead of a model. Using the pycbc strain and psd options.

--- a/docs/hwinj.rst
+++ b/docs/hwinj.rst
@@ -1,0 +1,66 @@
+################################################################
+Hardware injection waveform generation (``pycbc_generate_hwinj``)
+################################################################
+
+=====================================
+Introduction
+=====================================
+
+The executable ``pycbc_generate_hwinj`` is for generating waveforms to be
+used for hardware injections.
+
+The procedure for generating a waveform is
+
+ * Generate the waveform using the parameters given on the command line.
+ * Generate a PSD.
+ * Calculate the time delay and antenna pattern for each detector.
+ * Calculate sigma for each detector using the waveform and the PSD. Determine the network SNR.
+ * Rescale the waveform to the desired network SNR.
+ * Write an XML file with the waveform parameters and an ASCII file with the h(t) timeseries.
+
+This executable uses the ``pycbc.waveform`` module to generate the waveforms that uses the lalsimulation ``lalsimulation.SimInspiralChooseTDWaveform`` routine to return the two h(t) polarizations.
+
+The command line options to ``pycbc_generate_hwinj`` are
+
+ * ``--approximant`` the waveform approximant to use
+ * ``--mass1`` and ``--mass2`` the component masses of the binary
+ * ``--gps-end-time`` the geocentric end time of the hardware injection
+ * ``--network-snr`` the network SNR of the hardware injection, network SNR is 
+ * ``--ifos`` a list of the interferometers to include in the hardware injection
+ * ``--output-waveform-file`` a list of ASCII filenames that will have a single-column with the h(t) timeseries, the ordering of the IFOs must match `--ifos`
+ * ``--output-xml-file`` an XML filename with a ``sim_inspiral`` and ``sngl_inspiral`` table for the injection
+ * ``--psd-model`` or ``--psd-estimate`` if you want to use a model noise curve or estimate the noise curve from data, if you estimate the PSD then you will need to include the additional options found in the PSD option group (see ``pycbc_generate_hwinj --help``)
+
+==================================
+How to generate a single waveform
+==================================
+
+Here is a usage example for generating a CBC waveform that could
+be used as a hardware injection. ::
+
+    pycbc_generate_hwinj --approximant EOBNRv2 \
+                         --mass1 1.4 \
+                         --mass2 1.4 \
+                         --output-xml-file injection.xml.gz \
+                         --output-waveform-file h1_injection.txt l1_injection.txt \
+                         --gps-end-time 1117982141 \
+                         --ifos H1 L1 \
+                         --psd-model aLIGOZeroDetHighPower \
+                         --psd-output injection_psd.txt \
+                         --inclination 0.0 \
+                         --network-snr 8
+
+You can generate a CBC waveform using data to estimate the PSD instead of a model.
+Here is a usage example. ::
+
+    pycbc_generate_hwinj --approximant EOBNRv2 \
+                         --mass1 1.4 \
+                         --mass2 1.4 \
+                         --output-xml-file injection.xml.gz \
+                         --output-waveform-file h1_injection.txt l1_injection.txt \
+                         --gps-end-time 1117982141 \
+                         --ifos H1 L1 \
+                         --psd-model aLIGOZeroDetHighPower \
+                         --psd-output injection_psd.txt \
+                         --inclination 0.0 \
+                         --network-snr 8

--- a/setup.py
+++ b/setup.py
@@ -397,6 +397,8 @@ setup (
                'bin/hdfcoinc/pycbc_plot_range',
                'bin/hdfcoinc/pycbc_foreground_censor',
                'bin/hdfcoinc/pycbc_plot_hist',
+               'bin/hwinj/pycbc_generate_hwinj',
+               'bin/hwinj/pycbc_plot_hwinj',
                'bin/sngl/pycbc_ligolw_cluster',
                'bin/sngl/pycbc_plot_bank',
                'bin/sngl/pycbc_plot_glitchgram',


### PR DESCRIPTION
This PR adds two executables and docs for them.

The first executable ``pycbc_generate_hwinj`` takes waveform parameters on the command line and outputs a ``sim_inspiral``/``sngl_inspiral`` XML file with the parameters and single-column ASCII files with the generated waveforms. The layout of this script is a modern re-creation of ``lalapps_coinj`` for aLIGO data:
 * Generate the waveform using the parameters given on the command line.
 * Generate a PSD that will be used for calculating sigma squared.
 * Apply the antenna pattern for each detector.
 * Calculate sigma squared for each detector using the waveform and the PSD. We do this to determine the network SNR.
 * Rescale the waveform to the desired network SNR.
 * Write an XML file with the waveform parameters and single-column ASCII files that contain the h(t) timeseries.

The second executable ``pycbc_plot_hwinj`` plots the single-column ASCII files for inspection by the user.

The doc for these scripts is ``hwinj.rst``.