### PR TITLE
add file to combine statmap output files with a trials factor

### DIFF
--- a/bin/hdfcoinc/pycbc_combine_statmap
+++ b/bin/hdfcoinc/pycbc_combine_statmap
@@ -35,6 +35,11 @@ f.attrs['foreground_time'] = files[0].attrs['foreground_time']
 f.attrs['background_time_exc'] = files[0].attrs['background_time_exc']
 f.attrs['foreground_time_exc'] = files[0].attrs['foreground_time_exc']
 
+for attr in  ['detector_1', 'detector_2', 'timeslide_interval', 
+              'background_time', 'foreground_time']:
+    for i in range(len(files)-1):
+        assert files[i].attrs[attr] == files[i+1].attrs[attr]
+
 # combine times that are foreground vetoed as they may differ between bins
 for key in files[0]['segments'].keys():
     if key == 'foreground_veto':

--- a/bin/hdfcoinc/pycbc_combine_statmap
+++ b/bin/hdfcoinc/pycbc_combine_statmap
@@ -66,8 +66,9 @@ cidx = pycbc.events.cluster_coincs(f['foreground/ifar'][:],
 
 # downsample the foreground columns to only the loudest ifar between the multiple files
 for key in f['foreground'].keys():
-    dset = f['foreground/%s' % key]
-    dset = dset[:][cidx]
+    dset = f['foreground/%s' % key][:][cidx]
+    del f['foreground/%s' % key]
+    f['foreground/%s' % key] = dset
 
 # If there is a background set (full_data as opposed to injection run), then recalculate 
 # the values for its triggers as well

--- a/bin/hdfcoinc/pycbc_combine_statmap
+++ b/bin/hdfcoinc/pycbc_combine_statmap
@@ -1,0 +1,82 @@
+#!/bin/env python
+""" Apply a naive mass binning, assuming that each bin is fully independent, which 
+is a conservative estimate. This clusters to find the most significant foreground, but
+leaves the background triggers alone. """
+
+import h5py, numpy, argparse, logging, pycbc, pycbc.events
+
+def com(f, files, group):
+    f[group] = numpy.concatenate([fi[group][:] for fi in files])
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--verbose', action='store_true')
+parser.add_argument('--statmap-files', nargs='+',
+                    help="List of coinc files to be redistributed")
+parser.add_argument('--cluster-window', type=float)
+parser.add_argument('--output-file', help="name of output file")
+args = parser.parse_args()
+
+pycbc.init_logging(args.verbose)
+
+# We apply a dumb factor of the number of bins only, nothing smart for now
+# Note that this is a conservative estimate.
+files = [h5py.File(n) for n in args.statmap_files]
+
+fac = len(args.statmap_files)
+
+f = h5py.File(args.output_file, "w")
+f.attrs['detector_1'] = files[0].attrs['detector_1']
+f.attrs['detector_2'] = files[0].attrs['detector_2']
+f.attrs['timeslide_interval'] = files[0].attrs['timeslide_interval']
+
+f.attrs['background_time'] = files[0].attrs['background_time']
+f.attrs['foreground_time'] = files[0].attrs['foreground_time']
+f.attrs['background_time_exc'] = files[0].attrs['background_time_exc']
+f.attrs['foreground_time_exc'] = files[0].attrs['foreground_time_exc']
+
+for key in files[0]['segments'].keys():
+    if key == 'foreground_veto':
+        continue
+    f['segments/%s/start' % key] = files[0]['segments/%s/start' % key][:]
+    f['segments/%s/end' % key] = files[0]['segments/%s/end' % key][:]
+
+
+for key in files[0]['foreground'].keys():
+    com(f, files, 'foreground/%s' % key)
+    
+ifar = f['foreground/ifar'][:] / fac
+coinc_time = f.attrs['foreground_time']
+f['foreground/ifar'][:] = ifar
+f['foreground/fap'][:] = 1 - numpy.exp( - coinc_time / ifar)
+
+ifar = f['foreground/ifar_exc'][:] / fac
+coinc_time = f.attrs['foreground_time_exc']
+f['foreground/ifar_exc'][:] = ifar
+f['foreground/fap_exc'][:] = 1 - numpy.exp( - coinc_time / ifar)
+
+cidx = pycbc.events.cluster_coincs(f['foreground/ifar'][:], 
+                                   f['foreground/time1'][:], 
+                                   f['foreground/time2'][:], 
+                                   numpy.zeros(len(ifar)),
+                                   0, args.cluster_window)
+
+for key in f['foreground'].keys():
+    dset = f['foreground/%s' % key]
+    dset = dset[:][cidx]
+
+if 'background' in files[0]:  
+    for key in files[0]['background'].keys():
+        com(f, files, 'background/%s' % key)
+     
+    f['background/ifar'][:] =  f['background/ifar'][:] / fac
+    
+    for key in files[0]['background_exc'].keys():
+        com(f, files, 'background_exc/%s' % key)
+     
+    f['background_exc/ifar'][:] = f['background_exc/ifar'][:] / fac
+
+    com(f, files, 'segments/foreground_veto/start')
+    com(f, files, 'segments/foreground_veto/end')
+
+
+f.close()

--- a/bin/hdfcoinc/pycbc_combine_statmap
+++ b/bin/hdfcoinc/pycbc_combine_statmap
@@ -6,6 +6,7 @@ leaves the background triggers alone. """
 import h5py, numpy, argparse, logging, pycbc, pycbc.events
 
 def com(f, files, group):
+    """ Combine the same column from multiple files and saave to a third"""
     f[group] = numpy.concatenate([fi[group][:] for fi in files])
 
 parser = argparse.ArgumentParser()
@@ -18,12 +19,12 @@ args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)
 
-# We apply a dumb factor of the number of bins only, nothing smart for now
-# Note that this is a conservative estimate.
+# We apply a dumb factor of the number of bins only, nothing smart for now, no clustering of the background
 files = [h5py.File(n) for n in args.statmap_files]
 
 fac = len(args.statmap_files)
 
+# copy over the standard data that is constant
 f = h5py.File(args.output_file, "w")
 f.attrs['detector_1'] = files[0].attrs['detector_1']
 f.attrs['detector_2'] = files[0].attrs['detector_2']
@@ -34,16 +35,18 @@ f.attrs['foreground_time'] = files[0].attrs['foreground_time']
 f.attrs['background_time_exc'] = files[0].attrs['background_time_exc']
 f.attrs['foreground_time_exc'] = files[0].attrs['foreground_time_exc']
 
+# combine times that are foreground vetoed as they may differ between bins
 for key in files[0]['segments'].keys():
     if key == 'foreground_veto':
         continue
     f['segments/%s/start' % key] = files[0]['segments/%s/start' % key][:]
     f['segments/%s/end' % key] = files[0]['segments/%s/end' % key][:]
 
-
+# copy over all the columns in the foreground group, we recalculate ifar/fap later
 for key in files[0]['foreground'].keys():
     com(f, files, 'foreground/%s' % key)
     
+# recalculate ifar/fap for the foreground triggers by applying a trials factor = num_files(num_bins)
 ifar = f['foreground/ifar'][:] / fac
 coinc_time = f.attrs['foreground_time']
 f['foreground/ifar'][:] = ifar
@@ -54,16 +57,20 @@ coinc_time = f.attrs['foreground_time_exc']
 f['foreground/ifar_exc'][:] = ifar
 f['foreground/fap_exc'][:] = 1 - numpy.exp( - coinc_time / ifar)
 
+# cluster for the loudest ifar value 
 cidx = pycbc.events.cluster_coincs(f['foreground/ifar'][:], 
                                    f['foreground/time1'][:], 
                                    f['foreground/time2'][:], 
                                    numpy.zeros(len(ifar)),
                                    0, args.cluster_window)
 
+# downsample the foreground columns to only the loudest ifar between the multiple files
 for key in f['foreground'].keys():
     dset = f['foreground/%s' % key]
     dset = dset[:][cidx]
 
+# If there is a background set (full_data as opposed to injection run), then recalculate 
+# the values for its triggers as well
 if 'background' in files[0]:  
     for key in files[0]['background'].keys():
         com(f, files, 'background/%s' % key)

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -157,7 +157,7 @@ def time_coincidence(t1, t2, window, slide_step=0):
     else:
         slide = numpy.zeros(len(idx1))
         
-    return idx1, idx2, slide
+    return idx1.astype(numpy.uint32), idx2.astype(numpy.uint32), slide.astype(numpy.int32)
 
 
 def cluster_coincs(stat, time1, time2, timeslide_id, slide, window):
@@ -184,7 +184,6 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window):
     cindex: numpy.ndarray 
         The set of indices corresponding to the surviving coincidences.
     """
-    
     logging.info('clustering coinc triggers over %ss window' % window)
     
     indices = []
@@ -195,6 +194,7 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window):
         
     tslide = timeslide_id.astype(numpy.float128)
     time = time.astype(numpy.float128)
+    
     span = (time.max() - time.min()) + window * 10
     time = time + span * tslide
     
@@ -214,7 +214,7 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window):
     while i < len(left):
         l = left[i]
         r = right[i]
-        
+       
         # If there are no other points to compare it is obviosly the max
         if (r - l) == 1:
             indices[j] = i

--- a/setup.py
+++ b/setup.py
@@ -426,6 +426,8 @@ setup (
                'bin/pycbc_submit_dax',
                'bin/pycbc_submit_dax_stampede',
                'bin/hdfcoinc/pycbc_page_coinc_snrchi',
+               'bin/hdfcoinc/pycbc_distribute_mass_bins',
+               'bin/hdfcoinc/pycbc_combine_statmap',
                'bin/hdfcoinc/pycbc_stat_dtphase',
                'bin/hdfcoinc/pycbc_plot_singles_vs_params',
                'bin/hdfcoinc/pycbc_plot_singles_timefreq',


### PR DESCRIPTION
This add a script to combine multiple statmap output files (say coming from different mass bins) by clustering for the loudest foreground trigger by IFAR and then dividing all IFARs in the foreground or background (if there are background triggers) by the trials factor. The trials factor is taken to be the number of input files. 

The idea is that this is used in conjuction with #222 
