### PR TITLE
can't assert foreground time exactly the same between background bins…

### DIFF
--- a/bin/hdfcoinc/pycbc_combine_statmap
+++ b/bin/hdfcoinc/pycbc_combine_statmap
@@ -36,8 +36,7 @@ f.attrs['foreground_time'] = files[0].attrs['foreground_time']
 f.attrs['background_time_exc'] = files[0].attrs['background_time_exc']
 f.attrs['foreground_time_exc'] = files[0].attrs['foreground_time_exc']
 
-for attr in  ['detector_1', 'detector_2', 'timeslide_interval', 
-              'background_time', 'foreground_time']:
+for attr in  ['detector_1', 'detector_2', 'timeslide_interval']:
     for i in range(len(files)-1):
         assert files[i].attrs[attr] == files[i+1].attrs[attr]
 


### PR DESCRIPTION
In a test of the desired background binning for ER8, I found that one of the asserts was too strong in the combine statmap files. It checked that foreground times were identical between the combined triggers, however, for injection runs, this is not the case, as they are done after removing zerolag triggers. They will have slightly different foreground time as a result. This patch relaxes this issue and now the workflow runs as expected. 

https://atlas1.atlas.aei.uni-hannover.de/~ahnitz/LSC/ahnitz/O1/run0_ini_test/run/