### PR TITLE
Remove hardcoded table of veto segment names and add missing executable to example ini file

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -227,9 +227,7 @@ seg_summ_names    = ['DATA', 'ANALYZABLE_DATA', 'TRIGGERS_PRODUCED']
 seg_summ_seglists = [data_segs, science_segs, insp_segs]
 
 # declare comparasion segments for table on summary page
-veto_summ_names = ['TRIGGERS_PRODUCED&CUMULATIVE_CAT_1H',
-                   'TRIGGERS_PRODUCED&CUMULATIVE_CAT_12H',
-                   'TRIGGERS_PRODUCED&CUMULATIVE_CAT_123H']
+veto_summ_names = ['TRIGGERS_PRODUCED&'+veto_name for veto_name in veto_names+final_veto_name]
 
 # write segment summary XML file
 seg_list = []; names = []; ifos = []

--- a/pycbc/workflow/ini_files/example_hdf_bns.ini
+++ b/pycbc/workflow/ini_files/example_hdf_bns.ini
@@ -92,7 +92,7 @@ plot_spectrum = ${which:pycbc_plot_psd_file}
 plot_hist = ${which:pycbc_plot_hist}
 foreground_censor = ${which:pycbc_foreground_censor}
 page_ifar = ${which:pycbc_page_ifar}
-
+plot_bank = ${which:pycbc_plot_bank_bins}
 
 [llwadd]
 [datafind]
@@ -440,3 +440,4 @@ output-path=../../html
 analysis-title="PyCBC Coincident Analysis"
 analysis-subtitle="Alex Nitz"
 
+[plot_bank]


### PR DESCRIPTION
This PR removes a list that has the veto segment names hardcoded. And it adds a missing executable to the example ini file.