### PR TITLE
Convert FAR to units of Hz when dumping to XML

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -5,11 +5,12 @@ by pycbc_coinc_findtrigs to generated a mapping between SNR and FAP, along
 with producing the combined foreground and background triggers
 """
 import argparse, h5py, logging, itertools, numpy
+import lal
 from pycbc.events import veto, coinc
 import pycbc.version, pycbc.pnutils, pycbc.io
 
 def sec_to_year(sec):
-    return sec / (3.15569e7)
+    return sec / lal.YRJUL_SI
 
 parser = argparse.ArgumentParser()
 # General required options

--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -5,13 +5,14 @@ by pycbc_coinc_findtrigs to generated a mapping between SNR and FAP, along
 with producing the combined foreground and background triggers
 """
 import argparse, h5py, logging, itertools, copy, pycbc.io
+import lal
 from pycbc.future import numpy
 from itertools import izip
 from pycbc.events import veto, coinc
 import pycbc.version
 
 def sec_to_year(sec):
-    return sec / (3.15569e7)
+    return sec / lal.YRJUL_SI
 
 parser = argparse.ArgumentParser()
 # General required options

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -7,7 +7,7 @@ import numpy as np
 import logging
 import inspect
 
-from lal import LIGOTimeGPS
+from lal import LIGOTimeGPS, YRJUL_SI
 
 from glue.ligolw import ligolw
 from glue.ligolw import table
@@ -539,6 +539,9 @@ class ForegroundTriggers(object):
             coinc_inspiral_row.snr = coinc_event_vals['stat'][idx]
             coinc_inspiral_row.false_alarm_rate = coinc_event_vals['fap'][idx]
             coinc_inspiral_row.combined_far = 1./coinc_event_vals['ifar'][idx]
+            # Transform to Hz
+            coinc_inspiral_row.combined_far = \
+                                    coinc_inspiral_row.combined_far / YRJUL_SI
             coinc_event_row.likelihood = 0.
             coinc_inspiral_row.minimum_duration = 0.
             coinc_event_table.append(coinc_event_row)


### PR DESCRIPTION
This is a small patch to convert the units of combined_far in our XML coinc output files to Hz. Note that our conversion between seconds and years is slightly unclear as described in #217, this should be fixed.