### PR TITLE
Modify return type to work around pyinstaller incompatibility

### DIFF
--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -69,7 +69,7 @@ def get_psd((seg, i)):
     for psegs in groups:
         strain_part = gwstrain[psegs[0].start:psegs[-1].stop]
         psd = pycbc.psd.from_cli(args, flen, delta_f, flow, strain_part, pycbc.DYN_RANGE_FAC)        
-        lpsd.append((psd, int(strain_part.start_time), int(strain_part.end_time)))
+        lpsd.append((psd.numpy(), psd.delta_f, int(strain_part.start_time), int(strain_part.end_time)))
 
     return lpsd
 
@@ -92,15 +92,15 @@ psds = psds.get()
 f = h5py.File(args.output_file, 'w')
 inc, start, end = 0, [], []
 for gpsd in psds:
-    for psd, s, e in gpsd:
+    for psd_numpy, psd_delta_f, s, e in gpsd:
         logging.info('writing psd %d', inc)
         key = ifo + '/psds/' + str(inc)
         start.append(int(s))
         end.append(int(e))
-        f.create_dataset(key, data= (psd.numpy()), 
+        f.create_dataset(key, data= (psd_numpy), 
                          compression='gzip', compression_opts=9, shuffle=True)
         f[key].attrs['epoch'] = int(s)
-        f[key].attrs['delta_f'] = float(psd.delta_f)
+        f[key].attrs['delta_f'] = float(psd_delta_f)
         inc += 1
 
 f[ifo + '/start_time'] = numpy.array(start, dtype=numpy.uint32)


### PR DESCRIPTION
Running with pyinstaller the FrequencySeries could not be pickled for return, because of a problem pickling the member LIGOTimeGPS.  The works around the problem by returning only the components that are needed.