### PR TITLE
fixed spelling of nojeckyll file

### DIFF
--- a/docs/build_gh_pages.rst
+++ b/docs/build_gh_pages.rst
@@ -15,9 +15,9 @@ repository, make a ``gh-pages`` branch in your repository as follows:
     git checkout --orphan gh-pages
     git rm -rf .
     git clean -dxf
-    touch .nojeckyl
+    touch .nojeckyll
     mkdir latest
-    git add .nojeckyl latest
+    git add .nojeckyll latest
     git commit -a -m "set up gh-pages branch"
     git push origin gh-pages
     git branch --set-upstream gh-pages origin/gh-pages


### PR DESCRIPTION
This fixes an error in the documentation for making gh pages.