### PR TITLE
Tweak to time-clustering

### DIFF
--- a/pycbc/events/simd_threshold.py
+++ b/pycbc/events/simd_threshold.py
@@ -532,7 +532,7 @@ int parallel_thresh_cluster(std::complex<float> * __restrict inarr, const uint32
   */
 
   int64_t i, j, nsegs, nwins_ps, last_arrlen, last_nwins_ps, outlen, curr_mloc;
-  int64_t cnt, s_segsize, s_arrlen, s_winsize, curr_mark, cluster_win;
+  int64_t cnt, s_segsize, s_arrlen, s_winsize, curr_mark;
   int64_t *startlocs, *stoplocs, *mlocs, *seglens;
   float *norms, thr_sqr, curr_norm;
   std::complex<float> *cvals, curr_cval;
@@ -544,11 +544,7 @@ int parallel_thresh_cluster(std::complex<float> * __restrict inarr, const uint32
   // logic and calls to other functions are safe.
   s_segsize = (int64_t) segsize;
   s_arrlen = (int64_t) arrlen;
-
-  // We divide segsize by two since our initial pass must be with a segment
-  // half the length of that we will use for clustering.
-  s_winsize = (int64_t) winsize/2;
-  cluster_win = (int64_t) winsize;
+  s_winsize = (int64_t) winsize;
 
   /*
 
@@ -731,7 +727,7 @@ int parallel_thresh_cluster(std::complex<float> * __restrict inarr, const uint32
 
   cnt = 0;
   for (i = outlen-2; i >= 0; i--){
-    if ( (curr_mloc - stoplocs[i]) > cluster_win){
+    if ( (curr_mloc - stoplocs[i]) > s_winsize){
       marks[curr_mark] = 1;
       curr_mark = i;
       curr_norm = norms[i];
@@ -767,7 +763,7 @@ int parallel_thresh_cluster(std::complex<float> * __restrict inarr, const uint32
   curr_mark = marks[0];
 
   for (i = 1; i < outlen; i++){    
-    if ( (startlocs[i] - curr_mloc) > cluster_win){
+    if ( (startlocs[i] - curr_mloc) > s_winsize){
       // The last one is a maximum for all points following,
       // so if also for points preceding (curr_mark) and
       // if above threshold, then write it out.

--- a/pycbc/events/simd_threshold.py
+++ b/pycbc/events/simd_threshold.py
@@ -531,21 +531,104 @@ int parallel_thresh_cluster(std::complex<float> * __restrict inarr, const uint32
 
   */
 
-  int64_t i, nsegs, nwins_ps, last_arrlen, last_nwins_ps, outlen, curr_mloc;
-  int64_t *seglens, *mlocs, cnt, s_segsize, s_arrlen, s_winsize, curr_mark, cluster_win;
+  int64_t i, j, nsegs, nwins_ps, last_arrlen, last_nwins_ps, outlen, curr_mloc;
+  int64_t cnt, s_segsize, s_arrlen, s_winsize, curr_mark, cluster_win;
+  int64_t *startlocs, *stoplocs, *mlocs, *seglens;
   float *norms, thr_sqr, curr_norm;
   std::complex<float> *cvals, curr_cval;
   short int *marks;
 
   thr_sqr = (thresh * thresh);
+
   // Signed versions of all our array length inputs, so loop
   // logic and calls to other functions are safe.
-  s_segsize = (int64_t) segsize; 
+  s_segsize = (int64_t) segsize;
   s_arrlen = (int64_t) arrlen;
+
   // We divide segsize by two since our initial pass must be with a segment
   // half the length of that we will use for clustering.
   s_winsize = (int64_t) winsize/2;
   cluster_win = (int64_t) winsize;
+
+  /*
+
+   Before diving into a great number of fairly tedious calculations about
+   sizes of various subarrays, consider the following picture:
+
+       segment 0       segment 1       segment 2
+   | - - - - - - - | - - - - - - - | - - - - - - - | ...
+
+   | === | === | = | === | === | = | === | === | = |
+      0     1    2    3     4    5    6     7    8
+
+   For efficiency, our algorithm chops up the input array into segments,
+   whose size 'segsize' is an input parameter to the function but which
+   must be chosen to be vey close to (possibly less than) the size of a
+   complex, single-precision float array that will fit into the memory
+   local to a single processor core. It cannot be more than that, and
+   should not be too much less than that. But what we care about are the
+   maxima of the array within subarrays of size 'winsize'. The diagram
+   above shows what happens when 'winsize' is less than 'segsize' but does
+   not evenly divide it: the last window in each segment is shorter than
+   'winsize', and the next window still starts on a multiple of 'segsize'.
+   The function that this function calls directly (within the OpenMP loop)
+   is 'windowed_max'. It is given a chunk of the original array of size
+   'segsize', as well as the window size and the chunk of the various output
+   arrays into which it should write the complex values of the maxima,
+   absolute values squared, and location of the maxima.  'windowed_max' is
+   prepared for the last window to possibly be shorter than the rest, and will
+   calculate that size before calling (for each window) the function that
+   actually finds the maximum (either max_simd or max_simple). It knows
+   nothing about the other segments.
+
+   This top level function must allocate all of the arrays into which the
+   outputs of 'windowed_max' are written, keeping in mind that there may
+   be several such window in each segment, the last window in each may be
+   shorter, and the last segment may be shorter than the rest if 'segsize'
+   does not evenly divide 'arrlen'.
+
+   It must also be prepared for the following possibility, where 'winsize'
+   is *greater* than 'segsize':
+
+       segment 0       segment 1       segment 2
+   | - - - - - - - | - - - - - - - | - - - - - - - | ...
+
+   | =========================== | ================= ...
+                 0                         1
+
+   The way it behaves in this case is to consider only the segment size: it
+   will find the maxima in each segment, starting them anew at each segment
+   boundary.  The actual value of 'winsize' will then be irrelevant in the
+   initial parallel pass, and will only enter when we sweep through the
+   maxima to perform our final clustering.
+
+   Both of these examples show why that last pass is tricky to write: the
+   different maxima written to our output arrays will NOT in general correspond
+   to the maxima over exactly 'winsize' subarrays. Hence we cannot simply compare
+   an candidate trigger to the elements on either side of it to determine if it
+   is a local maximum.  Instead, we use the 'sliding window' approach that was
+   deployed in lalapps_inspiral.  However, we have still a few subtleties:
+
+   (1) We must slide the window both forward and backwards.  We start with
+       backwards, and mark in an auxiliary boolean array ('marks') whether
+       a candidate survived the comparisons within the sliding reverse window.
+       Then we slide forward, and if a candidate survives that we check its
+       boolean from the first pass and that it is above threshold.
+
+   (2) Because we are not sliding windows over the full data, what we compare
+       when deciding to keep a candidate is not whether its location is further
+       than 'winsize' away from the previous candidate, but rather whether the edge
+       of the window over which it is the maximum is greater than 'winsize' from
+       the last candidate trigger retained.  In the first (reverse) pass,
+       we compare to the end of the window; in the second (forward pass) to the
+       start of the window.
+
+    After both passes, candidates that survive will not only be above threshold,
+    but will have the property that there is no point in the full time series
+    louder than they are and less than 'winsize' away from the trigger.
+
+  */
+
 
   // If segsize divides arrlen evenly, then the number of segments 'nsegs' is that
   // ratio; if not, it is one more than the floor of that ratio and the last segment
@@ -568,31 +651,50 @@ int parallel_thresh_cluster(std::complex<float> * __restrict inarr, const uint32
 
   // Now dynamic allocation.  No reason really to align this memory; it will be parceled
   // out to different cores anyway.
-
   cvals = (std::complex<float> *) malloc(outlen * sizeof(std::complex<float>) );
   norms = (float *) malloc(outlen * sizeof(float) );
   mlocs = (int64_t *) malloc(outlen * sizeof(int64_t) );
+
+  // This array holds the starting location of each window
+  startlocs = (int64_t *) malloc(outlen * sizeof(int64_t) );
+
+  // This array holds the ending location of each window
+  stoplocs = (int64_t *) malloc(outlen * sizeof(int64_t) );
 
   // The next array will be used in our forward/reverse algorithm for
   // clustering.  Note the calloc, rather than malloc!
   marks = (short int *) calloc((size_t) outlen, sizeof(short int));
 
-  // The next array allows us to dynamically communicate possibly changed sizes to the
-  // many parallel calls to windowed_max:
+  // The next array allows us to tell 'windowed_max' the actual size
+  // of each window, which might be less than 'winsize'.
 
   seglens = (int64_t *) malloc(nsegs * sizeof(int64_t) );
 
   // check to see if anything failed
-  if ( (cvals == NULL) || (norms == NULL) || (mlocs == NULL) || (seglens == NULL) || (marks == NULL) ){
+  if ( (cvals == NULL) || (norms == NULL) || (mlocs == NULL) || (seglens == NULL) || (marks == NULL)
+        || (startlocs == NULL) || (stoplocs == NULL) ){
     error(EXIT_FAILURE, ENOMEM, "Could not allocate temporary memory needed by parallel_thresh_cluster");
   }
 
   for (i = 0; i < (nsegs-1); i++){
-    seglens[i] = segsize;
+    seglens[i] = s_segsize;
+    for (j = 0; j < (nwins_ps -1); j++){
+      startlocs[i*nwins_ps+j] = i*s_segsize + j*s_winsize;
+      stoplocs[i*nwins_ps+j] = i*s_segsize + (j+1)*s_winsize - 1;
+    }
+    startlocs[i*nwins_ps+j] = i*s_segsize + j*s_winsize;
+    stoplocs[i*nwins_ps+j] = (i+1)*s_segsize - 1;
   }
   seglens[i] = last_arrlen;
+  for (j = 0; j < last_nwins_ps - 1; j++){
+    startlocs[(nsegs-1)*nwins_ps+j] = (nsegs-1)*s_segsize + j*s_winsize;
+    stoplocs[(nsegs-1)*nwins_ps+j] = (nsegs-1)*s_segsize + (j+1)*s_winsize - 1; 
+  }
+  startlocs[outlen-1] = (nsegs-1)*s_segsize + (last_nwins_ps-1)*s_winsize;
+  stoplocs[outlen-1] = arrlen-1;
 
   // Now the real work, in an OpenMP parallel for loop:
+
 #pragma omp parallel for schedule(dynamic,1)
   for (i = 0; i < nsegs; i++){
     windowed_max(&inarr[i*segsize], seglens[i], &cvals[i*nwins_ps],
@@ -605,11 +707,6 @@ int parallel_thresh_cluster(std::complex<float> * __restrict inarr, const uint32
   We have now the requisite maxima over our windows in cvals,
   norms, and mlocs. We want to apply the threshold and cluster over
   time.
-
-  Our time clustering algorithm is that we should keep a candidate
-  trigger if it is above threshold and louder than anything before
-  or after it within 'window' in index. We test this by sliding through
-  our candidate triggers and comparing to what comes before and after.
 
   */
 
@@ -629,10 +726,12 @@ int parallel_thresh_cluster(std::complex<float> * __restrict inarr, const uint32
   //
   // Note that in this reverse loop, 'curr_mark' records
   // where in the arrays (of lengths 'outlen') we found
-  // our last potential local maximum.
+  // our last potential local maximum---it is *not* an
+  // index into the full array.
+
   cnt = 0;
   for (i = outlen-2; i >= 0; i--){
-    if ( (curr_mloc - mlocs[i]) > cluster_win){
+    if ( (curr_mloc - stoplocs[i]) > cluster_win){
       marks[curr_mark] = 1;
       curr_mark = i;
       curr_norm = norms[i];
@@ -661,13 +760,14 @@ int parallel_thresh_cluster(std::complex<float> * __restrict inarr, const uint32
   curr_norm = norms[0];
   curr_mloc = mlocs[0];
   curr_cval = cvals[0];
+
   // Note that in this pass, we treat 'curr_mark' as a
   // boolean, to know whether our forward potential
   // maximum was also marked on the reverse loop earlier.
   curr_mark = marks[0];
 
   for (i = 1; i < outlen; i++){    
-    if ( (mlocs[i] - curr_mloc) > cluster_win){
+    if ( (startlocs[i] - curr_mloc) > cluster_win){
       // The last one is a maximum for all points following,
       // so if also for points preceding (curr_mark) and
       // if above threshold, then write it out.
@@ -710,6 +810,8 @@ int parallel_thresh_cluster(std::complex<float> * __restrict inarr, const uint32
   free(mlocs);
   free(seglens);
   free(marks);
+  free(startlocs);
+  free(stoplocs);
 
   return cnt;
 }


### PR DESCRIPTION
This last commit includes two changes to the CPU time clustering code:

1.  More extensive comments to explain the logic behind the clustering
2. Adjusting the sliding-window maximization to compare not the time of a candidate trigger to the last trigger, but the edge of the window over which it is a maximum to the last trigger.

The time clustering attempts to do basically what was done in coh_PTF, by maximizing over windows of a specified size, and then keeping only those maxima that are *local* maxima, that is, louder than the maxima before and after them within that window size.  However because of the multi-threading parallelization, the list of maxima returned is not necessarily over segments all of the window size, so a comparison to elements before and after a candidate within that list of maxima will not work. Hence the (forward and backward) sliding window approach.

It should be the case now that any trigger surviving the time-clustering and thresholding is guaranteed to be louder than any other point in the time series before or after it and less than 'window' away.