### PR TITLE
fix versioning to deal with line breaks

### DIFF
--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -171,17 +171,14 @@ def get_code_version_numbers(cp):
             if not retcode == 0:
                 raise subprocess.CalledProcessError(retcode, '')
             # End of legacy block
-            version_output = output + error
-            version_output = version_output.split('\n')
-            for line in version_output:
-                line = line.split(" ")
-                # Look for a version
-                if "Id:" in line:
-                    index = line.index("Id:") + 1
-                    version_string = 'Version is %s.' %(line[index],)
-                elif "LALApps:" in line:
-                    index = line.index("LALApps:") + 3
-                    version_string = 'Version (lalapps) is %s.' %(line[index],)
+            version_output = (output + error).replace('\n', ' ').split()
+            # Look for a version
+            if "Id:" in version_output:
+                index = version_output.index("Id:") + 1
+                version_string = 'Version is %s.' %(version_output[index],)
+            elif "LALApps:" in version_output:
+                index = version_output.index("LALApps:") + 3
+                version_string = 'Version (lalapps) is %s.' %(version_output[index],)
             if version_string is None:
                 version_string = "Cannot identify version string in output."
         except subprocess.CalledProcessError:


### PR DESCRIPTION
The function get_code_version_numbers tries to parse the output of programs' --version argument into a string for the result pages. Currently the function relies on line breaks being in certain predefined areas. However, argparse will sometimes add it's own linebreaks in if a line is too long, which breaks get_code_version_numbers. For example, in my test, the hash after ID was put on it's own line by argparse, which caused an IndexError at line 181. This patch fixes this by doing away with line breaks, and just looking for the relevant arguments in the --version string.

This is Ian's code, but since he is on vacation, assigning to Chris.