### PR TITLE
add mass bins to workflow

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -61,10 +61,9 @@ for key in d.seg.keys():
     f['segments/%s/start' % key] = d.seg[key]['start'][:]
     f['segments/%s/end' % key] = d.seg[key]['end'][:]
 
-f['segments/foreground_veto/start'] = veto_start
-f['segments/foreground_veto/end'] = veto_end
-
 if fore_locs.sum() > 0:
+    f['segments/foreground_veto/start'] = veto_start
+    f['segments/foreground_veto/end'] = veto_end
     for k in d.data:
         f['foreground/' + k] = d.data[k][fore_locs]
 

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -125,4 +125,7 @@ if fore_locs.sum() > 0:
     f['foreground/ifar_exc'] = sec_to_year(ifar_exc)
     f['foreground/fap_exc'] = fap_exc
 
+if 'name' in d.attrs:
+    f.attrs['name'] = d.attrs['name']
+
 logging.info("Done") 

--- a/bin/hdfcoinc/pycbc_combine_statmap
+++ b/bin/hdfcoinc/pycbc_combine_statmap
@@ -35,6 +35,11 @@ f.attrs['foreground_time'] = files[0].attrs['foreground_time']
 f.attrs['background_time_exc'] = files[0].attrs['background_time_exc']
 f.attrs['foreground_time_exc'] = files[0].attrs['foreground_time_exc']
 
+for attr in  ['detector_1', 'detector_2', 'timeslide_interval', 
+              'background_time', 'foreground_time']:
+    for i in range(len(files)-1):
+        assert files[i].attrs[attr] == files[i+1].attrs[attr]
+
 # combine times that are foreground vetoed as they may differ between bins
 for key in files[0]['segments'].keys():
     if key == 'foreground_veto':

--- a/bin/hdfcoinc/pycbc_combine_statmap
+++ b/bin/hdfcoinc/pycbc_combine_statmap
@@ -66,8 +66,9 @@ cidx = pycbc.events.cluster_coincs(f['foreground/ifar'][:],
 
 # downsample the foreground columns to only the loudest ifar between the multiple files
 for key in f['foreground'].keys():
-    dset = f['foreground/%s' % key]
-    dset = dset[:][cidx]
+    dset = f['foreground/%s' % key][:][cidx]
+    del f['foreground/%s' % key]
+    f['foreground/%s' % key] = dset
 
 # If there is a background set (full_data as opposed to injection run), then recalculate 
 # the values for its triggers as well

--- a/bin/hdfcoinc/pycbc_combine_statmap
+++ b/bin/hdfcoinc/pycbc_combine_statmap
@@ -1,0 +1,82 @@
+#!/bin/env python
+""" Apply a naive mass binning, assuming that each bin is fully independent, which 
+is a conservative estimate. This clusters to find the most significant foreground, but
+leaves the background triggers alone. """
+
+import h5py, numpy, argparse, logging, pycbc, pycbc.events
+
+def com(f, files, group):
+    f[group] = numpy.concatenate([fi[group][:] for fi in files])
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--verbose', action='store_true')
+parser.add_argument('--statmap-files', nargs='+',
+                    help="List of coinc files to be redistributed")
+parser.add_argument('--cluster-window', type=float)
+parser.add_argument('--output-file', help="name of output file")
+args = parser.parse_args()
+
+pycbc.init_logging(args.verbose)
+
+# We apply a dumb factor of the number of bins only, nothing smart for now
+# Note that this is a conservative estimate.
+files = [h5py.File(n) for n in args.statmap_files]
+
+fac = len(args.statmap_files)
+
+f = h5py.File(args.output_file, "w")
+f.attrs['detector_1'] = files[0].attrs['detector_1']
+f.attrs['detector_2'] = files[0].attrs['detector_2']
+f.attrs['timeslide_interval'] = files[0].attrs['timeslide_interval']
+
+f.attrs['background_time'] = files[0].attrs['background_time']
+f.attrs['foreground_time'] = files[0].attrs['foreground_time']
+f.attrs['background_time_exc'] = files[0].attrs['background_time_exc']
+f.attrs['foreground_time_exc'] = files[0].attrs['foreground_time_exc']
+
+for key in files[0]['segments'].keys():
+    if key == 'foreground_veto':
+        continue
+    f['segments/%s/start' % key] = files[0]['segments/%s/start' % key][:]
+    f['segments/%s/end' % key] = files[0]['segments/%s/end' % key][:]
+
+
+for key in files[0]['foreground'].keys():
+    com(f, files, 'foreground/%s' % key)
+    
+ifar = f['foreground/ifar'][:] / fac
+coinc_time = f.attrs['foreground_time']
+f['foreground/ifar'][:] = ifar
+f['foreground/fap'][:] = 1 - numpy.exp( - coinc_time / ifar)
+
+ifar = f['foreground/ifar_exc'][:] / fac
+coinc_time = f.attrs['foreground_time_exc']
+f['foreground/ifar_exc'][:] = ifar
+f['foreground/fap_exc'][:] = 1 - numpy.exp( - coinc_time / ifar)
+
+cidx = pycbc.events.cluster_coincs(f['foreground/ifar'][:], 
+                                   f['foreground/time1'][:], 
+                                   f['foreground/time2'][:], 
+                                   numpy.zeros(len(ifar)),
+                                   0, args.cluster_window)
+
+for key in f['foreground'].keys():
+    dset = f['foreground/%s' % key]
+    dset = dset[:][cidx]
+
+if 'background' in files[0]:  
+    for key in files[0]['background'].keys():
+        com(f, files, 'background/%s' % key)
+     
+    f['background/ifar'][:] =  f['background/ifar'][:] / fac
+    
+    for key in files[0]['background_exc'].keys():
+        com(f, files, 'background_exc/%s' % key)
+     
+    f['background_exc/ifar'][:] = f['background_exc/ifar'][:] / fac
+
+    com(f, files, 'segments/foreground_veto/start')
+    com(f, files, 'segments/foreground_veto/end')
+
+
+f.close()

--- a/bin/hdfcoinc/pycbc_combine_statmap
+++ b/bin/hdfcoinc/pycbc_combine_statmap
@@ -6,6 +6,7 @@ leaves the background triggers alone. """
 import h5py, numpy, argparse, logging, pycbc, pycbc.events
 
 def com(f, files, group):
+    """ Combine the same column from multiple files and saave to a third"""
     f[group] = numpy.concatenate([fi[group][:] for fi in files])
 
 parser = argparse.ArgumentParser()
@@ -18,12 +19,12 @@ args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)
 
-# We apply a dumb factor of the number of bins only, nothing smart for now
-# Note that this is a conservative estimate.
+# We apply a dumb factor of the number of bins only, nothing smart for now, no clustering of the background
 files = [h5py.File(n) for n in args.statmap_files]
 
 fac = len(args.statmap_files)
 
+# copy over the standard data that is constant
 f = h5py.File(args.output_file, "w")
 f.attrs['detector_1'] = files[0].attrs['detector_1']
 f.attrs['detector_2'] = files[0].attrs['detector_2']
@@ -34,16 +35,18 @@ f.attrs['foreground_time'] = files[0].attrs['foreground_time']
 f.attrs['background_time_exc'] = files[0].attrs['background_time_exc']
 f.attrs['foreground_time_exc'] = files[0].attrs['foreground_time_exc']
 
+# combine times that are foreground vetoed as they may differ between bins
 for key in files[0]['segments'].keys():
     if key == 'foreground_veto':
         continue
     f['segments/%s/start' % key] = files[0]['segments/%s/start' % key][:]
     f['segments/%s/end' % key] = files[0]['segments/%s/end' % key][:]
 
-
+# copy over all the columns in the foreground group, we recalculate ifar/fap later
 for key in files[0]['foreground'].keys():
     com(f, files, 'foreground/%s' % key)
     
+# recalculate ifar/fap for the foreground triggers by applying a trials factor = num_files(num_bins)
 ifar = f['foreground/ifar'][:] / fac
 coinc_time = f.attrs['foreground_time']
 f['foreground/ifar'][:] = ifar
@@ -54,16 +57,20 @@ coinc_time = f.attrs['foreground_time_exc']
 f['foreground/ifar_exc'][:] = ifar
 f['foreground/fap_exc'][:] = 1 - numpy.exp( - coinc_time / ifar)
 
+# cluster for the loudest ifar value 
 cidx = pycbc.events.cluster_coincs(f['foreground/ifar'][:], 
                                    f['foreground/time1'][:], 
                                    f['foreground/time2'][:], 
                                    numpy.zeros(len(ifar)),
                                    0, args.cluster_window)
 
+# downsample the foreground columns to only the loudest ifar between the multiple files
 for key in f['foreground'].keys():
     dset = f['foreground/%s' % key]
     dset = dset[:][cidx]
 
+# If there is a background set (full_data as opposed to injection run), then recalculate 
+# the values for its triggers as well
 if 'background' in files[0]:  
     for key in files[0]['background'].keys():
         com(f, files, 'background/%s' % key)

--- a/bin/hdfcoinc/pycbc_combine_statmap
+++ b/bin/hdfcoinc/pycbc_combine_statmap
@@ -7,7 +7,7 @@ import h5py, numpy, argparse, logging, pycbc, pycbc.events
 
 def com(f, files, group):
     """ Combine the same column from multiple files and saave to a third"""
-    f[group] = numpy.concatenate([fi[group][:] for fi in files])
+    f[group] = numpy.concatenate([fi[group][:] if group in fi else numpy.array([], dtype=numpy.uint32) for fi in files])
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--verbose', action='store_true')

--- a/bin/hdfcoinc/pycbc_combine_statmap
+++ b/bin/hdfcoinc/pycbc_combine_statmap
@@ -3,7 +3,7 @@
 is a conservative estimate. This clusters to find the most significant foreground, but
 leaves the background triggers alone. """
 
-import h5py, numpy, argparse, logging, pycbc, pycbc.events
+import h5py, numpy, argparse, logging, pycbc, pycbc.events, lal
 
 def com(f, files, group):
     """ Combine the same column from multiple files and saave to a third"""
@@ -19,7 +19,8 @@ args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)
 
-# We apply a dumb factor of the number of bins only, nothing smart for now, no clustering of the background
+# We apply a dumb factor of the number of bins only, nothing smart for now, 
+# no clustering of the background
 files = [h5py.File(n) for n in args.statmap_files]
 
 fac = len(args.statmap_files)
@@ -51,14 +52,15 @@ for key in files[0]['segments'].keys():
 for key in files[0]['foreground'].keys():
     com(f, files, 'foreground/%s' % key)
     
-# recalculate ifar/fap for the foreground triggers by applying a trials factor = num_files(num_bins)
+# recalculate ifar/fap for the foreground triggers by 
+#  applying a trials factor = num_files(num_bins)
 ifar = f['foreground/ifar'][:] / fac
-coinc_time = f.attrs['foreground_time']
+coinc_time = f.attrs['foreground_time'] / lal.YRJUL_SI
 f['foreground/ifar'][:] = ifar
 f['foreground/fap'][:] = 1 - numpy.exp( - coinc_time / ifar)
 
 ifar = f['foreground/ifar_exc'][:] / fac
-coinc_time = f.attrs['foreground_time_exc']
+coinc_time = f.attrs['foreground_time_exc'] / lal.YRJUL_SI
 f['foreground/ifar_exc'][:] = ifar
 f['foreground/fap_exc'][:] = 1 - numpy.exp( - coinc_time / ifar)
 

--- a/bin/hdfcoinc/pycbc_distribute_background_bins
+++ b/bin/hdfcoinc/pycbc_distribute_background_bins
@@ -28,7 +28,7 @@ logging.info('%s coinc triggers' % len(d))
 
 used = numpy.array([], dtype=numpy.uint32)
 for mbin, outname in zip(args.background_bins, args.output_files):
-    bin_type, boundary = tuple(mbin.split('-'))
+    name, bin_type, boundary = tuple(mbin.split('-'))
     if bin_type == 'component':
         locs = numpy.maximum(m1, m2) < float(boundary)
     elif bin_type == 'total':
@@ -47,3 +47,5 @@ for mbin, outname in zip(args.background_bins, args.output_files):
     e = d.select(numpy.in1d(d.template_id, locs))
     logging.info('%s coincs in mass bin: %s' % (len(e), mbin))
     e.save(outname)
+    f = h5py.File(outname, 'r+')
+    f.attrs['name'] = name

--- a/bin/hdfcoinc/pycbc_distribute_background_bins
+++ b/bin/hdfcoinc/pycbc_distribute_background_bins
@@ -1,5 +1,5 @@
 #!/bin/env python
-import h5py, argparse, numpy, pycbc.pnutils, logging, pycbc.events, pycbc.io
+import h5py, argparse, numpy, pycbc.events, logging, pycbc.events, pycbc.io
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--verbose', action='store_true')
@@ -26,26 +26,15 @@ if len(args.output_files) != len(args.background_bins):
 d = pycbc.io.StatmapData(files=args.coinc_files)
 logging.info('%s coinc triggers' % len(d))
 
-used = numpy.array([], dtype=numpy.uint32)
-for mbin, outname in zip(args.background_bins, args.output_files):
-    name, bin_type, boundary = tuple(mbin.split('-'))
-    if bin_type == 'component':
-        locs = numpy.maximum(m1, m2) < float(boundary)
-    elif bin_type == 'total':
-        locs = m1 + m2 < float(boundary)
-    elif bin_type == 'chirp':
-        locs = pycbc.pnutils.mass1_mass2_to_mchirp_eta(m1, m2)[0] < float(boundary)
-    else:
-        raise ValueError('Invalid bin type %s' % bin_type)    
-    
-    # make sure we don't reuse anythign from an earlier bin
-    locs = numpy.where(locs)[0]
-    locs = numpy.delete(locs, numpy.where(numpy.in1d(locs, used))[0])
-    used = numpy.concatenate([used, locs])    
+data = {'mass1':f['mass1'][:], 'mass2':f['mass2'][:],
+        'spin1z':f['spin1z'][:], 'spin2z':f['spin2z'][:]}
 
+locs_dict = pycbc.events.background_bin_from_string(args.background_bins, data)
+
+for name, outname in zip(locs_dict, args.output_file):
     # select the coincs from only this bin and save to a single combined file
+    locs = locs_dict[name]
     e = d.select(numpy.in1d(d.template_id, locs))
     logging.info('%s coincs in mass bin: %s' % (len(e), mbin))
+    e.attrs['name'] = name
     e.save(outname)
-    f = h5py.File(outname, 'r+')
-    f.attrs['name'] = name

--- a/bin/hdfcoinc/pycbc_distribute_background_bins
+++ b/bin/hdfcoinc/pycbc_distribute_background_bins
@@ -17,20 +17,19 @@ args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)
 
-f = h5py.File(args.bank_file)
-m1, m2 = f['mass1'][:], f['mass2']
+
 
 if len(args.output_files) != len(args.background_bins):
     raise ValueError('Number of mass bins and output files does not match') 
 
-d = pycbc.io.StatmapData(files=args.coinc_files)
-logging.info('%s coinc triggers' % len(d))
-
+f = h5py.File(args.bank_file)
 data = {'mass1':f['mass1'][:], 'mass2':f['mass2'][:],
         'spin1z':f['spin1z'][:], 'spin2z':f['spin2z'][:]}
 
 locs_dict = pycbc.events.background_bin_from_string(args.background_bins, data)
 
+d = pycbc.io.StatmapData(files=args.coinc_files)
+logging.info('%s coinc triggers' % len(d))
 for name, outname in zip(locs_dict, args.output_file):
     # select the coincs from only this bin and save to a single combined file
     locs = locs_dict[name]

--- a/bin/hdfcoinc/pycbc_distribute_background_bins
+++ b/bin/hdfcoinc/pycbc_distribute_background_bins
@@ -5,7 +5,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--coinc-files', nargs='+',
                     help="List of coinc files to be redistributed")
-parser.add_argument('--mass-bins', nargs='+',
+parser.add_argument('--background-bins', nargs='+',
                     help="Ordered list of mass bin upper boundaries. "
                          "An ordered list of type-boundary pairs, applied sequentially."
                          "Ex. component-2 total-15 chirp-30")
@@ -20,14 +20,14 @@ pycbc.init_logging(args.verbose)
 f = h5py.File(args.bank_file)
 m1, m2 = f['mass1'][:], f['mass2']
 
-if len(args.output_files) != len(args.mass_bins):
+if len(args.output_files) != len(args.background_bins):
     raise ValueError('Number of mass bins and output files does not match') 
 
 d = pycbc.io.StatmapData(files=args.coinc_files)
 logging.info('%s coinc triggers' % len(d))
 
 used = numpy.array([], dtype=numpy.uint32)
-for mbin, outname in zip(args.mass_bins, args.output_files):
+for mbin, outname in zip(args.background_bins, args.output_files):
     bin_type, boundary = tuple(mbin.split('-'))
     if bin_type == 'component':
         locs = numpy.maximum(m1, m2) < float(boundary)

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -138,16 +138,16 @@ bg_files = wf.setup_interval_coinc(workflow, hdfbank, insps,
 final_bg_files =  wf.setup_interval_coinc(workflow, hdfbank, insps, 
                                final_veto_file, final_veto_name,
                                output_dir, tags=ctags)
+final_bg_file = final_bg_files[0][0]                   
+bin_files = final_bg_files[0][1]
      
 censored_veto = wf.make_foreground_censored_veto(workflow, 
                        final_bg_file, final_veto_file[0], final_veto_name[0],
                        'closed_box', 'segments')      
               
-final_bg_file = final_bg_files[0][0]                   
-bin_files = final_bg_files[0][1]
 
 closed_snrifar = []
-for bg_file, bg_bins in (bg_files + final_bg_file):
+for bg_file, bg_bins in (bg_files + final_bg_files):
     for bg_bin in bg_bins:
         snrifar = wf.make_snrifar_plot(workflow, bg_bin,
                         rdir['coincident_triggers'], 
@@ -269,7 +269,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
                                                insps, output_dir, tags=[tag])
                                                
     inj_coinc = wf.setup_interval_coinc_inj(workflow, hdfbank,
-                                    full_insps, insps, final_bg_file, 
+                                    full_insps, insps, wf.FileList([final_bg_file]), 
                                     final_veto_file[0], final_veto_name[0],
                                     output_dir, tags = ctags)
     found_inj = wf.find_injections_in_hdf_coinc(workflow, wf.FileList([inj_coinc]),
@@ -313,7 +313,7 @@ if len(inj_files) > 0:
                             
 # make full summary
 summ = [(seg_summ_plot,)] + [(seg_summ_table, veto_summ_table)] + \
-       det_summ + hist_summ + closed_snrifar + inj_summ
+       det_summ + hist_summ + list(grouper(closed_snrifar, 2)) + inj_summ
 for row in summ:
     for f in row:
         if f is None:

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -155,12 +155,15 @@ for bg_file, bg_bins in (bg_files + final_bg_files):
         if bg_file == final_bg_file:
             closed_snrifar.append(snrifar)
     
-ifar = wf.make_ifar_plot(workflow, final_bg_file, rdir['result'])
-
-snrifars = []        
+results_page = []        
 for bin_file in bin_files:
-    snrifars.append(wf.make_snrifar_plot(workflow, bin_file,
-                    rdir['result'], tags=bin_file.tags))
+    snrifar = wf.make_snrifar_plot(workflow, bin_file,
+                    rdir['result'], tags=bin_file.tags)
+    ifar = wf.make_ifar_plot(workflow, bin_file, 
+                    rdir['result'], tags=bin_file.tags)
+    results_page += [(snrifar, ifar)]
+
+wf.make_ifar_plot(workflow, final_bg_file, rdir['result'])
 
 table = wf.make_foreground_table(workflow, final_bg_file, 
                     hdfbank[0], tag, rdir['result'], singles=insps,
@@ -171,8 +174,7 @@ fore_xmlall = wf.make_foreground_table(workflow, final_bg_file,
 fore_xmlloudest = wf.make_foreground_table(workflow, final_bg_file,
                     hdfbank[0], tag, rdir['result'], singles=insps,
                     extension='.xml', tags=["xmlloudest"])
-
-single_layout(rdir['result'], snrifars + [table])
+layout(rdir['result'], results_page + [(table,)])
 
 snrchi = wf.make_snrchi_plot(workflow, insps, censored_veto, 
                     'closed_box', rdir['single_triggers'], tags=[tag])
@@ -316,8 +318,8 @@ if len(inj_files) > 0:
     inj_summ = list(grouper(inj + sen, 2))
                             
 # make full summary
-summ = [(seg_summ_plot,)] + [(seg_summ_table, veto_summ_table)] + \
-       det_summ + hist_summ + list(grouper(closed_snrifar, 2)) + inj_summ
+summ = ([(seg_summ_plot,)] + [(seg_summ_table, veto_summ_table)] + 
+       det_summ + hist_summ + list(grouper(closed_snrifar, 2)) + inj_summ)
 for row in summ:
     for f in row:
         if f is None:

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -154,6 +154,8 @@ for bg_file, bg_bins in (bg_files + final_bg_files):
                          closed_box=True, tags=bg_bin.tags + ['closed'])
         if bg_file == final_bg_file:
             closed_snrifar.append(snrifar)
+    
+ifar = wf.make_ifar_plot(workflow, final_bg_file, rdir['result'])
         
 for bin_file in bin_files:
     snrifar = wf.make_snrifar_plot(workflow, bin_file,
@@ -269,7 +271,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
                                                insps, output_dir, tags=[tag])
                                                
     inj_coinc = wf.setup_interval_coinc_inj(workflow, hdfbank,
-                                    full_insps, insps, wf.FileList([final_bg_file]), 
+                                    full_insps, insps, bin_files, 
                                     final_veto_file[0], final_veto_name[0],
                                     output_dir, tags = ctags)
     found_inj = wf.find_injections_in_hdf_coinc(workflow, wf.FileList([inj_coinc]),

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -156,10 +156,11 @@ for bg_file, bg_bins in (bg_files + final_bg_files):
             closed_snrifar.append(snrifar)
     
 ifar = wf.make_ifar_plot(workflow, final_bg_file, rdir['result'])
-        
+
+snrifars = []        
 for bin_file in bin_files:
-    snrifar = wf.make_snrifar_plot(workflow, bin_file,
-                    rdir['result'], tags=bin_file.tags)
+    snrifars.append(wf.make_snrifar_plot(workflow, bin_file,
+                    rdir['result'], tags=bin_file.tags))
 
 table = wf.make_foreground_table(workflow, final_bg_file, 
                     hdfbank[0], tag, rdir['result'], singles=insps,
@@ -170,7 +171,8 @@ fore_xmlall = wf.make_foreground_table(workflow, final_bg_file,
 fore_xmlloudest = wf.make_foreground_table(workflow, final_bg_file,
                     hdfbank[0], tag, rdir['result'], singles=insps,
                     extension='.xml', tags=["xmlloudest"])
-single_layout(rdir['result'], [snrifar, table])
+
+single_layout(rdir['result'], snrifars + [table])
 
 snrchi = wf.make_snrchi_plot(workflow, insps, censored_veto, 
                     'closed_box', rdir['single_triggers'], tags=[tag])

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -135,32 +135,37 @@ full_insps = insps
 bg_files = wf.setup_interval_coinc(workflow, hdfbank, insps, 
                                cum_veto_files, veto_names, 
                                output_dir, tags=ctags)  
-final_bg_file =  wf.setup_interval_coinc(workflow, hdfbank, insps, 
+final_bg_files =  wf.setup_interval_coinc(workflow, hdfbank, insps, 
                                final_veto_file, final_veto_name,
                                output_dir, tags=ctags)
      
 censored_veto = wf.make_foreground_censored_veto(workflow, 
-                       final_bg_file[0], final_veto_file[0], final_veto_name[0],
+                       final_bg_file, final_veto_file[0], final_veto_name[0],
                        'closed_box', 'segments')      
-                                 
-for bg_file in (bg_files + final_bg_file):
-    snrifar = wf.make_snrifar_plot(workflow, bg_file,
+              
+final_bg_file = final_bg_files[0][0]                   
+bin_files = final_bg_files[0][1]
+
+closed_snrifar = []
+for bg_file, bg_bins in (bg_files + final_bg_file):
+    for bg_bin in bg_bins:
+        snrifar = wf.make_snrifar_plot(workflow, bg_bin,
                         rdir['coincident_triggers'], 
-                         closed_box=True, tags=bg_file.tags + ['closed'])
-    if bg_file == final_bg_file[0]:
-        closed_snrifar = snrifar
+                         closed_box=True, tags=bg_bin.tags + ['closed'])
+        if bg_file == final_bg_file:
+            closed_snrifar.append(snrifar)
         
+for bin_file in bin_files:
+    snrifar = wf.make_snrifar_plot(workflow, bin_file,
+                    rdir['result'], tags=bin_file.tags)
 
-snrifar = wf.make_snrifar_plot(workflow, final_bg_file[0],
-                    rdir['result'], tags=final_bg_file[0].tags)
-
-table = wf.make_foreground_table(workflow, final_bg_file[0], 
+table = wf.make_foreground_table(workflow, final_bg_file, 
                     hdfbank[0], tag, rdir['result'], singles=insps,
                     extension='.html', tags=["html"])
-fore_xmlall = wf.make_foreground_table(workflow, final_bg_file[0],
+fore_xmlall = wf.make_foreground_table(workflow, final_bg_file,
                     hdfbank[0], tag, rdir['result'], singles=insps,
                     extension='.xml', tags=["xmlall"])
-fore_xmlloudest = wf.make_foreground_table(workflow, final_bg_file[0],
+fore_xmlloudest = wf.make_foreground_table(workflow, final_bg_file,
                     hdfbank[0], tag, rdir['result'], singles=insps,
                     extension='.xml', tags=["xmlloudest"])
 single_layout(rdir['result'], [snrifar, table])
@@ -283,7 +288,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
                              
     for inj_insp, trig_insp in zip(insps, full_insps):
         wf.make_coinc_snrchi_plot(workflow, found_inj, inj_insp, 
-                                  final_bg_file[0], trig_insp,
+                                  final_bg_file, trig_insp,
                                   rdir['injections/%s' % tag], tags=[tag])
 
 # Make combined injection plots
@@ -308,7 +313,7 @@ if len(inj_files) > 0:
                             
 # make full summary
 summ = [(seg_summ_plot,)] + [(seg_summ_table, veto_summ_table)] + \
-       det_summ + hist_summ + [(closed_snrifar,)] + inj_summ
+       det_summ + hist_summ + closed_snrifar + inj_summ
 for row in summ:
     for f in row:
         if f is None:

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -113,6 +113,7 @@ bank_files = wf.setup_tmpltbank_workflow(workflow, science_segs,
 hdfbank = wf.convert_bank_to_hdf(workflow, bank_files, "bank")
 splitbank_files = wf.setup_splittable_workflow(workflow, bank_files, "bank") 
 
+bank_plot = [(wf.make_template_plot(workflow, hdfbank[0], rdir['coincident_triggers']),)]
 
 # setup the injection files
 inj_files, inj_tags = wf.setup_injection_workflow(workflow, 
@@ -319,7 +320,7 @@ if len(inj_files) > 0:
                             
 # make full summary
 summ = ([(seg_summ_plot,)] + [(seg_summ_table, veto_summ_table)] + 
-       det_summ + hist_summ + list(grouper(closed_snrifar, 2)) + inj_summ)
+       det_summ + hist_summ + bank_plot + list(grouper(closed_snrifar, 2)) + inj_summ)
 for row in summ:
     for f in row:
         if f is None:

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-
 # Copyright (C) 2015 Christopher M. Biwer
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -20,6 +19,7 @@ import argparse
 import h5py
 import numpy
 import sys
+import lal
 import matplotlib as mpl; mpl.use('Agg')
 import pylab
 import pycbc.results
@@ -40,9 +40,9 @@ def calculate_time_slide_duration(ifo1_segments, ifo2_segments, offset=0):
 
 # parser command line
 parser = argparse.ArgumentParser(usage='pycbc_page_ifar [--options]',
-                    description='Plots a cumulative histogram of IFAR for' \
-                         + 'coincident foreground triggers and a subset of' \
-                         + 'the coincident time slide triggers.')
+                    description='Plots a cumulative histogram of IFAR for'
+                          'coincident foreground triggers and a subset of' 
+                          'the coincident time slide triggers.')
 parser.add_argument('--version', action='version',
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--trigger-file', type=str, required=True,
@@ -50,10 +50,10 @@ parser.add_argument('--trigger-file', type=str, required=True,
 parser.add_argument('--output-file', type=str, required=True,
                     help='Path to output plot.')
 parser.add_argument('--decimation-factor', type=int, required=True,
-                    help='Decimation factor used in background estimation.' \
-                         + 'Decimation factor means that every nth time' \
-                         + 'slide kept all of its coincident triggers in' \
-                         + 'the HDF file.')
+                    help='Decimation factor used in background estimation.' 
+                          'Decimation factor means that every nth time' 
+                          'slide kept all of its coincident triggers in' 
+                          'the HDF file.')
 opts = parser.parse_args()
 
 # read file
@@ -65,9 +65,8 @@ fore_ifar.sort()
 fore_cumnum = numpy.arange(len(fore_ifar), 0, -1)
 
 # get expected foreground IFAR values and cumulative number for each IFAR value
-seconds_to_years = 3.16888e-8
 expected_ifar = numpy.logspace(-8, 2, num=100, endpoint=True, base=10.0)
-expected_cumnum = fp.attrs['foreground_time'] / expected_ifar * seconds_to_years
+expected_cumnum = fp.attrs['foreground_time'] / expected_ifar / lal.YRJUL_SI 
 
 # get background timeslide IDs and IFAR values
 back_tsid = fp['background/timeslide_id'][:]
@@ -91,7 +90,7 @@ xs, ys = pylab.poly_between(expected_ifar, error_minus, error_plus)
 pylab.fill(xs, ys, facecolor='y', alpha=0.4, label='$N^{1/2}$ Errors')
 
 # plot the counting error
-error_plus = expected_cumnum + 2*numpy.sqrt(expected_cumnum)
+error_plus = expected_cumnum + 2 * numpy.sqrt(expected_cumnum)
 error_minus = expected_cumnum - 2*numpy.sqrt(expected_cumnum)
 error_minus = numpy.where(error_minus<=0, 1e-5, error_minus)
 xs, ys = pylab.poly_between(expected_ifar, error_minus, error_plus)
@@ -127,6 +126,7 @@ pylab.loglog(fore_ifar, fore_cumnum, linestyle='None', color='blue', marker='^',
 # format plot
 pylab.ylim(0.8, 1.1 * len(fore_cumnum))
 pylab.xlim(0.9 * min(fore_ifar))
+pylab.grid()
 pylab.legend()
 pylab.ylabel('Cumulative Number')
 pylab.xlabel('Inverse False Alarm Rate (yr)')

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -76,7 +76,7 @@ pylab.legend(loc="lower left")
 pylab.grid()
 
 pycbc.results.save_fig_with_metadata(fig, args.output_file, 
-     title="FAR vs Stat: %s" % args.output_file, 
+     title="FAR vs Stat", 
      caption="Mapping between the ranking statistic and false alarm rate: "
              "Blue triangles represent the zerola analysis. The solid line is "
              "the background inclusive of zerolag events, and the grey line "

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -75,8 +75,8 @@ pylab.ylim(far_back.min() / 10.0, far_back.max())
 pylab.legend(loc="lower left")
 pylab.grid()
 
-pycbc.results.save_fig_with_metadata(fig, args.output_file, 
-     title="FAR vs Stat", 
+pycbc.results.save_fig_with_metadata(fig, args.output_file,
+     title="%s bin, FAR vs Rank" % f.attrs['name'] if 'name' in f.attrs else "FAR vs Rank", 
      caption="Mapping between the ranking statistic and false alarm rate: "
              "Blue triangles represent the zerola analysis. The solid line is "
              "the background inclusive of zerolag events, and the grey line "

--- a/bin/hdfcoinc/pycbc_plot_bank_bins
+++ b/bin/hdfcoinc/pycbc_plot_bank_bins
@@ -21,7 +21,7 @@ data = {'mass1':f['mass1'][:], 'mass2':f['mass2'][:],
 if args.background_bins:
     locs_dict = pycbc.events.background_bin_from_string(args.background_bins, data)
 else:
-    locs_dict = {'Template Bank':numpy.arange(0, 1, len(data['mass1'])}
+    locs_dict = {'Template Bank':numpy.arange(0, 1, len(data['mass1']))}
 
 color = cycle(['red', 'green', 'blue', 'purple'])
 

--- a/bin/hdfcoinc/pycbc_plot_bank_bins
+++ b/bin/hdfcoinc/pycbc_plot_bank_bins
@@ -1,0 +1,43 @@
+#!/bin/env python
+""" plot a an hdf bank file based on background binning
+"""
+import argparse, h5py, pycbc.events, pycbc.version, pycbc.results, sys
+import matplotlib; matplotlib.use('Agg')
+import pylab
+from itertools import cycle
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
+parser.add_argument('--bank-file', help='hdf format template bank file')
+parser.add_argument('--background-bins', nargs='+', help='list of background bin format strings')
+parser.add_argument('--output-file', help='output file')
+args = parser.parse_args()
+
+fig = pylab.figure()
+f = h5py.File(args.bank_file)
+data = {'mass1':f['mass1'][:], 'mass2':f['mass2'][:],
+        'spin1z':f['spin1z'][:], 'spin2z':f['spin2z'][:]}
+
+if args.background_bins:
+    locs_dict = pycbc.events.background_bin_from_string(args.background_bins, data)
+else:
+    locs_dict = {'Template Bank':numpy.arange(0, 1, len(data['mass1'])}
+
+color = cycle(['red', 'green', 'blue', 'purple'])
+
+pylab.grid()
+for name in locs_dict:
+    locs = locs_dict[name]
+    pylab.scatter(data['mass1'][locs], data['mass2'][locs], 
+    label=name, linewidth=0, s=1, c=color.next())
+    
+pylab.legend(loc='upper left', markerscale=5)
+pylab.xlabel('Mass1 $M_\odot$')
+pylab.ylabel('Mass2 $M_\odot$')
+pylab.xlim(data['mass1'].min(), data['mass2'].max())
+pylab.ylim(data['mass1'].min(), data['mass2'].max())
+
+pycbc.results.save_fig_with_metadata(fig, args.output_file,
+    title="Template Bank Background Bins",
+    caption="",
+    cmd=' '.join(sys.argv))

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -157,7 +157,7 @@ def time_coincidence(t1, t2, window, slide_step=0):
     else:
         slide = numpy.zeros(len(idx1))
         
-    return idx1, idx2, slide
+    return idx1.astype(numpy.uint32), idx2.astype(numpy.uint32), slide.astype(numpy.int32)
 
 
 def cluster_coincs(stat, time1, time2, timeslide_id, slide, window):
@@ -184,7 +184,6 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window):
     cindex: numpy.ndarray 
         The set of indices corresponding to the surviving coincidences.
     """
-    
     logging.info('clustering coinc triggers over %ss window' % window)
     
     indices = []
@@ -195,6 +194,7 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window):
         
     tslide = timeslide_id.astype(numpy.float128)
     time = time.astype(numpy.float128)
+    
     span = (time.max() - time.min()) + window * 10
     time = time + span * tslide
     
@@ -214,7 +214,7 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window):
     while i < len(left):
         l = left[i]
         r = right[i]
-        
+       
         # If there are no other points to compare it is obviosly the max
         if (r - l) == 1:
             indices[j] = i

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -28,6 +28,46 @@ import numpy, logging, h5py
 from itertools import izip
 from scipy.interpolate import interp1d  
 
+def background_bin_from_string(bins, data):
+    """ Return template ids for each bin as defined by the format string
+    
+    Parameters
+    ----------
+    bins: list of strings
+        List of strings which define how a background bin is taken from the
+        list of templates.
+    data: dict of numpy.ndarrays
+        Dict with parameter key values and numpy.ndarray values which define
+        the parameters of the template bank to bin up.
+    
+    Returns
+    -------
+    bins: dict
+        Dictionary of location indices indexed by a bin name
+    
+    """
+    used = numpy.array([], dtype=numpy.uint32)
+    bins = {}
+    for mbin in bins:
+        name, bin_type, boundary = tuple(mbin.split('-'))
+        
+        if bin_type == 'component':
+            locs = numpy.maximum(m1, m2) < float(boundary)
+        elif bin_type == 'total':
+            locs = m1 + m2 < float(boundary)
+        elif bin_type == 'chirp':
+            locs = pycbc.pnutils.mass1_mass2_to_mchirp_eta(m1, m2)[0] < float(boundary)
+        else:
+            raise ValueError('Invalid bin type %s' % bin_type)    
+        
+        # make sure we don't reuse anythign from an earlier bin
+        locs = numpy.where(locs)[0]
+        locs = numpy.delete(locs, numpy.where(numpy.in1d(locs, used))[0])
+        used = numpy.concatenate([used, locs])   
+        bins[name] = locs
+    return bins
+           
+
 def calculate_n_louder(bstat, fstat, dec):
     """ Calculate for each foreground event the number of background events
     that are louder than it.

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -24,7 +24,7 @@
 """ This modules contains functions for calculating and manipulating
 coincident triggers.
 """
-import numpy, logging, h5py
+import numpy, logging, h5py, pycbc.pnutils
 from itertools import izip
 from scipy.interpolate import interp1d  
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -28,7 +28,7 @@ import numpy, logging, h5py, pycbc.pnutils
 from itertools import izip
 from scipy.interpolate import interp1d  
 
-def background_bin_from_string(bins, data):
+def background_bin_from_string(background_bins, data):
     """ Return template ids for each bin as defined by the format string
     
     Parameters
@@ -48,15 +48,14 @@ def background_bin_from_string(bins, data):
     """
     used = numpy.array([], dtype=numpy.uint32)
     bins = {}
-    for mbin in bins:
+    for mbin in background_bins:
         name, bin_type, boundary = tuple(mbin.split('-'))
-        
         if bin_type == 'component':
-            locs = numpy.maximum(m1, m2) < float(boundary)
+            locs = numpy.maximum(data['mass1'], data['mass2']) < float(boundary)
         elif bin_type == 'total':
-            locs = m1 + m2 < float(boundary)
+            locs = data['mass1'] + data['mass2'] < float(boundary)
         elif bin_type == 'chirp':
-            locs = pycbc.pnutils.mass1_mass2_to_mchirp_eta(m1, m2)[0] < float(boundary)
+            locs = pycbc.pnutils.mass1_mass2_to_mchirp_eta(data['mass1'], data['mass2'])[0] < float(boundary)
         else:
             raise ValueError('Invalid bin type %s' % bin_type)    
         

--- a/pycbc/events/veto.py
+++ b/pycbc/events/veto.py
@@ -125,6 +125,10 @@ def indices_within_times(times, start, end):
     times_sorted = times[tsort]
     left = numpy.searchsorted(times_sorted, start)
     right = numpy.searchsorted(times_sorted, end)
+
+    if len(left) == 0:
+        return numpy.array([], dtype=numpy.uint32)
+
     return tsort[numpy.hstack(numpy.r_[s:e] for s, e in zip(left, right))]
 
 def indices_outside_times(times, start, end):

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -657,7 +657,7 @@ def setup_simple_statmap(workflow, coinc_files, out_dir, tags=None):
 
     stat_node = statmap_exe.create_node(coinc_files, tags=tags)
     workflow.add_node(stat_node)
-    return stat_node.output_files[0]
+    return stat_node.output_files[0], stat_node.output_files
 
 def setup_mass_bins(workflow, coinc_files, bank_file, out_dir, tags=None):
     tags = [] if tags is None else tags
@@ -685,7 +685,7 @@ def setup_mass_bins(workflow, coinc_files, bank_file, out_dir, tags=None):
     cstat_node = cstat_exe.create_node(stat_files, tags=tags)
     workflow += cstat_node
     
-    return cstat_node.output_files[0]
+    return cstat_node.output_files[0], stat_files
     
 def setup_statmap_inj(workflow, coinc_files, background_file, bank_file, out_dir, tags=None):
     tags = [] if tags is None else tags
@@ -813,7 +813,7 @@ def setup_interval_coinc(workflow, hdfbank, trig_files,
     # Wall time knob and memory knob
     factor = int(workflow.cp.get_opt_tags('workflow-coincidence', 'parallelization-factor', tags))
 
-    stat_files = FileList()
+    stat_files = []
     for veto_file, veto_name in zip(veto_files, veto_names):
         bg_files = FileList()
         for i in range(factor):
@@ -826,6 +826,6 @@ def setup_interval_coinc(workflow, hdfbank, trig_files,
             workflow.add_node(coinc_node)
              
         stat_files += [setup_statmap(workflow, bg_files, hdfbank, out_dir, tags=tags + [veto_name])]
-        
+
     return stat_files
     logging.info('...leaving coincidence ')

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -729,7 +729,7 @@ def setup_mass_bins_inj(workflow, coinc_files, background_file, bank_file, out_d
     
     stat_files = FileList([])
     for i in range(len(mass_bins)):
-        statnode = statmap_exe.create_node(FileList([coinc_files['injinj'][i]]), background_file, 
+        statnode = statmap_exe.create_node(FileList([coinc_files['injinj'][i]]), FileList([background_file[i]]), 
                                      FileList([coinc_files['injfull'][i]]), FileList([coinc_files['fullinj'][i]]), 
                                      tags=tags + ['BIN_%s' % i])
         workflow += statnode

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -46,6 +46,21 @@ class PlotExecutable(Executable):
     """
     current_retention_level = Executable.FINAL_RESULT
 
+def make_template_plot(workflow, bank_file, out_dir, tags=None):
+    tags = [] if tags is None else tags
+    makedir(out_dir)
+    node = PlotExecutable(workflow.cp, 'plot_bank', ifos=workflow.ifos,
+                          out_dir=out_dir, tags=tags).create_node()
+    node.add_input_list_opt('--bank-file', bank_file)
+    
+    if workflow.cp.has_option_tags('workflow-coincidence', 'background-bins'):
+        bins = workflow.cp.get_option_tags('workflow-coincidence', 'background-bins')
+        node.add_opt('--background-bins', bins)
+    
+    node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
+    workflow += node
+    return node.output_files[0]     
+
 def make_range_plot(workflow, psd_files, out_dir, tags=None):
     tags = [] if tags is None else tags
     makedir(out_dir)

--- a/setup.py
+++ b/setup.py
@@ -426,6 +426,8 @@ setup (
                'bin/pycbc_submit_dax',
                'bin/pycbc_submit_dax_stampede',
                'bin/hdfcoinc/pycbc_page_coinc_snrchi',
+               'bin/hdfcoinc/pycbc_distribute_mass_bins',
+               'bin/hdfcoinc/pycbc_combine_statmap',
                'bin/hdfcoinc/pycbc_stat_dtphase',
                'bin/hdfcoinc/pycbc_plot_singles_vs_params',
                'bin/hdfcoinc/pycbc_plot_singles_timefreq',

--- a/setup.py
+++ b/setup.py
@@ -433,6 +433,7 @@ setup (
                'bin/hdfcoinc/pycbc_plot_singles_timefreq',
                'bin/mvsc/pycbc_mvsc_get_features',
                'bin/hdfcoinc/pycbc_plot_background_coincs',
+               'bin/hdfcoinc/pycbc_plot_bank_bins',
                ],
     packages = [
                'pycbc',

--- a/setup.py
+++ b/setup.py
@@ -426,7 +426,7 @@ setup (
                'bin/pycbc_submit_dax',
                'bin/pycbc_submit_dax_stampede',
                'bin/hdfcoinc/pycbc_page_coinc_snrchi',
-               'bin/hdfcoinc/pycbc_distribute_mass_bins',
+               'bin/hdfcoinc/pycbc_distribute_background_bins',
                'bin/hdfcoinc/pycbc_combine_statmap',
                'bin/hdfcoinc/pycbc_stat_dtphase',
                'bin/hdfcoinc/pycbc_plot_singles_vs_params',


### PR DESCRIPTION
This rolls up #223  and #222 and adds basic mass bins into the workflow. They can be controlled by setting. 

```
[workflow-coincidence]
background-bins = LOW-mchirp-3.48 HIGH-mchirp-6.3

[combine_statmap]
cluster-window = CLUSTER_WINDOW ; Time window to cluster the triggers from the mass bins
```
Please let me know ASAP if you guys think this is a sensible way to present the results and if there should be modifications to other plots/ new plots to be able to understand a mass binned search. 