### PR TITLE
Code must import numpy

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_bank_bins
+++ b/bin/hdfcoinc/pycbc_plot_bank_bins
@@ -2,6 +2,7 @@
 """ plot a an hdf bank file based on background binning
 """
 import argparse, h5py, pycbc.events, pycbc.version, pycbc.results, sys
+import numpy
 import matplotlib; matplotlib.use('Agg')
 import pylab
 from itertools import cycle

--- a/bin/hdfcoinc/pycbc_plot_bank_bins
+++ b/bin/hdfcoinc/pycbc_plot_bank_bins
@@ -22,7 +22,7 @@ data = {'mass1':f['mass1'][:], 'mass2':f['mass2'][:],
 if args.background_bins:
     locs_dict = pycbc.events.background_bin_from_string(args.background_bins, data)
 else:
-    locs_dict = {'Template Bank':numpy.arange(0, 1, len(data['mass1']))}
+    locs_dict = {'Template Bank':numpy.arange(0, len(data['mass1']), 1)}
 
 color = cycle(['red', 'green', 'blue', 'purple'])
 


### PR DESCRIPTION
pycbc_plot_bank_bins is missing an import. Given the trivialness of this, and the fact that workflows are broken without it, I will merge this after sanity checks complete. (You can clearly see numpy being used on line 25)