### PR TITLE
ignore the docs makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ html/
 pycbc_inspiralc
 build/
 *.pyc
+docs/Makefile


### PR DESCRIPTION
This file is now automatically generated from one of two templates, so git should ignore it.