### PR TITLE
handle edge case where ylabel is undefined as no injections are found

### DIFF
--- a/bin/hdfcoinc/pycbc_page_sensitivity
+++ b/bin/hdfcoinc/pycbc_page_sensitivity
@@ -110,6 +110,7 @@ labels['mchirp'] = "$ M_{chirp} \in [%5.2f, %5.2f] M_\odot $"
 labels['total_mass'] = "$ M_{total} \in [%5.2f, %5.2f] M_\odot $"
 labels['spin'] = "$Eff Spin \in [%5.2f, %5.2f] $"
 
+ylabel = xlabel = ""
 
 if args.sig_type == 'stat':
     sig = f['found_after_vetoes/stat'][:]
@@ -142,7 +143,6 @@ do_labels = [True, False]
 alphas = [.8, .3]
 
 fig = pylab.figure()
-
 # Plot each injection parameter bin
 for j in range(len(args.bins)-1):
     c = next(color)


### PR DESCRIPTION
If there are no injections found the sensitivity plots currently fail as the ylabel never gets set, this adds initializer so the code completes. 