### PR TITLE
add low frequency option for waveform generation and SNR calculation in hwinj

### DIFF
--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -139,6 +139,8 @@ parser.add_argument('--inclination', type=float, required=True,
 parser.add_argument('--taper',  required=True,
                     choices=['TAPER_NONE', 'TAPER_START', 'TAPER_END', 'TAPER_STARTEND'],
                     help='Taper the wavform before FFT.')
+parser.add_argument('--waveform-low-frequency-cutoff', type=float, required=True,
+                  help='Frequency to begin generating the waveform in Hz.')
 
 # waveform spin parameter options
 parser.add_argument('--spin1z', type=float, default=0.0,
@@ -159,7 +161,7 @@ parser.add_argument('--geocentric-end-time', type=float, required=True,
                   help='The geocentric GPS end time of the injection.')
 
 # data conditioning options
-parser.add_argument('--low-frequency-cutoff', type=float, required=True,
+parser.add_argument('--psd-low-frequency-cutoff', type=float, required=True,
                   help='Frequency to begin generating the waveform in Hz.')
 
 # output options
@@ -217,7 +219,7 @@ outdoc.childNodes[0].appendChild(sim_table)
 # create sim_inspiral row for injection
 # and populate non-IFO-specific columns in XML output file
 sim = _empty_row(lsctables.SimInspiral)
-sim.f_lower = opts.low_frequency_cutoff
+sim.f_lower = opts.waveform_low_frequency_cutoff
 sim.geocent_end_time = int(opts.geocentric_end_time)
 sim.geocent_end_time_ns = int(opts.geocentric_end_time % 1 * 1e9)
 sim.inclination = opts.inclination
@@ -263,7 +265,7 @@ sngl.spin2y = opts.spin2y
 sngl.spin2x = opts.spin2x
 
 # generate waveform
-logging.info('Generating waveform at %.3fMpc', distance)
+logging.info('Generating waveform at %.3fMpc beginning at %.3fHz', sim.distance, opts.waveform_low_frequency_cutoff)
 h_plus, h_cross = get_td_waveform(sim, approximant=name, phase_order=phase_order,
                       delta_t=1.0/opts.sample_rate)
 
@@ -279,7 +281,7 @@ logging.info('Generating PSD')
 N = len(h_plus)
 n = N/2+1
 delta_f = 1.0 / ( N * h_plus.delta_t )
-psd = _psd.from_cli(opts, n, delta_f, opts.low_frequency_cutoff,
+psd = _psd.from_cli(opts, n, delta_f, opts.psd_low_frequency_cutoff,
              strain=data, dyn_range_factor=DYN_RANGE_FAC, precision='double')
 
 # loop over IFOs to calculate sigma
@@ -306,8 +308,8 @@ for ifo in ifos:
 
     # calculate sigma-squared SNR
     logging.info('Calculating sigma for %s', ifo)
-    sigma_squared = sigmasq(DYN_RANGE_FAC * strain_tilde, psd=psd, low_frequency_cutoff=opts.low_frequency_cutoff, high_frequency_cutoff=f_high)
-    logging.info('Sigma integrated from %.3f to %.3fHz for %s is %.3f', opts.low_frequency_cutoff, f_high, ifo, numpy.sqrt(sigma_squared))
+    sigma_squared = sigmasq(DYN_RANGE_FAC * strain_tilde, psd=psd, low_frequency_cutoff=opts.psd_low_frequency_cutoff, high_frequency_cutoff=f_high)
+    logging.info('Sigma integrated from %.3f to %.3fHz for %s is %.3f', opts.psd_low_frequency_cutoff, f_high, ifo, numpy.sqrt(sigma_squared))
 
     # include sigma in network SNR calculation
     network_snr += sigma_squared
@@ -321,7 +323,7 @@ sim.distance = scale*sim.distance
 network_snr = 0.0
 
 # generate waveform
-logging.info('Generating waveform at %.3fMpc', sim.distance)
+logging.info('Generating waveform at %.3fMpc beginning at %.3fHz', sim.distance, opts.waveform_low_frequency_cutoff)
 h_plus, h_cross = get_td_waveform(sim, approximant=name, phase_order=phase_order,
                       delta_t=1.0/opts.sample_rate)
 
@@ -358,8 +360,8 @@ for ifo in ifos:
 
     # calculate sigma-squared SNR
     logging.info('Calculating sigma for %s', ifo)
-    sigma_squared = sigmasq(DYN_RANGE_FAC * strain_tilde, psd=psd, low_frequency_cutoff=opts.low_frequency_cutoff, high_frequency_cutoff=f_high)
-    logging.info('Sigma integrated from %.3f to %.3fHz for %s is %.3f', opts.low_frequency_cutoff, f_high, ifo, numpy.sqrt(sigma_squared))
+    sigma_squared = sigmasq(DYN_RANGE_FAC * strain_tilde, psd=psd, low_frequency_cutoff=opts.psd_low_frequency_cutoff, high_frequency_cutoff=f_high)
+    logging.info('Sigma integrated from %.3f to %.3fHz for %s is %.3f', opts.psd_low_frequency_cutoff, f_high, ifo, numpy.sqrt(sigma_squared))
 
     # populate IFO end time columns
     setattr(sim, ifo[0].lower()+'_end_time', int(end_time))

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -162,7 +162,7 @@ parser.add_argument('--geocentric-end-time', type=float, required=True,
 
 # data conditioning options
 parser.add_argument('--psd-low-frequency-cutoff', type=float, required=True,
-                  help='Frequency to begin generating the waveform in Hz.')
+                  help='Frequency to begin generating the PSD in Hz. This is the start frequency of the SNR calculation.')
 
 # output options
 parser.add_argument('--h1', action='store_true',

--- a/docs/hwinj.rst
+++ b/docs/hwinj.rst
@@ -66,9 +66,9 @@ We specify the network SNR we want the coherent injection to have on the command
 
 We are going to use data to estimate the PSD so we must include ``--pad-data`` which is the number of seconds at the start and end of the h(t) time series to discard. The option ``--strain-high-pass`` applies a high-pass on the h(t) time series that will be used to calculate PSD.
 
-The method for PSD estimation is set with ``--psd-estimation``. The option ``--psd-segment-length`` is how many seconds to use for a PSD and the option ``--psd-segment-stride`` is how many seconds the code will increment before calculating the next PSD. The option ``--psd-low-frequency-cutoff`` is the frequency to begin genrating the PSD.
+The method for PSD estimation is set with ``--psd-estimation``. The option ``--psd-segment-length`` is how many seconds to use for a PSD and the option ``--psd-segment-stride`` is how many seconds the code will increment before calculating the next PSD. The option ``--psd-low-frequency-cutoff`` is the frequency to begin generating the PSD.
 
-The option ``--waveform-low-frequency-cutoff`` is the frequency to begin genrating the waveform that will be saved to the file.
+The option ``--waveform-low-frequency-cutoff`` is the frequency to begin generating the waveform that will be saved to the file.
 
 Here is the example command ::
 

--- a/docs/hwinj.rst
+++ b/docs/hwinj.rst
@@ -66,11 +66,13 @@ We specify the network SNR we want the coherent injection to have on the command
 
 We are going to use data to estimate the PSD so we must include ``--pad-data`` which is the number of seconds at the start and end of the h(t) time series to discard. The option ``--strain-high-pass`` applies a high-pass on the h(t) time series that will be used to calculate PSD.
 
-The method for PSD estimation is set with ``--psd-estimation``. The option ``--psd-segment-length`` is how many seconds to use for a PSD and the option ``--psd-segment-stride`` is how many seconds the code will increment before calculating the next PSD.
+The method for PSD estimation is set with ``--psd-estimation``. The option ``--psd-segment-length`` is how many seconds to use for a PSD and the option ``--psd-segment-stride`` is how many seconds the code will increment before calculating the next PSD. The option ``--psd-low-frequency-cutoff`` is the frequency to begin genrating the PSD.
+
+The option ``--waveform-low-frequency-cutoff`` is the frequency to begin genrating the waveform that will be saved to the file.
 
 Here is the example command ::
 
-  pycbc_generate_hwinj --geocentric-end-time ${GEOCENT_END_TIME} --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --frame-type ${FRAME_TYPE} --channel-name ${CHANNEL_NAME} --approximant EOBNRv2 --order pseudoFourPN --mass1 1.4 --mass2 1.4 --inclination 60.0 --polarization 0.0 --ra 0.0 --dec 0.0 --taper TAPER_START --network-snr 28 --low-frequency-cutoff 10.0 --l1 --sample-rate 16384 --pad-data 8 --strain-high-pass 30.0 --psd-estimation median --psd-segment-length 16 --psd-segment-stride 8
+  pycbc_generate_hwinj --geocentric-end-time ${GEOCENT_END_TIME} --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --frame-type ${FRAME_TYPE} --channel-name ${CHANNEL_NAME} --approximant EOBNRv2 --order pseudoFourPN --mass1 1.4 --mass2 1.4 --inclination 60.0 --polarization 0.0 --ra 0.0 --dec 0.0 --taper TAPER_START --network-snr 28 --waveform-low-frequency-cutoff 10.0 --l1 --sample-rate 16384 --pad-data 8 --strain-high-pass 30.0 --psd-estimation median --psd-segment-length 16 --psd-segment-stride 8 --psd-low-frequency-cutoff 40.0
 
 This will generate a single-column ASCII files that contains the h(t) time series for each detector and a LIGOLW XML file with the waveform parameters. The output filenames are not specified on the command line, they are determined internally by ``pycbc_generate_hwinj``. In this example the ASCII file with the waveform will be named ``L1-HWINJ_CBC-${START}-${DURATION}.txt`` where ``${START}`` is the start time stamp of the time series and ``${DURATION}`` is the length in seconds of the ASCII waveform file. The LIGOLW XML file will be named ``H1L1-HWINJ_CBC-${START}-${DURATION}.xml.gz``.
 


### PR DESCRIPTION
This PR gives ``pycbc_generate_hwinj`` both a ``--psd-low-frequency-cutoff`` and a ``--waveform-low-frequency-cutoff``.

The ``--psd-low-frequency-cutoff`` option is the start frequency for generating the PSD that is used in calculating SNR. The waveform used in the SNR calculation is also started at this frequency.

The ``--waveform-low-frequency-cutoff`` option is the start frequency for generating the waveform that gets saved to the ASCII file.

This PR also updates the hwinj doc page with the new options.