### PR TITLE
Sort found in foundmissed plots by FAR 

### DIFF
--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -84,19 +84,19 @@ if not args.gradient_far:
               "Blue circles are found with IFAR < 100 years, green are < 1000 years, and "
               "red are found with IFAR >=1000 years. ")
 else:
-    vals = vals[args.axis_type][found]
-    dval = dvals[args.distance_type][found]
+    fvals = vals[args.axis_type][found]
+    fdval = dvals[args.distance_type][found]
     color = 1.0 / ifar_found
     
     # sort so quiet found is on top
     csort = color.argsort()
-    vals = vals[csort]
-    dval = dva[csort]
+    fvals = fvals[csort]
+    fdval = fdval[csort]
     color = color[csort]
 
     mpoints = plot.scatter(vals[args.axis_type][missed], dvals[args.distance_type][missed], 
                            marker='x', color='red', label='missed', zorder=zmissed)
-    points = plot.scatter(vals, dval, c=color, linewidth=0, 
+    points = plot.scatter(fvals, fdval, c=color, linewidth=0, 
                           norm=matplotlib.colors.LogNorm(),
                           marker='o', label='found', zorder=zfound)
     caption = ("Found and missed injections: Red x's are missed injections. "

--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -74,6 +74,7 @@ if not args.gradient_far:
     thousand = numpy.where(ifar_found > 1000)[0]
     color[hundred] = 0.5
     color[thousand] = 1.0
+    
     mpoints = plot.scatter(vals[args.axis_type][missed], dvals[args.distance_type][missed], 
                            marker='x', color='black', label='missed', zorder=zmissed)
     points = plot.scatter(vals[args.axis_type][found], dvals[args.distance_type][found], 
@@ -83,11 +84,21 @@ if not args.gradient_far:
               "Blue circles are found with IFAR < 100 years, green are < 1000 years, and "
               "red are found with IFAR >=1000 years. ")
 else:
+    vals = vals[args.axis_type][found]
+    dval = dvals[args.distance_type][found]
+    color = 1.0 / ifar_found
+    
+    # sort so quiet found is on top
+    csort = color.argsort()
+    vals = vals[csort]
+    dval = dva[csort]
+    color = color[csort]
+
     mpoints = plot.scatter(vals[args.axis_type][missed], dvals[args.distance_type][missed], 
                            marker='x', color='red', label='missed', zorder=zmissed)
-    points = plot.scatter(vals[args.axis_type][found], dvals[args.distance_type][found], 
-                           c=1.0 / ifar_found, linewidth=0, norm=matplotlib.colors.LogNorm(),
-                           marker='o', label='found', zorder=zfound)
+    points = plot.scatter(vals, dval, c=color, linewidth=0, 
+                          norm=matplotlib.colors.LogNorm(),
+                          marker='o', label='found', zorder=zfound)
     caption = ("Found and missed injections: Red x's are missed injections. "
                "Circles are found injections. The color indicates the value of "
                "the false alarm rate" )


### PR DESCRIPTION
This change sorts the found injections so that the quieter injections are always on top of the loudly found ones.

Original
https://sugar-jobs.phy.syr.edu/~ahnitz/projects/plots/t1/gw/html/H1L1-PLOT_FOUNDMISSED_SUMMARY_ALLINJ-962582415-604800.png

New
https://sugar-jobs.phy.syr.edu/~ahnitz/projects/plots/t2/gw/html/H1L1-PLOT_FOUNDMISSED_SUMMARY_ALLINJ-962582415-604800.png