### PR TITLE
add example to cal dir to test ETMY DAC saturation

### DIFF
--- a/examples/cal/foton_filter_esd_saturation/pycbc_check_esd_saturation.sh
+++ b/examples/cal/foton_filter_esd_saturation/pycbc_check_esd_saturation.sh
@@ -1,19 +1,9 @@
 #! /bin/bash -e
 
-# frame options note these options are for reading SWSTAT and GAIN channels
-GPS_START_TIME=1126256416
-GPS_END_TIME=$((${GPS_START_TIME} + 1))
-IFO=H1
-FRAME_TYPE=H1_R
-SAMPLE_RATE=16384
-
-# foton options
-CALCS_FILTER_FILE=/home/${USER}/src/calsvn/h1_archive/H1CALCS.txt
-SUS_FILTER_FILE=/home/${USER}/src/calsvn/h1_archive/H1SUSETMY.txt
-
 # where to run the executables
 RUN_DIR=./esd_output
 
+# default option values
 DATA_FILE=""
 GPS_START_TIME=""
 GPS_END_TIME=""
@@ -23,9 +13,9 @@ SAMPLE_RATE=16384
 CALCS_FILTER_FILE=""
 SUS_FILTER_FILE=""
 
+# parse command line
 GETOPT_CMD=`getopt -o d:c:a:F:h:l --long data-file:,gps-start-time:,gps-end-time:,ifo:,frame-type:,sample-rate:,calcs-filter-file:,sus-filter-file:,help -n 'pycbc_check_esd_saturation.sh' -- "$@"`
 eval set -- "$GETOPT_CMD"
-
 while true ; do
   case "$1" in
     -d|--data-file)

--- a/examples/cal/foton_filter_esd_saturation/pycbc_check_esd_saturation.sh
+++ b/examples/cal/foton_filter_esd_saturation/pycbc_check_esd_saturation.sh
@@ -1,0 +1,134 @@
+#! /bin/bash -e
+
+# frame options note these options are for reading SWSTAT and GAIN channels
+GPS_START_TIME=1126256416
+GPS_END_TIME=$((${GPS_START_TIME} + 1))
+IFO=H1
+FRAME_TYPE=H1_R
+SAMPLE_RATE=16384
+
+# foton options
+CALCS_FILTER_FILE=/home/${USER}/src/calsvn/h1_archive/H1CALCS.txt
+SUS_FILTER_FILE=/home/${USER}/src/calsvn/h1_archive/H1SUSETMY.txt
+
+# where to run the executables
+RUN_DIR=./esd_output
+
+DATA_FILE=""
+GPS_START_TIME=""
+GPS_END_TIME=""
+IFO=""
+FRAME_TYPE=""
+SAMPLE_RATE=16384
+CALCS_FILTER_FILE=""
+SUS_FILTER_FILE=""
+
+GETOPT_CMD=`getopt -o d:c:a:F:h:l --long data-file:,gps-start-time:,gps-end-time:,ifo:,frame-type:,sample-rate:,calcs-filter-file:,sus-filter-file:,help -n 'pycbc_check_esd_saturation.sh' -- "$@"`
+eval set -- "$GETOPT_CMD"
+
+while true ; do
+  case "$1" in
+    -d|--data-file)
+      case "$2" in
+        "") shift 2 ;;
+        *) DATA_FILE=$2 ; shift 2 ;;
+      esac ;;
+    -s|--gps-start-time)
+      case "$2" in
+        "") shift 2 ;;
+        *) GPS_START_TIME=$2 ; shift 2 ;;
+      esac ;;
+    -e|--gps-end-time)
+      case "$2" in
+        "") shift 2 ;;
+        *) GPS_END_TIME=$2 ; shift 2 ;;
+      esac ;;
+    -i|--ifo)
+      case "$2" in
+        "") shift 2 ;;
+        *) IFO=$2 ; shift 2 ;;
+      esac ;;
+    -f|--frame-type)
+      case "$2" in
+        "") shift 2 ;;
+        *) FRAME_TYPE=$2 ; shift 2 ;;
+      esac ;;
+    -r|--sample-rate)
+      case "$2" in
+        "") shift 2 ;;
+        *) SAMPLE_RATE=$2 ; shift 2 ;;
+      esac ;;
+    -s|--sus-filter-file)
+      case "$2" in
+        "") shift 2 ;;
+        *) SUS_FILTER_FILE=$2 ; shift 2 ;;
+      esac ;;
+    -c|--calcs-filter-file)
+      case "$2" in
+        "") shift 2 ;;
+        *) CALCS_FILTER_FILE=$2 ; shift 2 ;;
+      esac ;;
+    -h|--help)
+      echo "usage: pycbc_check_esd_saturation.sh [-h] [--options]"
+      echo
+      echo "required arguments:"
+      echo "  -d, --data-file DATA_FILE                       single-column ASCII file"
+      echo "  -s, --gps-start-time GPS_START_TIME             time to start reading data for filterbank values"
+      echo "  -e, --gps-end-time GPS_END_TIME                 time to stop reading data for filterbank values"
+      echo "  -i, --ifo IFO                                   IFO, eg. H1 or L1"
+      echo "  -f, --frame-type FRAME_TYPE                     frame type that has SWSTAT and GAIN channels"
+      echo "  -r, --sample-rate SAMPLE_RATE                   sample rate of the input file"
+      echo "  -s, --sus-filter-file SUS_FILTER_FILE           path to SUSETMY.txt"
+      echo "  -c, --calcs-filter-file CALCS_FILTER_FILE       path to CALCS.txt"
+      echo
+      echo "Filter a single-column ASCII file to see if it saturates the ETMY DAC."
+      echo
+      exit 0 ;;
+    --) shift ; break ;;
+    *) echo "Internal error!" ; exit 1 ;;
+  esac
+done
+
+# save current directory to get path to executables
+EXE_DIR=${PWD}
+
+# change into directory where executables will be run
+mkdir -p ${RUN_DIR}
+cd ${RUN_DIR}
+
+# filter with CAL-INJ_HARDWARE
+MODEL_NAME=CAL
+FILTERBANK_NAME=INJ_HARDWARE
+#DATA_FILE=`ls /home/cbiwer/src/pycbc_foton_dev/examples/cal/foton_filter_INJ_BLIND/hwinj/${IFO}-HWINJ_CBC-*-*.txt`
+OUTPUT_FILE=${IFO}-FILTER_${FILTERBANK_NAME}-${GPS_START_TIME}.txt
+python ${EXE_DIR}/pycbc_foton_filter --filterbank-ignore-off --model-name ${MODEL_NAME} --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --filterbank-name ${FILTERBANK_NAME} --data-file ${DATA_FILE} --filter-file ${CALCS_FILTER_FILE} --output-file ${OUTPUT_FILE} --sample-rate ${SAMPLE_RATE} --frame-type ${FRAME_TYPE} --ifo ${IFO}
+
+# filter with SUS-ETMY_L3_LOCK_L
+MODEL_NAME=SUS
+FILTERBANK_NAME=ETMY_L3_LOCK_L
+DATA_FILE=${OUTPUT_FILE}
+OUTPUT_FILE=${IFO}-FILTER_${FILTERBANK_NAME}-${GPS_START_TIME}.txt
+python ${EXE_DIR}/pycbc_foton_filter --filterbank-ignore-off --model-name ${MODEL_NAME} --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --filterbank-name ${FILTERBANK_NAME} --data-file ${DATA_FILE} --filter-file ${SUS_FILTER_FILE} --output-file ${OUTPUT_FILE} --sample-rate ${SAMPLE_RATE} --frame-type ${FRAME_TYPE} --ifo ${IFO}
+
+# filter with SUS-ETMY_L3_DRIVEALIGN_L2L
+MODEL_NAME=SUS
+FILTERBANK_NAME=ETMY_L3_DRIVEALIGN_L2L
+DATA_FILE=${OUTPUT_FILE}
+OUTPUT_FILE=${IFO}-FILTER_${FILTERBANK_NAME}-${GPS_START_TIME}.txt
+python ${EXE_DIR}/pycbc_foton_filter --filterbank-ignore-off --model-name ${MODEL_NAME} --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --filterbank-name ${FILTERBANK_NAME} --data-file ${DATA_FILE} --filter-file ${SUS_FILTER_FILE} --output-file ${OUTPUT_FILE} --sample-rate ${SAMPLE_RATE} --frame-type ${FRAME_TYPE} --ifo ${IFO}
+
+# apply matrix element SUS-ETMY_L3_EUL2ESD_2_1
+MODEL_NAME=SUS
+MTRX_ELEMENT_NAME=ETMY_L3_EUL2ESD_2_1
+GAIN_CHANNEL_NAME=${IFO}:${MODEL_NAME}-${MTRX_ELEMENT_NAME}
+DATA_FILE=${OUTPUT_FILE}
+OUTPUT_FILE=${IFO}-MTRX_${MTRX_ELEMENT_NAME}-${GPS_START_TIME}.txt
+python ${EXE_DIR}/pycbc_foton_filter --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --gain-channel-name ${GAIN_CHANNEL_NAME} --data-file ${DATA_FILE} --output-file ${OUTPUT_FILE} --frame-type ${FRAME_TYPE} --sample-rate ${SAMPLE_RATE} --ifo ${IFO}
+
+# filter with SUS-ETMY_L3_ESDOUTF_LL
+MODEL_NAME=SUS
+FILTERBANK_NAME=ETMY_L3_ESDOUTF_LL
+DATA_FILE=${OUTPUT_FILE}
+OUTPUT_FILE=${IFO}-FILTER_${FILTERBANK_NAME}-${GPS_START_TIME}.txt
+python ${EXE_DIR}/pycbc_foton_filter --filterbank-ignore-off --model-name ${MODEL_NAME} --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --filterbank-name ${FILTERBANK_NAME} --data-file ${DATA_FILE} --filter-file ${SUS_FILTER_FILE} --output-file ${OUTPUT_FILE} --sample-rate ${SAMPLE_RATE} --frame-type ${FRAME_TYPE} --ifo ${IFO}
+

--- a/examples/cal/foton_filter_esd_saturation/pycbc_foton_filter
+++ b/examples/cal/foton_filter_esd_saturation/pycbc_foton_filter
@@ -1,0 +1,157 @@
+#! /usr/bin/python
+
+# Copyright (C) 2015  Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import argparse
+import logging
+import numpy
+import sys
+from pycbc.filter.fotonfilter import filter_data, get_swstat_bits, read_gain_from_frames
+from pycbc.frame import frame_paths
+from pycbc.inject import InjectionSet, legacy_approximant_name
+from pycbc.types import TimeSeries
+from pycbc.waveform import get_td_waveform
+
+# list of IFOs
+ifo_list = ['H1', 'L1']
+
+# command line usage
+parser = argparse.ArgumentParser(usage='pycbc_foton_filter [--options]',
+             description='Filter a single-column ASCII time series.')
+
+# injection options
+parser.add_argument("--data-file", type=str, required=True,
+             help="Path to single-column ASCII file with time series.")
+parser.add_argument("--ifo", choices=ifo_list,
+             help="IFO to generate waveform.")
+
+# foton options
+parser.add_argument("--filter-file", type=str,
+             help="Path to foton filter file to extract filterbanks.")
+parser.add_argument("--model-name", type=str,
+             help="Name of the model.")
+parser.add_argument("--filterbank-name", type=str,
+             help="Name of the filterbank to filter time series.")
+parser.add_argument("--filterbank-ignore-off", action="store_true", default=False,
+             help="Ignore filterbank input and output bits.")
+parser.add_argument("--filterbank-bits", type=str, default='',
+             help="Bit mask for filter modules.")
+
+# frame file options
+parser.add_argument("--frame-type", type=str,
+             help="Frame type that has SWSTAT channels.")
+parser.add_argument("--gps-start-time", type=int,
+             help="Time to start reading data.")
+parser.add_argument("--gps-end-time", type=int,
+             help="Time to stop reading data.")
+
+# SWSTAT options
+parser.add_argument("--swstat-channel-name", type=str,
+            help="Name of the SWSTAT channel.")
+
+# gain options
+parser.add_argument("--gain-channel-name", type=str,
+            help="Name of the gain channel.")
+parser.add_argument("--filterbank-gain", type=float,
+            help="Value to apply as gain of filterbank.")
+
+# output options
+parser.add_argument("--output-file", type=str, required=True,
+             help="The name of the ASCII output file that contains h(t).")
+parser.add_argument("--sample-rate", type=int, required=True,
+             help="The sample rate of the ASCII output file that contains h(t).")
+
+# parse command line
+opts = parser.parse_args()
+
+# import dependencies that are not standard to pycbc
+try:
+    import ROOT
+    ROOT.gSystem.Load('/usr/lib64/libdmtsigp.so')
+    ROOT.gSystem.Load('/usr/lib64/libgdsplot.so')
+    from foton import FilterFile, Filter
+except ImportError as e:
+    print e
+    sys.exit()
+
+# setup log
+logging_level = logging.DEBUG
+logging.basicConfig(format='%(asctime)s : %(message)s', level=logging_level)
+
+# read data file with time series
+data = numpy.loadtxt(opts.data_file)
+
+# read foton filter file
+if opts.filter_file:
+    logging.info('Reading foton filter file')
+    filter_file = FilterFile(opts.filter_file)
+else:
+    logging.info('No filter file name was given on the command line')
+    filter_file = None
+
+# read frame files
+logging.info('Querying frame files')
+frame_paths = frame_paths(opts.frame_type, opts.gps_start_time, opts.gps_end_time)
+
+# filter data
+if opts.filter_file and opts.filterbank_name:
+
+    # get channel name for SWSTAT
+    if opts.swstat_channel_name:
+        swstat_channel_name = opts.swstat_channel_name
+    else:
+        swstat_channel_name = '%s:%s-%s_SWSTAT'%(opts.ifo, opts.model_name, opts.filterbank_name)
+
+    # get bits for filter modules on/off and if filterbank was on/off
+    if ( not opts.filterbank_ignore_off or len(opts.filterbank_bits) == 0 ):
+        bits, filterbank_off = get_swstat_bits(frame_paths, swstat_channel_name, opts.gps_start_time, opts.gps_start_time+1)
+    if opts.filterbank_ignore_off:
+        filterbank_off = False
+    if len(opts.filterbank_bits) > 0:
+        bits = opts.filterbank_bits
+    logging.info('Will use bits %s and the input/output was off at this time is %s', bits, filterbank_off)
+
+    # filter
+    logging.info('Filtering with %s filterbank', opts.filterbank_name)
+    data_filt = filter_data(data, opts.filterbank_name, filter_file, bits, filterbank_off=filterbank_off)
+
+# else do not filter
+else:
+    logging.info('No filter file or filterbank name was given on the command line so not filtering')
+    data_filt = data
+
+# get channel name for gain
+if opts.gain_channel_name:
+    gain_channel_name = opts.gain_channel_name
+else:
+    gain_channel_name = '%s:%s-%s_GAIN'%(opts.ifo, opts.model_name, opts.filterbank_name)
+
+# apply filterbank gain
+if not opts.filterbank_gain:
+    logging.info('Reading frame files to get gain')
+    gain = read_gain_from_frames(frame_paths, gain_channel_name, opts.gps_start_time, opts.gps_start_time+1)
+else:
+    gain = opts.filterbank_gain
+logging.info('Applying gain of %f', gain)
+data_filt = gain * data_filt
+
+# write output
+logging.info('Writing filtered data')
+numpy.savetxt(opts.output_file, data_filt)
+
+# exit
+logging.info('Done')

--- a/pycbc/filter/fotonfilter.py
+++ b/pycbc/filter/fotonfilter.py
@@ -60,7 +60,8 @@ def get_swstat_bits(frame_filenames, swstat_channel_name, start_time, end_time):
     return bits[-10:], filterbank_off
 
 
-def filter_data(data, filter_name, filter_file, bits, filterbank_off=False):
+def filter_data(data, filter_name, filter_file, bits, filterbank_off=False,
+                    swstat_channel_name=None):
     '''
     A naive function to determine if the filter was on at the time
     and then filter the data.


### PR DESCRIPTION
This PR adds an example to the ``cal/`` dir that filters a single-column ASCII file that contains h(t) to get ETMY DAC counts.

Example command:
```
sh pycbc_check_esd_saturation.sh --data-file ~/src/pycbc_foton_dev/examples/cal/foton_filter_INJ_BLIND/hwinj/H1-HWINJ_CBC-1126257409-13.txt --gps-start-time 1126256416 --gps-end-time 1126256417 --ifo H1 --frame-type H1_R --sample-rate 16384 --calcs-filter-file /home/${USER}/src/calsvn/h1_archive/H1CALCS.txt --sus-filter-file /home/${USER}/src/calsvn/h1_archive/H1SUSETMY.txt
```