### PR TITLE
Script to pyinstall all programs, some restrictions on what gets bundled

### DIFF
--- a/tools/static/build_static_executables.sh
+++ b/tools/static/build_static_executables.sh
@@ -6,20 +6,19 @@ then
 	exit 1
 fi
 
-for prog in `find ../../bin -type f`
+for prog in `find ../../bin -type f | grep inspiral`
 do
 	# don't try to pyinstall shell scripts
 	if `head -1 ${prog} | grep -q python`
 	then 
 		exename=`basename ${prog}`
-		target=${exename}_static
 
 		# don't rebuild if the executable is already
 		# present
-		if [ ! -e dist/${target} ]
+		if [ ! -e dist/${exename} ]
 		then
 			# remove any cached information
-			rm -rf ${target}.spec build/${target}
+			rm -rf ${exename}.spec build/${exename}
 
 			# This will be used by hooks/hook-pycbc.py to
 			# determine what needs to be included
@@ -28,7 +27,7 @@ do
 			pyinstaller ${prog} \
 			  --additional-hooks-dir ./hooks/ \
 			  --runtime-hook runtime-scipy.py \
-			  --name ${target} \
+			  --name ${exename} \
 			  --strip \
 			  --onefile
 		fi

--- a/tools/static/build_static_executables.sh
+++ b/tools/static/build_static_executables.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [ ! -e ../../bin/pycbc_inspiral ]
+then
+	echo "Please run this script from the tools/static directory of your source installation"
+	exit 1
+fi
+
+for prog in `find ../../bin -type f`
+do
+	# don't try to pyinstall shell scripts
+	if `head -1 ${prog} | grep -q python`
+	then 
+		exename=`basename ${prog}`
+		target=${exename}_static
+
+		# don't rebuild if the executable is already
+		# present
+		if [ ! -e dist/${target} ]
+		then
+			# remove any cached information
+			rm -rf ${target}.spec build/${target}
+
+			# This will be used by hooks/hook-pycbc.py to
+			# determine what needs to be included
+			export NOW_BUILDING=${exename}
+
+			pyinstaller ${prog} \
+			  --additional-hooks-dir ./hooks/ \
+			  --runtime-hook runtime-scipy.py \
+			  --name ${target} \
+			  --strip \
+			  --onefile
+		fi
+	fi
+done
+

--- a/tools/static/hooks/hook-pycbc.py
+++ b/tools/static/hooks/hook-pycbc.py
@@ -56,12 +56,17 @@ hiddenimports = ['pycbc.fft.fft_cpu',
 datas = [] 
 
 if os.environ["NOW_BUILDING"] == 'pycbc_make_html_page':
-    for root, subdirs, files in os.walk('/home/lppekows/pycbc-dev/src/pycbc/pycbc/results'):
+    cwd     = os.getcwd()
+    basedir = cwd.replace('tools/static','')
+    rootdir = basedir + 'pycbc/results'
+
+    for root, subdirs, files in os.walk(rootdir):
         for filename in files:
             if not filename.endswith('.py') and not filename.endswith('.pyc'):
                 file_path  = os.path.join(root, filename)
                 store_path = '/'.join(file_path.split('/')[:-1])
-                store_path = store_path.replace('/home/lppekows/pycbc-dev/src/pycbc/','')
+                store_path = store_path.replace(basedir, '')
+                print (file_path, store_path)
                 datas.append( (file_path, store_path) )
 
 if os.environ["NOW_BUILDING"] == 'pycbc_inspiral':

--- a/tools/static/hooks/hook-pycbc.py
+++ b/tools/static/hooks/hook-pycbc.py
@@ -44,19 +44,37 @@ hiddenimports = ['pycbc.fft.fft_cpu',
                  'pycbc.fft.npfft',
                  'pycbc.fft.__init__',
                  'pycbc.events.threshold_cpu',
+                 'scipy.linalg.cython_blas',
+                 'scipy.linalg.cython_lapack',
+                 'scipy.special._ufuncs_cxx',
+                 'h5py',
+                 'h5py._conv',
+                 'h5py._stub',
+                 'mpld3'
                  ]
-datas = []
 
-# pull in all the mkl .so files
-#datas += find_lib_path('mkl_rt', [])
-#datas += find_lib_path('mkl_core', [])
-#datas += find_lib_path('mkl_intel_thread', [])
-#datas += find_lib_path('mkl_intel_lp64', [])
-#datas += find_lib_path('mkl_avx2', [])
-#datas += find_lib_path('mkl_def', [])
+datas = [] 
+
+if os.environ["NOW_BUILDING"] == 'pycbc_make_html_page':
+    for root, subdirs, files in os.walk('/home/lppekows/pycbc-dev/src/pycbc/pycbc/results'):
+        for filename in files:
+            if not filename.endswith('.py') and not filename.endswith('.pyc'):
+                file_path  = os.path.join(root, filename)
+                store_path = '/'.join(file_path.split('/')[:-1])
+                store_path = store_path.replace('/home/lppekows/pycbc-dev/src/pycbc/','')
+                datas.append( (file_path, store_path) )
+
+if os.environ["NOW_BUILDING"] == 'pycbc_inspiral':
+    # pull in all the mkl .so files
+    datas += find_lib_path('mkl_rt', [])
+    datas += find_lib_path('mkl_core', [])
+    datas += find_lib_path('mkl_intel_thread', [])
+    datas += find_lib_path('mkl_intel_lp64', [])
+    datas += find_lib_path('mkl_avx2', [])
+    datas += find_lib_path('mkl_def', [])
 
 # try to pull in the openmp fftw files
-datas += find_lib_path('fftw3', ['fftw3'])
-datas += find_lib_path('fftw3f', ['fft3f'])
-datas += find_lib_path('fftw3f_omp', ['fftw3f'])
-datas += find_lib_path('fftw3_omp', ['fftw3'])
+#datas += find_lib_path('fftw3', ['fftw3'])
+#datas += find_lib_path('fftw3f', ['fft3f'])
+#datas += find_lib_path('fftw3f_omp', ['fftw3f'])
+#datas += find_lib_path('fftw3_omp', ['fftw3'])


### PR DESCRIPTION
This adds a new script under tools/static to run pyinstaller over all available programs.  In addition hooks/hook-pycbc has been modified to
 * add a few additional hidden dependancies to all programs
 * include mkl for pycbc_inspiral only
 * include the html files and other assets for pycbc_make_html_page

We could probably save a little disk space by customizing the hidden dependancies on a per-executable basis, but at the moment I'm not sure that's worth the effort.