### PR TITLE
Allow the location of the top-level template to be relative

### DIFF
--- a/bin/pycbc_make_html_page
+++ b/bin/pycbc_make_html_page
@@ -178,8 +178,14 @@ opts = parser.parse_args()
 # edit command line options
 analysis_title = opts.analysis_title.strip('"').rstrip('"')
 analysis_subtitle = opts.analysis_subtitle.strip('"').rstrip('"')
-input_template = opts.template_file.split('/')[-1]
-input_path = opts.template_file.rstrip(input_template)
+
+if opts.template_file[0] != '/':
+    full_template_path = pycbc.results.__path__[0] + '/' + opts.template_file
+else:
+    full_template_path = opts.template_file
+
+input_template = full_template_path.split('/')[-1]
+input_path = full_template_path.rstrip(input_template)
 
 # setup template
 env = Environment(loader=FileSystemLoader(input_path))

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -259,7 +259,7 @@ def make_snrifar_plot(workflow, bg_file, out_dir, closed_box=False, tags=[]):
     
 def make_results_web_page(workflow, results_dir):
     import pycbc.results
-    template_path =  pycbc.results.__path__[0] + '/templates/orange.html'
+    template_path = 'templates/orange.html'
 
     out_dir = workflow.cp.get('results_page', 'output-path')
     makedir(out_dir)

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -258,7 +258,6 @@ def make_snrifar_plot(workflow, bg_file, out_dir, closed_box=False, tags=[]):
     return node.output_files[0]
     
 def make_results_web_page(workflow, results_dir):
-    import pycbc.results
     template_path = 'templates/orange.html'
 
     out_dir = workflow.cp.get('results_page', 'output-path')


### PR DESCRIPTION
This allows the location of the top-level template in pycbc_make_html_page to be specified relative to the installation directory, as with the other assets.  If a full path is provided it will be used, otherwise the template will be found under pycbc.results.__path__.  In addition this changes the workflow generator to pass a relative location.

I have confirmed that with these changes it is possible to run a full workflow with executables built by pyinstaller.