### PR TITLE
Add ability to bin coincs using SEOBNRv2Peak

### DIFF
--- a/bin/hdfcoinc/pycbc_distribute_background_bins
+++ b/bin/hdfcoinc/pycbc_distribute_background_bins
@@ -8,7 +8,9 @@ parser.add_argument('--coinc-files', nargs='+',
 parser.add_argument('--background-bins', nargs='+',
                     help="Ordered list of mass bin upper boundaries. "
                          "An ordered list of type-boundary pairs, applied sequentially."
-                         "Ex. component-2 total-15 chirp-30")
+                         "Must provide a name (can be anything, this is just for tagging "
+                         "puproses), the parameter to bin on, and the upper-boundary. "
+                         "Ex. name1:component:2 name2:total:15 name3:SEOBNRv2Peak:1000")
 parser.add_argument('--bank-file',
                     help="hdf format template bank file")
 parser.add_argument('--output-files', nargs='+',

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -49,13 +49,16 @@ def background_bin_from_string(background_bins, data):
     used = numpy.array([], dtype=numpy.uint32)
     bins = {}
     for mbin in background_bins:
-        name, bin_type, boundary = tuple(mbin.split('-'))
+        name, bin_type, boundary = tuple(mbin.split(':'))
         if bin_type == 'component':
             locs = numpy.maximum(data['mass1'], data['mass2']) < float(boundary)
         elif bin_type == 'total':
             locs = data['mass1'] + data['mass2'] < float(boundary)
         elif bin_type == 'chirp':
             locs = pycbc.pnutils.mass1_mass2_to_mchirp_eta(data['mass1'], data['mass2'])[0] < float(boundary)
+        elif bin_type == 'SEOBNRv2Peak':
+            locs = pycbc.pnutils.get_freq('fSEOBNRv2Peak', data['mass1'],
+                data['mass2'], data['spin1z'], data['spin2z']) < float(boundary)
         else:
             raise ValueError('Invalid bin type %s' % bin_type)    
         


### PR DESCRIPTION
This allows distribute_background_bins to bin in SEOBNRv2Peak. It also changes the syntax of the bin argument to use colons instead of '-', in case a parameter is added that can have negative values. Tested and seems to work, although the syntax change will mean config files will have to change.