### PR TITLE
add veto definer table to summary pages

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -252,6 +252,9 @@ seg_summ_plot = wf.make_seg_plot(workflow, [seg_summ_file],
                         rdir['analysis_time/segments'],
                         seg_summ_names, ['SUMMARY'])
 
+# make veto definer table
+vetodef_table = wf.make_veto_table(workflow, rdir['analysis_time/veto_definer'])
+
 ############################## Setup the injection runs                                                                           
 inj_coincs = wf.FileList()
 for inj_file, tag in zip(inj_files, inj_tags):

--- a/bin/hdfcoinc/pycbc_page_vetotable
+++ b/bin/hdfcoinc/pycbc_page_vetotable
@@ -1,0 +1,109 @@
+#!/usr/bin/python
+
+# Copyright (C) 2015 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import argparse
+import h5py
+import logging
+import numpy
+import pycbc.results
+import sys
+from glue import segments
+from glue.ligolw import ligolw
+from glue.ligolw import lsctables
+from glue.ligolw import table
+from glue.ligolw import utils
+from pycbc.events.veto import get_segment_definer_comments
+from pycbc.results import save_fig_with_metadata
+from pycbc.workflow import fromsegmentxml
+
+class DefaultContentHandler(lsctables.ligolw.LIGOLWContentHandler):
+    pass
+lsctables.use_in(DefaultContentHandler)
+
+# usage
+parser = argparse.ArgumentParser(usage='pycbc_page_vetotable [--options]',
+             description="Writes veto_definer table contents to HTML table."
+)
+
+# add command line options
+parser.add_argument('--veto-definer-file', type=str,
+                        help='XML files with a veto_definer table to read.')
+parser.add_argument('--output-file', type=str,
+                        help='Path of the output HTML file.')
+
+# parse command line
+opts = parser.parse_args()
+
+# setup log
+logging.basicConfig(format='%(asctime)s:%(levelname)s, %(message)s',
+                    level=logging.INFO,datefmt='%I:%M:%S')
+
+# set column names
+columns = (('Category', []),
+           ('IFO', []),
+           ('Name', []),
+           ('Version', []),
+           ('Start Padding (s)', []),
+           ('End Padding (s)', []),
+           ('Start Time', []),
+           ('End Time', []),
+           ('Comment', []),
+)
+
+# set caption name
+caption = "This table shows each veto in the veto definer table."
+
+# read input file
+logging.info('Reading veto definer XML file')
+vetodef_xml = utils.load_filename(opts.veto_definer_file,
+                                   contenthandler=DefaultContentHandler)
+
+# get veto_definer table
+vetodef_table = table.get_table(vetodef_xml,
+                             lsctables.VetoDefTable.tableName)
+
+# loop over rows in veto_definer table
+logging.info('Looping through veto_definer table and saving information')
+for vetodef in vetodef_table:
+
+    # put values into columns
+    columns[0][1].append(vetodef.category)
+    columns[1][1].append(str(vetodef.ifo))
+    columns[2][1].append(str(vetodef.name))
+    columns[3][1].append(vetodef.version)
+    columns[4][1].append(vetodef.start_pad)
+    columns[5][1].append(vetodef.end_pad)
+    columns[6][1].append(vetodef.start_time)
+    columns[7][1].append(vetodef.end_time)
+    columns[8][1].append(str(vetodef.comment))
+
+# cast columns into arrays
+keys = [numpy.array(key, dtype=type(key[0])) for key,_ in columns]
+vals = [numpy.array(val, dtype=type(val[0])) for _,val in columns]
+
+# write HTML table
+logging.info('Writing HTML table')
+fig_kwds = {}
+html_table = pycbc.results.table(vals, keys, page_size=25)
+save_fig_with_metadata(str(html_table), opts.output_file,
+                     fig_kwds=fig_kwds,
+                     title='Veto Definer Table',
+                     cmd=' '.join(sys.argv),
+                     caption=caption)
+
+logging.info('Done.')

--- a/pycbc/workflow/ini_files/example_hdf_bns.ini
+++ b/pycbc/workflow/ini_files/example_hdf_bns.ini
@@ -92,7 +92,8 @@ plot_spectrum = ${which:pycbc_plot_psd_file}
 plot_hist = ${which:pycbc_plot_hist}
 foreground_censor = ${which:pycbc_foreground_censor}
 page_ifar = ${which:pycbc_page_ifar}
-plot_bank = ${which:pycbc_plot_bank_bins}
+plot_bank = ${which:pycbc_plot_bank_bins} 
+page_vetotable = ${which:pycbc_page_vetotable}
 
 [llwadd]
 [datafind]
@@ -138,7 +139,7 @@ approximant = SPAtmplt
 order = 7
 cluster-method = window
 cluster-window = 1.0
-processing-scheme = mkl
+processing-scheme = cpu
 ;keep-loudest-interval = 2
 ;keep-loudest-num = 100
 

--- a/pycbc/workflow/ini_files/example_hdf_bns.ini
+++ b/pycbc/workflow/ini_files/example_hdf_bns.ini
@@ -139,7 +139,7 @@ approximant = SPAtmplt
 order = 7
 cluster-method = window
 cluster-window = 1.0
-processing-scheme = cpu
+processing-scheme = mkl
 ;keep-loudest-interval = 2
 ;keep-loudest-num = 100
 

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -161,6 +161,22 @@ def make_seg_table(workflow, seg_files, seg_names, out_dir, tags=None):
     workflow += node
     return node.output_files[0]
 
+def make_veto_table(workflow, out_dir, vetodef_file=None, tags=None):
+    """ Creates a node in the workflow for writing the veto_definer
+    table. Returns a File instances for the output file.
+    """
+    if vetodef_file is None:
+        vetodef_file = workflow.cp.get_opt_tags("workflow-segments",
+                                           "segments-veto-definer-file", [])
+    if tags is None: tags = []
+    makedir(out_dir)
+    node = PlotExecutable(workflow.cp, 'page_vetotable', ifos=workflow.ifos,
+                    out_dir=out_dir, tags=tags).create_node()
+    node.add_opt('--veto-definer-file', vetodef_file)
+    node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
+    workflow += node
+    return node.output_files[0]
+
 def make_seg_plot(workflow, seg_files, out_dir, seg_names=None, tags=None):
     """ Creates a node in the workflow for plotting science, and veto segments.
     """

--- a/setup.py
+++ b/setup.py
@@ -407,6 +407,7 @@ setup (
                'bin/hdfcoinc/pycbc_page_segments',
                'bin/hdfcoinc/pycbc_page_segtable',
                'bin/hdfcoinc/pycbc_page_segplot',
+               'bin/hdfcoinc/pycbc_page_vetotable',
                'bin/hdfcoinc/pycbc_plot_psd_file',
                'bin/hdfcoinc/pycbc_plot_range',
                'bin/hdfcoinc/pycbc_foreground_censor',


### PR DESCRIPTION
This PR adds the veto definer table to the summary pages. See for example: https://sugar-jobs.phy.syr.edu/~cbiwer/pycbc_test_workflow/mf_test/1._analysis_time/1.2_veto_definer/