### PR TITLE
In InjectionSet.apply taper before project_wave

### DIFF
--- a/pycbc/inject.py
+++ b/pycbc/inject.py
@@ -199,13 +199,10 @@ class InjectionSet(object):
             hc_tapered_pycbc = TimeSeries(hc_tapered.data.data[:],
                                    delta_t=hc_tapered.deltaT, epoch=hc_tapered.epoch)
 
-            # compute the detector response, taper it if requested 
-            # and add it to the strain
+            # compute the detector response and add it to the strain
             signal = detector.project_wave(hp_tapered_pycbc, hc_tapered_pycbc,
                                    inj.longitude, inj.latitude, inj.polarization)
-            # the taper_timeseries function converts to a LAL TimeSeries
             signal = signal.astype(strain.dtype)
-#            signal_lal = wfutils.taper_timeseries(signal, inj.taper, return_lal=True)
             signal_lal = signal.lal()
             add_injection(lalstrain, signal_lal, None)
 

--- a/pycbc/inject.py
+++ b/pycbc/inject.py
@@ -192,16 +192,12 @@ class InjectionSet(object):
                    continue
 
             # taper the polarizations
-            hp_tapered = wfutils.taper_timeseries(hp, inj.taper, return_lal=True)
-            hc_tapered = wfutils.taper_timeseries(hc, inj.taper, return_lal=True)
-            hp_tapered_pycbc = TimeSeries(hp_tapered.data.data[:],
-                                   delta_t=hp_tapered.deltaT, epoch=hp_tapered.epoch)
-            hc_tapered_pycbc = TimeSeries(hc_tapered.data.data[:],
-                                   delta_t=hc_tapered.deltaT, epoch=hc_tapered.epoch)
+            hp_tapered = wfutils.taper_timeseries(hp, inj.taper)
+            hc_tapered = wfutils.taper_timeseries(hc, inj.taper)
 
             # compute the detector response and add it to the strain
-            signal = detector.project_wave(hp_tapered_pycbc, hc_tapered_pycbc,
-                                   inj.longitude, inj.latitude, inj.polarization)
+            signal = detector.project_wave(hp_tapered, hc_tapered,
+                                 inj.longitude, inj.latitude, inj.polarization)
             signal = signal.astype(strain.dtype)
             signal_lal = signal.lal()
             add_injection(lalstrain, signal_lal, None)

--- a/pycbc/inject.py
+++ b/pycbc/inject.py
@@ -191,13 +191,22 @@ class InjectionSet(object):
                 if float(hp.start_time) > t1:
                    continue
 
-            # compute the detector response, taper it if requested
+            # taper the polarizations
+            hp_tapered = wfutils.taper_timeseries(hp, inj.taper, return_lal=True)
+            hc_tapered = wfutils.taper_timeseries(hc, inj.taper, return_lal=True)
+            hp_tapered_pycbc = TimeSeries(hp_tapered.data.data[:],
+                                   delta_t=hp_tapered.deltaT, epoch=hp_tapered.epoch)
+            hc_tapered_pycbc = TimeSeries(hc_tapered.data.data[:],
+                                   delta_t=hc_tapered.deltaT, epoch=hc_tapered.epoch)
+
+            # compute the detector response, taper it if requested 
             # and add it to the strain
-            signal = detector.project_wave(
-                    hp, hc, inj.longitude, inj.latitude, inj.polarization)
+            signal = detector.project_wave(hp_tapered_pycbc, hc_tapered_pycbc,
+                                   inj.longitude, inj.latitude, inj.polarization)
             # the taper_timeseries function converts to a LAL TimeSeries
             signal = signal.astype(strain.dtype)
-            signal_lal = wfutils.taper_timeseries(signal, inj.taper, return_lal=True)
+#            signal_lal = wfutils.taper_timeseries(signal, inj.taper, return_lal=True)
+            signal_lal = signal.lal()
             add_injection(lalstrain, signal_lal, None)
 
         strain.data[:] = lalstrain.data.data[:]


### PR DESCRIPTION
This PR tapers software injections in ``InjectionSet.apply`` before the call to ``project_wave``.

This way the call to LALSimulation inside ``project_wave`` that offsets the waveforms doesn't have to interpolation across a step since its already been tapered.

Image of waveform tapering with this PR: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/inject_fix_2_tapering_start.png