### PR TITLE
Test threads

### DIFF
--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -134,12 +134,12 @@ class CPUScheme(Scheme):
         Scheme.__enter__(self)
         os.environ["OMP_NUM_THREADS"] = str(self.num_threads)
         if _libgomp is not None:
-            libgomp.omp_set_num_threads( int(self.num_threads) )
+            _libgomp.omp_set_num_threads( int(self.num_threads) )
 
     def __exit__(self, type, value, traceback):
         os.environ["OMP_NUM_THREADS"] = "1"
         if _libgomp is not None:
-            libgomp.omp_set_num_threads(1)
+            _libgomp.omp_set_num_threads(1)
         Scheme.__exit__(self, type, value, traceback)
 
 class MKLScheme(CPUScheme):

--- a/tools/tests/thread_change.py
+++ b/tools/tests/thread_change.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2015 Joshua Willis
+#
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+
+import argparse
+from pycbc import scheme
+from scipy import weave
+
+test_support_code = """
+#include <omp.h>
+#include <stdio.h>
+"""
+
+test_code = """
+  int tid, nthreads;
+
+#pragma omp parallel private(nthreads, tid)
+  {
+   tid = omp_get_thread_num();
+   if (tid == 0){
+     nthreads = omp_get_num_threads();
+     printf("Total number of threads is %d\\n", nthreads);
+    }
+  }
+"""
+
+def print_total_threads():
+    weave.inline(test_code, [], extra_compile_args = ['-fopenmp'],
+                 support_code = test_support_code, libraries = ['gomp'])
+
+parser = argparse.ArgumentParser(usage='',
+    description="Test changing number of threads in pycbc")
+
+scheme.insert_processing_option_group(parser)
+opt = parser.parse_args()
+scheme.verify_processing_options(opt, parser)
+ctx = scheme.from_cli(opt)
+
+print_total_threads()
+
+with ctx:
+    print_total_threads()
+

--- a/tools/tests/thread_change.py
+++ b/tools/tests/thread_change.py
@@ -58,3 +58,7 @@ print_total_threads()
 with ctx:
     print_total_threads()
 
+new_ctx = scheme.CPUScheme(num_threads = 4)
+
+with new_ctx:
+    print_total_threads()


### PR DESCRIPTION
This pull request adds explicit calls to the OpenMP function `omp_set_num_threads()` within the `__enter__` and `__exit__` special methods of `CPUScheme`. It should allow (at least where `libgomp` is present) the toggling of the number of threads multiple times within an executable, and also fix issues where a multithreaded library is loaded before a scheme is entered, causing the number of threads of that scheme instance to be ignored.

It would be nice to find a more portable way to do this, that does not depend on `libgomp` (which is `gcc` specific), but at the moment we also explicitly assume `libgomp` in our weave code also.