### PR TITLE
Fix an edge-case bug in jobsetup.py

### DIFF
--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -424,6 +424,10 @@ class JobSegmenter(object):
         elif compatibility_mode:
             # What is the incremental shift between jobs
             self.job_time_shift = self.valid_length
+        elif self.curr_seg_length == self.data_length:
+            # If the segment length is identical to the data length then I
+            # will have exactly 1 job!
+            self.job_time_shift = 0
         else:
             # What is the incremental shift between jobs
             self.job_time_shift = (self.curr_seg_length - self.data_length) / \


### PR DESCRIPTION
There is an edge-case bug in jobsetup.py that will cause the setup code to fail if the length of a data segment is exactly equal to the data that the job wants to read in. In this particular ER8 example there is a 2064 second long data stretch raising this failure. This causes a divide-by-zero error at line 429, which can be avoided by catching this special case and setting the job_time_shift (which will never be used as there is only one job for this segment) to 0.