### PR TITLE
Allow location of html assets to be specified on the command line

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -32,6 +32,8 @@ parser.add_argument('--version', action='version',
 parser.add_argument('--workflow-name', default='my_unamed_run')
 parser.add_argument("-d", "--output-dir", default=None,
                     help="Path to output directory.")
+parser.add_argument("-a", "--asset-dir", default=None,
+                    help="Path to directory containing html assets.")
 wf.add_workflow_command_line_group(parser)
 args = parser.parse_args()
 
@@ -48,7 +50,7 @@ os.chdir(args.output_dir)
 # layout initialization / helper functions 
 def layout(path, cols):
     path = os.path.join(os.getcwd(), path, 'well.html')
-    render_workflow_html_template(path, 'two_column.html', cols)
+    render_workflow_html_template(path, 'two_column.html', cols, args.asset_dir)
 
 def single_layout(path, files):
     layout(path, [(f,) for f in files])

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -27,10 +27,13 @@ from pycbc.results import unescape_table
 from pycbc.results.metadata import save_html_with_metadata
 from pycbc.workflow.segment import fromsegmentxml
 
-def render_workflow_html_template(filename, subtemplate, filelists):
+def render_workflow_html_template(filename, subtemplate, filelists, asset_dir=None):
     """ Writes a template given inputs from the workflow generator. Takes
     a list of tuples. Each tuple is a pycbc File object. Also the name of the
-    subtemplate to render and the filename of the output.
+    subtemplate to render and the filename of the output, and an optional 
+    directory containing html templates and other assets.  If this last argument
+    is not provided assets are obtained relative to the directory containing
+    pycbc/results.py
     """
 
     dir = os.path.dirname(filename)
@@ -41,7 +44,11 @@ def render_workflow_html_template(filename, subtemplate, filelists):
         filenames = []
 
     # render subtemplate
-    subtemplate_dir = pycbc.results.__path__[0] + '/templates/wells'
+    if asset_dir is None:
+        subtemplate_dir = pycbc.results.__path__[0] + '/templates/wells'
+    else:
+        subtemplate_dir = asset_dir + '/templates/wells'
+
     env = Environment(loader=FileSystemLoader(subtemplate_dir))
     env.globals.update(get_embedded_config=get_embedded_config)
     env.globals.update(path_exists=os.path.exists)


### PR DESCRIPTION
At present templates needed to generate the results pages are located relative to the location of the pycbc/results.py file.  This doesn't work when using a static binary built by pyinstaller, so this patch adds the ability to provide the location of these files on the command line.  I have tested by generating a workflow with both the standard install without the new flag, and a pyinstaller-built binary with the new flag, and both worked.