### PR TITLE
Split sections before filling in substitutions

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -136,6 +136,9 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         # Replace exe macros with full paths
         self.perform_exe_expansion()
 
+        # Split sections like [inspiral&tmplt] into [inspiral] and [tmplt]
+        self.split_multi_sections()
+
         # Check for any substitutions that can be made
         # FIXME: The python 3 version of ConfigParser can do this automatically
         # move over to that if it can be backported to python2.X.
@@ -144,9 +147,6 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         # This is described at
         # http://docs.python.org/3.4/library/configparser.html
         self.perform_extended_interpolation()
-
-        # Split sections like [inspiral&tmplt] into [inspiral] and [tmplt]
-        self.split_multi_sections()
 
         # Check for duplicate options in sub-sections
         self.sanity_check_subsections()


### PR DESCRIPTION
As mentioned in #250 there is a problem if using [inspiral&tmpltbank] and substitution with variables defined within these "&" sections. This fixes this by swapping the order so that we resolve the multiple section check before completing values.