### PR TITLE
Fix typo in example for hardware injection doc.

### DIFF
--- a/docs/hwinj.rst
+++ b/docs/hwinj.rst
@@ -104,7 +104,7 @@ Our source distribution will be random. The command line option will be ::
   
 We select to use the ``SpinTaylorT4`` approximant and begin the waveforms at 10.0Hz. Here we taper the injection at the start and end of the injection. The command line options will be ::
 
-  --waveform SpinTaylorT4threePointFivePN --f-lower 10 --taper-injection start --band-pass-injection
+  --waveform SpinTaylorT4threePointFivePN --f-lower 10 --taper-injection startend --band-pass-injection
 
 Now we can combine all the options above and run ``lalapps_inspinj`` as ::
 


### PR DESCRIPTION
The text correctly says to taper the ``SpinTaylorT4`` waveform at the start and end. And the example command does this. However the line that shows the command line options names is incorrect. This PR fixes a typo in the hardware injection documentation.