### PR TITLE
Fix hang in workflow setup with ER8 data.

### DIFF
--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -270,7 +270,7 @@ def sngl_ifo_job_setup(workflow, ifo, out_files, curr_exe_job, science_segs,
 
             if datafind_outs:
                 curr_dfouts = datafind_outs.find_all_output_in_range(ifo, 
-                                              job_data_seg, useSplitLists=True)
+                                              job_data_seg, useSplitLists=False)
                 if not curr_dfouts:
                     err_str = ("No datafind jobs found overlapping %d to %d."
                                 %(job_data_seg[0],job_data_seg[1]))


### PR DESCRIPTION
Creating an ER8 HDF5 workflow hangs at the matched filter stage for a reason yet to be understood. As a temporary fix, Ian suggested the change in this patch, which does fix the problem.