### PR TITLE
Enable calling pnutils to determine the number of chi^2 bins

### DIFF
--- a/pycbc/vetoes/chisq.py
+++ b/pycbc/vetoes/chisq.py
@@ -26,6 +26,7 @@ import numpy, logging, math, pycbc.fft
 from pycbc.types import zeros, real_same_precision_as, TimeSeries, complex_same_precision_as
 from pycbc.filter import sigmasq_series, make_frequency_series, matched_filter_core, get_cutoff_indices
 from pycbc.scheme import schemed
+import pycbc.pnutils
 
 BACKEND_PREFIX="pycbc.vetoes.chisq_"
 
@@ -301,6 +302,7 @@ class SingleDetPowerChisq(object):
         safe_dict = {}
         safe_dict.update(row.__dict__)
         safe_dict.update(math.__dict__)
+        safe_dict.update(pycbc.pnutils.__dict__)
         return eval(arg, {"__builtins__":None}, safe_dict)
 
     def cached_chisq_bins(self, template, psd):


### PR DESCRIPTION
Hi Ian, I found these two changes are needed to run in ER8.

One change enables using Tom's formula for the number of chi^2 bins, which requires calling pycbc.pnutils.get_freq().

The other change is what you suggested for getting the workflow generation to complete. Without this change, pycbc_make_hdf_coinc_workflow hangs forever during the creation of the matched filter jobs. I haven't discovered why that happens, but this change fixes it. Do you think we can merge this, or could it have some negative side effects?