### PR TITLE
Updates to PyCBC install instructions based on feedback from Steve

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,6 +75,7 @@ For Developers:
     :maxdepth: 1
     
     documentation
+    release
     
 Format Specifications:
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -34,26 +34,28 @@ Setting up a virtual environment for installing PyCBC
 
 The recommended way of installing PyCBC is to use `pip <https://pip.pypa.io/en/stable/>`_ within a `Python Virtual Environment <https://virtualenv.pypa.io/en/latest/>`_. Virtualenv isolates PyCBC and its dependencies from the system environment and installing with pip ensures that PyCBC picks up the correct dependencies. The following instructions will create a working virtual environment into which you can install PyCBC. 
 
-Make sure that you have at least version 13.1.1 of virtualenv by running 
+Make sure that you have at least version 13.1.1 of virtualenv. To do this, you can run the command below and check the return result. Run this command and note the result:
 
 .. code-block:: bash
 
     virtualenv --version
     
-If this returns ``virtualenv: command not found`` (as is the case with LIGO Data Grid Scientific Linux 6 systems) or the command returns a lower version than 13.1.1, then follow the instructions for setting virtualenv at:
+If this returns ``virtualenv: command not found`` or the command returns a lower version than ``13.1.1`` (as is the case with LIGO Data Grid Scientific Linux 6 systems) then follow the instructions for setting virtualenv at:
 
 .. toctree::
     :maxdepth: 1
 
     install_virtualenv
 
-Once you have virtualenv installed, unset your current ``PYTHONPATH`` so that you do not inherit any packages that may conflict with your installation. To do this, run the command:
+Once you have a version virtualenv installed that is at least as new as ``13.1.1`` you can continue with these instructions.
+
+Unset your current ``PYTHONPATH`` so that you do not inherit any packages that may conflict with your installation. To do this, run the command:
 
 .. code-block:: bash
 
     unset PYTHONPATH
 
-By default, virtualenv will modify your shell prompt so that it prepends the name of the virtual environment. This can be useful to make sure that you are developing in the virtual environment, or if you have several virtual environments. However, if you do not want this, then set
+By default, virtualenv will modify your shell prompt so that it prepends the name of the virtual environment. This can be very useful to make sure that you are developing in the virtual environment, or if you have several virtual environments, so it is not reccomended to disable this. However, if you do not want your prompt changed, then you can set
 
 .. code-block:: bash
 
@@ -62,6 +64,10 @@ By default, virtualenv will modify your shell prompt so that it prepends the nam
 Before running the command to create the new virtual environment.
 
 Next, you need to choose a directory name where you'd like to make your virtual environment, and then make it. In this example, we use ``${HOME}/pycbc-dev`` but this can be changed to any path that you you have write access to, except for ``${HOME}/.local`` as that will cause conflicts with pip.
+
+.. note::
+
+    It is very important that your ``virtualenv`` version is at least 13.1.1 before continuing. If read the preceeding instructions if you are not sure how to check this, or need to upgrade virtualenv.
 
 Set up the new virtual environment with the command
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -169,7 +169,7 @@ Install the PyCBC source code from the GitHub URL using the command:
 
 .. code-block:: bash
 
-    pip install -e git+git@github.com:duncan-brown/pycbc.git#egg=pycbc --process-dependency-links
+    pip install -e git+git@github.com:your-username-here/pycbc.git#egg=pycbc --process-dependency-links
 
 This will fetch the PyCBC source and will also install all the listed dependencies. The ``-e`` option to pip creates a directory called ``$NAME/src/pycbc`` with a git checkout which is fully editable. To prevent pip from removing this source directory run the command
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -100,7 +100,7 @@ First install unittest2, python-cjson, and numpy with the command:
 
 .. code-block:: bash
 
-    pip install "numpy>=1.6.4" unittest2 python-cjson
+    pip install "numpy>=1.6.4" unittest2 python-cjson Cython
 
 To authenticate with LIGO Data Grid services, you need M2Crypto which you should install with 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -69,13 +69,24 @@ Next, you need to choose a directory name where you'd like to make your virtual 
 
     It is very important that your ``virtualenv`` version is at least 13.1.1 before continuing. Read the preceding instructions if you are not sure how to check this, or need to upgrade virtualenv.
 
-Set up the new virtual environment with the command
+You first set up a new virtual environment. A virtual environment is defined by a directory path that will hold the contents of the virtual environment. We will reference this directory path a lot in the instructions below, so we first set a shell variable called ``NAME`` to the value of the path of the new virtual environment. Run with the command:
 
 .. code-block:: bash
 
     NAME=${HOME}/pycbc-dev
-    virtualenv $NAME
     
+Now you can initialize the virtual environment. This creates a new directory named by value of the variable ``$NAME`` containing your new virtual environment. To do this, run the command:
+
+.. code-block:: bash
+    
+    virtualenv $NAME
+
+You can create as many different virtual environments as you like, as long as they all have different paths (i.e. different values of ``$NAME``).
+
+.. note::
+
+    Do not run ``virtualenv`` twice with the same value of ``$NAME`` as it will overwrite the existing virtual environment with a new one, destroying the environment.
+
 To enter your virtual environment run the command
 
 .. code-block:: bash

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,7 +12,7 @@ This page documents the first two use cases. For production analysis, users must
 
 .. note::
 
-    If you wish to develop PyCBC, then you will need an account on `GitHub <https://www.github.com>`_. Once you have set up your account you should follow the instructions to `fork a repository <https://help.github.com/articles/fork-a-repo/>`_ to fork the `ligo-cbc/pycbc <https://github.com/ligo-cbc/pycbc>`_ repository into your own account.
+    PyCBC uses the `fork and pull <https://help.github.com/articles/using-pull-requests/>`_ model for development. If you wish to develop PyCBC, then you will need an account on `GitHub <https://www.github.com>`_. Once you have set up your account you should follow the instructions to `fork a repository <https://help.github.com/articles/fork-a-repo/>`_ to fork the `ligo-cbc/pycbc <https://github.com/ligo-cbc/pycbc>`_ repository into your own account. From your own fork, you can follow the `GitHub flow model <https://help.github.com/articles/github-flow-in-the-browser/>`_ to develop and maintain the code. For each new feature or bug fix, you should `create a new branch <https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/>`_ to develop the feature. You can then `create a pull request <https://help.github.com/articles/creating-a-pull-request/>`_ so that the PyCBC maintainers can review and merge your changes into the official repository.
 
 These instructions walk you through the process of
 
@@ -155,7 +155,9 @@ Installing source from GitHub for development
 
     Make sure you have run the command in the section :ref:`Installing lalsuite into a virtual environment` above to install unittest2 before installing PyCBC.
 
-To install and editable version of PyCBC you need to have `forked PyCBC to your own account <https://help.github.com/articles/fork-a-repo/>`_ and know the URL of your fork. This can be obtained from the clone URL on your GitHub repository page. This example uses the URL git@github.com:duncan-brown/pycbc.git which you should change as appropriate. You can read the `pip git instructions <https://pip.pypa.io/en/latest/reference/pip_install.html#git>`_ for more details on how to install a branch or a specific tag.
+To install and editable version of PyCBC you need to have `forked PyCBC to your own account <https://help.github.com/articles/fork-a-repo/>`_ and know the URL of your fork. This can be obtained from the clone URL on your GitHub repository page. This example uses the URL ``git@github.com:your-username-here/pycbc.git`` which you should change to the URL of your fork of PyCBC on GitHub. 
+
+You can also read the `pip git instructions <https://pip.pypa.io/en/latest/reference/pip_install.html#git>`_ for more details on how to install a branch or a specific tag.
 
 Install the PyCBC source code from the GitHub URL using the command:
 
@@ -170,6 +172,8 @@ This will fetch the PyCBC source and will also install all the listed dependenci
     rm -f $NAME/src/pip-delete-this-directory.txt
 
 You can then make changes to your PyCBC source code in the directory ``$NAME/src/pycbc``
+
+You can also use the repository created by pip as your working repository, creating branches, commits, and `pull requests <https://help.github.com/articles/creating-a-pull-request/>`_ as you need to. To keep your repository in sync with the ligo-cbc/pycbc repository, you can read the GitHub instructions that explaion how to `sync a fork of a repository to keep it up-to-date with the upstream repository. <https://help.github.com/articles/syncing-a-fork/>`_.
 
 .. note::
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -55,7 +55,7 @@ Unset your current ``PYTHONPATH`` so that you do not inherit any packages that m
 
     unset PYTHONPATH
 
-By default, virtualenv will modify your shell prompt so that it prepends the name of the virtual environment. This can be very useful to make sure that you are developing in the virtual environment, or if you have several virtual environments, so it is not reccomended to disable this. However, if you do not want your prompt changed, then you can set
+By default, virtualenv will modify your shell prompt so that it prepends the name of the virtual environment. This can be very useful to make sure that you are developing in the virtual environment, or if you have several virtual environments, so it is not recommended to disable this. However, if you do not want your prompt changed, then you can set
 
 .. code-block:: bash
 
@@ -67,7 +67,7 @@ Next, you need to choose a directory name where you'd like to make your virtual 
 
 .. note::
 
-    It is very important that your ``virtualenv`` version is at least 13.1.1 before continuing. If read the preceeding instructions if you are not sure how to check this, or need to upgrade virtualenv.
+    It is very important that your ``virtualenv`` version is at least 13.1.1 before continuing. Read the preceding instructions if you are not sure how to check this, or need to upgrade virtualenv.
 
 Set up the new virtual environment with the command
 
@@ -137,11 +137,11 @@ Next install the Pegasus WMS python libraries needed to build the workflows with
 
     pip install http://download.pegasus.isi.edu/pegasus/4.5.2/pegasus-python-source-4.5.2.tar.gz
 
-To query the new Advanced LIGO and Advanced Virgo Segment Database, you will need to install the ``dqsegdb`` tools. At the moment, these are not avaialble from the Python Package Index, so you will need to install them from a branch in Duncan's repository with the command
+To query the new Advanced LIGO and Advanced Virgo Segment Database, you will need to install the ``dqsegdb`` tools. At the moment, these are not available from the Python Package Index, so you will need to install them from a branch in Duncan's repository with the command
 
 .. code-block:: bash
 
-    pip install -e git+git@github.com:duncan-brown/dqsegdb.git@pypi_release#egg=dqsegdb
+    pip install git+https://github.com/duncan-brown/dqsegdb.git@pypi_release#egg=dqsegdb
 
 You now need to decide whether you want to install a release of PyCBC or an editable version of the source code from a git repository for development. 
 
@@ -169,7 +169,8 @@ Installing source from GitHub for development
 
 To install and editable version of PyCBC you need to have `forked PyCBC to your own account <https://help.github.com/articles/fork-a-repo/>`_ and know the URL of your fork. This can be obtained from the clone URL on your GitHub repository page. This example uses the URL ``git@github.com:your-username-here/pycbc.git`` which you should change to the URL of your fork of PyCBC on GitHub. 
 
-You can also read the `pip git instructions <https://pip.pypa.io/en/latest/reference/pip_install.html#git>`_ for more details on how to install a branch or a specific tag.
+.. note:: 
+    There are two main authentication schemes for GitHub: SSH and HTTPS. The examples below use URLs containing ``git@github.com``, which assumed that you are usingg SSH authentication. If you have not already enabled ssh keys on your GitHub account, you can follow the `GitHub instructions for setting up ssh keys <https://help.github.com/articles/generating-ssh-keys/>`_ to set this up. Alternatively, you can use the HTTPS connection method, where ``git@github.com:`` is replaced with ``https://github.com/``. See the `GitHub documentation on URLs <https://help.github.com/articles/which-remote-url-should-i-use/>`_ for more information. You can also read the `pip git instructions <https://pip.pypa.io/en/latest/reference/pip_install.html#git>`_ for more details on how to install a branch or a specific tag.
 
 Install the PyCBC source code from the GitHub URL using the command:
 
@@ -185,7 +186,7 @@ This will fetch the PyCBC source and will also install all the listed dependenci
 
 You can then make changes to your PyCBC source code in the directory ``$NAME/src/pycbc``
 
-You can also use the repository created by pip as your working repository, creating branches, commits, and `pull requests <https://help.github.com/articles/creating-a-pull-request/>`_ as you need to. To keep your repository in sync with the ligo-cbc/pycbc repository, you can read the GitHub instructions that explaion how to `sync a fork of a repository to keep it up-to-date with the upstream repository. <https://help.github.com/articles/syncing-a-fork/>`_.
+You can also use the repository created by pip as your working repository, creating branches, commits, and `pull requests <https://help.github.com/articles/creating-a-pull-request/>`_ as you need to. To keep your repository in sync with the ligo-cbc/pycbc repository, you can read the GitHub instructions that explain how to `sync a fork of a repository to keep it up-to-date with the upstream repository. <https://help.github.com/articles/syncing-a-fork/>`_.
 
 .. note::
 
@@ -275,7 +276,7 @@ PyCBC has the ability to use optimized FFT libraries such as FFTW and MKL. If MK
 
     echo 'source /opt/intel/bin/compilervars.sh intel64' >> $NAME/bin/activate
 
-changing the path to the ``compilervars.sh`` script approriately for your cluster. 
+changing the path to the ``compilervars.sh`` script appropriately for your cluster. 
 
 ==========================================
 Graphics Processing Unit support with CUDA

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -131,6 +131,12 @@ Next install the Pegasus WMS python libraries needed to build the workflows with
 
     pip install http://download.pegasus.isi.edu/pegasus/4.5.2/pegasus-python-source-4.5.2.tar.gz
 
+To query the new Advanced LIGO and Advanced Virgo Segment Database, you will need to install the ``dqsegdb`` tools. At the moment, these are not avaialble from the Python Package Index, so you will need to install them from a branch in Duncan's repository with the command
+
+.. code-block:: bash
+
+    pip install -e git+git@github.com:duncan-brown/dqsegdb.git@pypi_release#egg=dqsegdb
+
 You now need to decide whether you want to install a release of PyCBC or an editable version of the source code from a git repository for development. 
 
 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,0 +1,34 @@
+##########################
+Creating Releases of PyCBC
+##########################
+
+..note:
+
+    Only authorized maintainers of PyCBC should use these instructions.
+
+
+==============================
+Creating the release on GitHub
+==============================
+
+To create a new PyCBC release:
+
+1. Make sure that the setup.py file contains the correct version number, which should be in the format ``x.y.x`` (where x, y, and z are the major, minor, and patch levels of the release) in PyCBC's setup.py file.
+1. Set ``release = True`` in the PyCBC's setup.py file.
+1. Commit the changed setup.py file and push to commit to the repository.
+1. Go to the `PyCBC release page <https://github.com/ligo-cbc/pycbc/releases>`_ and click on ``Draft a new release``. 
+1. Enter a tag version in the format ``vx.y.z``. Note the ``v`` in front of the major, minor, and patch numbers. 
+1. Enter a descriptive release title and write a desciption of the release in the text box provided.
+1. Click on ``Publish release`` to create the release.
+1. Update the setup.py file with an incremented major or minor version number and make sure that the string ``dev`` appears in that version. For example, if you just released ``1.2.1`` then change the string to ``1.3.dev0`` or ``2.0.dev0`` as appropriate. This is need to ensure that if someone is building from source, it always takes precedence over an older release version.
+1. Set ``release = False`` in PyCBC's setup.py file.
+1. Commit these changes and push them to the repository.
+
+=====================================
+Uploading to the Python Package Index
+=====================================
+
+Follow the `instructions for submitting a package to PyPI <http://peterdowns.com/posts/first-time-with-pypi.html>`_ to submit the package to the Python Package Index. 
+
+Keep in mind that once you register a version number with the package index and upload a package, you can never change it. You can only deactivate the package from the index, and increment the version number.
+

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -2,7 +2,7 @@
 Creating Releases of PyCBC
 ##########################
 
-..note:
+..note::
 
     Only authorized maintainers of PyCBC should use these instructions.
 
@@ -13,16 +13,16 @@ Creating the release on GitHub
 
 To create a new PyCBC release:
 
-1. Make sure that the setup.py file contains the correct version number, which should be in the format ``x.y.x`` (where x, y, and z are the major, minor, and patch levels of the release) in PyCBC's setup.py file.
-1. Set ``release = True`` in the PyCBC's setup.py file.
-1. Commit the changed setup.py file and push to commit to the repository.
-1. Go to the `PyCBC release page <https://github.com/ligo-cbc/pycbc/releases>`_ and click on ``Draft a new release``. 
-1. Enter a tag version in the format ``vx.y.z``. Note the ``v`` in front of the major, minor, and patch numbers. 
-1. Enter a descriptive release title and write a desciption of the release in the text box provided.
-1. Click on ``Publish release`` to create the release.
-1. Update the setup.py file with an incremented major or minor version number and make sure that the string ``dev`` appears in that version. For example, if you just released ``1.2.1`` then change the string to ``1.3.dev0`` or ``2.0.dev0`` as appropriate. This is need to ensure that if someone is building from source, it always takes precedence over an older release version.
-1. Set ``release = False`` in PyCBC's setup.py file.
-1. Commit these changes and push them to the repository.
+    1. Make sure that the setup.py file contains the correct version number, which should be in the format ``x.y.x`` (where x, y, and z are the major, minor, and patch levels of the release) in PyCBC's setup.py file.
+    1. Set ``release = True`` in the PyCBC's setup.py file.
+    1. Commit the changed setup.py file and push to commit to the repository.
+    1. Go to the `PyCBC release page <https://github.com/ligo-cbc/pycbc/releases>`_ and click on ``Draft a new release``. 
+    1. Enter a tag version in the format ``vx.y.z``. Note the ``v`` in front of the major, minor, and patch numbers. 
+    1. Enter a descriptive release title and write a desciption of the release in the text box provided.
+    1. Click on ``Publish release`` to create the release.
+    1. Update the setup.py file with an incremented major or minor version number and make sure that the string ``dev`` appears in that version. For example, if you just released ``1.2.1`` then change the string to ``1.3.dev0`` or ``2.0.dev0`` as appropriate. This is need to ensure that if someone is building from source, it always takes precedence over an older release version.
+    1. Set ``release = False`` in PyCBC's setup.py file.
+    1. Commit these changes and push them to the repository.
 
 =====================================
 Uploading to the Python Package Index

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -2,7 +2,7 @@
 Creating Releases of PyCBC
 ##########################
 
-..note::
+.. note::
 
     Only authorized maintainers of PyCBC should use these instructions.
 
@@ -13,22 +13,65 @@ Creating the release on GitHub
 
 To create a new PyCBC release:
 
-    1. Make sure that the setup.py file contains the correct version number, which should be in the format ``x.y.x`` (where x, y, and z are the major, minor, and patch levels of the release) in PyCBC's setup.py file.
-    1. Set ``release = True`` in the PyCBC's setup.py file.
-    1. Commit the changed setup.py file and push to commit to the repository.
-    1. Go to the `PyCBC release page <https://github.com/ligo-cbc/pycbc/releases>`_ and click on ``Draft a new release``. 
-    1. Enter a tag version in the format ``vx.y.z``. Note the ``v`` in front of the major, minor, and patch numbers. 
-    1. Enter a descriptive release title and write a desciption of the release in the text box provided.
-    1. Click on ``Publish release`` to create the release.
-    1. Update the setup.py file with an incremented major or minor version number and make sure that the string ``dev`` appears in that version. For example, if you just released ``1.2.1`` then change the string to ``1.3.dev0`` or ``2.0.dev0`` as appropriate. This is need to ensure that if someone is building from source, it always takes precedence over an older release version.
-    1. Set ``release = False`` in PyCBC's setup.py file.
-    1. Commit these changes and push them to the repository.
+#. Make sure that the setup.py file contains the correct version number, which should be in the format ``x.y.x`` (where x, y, and z are the major, minor, and patch levels of the release) in PyCBC's setup.py file.
+#. Set ``release = True`` in the PyCBC's setup.py file.
+#. Commit the changed setup.py file and push to commit to the repository.
+#. Go to the `PyCBC release page <https://github.com/ligo-cbc/pycbc/releases>`_ and click on ``Draft a new release``. 
+#. Enter a tag version in the format ``vx.y.z``. Note the ``v`` in front of the major, minor, and patch numbers. 
+#. Enter a descriptive release title and write a desciption of the release in the text box provided.
+#. Click on ``Publish release`` to create the release.
+#. Update the setup.py file with an incremented major or minor version number and make sure that the string ``dev`` appears in that version. For example, if you just released ``1.2.1`` then change the string to ``1.3.dev0`` or ``2.0.dev0`` as appropriate. This is need to ensure that if someone is building from source, it always takes precedence over an older release version.
+#. Set ``release = False`` in PyCBC's setup.py file.
+#. Commit these changes and push them to the repository.
 
 =====================================
 Uploading to the Python Package Index
 =====================================
 
-Follow the `instructions for submitting a package to PyPI <http://peterdowns.com/posts/first-time-with-pypi.html>`_ to submit the package to the Python Package Index. 
+.. note::
 
-Keep in mind that once you register a version number with the package index and upload a package, you can never change it. You can only deactivate the package from the index, and increment the version number.
+    Keep in mind that once you register a version number with the package index and upload a package, you can never change it. You can only deactivate the package from the index, and increment the version number.
 
+If this is the first time that you have pushed to PyPI, you will need to create a configuration file. Create a file in your home directory called ``.pypirc`` that contains the lines
+
+.. highlight:: 
+
+    [distutils] # this tells distutils what package indexes you can push to
+    index-servers =
+      pypi
+      pypitest
+
+    [pypi]
+    repository: https://pypi.python.org/pypi
+    username: your_username
+    password: your_password
+
+    [pypitest]
+    repository: https://testpypi.python.org/pypi
+    username: your_username
+    password: your_password
+
+Replace ``your_username`` and ``your_password`` with your PyPI and PyPI testing usernames and passwords.
+
+Once you have tagged the release of PyCBC a tarball should be available from the `GitHib PyCBC releases page <https://github.com/ligo-cbc/pycbc/releases>`_. Download this tarball, untar it, and change into the source directory of the tarball. 
+
+First check the release with the PyPI test repository. Register the package with 
+
+.. code:: bash
+
+    python setup.py register -r pypitest
+
+If you get no errors, you can then upload the package with
+
+.. code:: bash
+
+    python setup.py sdist upload -r pypitest
+
+You should now see the package uploaded in the `PyPI Test Repository <https://testpypi.python.org/pypi>`_. If this is successful, you can puhlish it to the main repository with the commands
+
+.. code:: bash
+
+    python setup.py register -r pypi
+    python setup.py sdist upload -r pypi
+
+The package should then be available in PyPI for download.


### PR DESCRIPTION
This pull request contains several fixed to the documentation:

* Deal with the pip bug that causes a (harmless) error if Cython is pulled in by hd5 by telling the user to install Cython before they get to the PyCBC install. This deals with the issue https://github.com/ligo-cbc/pycbc/issues/157
* Added documentation on how to build a release and publish it to PyPI
* Removed links to my GitHub repo from the examples and put in a generic username
* Added instructions to pip install the dqsegdb tools. At the moment this needs to be done from my GitHub fork because of some issues that prevent Ryan's dqsegdb from being compatible with PyPI. I will work with Ryan to fix these.
* Added some additional links to GitHub documentation on the fork and pull model that we use, including an explicit link on how to keep your fork synced.