### PR TITLE
Cuda

### DIFF
--- a/docs/install_cuda.rst
+++ b/docs/install_cuda.rst
@@ -41,7 +41,7 @@ Install the dependencies PyCUDA, SciKits.cuda and Mako with by running the comma
 .. code-block:: bash
 
     pip install pycuda
-    pip install scikits.cuda
+    pip install scikit-cuda
     pip install Mako
    
 You should now be able to use the CUDA features in PyCBC.

--- a/pycbc/fft/cufft.py
+++ b/pycbc/fft/cufft.py
@@ -27,7 +27,7 @@ for the PyCBC package.
 """
 
 import pycbc.scheme
-import scikits.cuda.fft as cu_fft
+import skcuda.fft as cu_fft
 from .core import _BaseFFT, _BaseIFFT
 
 _forward_plans = {}

--- a/setup.py
+++ b/setup.py
@@ -330,7 +330,7 @@ cmdclass = { 'test'  : test,
              'clean' : clean,
             }
             
-extras_require = {'cuda': ['pycuda>=2015.1', 'scikits.cuda']}
+extras_require = {'cuda': ['pycuda>=2015.1', 'scikit-cuda']}
 
 # do the actual work of building the package
 VERSION = get_version_info()


### PR DESCRIPTION
scikits.cuda is now scikit-cuda and the namespace containing the fft methods has changed to skcuda.fft (https://github.com/lebedov/scikit-cuda).  These patches bring pycbc up to date.  I have confirmed this works with a fresh build on spice-dev5.