### PR TITLE
Improve coincident SNR/chi^2 and sensitivity plots

### DIFF
--- a/bin/hdfcoinc/pycbc_page_coinc_snrchi
+++ b/bin/hdfcoinc/pycbc_page_coinc_snrchi
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+
+import sys
 import numpy, h5py, argparse, matplotlib
 from matplotlib import colors
 matplotlib.use('Agg')
@@ -15,27 +17,32 @@ def snr_from_chisq(chisq, newsnr, q=6.):
 eff_map = {'H1':'eff_dist_h', 'L1':'eff_dist_l', 'V1':'eff_dist_v'} 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--found-injection-file', help='HDF format found injection file')
-parser.add_argument('--single-injection-file', help='Single detector trigger files from the injection set. One per ifos')
-parser.add_argument('--coinc-statistic-file', help='HDF format statistic file')
-parser.add_argument('--single-trigger-file', help='Single detector triggers files from the zero lag run')
-parser.add_argument('--newsnr-contours', nargs='*', help="List of newsnr values to draw contours at.", default=[])
+parser.add_argument('--found-injection-file', required=True,
+                    help='HDF format found injection file')
+parser.add_argument('--single-injection-file', required=True,
+                    help='Single detector trigger files from the injection set. One per ifos')
+parser.add_argument('--coinc-statistic-file', required=True,
+                    help='HDF format statistic file')
+parser.add_argument('--single-trigger-file', required=True,
+                    help='Single detector triggers files from the zero lag run')
+parser.add_argument('--newsnr-contours', nargs='*', default=[],
+                    help="List of newsnr values to draw contours at.")
 parser.add_argument('--background-front', action='store_true', default=False)
 parser.add_argument('--chisq-choice', choices=chisq_choices,
                     default='traditional',
                     help='Which chisquared to plot. Default=traditional')
-parser.add_argument('--output-file')
+parser.add_argument('--output-file', required=True)
 args = parser.parse_args()
 
 import mpld3
 
 # Add the background triggers
-f = h5py.File(args.coinc_statistic_file)
+f = h5py.File(args.coinc_statistic_file, 'r')
 b_tids = {}
 b_tids[f.attrs['detector_1']] = f['background/trigger_id1']
 b_tids[f.attrs['detector_2']] = f['background/trigger_id2']
 
-f = h5py.File(args.single_trigger_file)
+f = h5py.File(args.single_trigger_file, 'r')
 ifo = f.keys()[0]
 f = f[ifo]
 tid = b_tids[ifo][:]
@@ -45,11 +52,11 @@ bkg_chisq = get_chisq_from_file_choice(f, args.chisq_choice)[tid]
 
 fig = pylab.figure()
 pylab.scatter(bkg_snr, bkg_chisq, marker='o', color='black',
-              linewidth=0, s=2.0, label='background', 
+              linewidth=0, s=2.0, label='Background', 
               zorder=args.background_front)
 
 # Add the found injection points
-f = h5py.File(args.found_injection_file)
+f = h5py.File(args.found_injection_file, 'r')
 inj_tids = {}
 inj_tids[f.attrs['detector_1']] = f['found_after_vetoes/trigger_id1']
 inj_tids[f.attrs['detector_2']] = f['found_after_vetoes/trigger_id2']
@@ -57,7 +64,7 @@ inj_tids[f.attrs['detector_2']] = f['found_after_vetoes/trigger_id2']
 inj_idx = f['found_after_vetoes/injection_index'][:]
 eff_dist = f['injections'][eff_map[ifo]][:][inj_idx]
 
-f = h5py.File(args.single_injection_file)[ifo]
+f = h5py.File(args.single_injection_file, 'r')[ifo]
 tid = inj_tids[ifo][:]
 if len(tid):
     inj_snr = f['snr'][:][tid]
@@ -105,6 +112,14 @@ except ValueError:
 pylab.legend(loc='lower right', prop={'size': 12})
 pylab.grid(which='major', ls='solid', alpha=0.7, linewidth=.5)
 pylab.grid(which='minor', ls='solid', alpha=0.7, linewidth=.1)
-pycbc.results.save_fig_with_metadata(fig, args.output_file, 
-                                     title='%s %s chisq vs SNR. Background with injections %s' % (ifo.upper(), args.chisq_choice, 'behind' if args.background_front else 'ontop'), 
-                                     caption='')
+
+title = '%s %s chisq vs SNR. Background with injections %s' \
+        % (ifo.upper(), args.chisq_choice,
+           'behind' if args.background_front else 'ontop')
+caption = """Distribution of SNR and %s chi-squared veto for single detector
+triggers. Black points are background triggers. Triangles are injection
+triggers colored by the effective distance of the injection. Dashed lines show
+contours of constant NewSNR.""" % args.chisq_choice
+pycbc.results.save_fig_with_metadata(fig, args.output_file, title=title, 
+                                     caption=caption, cmd=' '.join(sys.argv),
+                                     fig_kwds={'dpi':300})

--- a/bin/hdfcoinc/pycbc_page_sensitivity
+++ b/bin/hdfcoinc/pycbc_page_sensitivity
@@ -16,9 +16,7 @@ parser.add_argument('--output-file', required=True) # DOCUMENTME
 parser.add_argument('--bin-type', choices=['spin', 'mchirp',
                                            'total_mass', 'eta'],
                     default='mchirp',
-                    help="Parameter used to bin injections. Note that 'spin' "
-                         "uses the line-of-sight coordinate convention! "
-                         "Default 'mchirp'")
+                    help="Parameter used to bin injections. Default 'mchirp'")
 # FIXME: Make bins options properly optional, if no bins are specified then
 # plot everything together
 parser.add_argument('--bins', nargs='+',
@@ -58,6 +56,11 @@ parser.add_argument('--min-param', type=float,
                     help="Minimum value of Dlim, used by 'mc' method with log "
                          "distribution. If not given, min injected value will "
                          "be used")
+parser.add_argument('--spin-frame', choices=['line-of-sight', 'orbit'],
+                    default='orbit', help='Frame convention used by injections '
+                    'for specifying spin vectors. LAL versions after summer '
+                    '2015 should use the orbit convention, which is the '
+                    'default choice here.')
 
 args = parser.parse_args()
 
@@ -99,16 +102,18 @@ values['mchirp'] = mchirp
 values['eta'] = eta
 values['total_mass'] = m1 + m2
 
-#FIXME, this is only correct for SpinTaylor Convention!!!!!
-s1 = s1x * numpy.sin(inc) + s1z * numpy.cos(inc)
-s2 = s2x * numpy.sin(inc) + s2z * numpy.cos(inc)
+if args.spin_frame == 'line-of-sight':
+    s1 = s1x * numpy.sin(inc) + s1z * numpy.cos(inc)
+    s2 = s2x * numpy.sin(inc) + s2z * numpy.cos(inc)
+elif args.spin_frame == 'orbit':
+    s1, s2 = s1z, s2z
 values['spin'] = (m1 * s1 + m2 * s2) / (m1 + m2)
 
 # Legend labels for the binning
 labels = {}
-labels['mchirp'] = "$ M_{chirp} \in [%5.2f, %5.2f] M_\odot $"
-labels['total_mass'] = "$ M_{total} \in [%5.2f, %5.2f] M_\odot $"
-labels['spin'] = "$Eff Spin \in [%5.2f, %5.2f] $"
+labels['mchirp'] = "$ M_{\\rm chirp} \in [%5.2f, %5.2f] M_\odot $"
+labels['total_mass'] = "$ M_{\\rm total} \in [%5.2f, %5.2f] M_\odot $"
+labels['spin'] = "$\\chi^{\\parallel}_{\\rm eff} \in [%5.2f, %5.2f] $"
 
 ylabel = xlabel = ""
 


### PR DESCRIPTION
In pycbc_page_sensitivity, default to the current LALSimulation spin
convention, but let the user change it. In pycbc_page_coinc_snrchi,
fill in the caption and command line in figure metadata. Minor fixes
to the same scripts are also included.