### PR TITLE
Add optional sample_rate arg to psd.from_cli function

### DIFF
--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -70,6 +70,28 @@ def _empty_row(obj):
 
     return row
 
+def pad_timeseries_to_integer_length(timeseries, sample_rate):
+    ''' This function zero pads a time series so that its length is an integer
+    multiple of the sampling rate.
+
+    Padding is adding symmetically to the start and end of the time series.
+    If the number of samples to pad is odd then the end zero padding will have
+    one more sample than the start zero padding.
+    '''
+
+    # calculate how many sample points needed to pad to get integer second time series
+    remainder = sample_rate - len(timeseries) % sample_rate
+    start_pad = int(remainder / 2)
+    end_pad = int(remainder - start_pad)
+
+    # make arrays of zeroes
+    start_array = numpy.zeros(start_pad)
+    end_array = numpy.zeros(end_pad)
+
+    # pad waveform with arrays of zeroes
+    initial_array = numpy.concatenate([start_array,timeseries,end_array])
+    return TimeSeries(initial_array, delta_t=timeseries.delta_t, epoch=timeseries.start_time, dtype=timeseries.dtype)
+
 # map order integer to a string that can be parsed by lalsimulation
 pn_orders = {
     'default'          : -1,
@@ -251,20 +273,9 @@ h_plus, h_cross = get_td_waveform(approximant=opts.approximant,
                     distance=distance,
                     f_lower=opts.low_frequency_cutoff)
 
-# calculate how many sample points needed to pad to get integer second time series
-remainder = opts.sample_rate - len(h_plus) % opts.sample_rate
-start_pad = int(remainder / 2)
-end_pad = int(remainder - start_pad)
-
-# make arrays of zeroes
-start_array = numpy.zeros(start_pad)
-end_array = numpy.zeros(end_pad)
-
-# pad waveform with arrays of zeroes
-initial_array = numpy.concatenate([start_array,h_plus,end_array])
-h_plus = TimeSeries(initial_array, delta_t=h_plus.delta_t, epoch=h_plus.start_time, dtype=h_plus.dtype)
-initial_array = numpy.concatenate([start_array,h_cross,end_array])
-h_cross = TimeSeries(initial_array, delta_t=h_cross.delta_t, epoch=h_cross.start_time, dtype=h_cross.dtype)
+# zero pad polarizations to get integer second time series
+h_plus = pad_timeseries_to_integer_length(h_plus, opts.sample_rate)
+h_cross = pad_timeseries_to_integer_length(h_cross, opts.sample_rate)
 
 # get strain timeseries
 data = _strain.from_cli(opts, DYN_RANGE_FAC)
@@ -327,20 +338,9 @@ h_plus, h_cross = get_td_waveform(approximant=opts.approximant,
                     distance=scale*distance,
                     f_lower=opts.low_frequency_cutoff)
 
-# calculate how many sample points needed to pad to get integer second time series
-remainder = opts.sample_rate - len(h_plus) % opts.sample_rate
-start_pad = int(remainder / 2)
-end_pad = int(remainder - start_pad)
-
-# make arrays of zeroes for padding
-start_array = numpy.zeros(start_pad)
-end_array = numpy.zeros(end_pad)
-
-# pad waveform with arrays of zeroes
-initial_array = numpy.concatenate([start_array,h_plus,end_array])
-h_plus = TimeSeries(initial_array, delta_t=h_plus.delta_t, epoch=h_plus.start_time, dtype=h_plus.dtype)
-initial_array = numpy.concatenate([start_array,h_cross,end_array])
-h_cross = TimeSeries(initial_array, delta_t=h_cross.delta_t, epoch=h_cross.start_time, dtype=h_cross.dtype)
+# zero pad polarizations to get integer second time series
+h_plus = pad_timeseries_to_integer_length(h_plus, opts.sample_rate)
+h_cross = pad_timeseries_to_integer_length(h_cross, opts.sample_rate)
 
 # loop over IFOs to calculate sigma
 for ifo in ifos:
@@ -395,6 +395,7 @@ for ifo in ifos:
 network_snr = numpy.sqrt(network_snr)
 if not abs(opts.network_snr / network_snr) - 1 < 0.1:
     logging.warn('Exiting because network SNR is %f but requested %s', network_snr, opts.network_snr)
+    sys.exit()
 else:
     logging.info('Network SNR of injection is %.3f', network_snr)
 
@@ -430,12 +431,12 @@ for ifo in ifos:
     # set output filename
     txt_filename = ifo + '-' + 'HWINJ_CBC' + '-' + str(start_time) + '-' + str(end_time-start_time) + '.txt'
 
-    # check if filename does not exist
+    # check if filename exists
     if os.path.exists(txt_filename):
         logging.warn('Filename %s already exists and will not be overwritten', txt_filename)
         sys.exit()
 
-    # save waveform as single column ASCII for awgstream to use
+    # save waveform as single-column ASCII for awgstream to use
     logging.info('Writing strain for %s', ifo)
     numpy.savetxt(txt_filename, output)
 

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -251,6 +251,21 @@ h_plus, h_cross = get_td_waveform(approximant=opts.approximant,
                     distance=distance,
                     f_lower=opts.low_frequency_cutoff)
 
+# calculate how many sample points needed to pad to get integer second time series
+remainder = opts.sample_rate - len(h_plus) % opts.sample_rate
+start_pad = int(remainder / 2)
+end_pad = int(remainder - start_pad)
+
+# make arrays of zeroes
+start_array = numpy.zeros(start_pad)
+end_array = numpy.zeros(end_pad)
+
+# pad waveform with arrays of zeroes
+initial_array = numpy.concatenate([start_array,h_plus,end_array])
+h_plus = TimeSeries(initial_array, delta_t=h_plus.delta_t, epoch=h_plus.start_time, dtype=h_plus.dtype)
+initial_array = numpy.concatenate([start_array,h_cross,end_array])
+h_cross = TimeSeries(initial_array, delta_t=h_cross.delta_t, epoch=h_cross.start_time, dtype=h_cross.dtype)
+
 # get strain timeseries
 data = _strain.from_cli(opts, DYN_RANGE_FAC)
 
@@ -258,9 +273,9 @@ data = _strain.from_cli(opts, DYN_RANGE_FAC)
 logging.info('Generating PSD')
 N = len(h_plus)
 n = N/2+1
-delta_f = 1.0 / N / h_plus.delta_t
+delta_f = 1.0 / ( N * h_plus.delta_t )
 psd = _psd.from_cli(opts, n, delta_f, opts.low_frequency_cutoff,
-             strain=data, dyn_range_factor=DYN_RANGE_FAC)
+             strain=data, dyn_range_factor=DYN_RANGE_FAC, precision='double')
 
 # loop over IFOs to calculate sigma
 for ifo in ifos:
@@ -311,6 +326,21 @@ h_plus, h_cross = get_td_waveform(approximant=opts.approximant,
                     delta_t=1.0/opts.sample_rate,
                     distance=scale*distance,
                     f_lower=opts.low_frequency_cutoff)
+
+# calculate how many sample points needed to pad to get integer second time series
+remainder = opts.sample_rate - len(h_plus) % opts.sample_rate
+start_pad = int(remainder / 2)
+end_pad = int(remainder - start_pad)
+
+# make arrays of zeroes for padding
+start_array = numpy.zeros(start_pad)
+end_array = numpy.zeros(end_pad)
+
+# pad waveform with arrays of zeroes
+initial_array = numpy.concatenate([start_array,h_plus,end_array])
+h_plus = TimeSeries(initial_array, delta_t=h_plus.delta_t, epoch=h_plus.start_time, dtype=h_plus.dtype)
+initial_array = numpy.concatenate([start_array,h_cross,end_array])
+h_cross = TimeSeries(initial_array, delta_t=h_cross.delta_t, epoch=h_cross.start_time, dtype=h_cross.dtype)
 
 # loop over IFOs to calculate sigma
 for ifo in ifos:

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -29,7 +29,7 @@ from pycbc import pnutils
 from pycbc import psd as _psd
 from pycbc import strain as _strain
 from pycbc.detector import Detector
-from pycbc.inject import InjectionSet
+from pycbc.inject import InjectionSet, legacy_approximant_name
 from pycbc.filter import make_frequency_series
 from pycbc.filter import sigmasq
 from pycbc.types import Array, FrequencySeries, TimeSeries, zeros
@@ -234,12 +234,14 @@ sim.spin2y = opts.spin2y
 sim.spin2x = opts.spin2x
 sim.polarization = opts.polarization
 sim.taper = opts.taper
+sim.distance = distance
 
 # construct waveform string that can be parsed by lalsimulation
 waveform_string = opts.approximant
 if not pn_orders[opts.order] == -1:
     waveform_string += opts.order
 sim.waveform = waveform_string
+name, phase_order = legacy_approximant_name(sim.waveform)
 
 # create sngl_inspiral table
 sngl_table = lsctables.New(lsctables.SnglInspiralTable,
@@ -262,16 +264,8 @@ sngl.spin2x = opts.spin2x
 
 # generate waveform
 logging.info('Generating waveform at %.3fMpc', distance)
-h_plus, h_cross = get_td_waveform(approximant=opts.approximant,
-                    order=pn_orders[opts.order],
-                    mass1=opts.mass1,
-                    mass2=opts.mass2,
-                    spin1z=opts.spin1z, spin1y=opts.spin1y, spin1x=opts.spin1x,
-                    spin2z=opts.spin2z, spin2y=opts.spin2y, spin2x=opts.spin2x,
-                    inclination=opts.inclination,
-                    delta_t=1.0/opts.sample_rate,
-                    distance=distance,
-                    f_lower=opts.low_frequency_cutoff)
+h_plus, h_cross = get_td_waveform(sim, approximant=name, phase_order=phase_order,
+                      delta_t=1.0/opts.sample_rate)
 
 # zero pad polarizations to get integer second time series
 h_plus = pad_timeseries_to_integer_length(h_plus, opts.sample_rate)
@@ -321,22 +315,15 @@ for ifo in ifos:
 # distance scaling factor to get target snr
 network_snr = numpy.sqrt(network_snr)
 scale = network_snr / opts.network_snr
+sim.distance = scale*sim.distance
 
 # reset network SNR
 network_snr = 0.0
 
 # generate waveform
-logging.info('Generating waveform at %.3fMpc', scale*distance)
-h_plus, h_cross = get_td_waveform(approximant=opts.approximant,
-                    order=pn_orders[opts.order],
-                    mass1=opts.mass1,
-                    mass2=opts.mass2,
-                    spin1z=opts.spin1z, spin1y=opts.spin1y, spin1x=opts.spin1x,
-                    spin2z=opts.spin2z, spin2y=opts.spin2y, spin2x=opts.spin2x,
-                    inclination=opts.inclination,
-                    delta_t=1.0/opts.sample_rate,
-                    distance=scale*distance,
-                    f_lower=opts.low_frequency_cutoff)
+logging.info('Generating waveform at %.3fMpc', sim.distance)
+h_plus, h_cross = get_td_waveform(sim, approximant=name, phase_order=phase_order,
+                      delta_t=1.0/opts.sample_rate)
 
 # zero pad polarizations to get integer second time series
 h_plus = pad_timeseries_to_integer_length(h_plus, opts.sample_rate)
@@ -382,7 +369,6 @@ for ifo in ifos:
     eff_distance = 2 * distance 
     eff_distance /= ( 1 + numpy.cos( opts.inclination )**2 )**2 / 4 * f_plus**2 + numpy.cos( opts.inclination )**2 * f_cross**2
     setattr(sim, 'eff_dist_'+ifo[0].lower(), eff_distance)
-    setattr(sim, 'distance', scale*distance)
 
     # populate IFO end time columns
     sngl.end_time = int(end_time)


### PR DESCRIPTION
This PR adds an optional keyword arg to ``psd.from_cli`` called ``sample_rate``. And this PR allows ``pycbc_generate_hwinj`` to use this optional argument.

I received an error ``ValueError: Incorrect choice of segmentation parameters`` and noticed that the ``sample_rate`` var that is calculated is slightly off, eg. it was setting ``sample_rate`` to 16379Hz instead of 16384Hz.

For example:
```
>>> N=4011                                # length of h(t) time series in samples
>>> sample_rate=16384                     # sampling rate of time series
>>> delta_f = 1.0 / ( N ) * sample_rate   # calculate frequency step
>>> ((N/2 +1) -1) * 2 * delta_f           # calculate sampling rate like in psd.from_cli
16379.915233108952
```

I have witnessed this when ``N`` is not an integer multiple of the sampling rate, ie. not our standard ``pycbc_inspiral`` case.

Unless someone else has a better fix. Zero-padding the time series to be an integer multiple of the sampling rate seemed to work as well but gave a division by zero warning.