### PR TITLE
Add minifollowups module to pycbc.workflow

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -146,7 +146,6 @@ censored_veto = wf.make_foreground_censored_veto(workflow,
                        final_bg_file, final_veto_file[0], final_veto_name[0],
                        'closed_box', 'segments')      
               
-
 closed_snrifar = []
 for bg_file, bg_bins in (bg_files + final_bg_files):
     for bg_bin in bg_bins:
@@ -163,6 +162,10 @@ for bin_file in bin_files:
     ifar = wf.make_ifar_plot(workflow, bin_file, 
                     rdir['result'], tags=bin_file.tags)
     results_page += [(snrifar, ifar)]
+
+    # run minifollowups for each mass bin
+    mf_results = wf.setup_minifollowups(workflow, rdir, datafind_files,
+                    bin_file, hdfbank[0], 'foreground', tags=bin_file.tags)
 
 wf.make_ifar_plot(workflow, final_bg_file, rdir['result'])
 

--- a/pycbc/workflow/__init__.py
+++ b/pycbc/workflow/__init__.py
@@ -48,6 +48,7 @@ from pycbc.workflow.postprocessing import *
 from pycbc.workflow.analysislogging import *
 from pycbc.workflow.summaryplots import *
 from pycbc.workflow.plotting import *
+from pycbc.workflow.minifollowups import *
 
 # Set the configuration file base directory
 INI_FILE_DIRECTORY = os.path.join(os.path.dirname(__file__), 'ini_files')

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2015 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import logging
+from pycbc.workflow.core import Executable, FileList, Node
+
+def setup_minifollowups(workflow, out_dir, frame_files,
+                             coinc_file, tmpltbank_file, data_type, tags=None):
+    ''' This performs a series of followup jobs on the num_events-th loudest
+    events.
+    '''
+
+    logging.info('Entering minifollowups module')
+
+    if tags == None: tags = []
+
+    # create a FileList that will contain all output files
+    output_filelist = FileList([])
+
+    # check if minifollowups section exists
+    # if not then do not do add hardware injection job to the workflow
+    if not workflow.cp.has_section('workflow-minifollowups'):
+      logging.info('There is no [workflow-minifollowups] section in configuration file')
+      logging.info('Leaving minifollowups')
+      return output_filelist
+
+    # loop over number of loudest events to be followed up
+    num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
+    for num_event in range(num_events):
+
+        # increment by 1 for human readability
+        num_event += 1
+
+        # get output directory for this event
+        tag_str = '_'.join(tags)
+        output_dir = out_dir['result/loudest_event_%d_of_%d_%s'%(num_event, num_events, tag_str)]
+
+        # make a pycbc_mf_table node for this event
+        table_exe = MinifollowupsTableExecutable(workflow.cp, 'mf_table',
+                        workflow.ifo_string, output_dir, tags=tags)
+        table_node = table_exe.create_node(workflow.analysis_time, coinc_file,
+                        tmpltbank_file, data_type, num_event)
+        workflow.add_node(table_node)
+        output_filelist.extend(table_node.output_files)
+
+    logging.info('Leaving minifollowups module')
+
+    return output_filelist
+
+class MinifollowupsTableExecutable(Executable):
+    ''' The class responsible for creating jobs for pycbc_mf_table.'''
+
+    current_retention_level = Executable.FINAL_RESULT
+    def __init__(self, cp, exe_name,
+                 ifo=None, out_dir=None, tags=[], universe=None):
+        super(MinifollowupsTableExecutable, self).__init__(cp, exe_name, universe, ifo, out_dir, tags=tags)
+
+    def create_node(self, segment, coinc_file, tmpltbank_file, data_type, loudest_event_number):
+        ''' Creates a node for the loudest_event_number-th loudest event in the
+        coinc_file. '''
+
+        # make a node
+        node = Node(self)
+
+        # add input files
+        node.add_input_opt('--coinc-file', coinc_file)
+        node.add_input_opt('--tmpltbank-file', tmpltbank_file)
+
+        # add options
+        node.add_opt('--data-type', data_type)
+        node.add_opt('--loudest-event-number', loudest_event_number)
+
+        # add output file
+        node.new_output_file_opt(segment, '.html', '--output-file',
+                                 store_file=self.retain_files)
+
+        return node

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -31,7 +31,7 @@ def setup_minifollowups(workflow, out_dir, frame_files,
     output_filelist = FileList([])
 
     # check if minifollowups section exists
-    # if not then do not do add hardware injection job to the workflow
+    # if not then do not do add minifollowup jobs to the workflow
     if not workflow.cp.has_section('workflow-minifollowups'):
       logging.info('There is no [workflow-minifollowups] section in configuration file')
       logging.info('Leaving minifollowups')


### PR DESCRIPTION
This adds a skeleton module for minifollowups to ``pycbc.workflow``.

Note that the module will not run unless ``[workflow-minifollowups]`` is in the ini file, if it is not, then it will just exit the module and continue with the workflow generation. This section has not been added to the example ini files because there still is more work to do.

I provide an example of how to add an executable to the module.

https://github.com/ligo-cbc/pycbc/compare/ligo-cbc:master...cmbiwer:mf_pr?expand=1#diff-6d5d67ddd622a3b42cb10c895f203f90R62 - Create a class for creating nodes for the executable

https://github.com/ligo-cbc/pycbc/compare/ligo-cbc:master...cmbiwer:mf_pr?expand=1#diff-6d5d67ddd622a3b42cb10c895f203f90R50 - Then create an instance and create a node for the n-th loudest job.

At the end you should get a page under the Results section that looks like: https://sugar-jobs.phy.syr.edu/~cbiwer/pycbc_test_workflow/mf_test//7._result/7.1_loudest_event_1_of_10/

TJ - It looks like you have a executable that creates a separate file for all the follow ups. If that's the case, then the loop can be deleted and you just need to add that executable in as well.