### PR TITLE
Changes to make data_checker example work in ER8

### DIFF
--- a/examples/workflow/data_checker/daily_er8.ini
+++ b/examples/workflow/data_checker/daily_er8.ini
@@ -1,0 +1,74 @@
+; PLEASE NOTE, SECTION NAMES AND OPTIONS SHOULD BE BLOCK LOWER CASE
+
+[workflow]
+;pregenerated-template-bank=/home/spxiwh/aLIGO/ahope_devel/testing/bank.xml.gz
+h1-channel-name = H1:GDS-CALIB-STRAIN
+l1-channel-name = L1:GDS-CALIB_STRAIN
+v1-channel-name = V1:FAKE_h_16384Hz_4R
+
+[workflow-ifos]
+h1 =
+l1 =
+;v1 =
+
+[workflow-datafind]
+; See https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/datafind.html
+datafind-method = AT_RUNTIME_SINGLE_CACHES
+datafind-h1-frame-type = H1_HOFT_C00
+datafind-l1-frame-type = L1_HOFT_C00
+datafind-v1-frame-type = V1Online
+datafind-check-segment-gaps = update_times
+datafind-check-frames-exist = no_test
+; Set this to sepcify the datafind server. If this is not set the code will
+; use the value in ${LIGO_DATAFIND_SERVER}
+;datafind-ligo-datafind-server = ""
+
+[workflow-datafind-syr]
+datafind-check-segment-summary = warn
+datafind-ligo-datafind-server = ldr.phy.syr.edu:443
+
+[workflow-datafind-cit]
+datafind-check-segment-summary = no_test
+datafind-ligo-datafind-server = ldr.ligo.caltech.edu:443
+
+[workflow-datafind-llo]
+datafind-check-segment-summary = no_test
+datafind-ligo-datafind-server = ldr.ligo-la.caltech.edu:443
+
+[workflow-datafind-lho]
+datafind-check-segment-summary = no_test
+datafind-ligo-datafind-server = ldr.ligo-wa.caltech.edu:443
+
+[workflow-datafind-uwm]
+datafind-check-segment-summary = no_test
+datafind-ligo-datafind-server = nemo-dataserver1.cgca.uwm.edu:443
+
+[workflow-datafind-aei]
+datafind-check-segment-summary = no_test
+datafind-ligo-datafind-server = ldr.aei.uni-hannover.de:443
+
+[workflow-segments]
+; See https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/segments.html
+segments-method = AT_RUNTIME
+segments-h1-science-name = H1:DMT-ANALYSIS_READY:1
+segments-l1-science-name = L1:DMT-ANALYSIS_READY:1
+segments-v1-science-name = V1:ITF_SCIENCEMODE:1
+segments-database-url = https://segments.ligo.org
+; NOTE: This veto definer does not need "fake vetoes" like ihope does
+segments-veto-definer-url = file:///home/spxiwh/lscsoft_git/src/pycbc_2/pycbc/examples/workflow/data_checker/H1L1V1-ER8_CBC_OFFLINE.xml
+; USE THIS TO TURN OFF CAT_1 MISSING DATA
+;segments-veto-definer-url = https://www.lsc-group.phys.uwm.edu/ligovirgo/cbc/public/segments/ER5/H1L1V1-ER5_CBC_OFFLINE-1073779216-0.xml
+segments-veto-categories = 1
+segments-minimum-segment-length = 0
+; And not doing
+; segments-generate-coincident-segments =
+
+[executables]
+; setup of condor universe and location of executables
+segment_query = ${which:ligolw_segment_query_dqsegdb}
+segments_from_cats = ${which:ligolw_segments_from_cats_dqsegdb}
+llwadd = ${which:ligolw_add}
+ligolw_combine_segments = ${which:ligolw_combine_segments}
+
+[datafind]
+urltype=file

--- a/examples/workflow/data_checker/daily_test.py
+++ b/examples/workflow/data_checker/daily_test.py
@@ -36,6 +36,7 @@ import pycbc.workflow as _workflow
 
 logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s', \
                     level=logging.INFO,datefmt='%I:%M:%S')
+logger = logging.getLogger()
 
 # command line options
 _desc = __doc__[1:]
@@ -79,11 +80,15 @@ scienceSegs, segsList = _workflow.setup_segment_generation(workflow, segDir)
 
 segment_report(scienceSegs)
 
-print
+print "STARTING DF"
 print
 
 # Start with SYR comparison
-scienceSegsS = copy.deepcopy(scienceSegs)
+# FIXME: Used to use deecopy here, but now that seems to fail so repeating
+#        segment query calls with logging off. This may be slow!
+logger.disabled = True
+scienceSegsS, _ = _workflow.setup_segment_generation(workflow, segDir)
+logger.disabled = False
 print "RUNNING DATAFIND FOR SYR"
 datafinds, scienceSegsS = _workflow.setup_datafind_workflow(workflow, scienceSegsS,
                      dfDirSYR, segsList, tag="SYR")
@@ -93,7 +98,9 @@ segment_report(scienceSegsS)
 print 
 print
 print "RUNNING DATAFIND FOR CIT"
-scienceSegsC = copy.deepcopy(scienceSegs)
+logger.disabled = True
+scienceSegsC, _ = _workflow.setup_segment_generation(workflow, segDir)
+logger.disabled = False
 datafinds, scienceSegsC = _workflow.setup_datafind_workflow(workflow, scienceSegsC,
                        dfDirCIT, segsList, tag="CIT")
 
@@ -122,7 +129,9 @@ for ifo in scienceSegsC.keys():
 
 print
 print "RUNNING DATAFIND FOR LHO"
-scienceSegsS = copy.deepcopy(scienceSegs)
+logger.disabled = True
+scienceSegsS, _ = _workflow.setup_segment_generation(workflow, segDir)
+logger.disabled = False
 datafinds, scienceSegsS = _workflow.setup_datafind_workflow(workflow, scienceSegsS,
                        dfDirLHO, segsList, tag="LHO")
 
@@ -151,7 +160,9 @@ for ifo in scienceSegsC.keys():
 
 print
 print "RUNNING DATAFIND FOR LLO"
-scienceSegsS = copy.deepcopy(scienceSegs)
+logger.disabled = True
+scienceSegsS, _ = _workflow.setup_segment_generation(workflow, segDir)
+logger.disabled = False
 datafinds, scienceSegsS = _workflow.setup_datafind_workflow(workflow, scienceSegsS,
                        dfDirLLO, segsList, tag="LLO")
 
@@ -180,7 +191,9 @@ for ifo in scienceSegsC.keys():
 
 print
 print "RUNNING DATAFIND FOR UWM"
-scienceSegsS = copy.deepcopy(scienceSegs)
+logger.disabled = True
+scienceSegsS, _ = _workflow.setup_segment_generation(workflow, segDir)
+logger.disabled = False
 datafinds, scienceSegsS = _workflow.setup_datafind_workflow(workflow, scienceSegsS,
                        dfDirUWM, segsList, tag="UWM")
 

--- a/examples/workflow/data_checker/run_daily_test.sh
+++ b/examples/workflow/data_checker/run_daily_test.sh
@@ -1,1 +1,1 @@
-./daily_test.py --local-config-files daily_er6.ini --config-overrides workflow:start-time:1102435216 workflow:end-time:1102863616
+./daily_test.py --local-config-files daily_er8.ini --config-overrides workflow:start-time:1125511217 workflow:end-time:1125800952


### PR DESCRIPTION
This updates the data_checker example so that it can run on ER8 data (also adding an ER8 ini file).

Currently this points to a local veto-definer file, but I can update this once the ER8 veto definer is up and running.

Most of the changes to the script itself are needed because it seems I can no longer copy the segment list returned by the segment generation function.