### PR TITLE
add examples for recovering hardware injections to doc

### DIFF
--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -189,6 +189,10 @@ opts = parser.parse_args()
 _strain.verify_strain_options_multi_ifo(opts, parser, opts.instruments)
 _psd.verify_psd_options(opts, parser)
 
+# setup log
+logging_level = logging.DEBUG
+logging.basicConfig(format='%(asctime)s : %(message)s', level=logging_level)
+
 # check that sample rates are the same
 for ifo in opts.instruments:
     if opts.sample_rate[ifo] != opts.sample_rate[opts.instruments[0]]:
@@ -213,10 +217,6 @@ distance = 40.0
 
 # set network SNR to 0.0
 network_snr = 0.0
-
-# setup log
-logging_level = logging.DEBUG
-logging.basicConfig(format='%(asctime)s : %(message)s', level=logging_level)
 
 # create output XML file
 logging.info('Creating XML file')

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -288,8 +288,8 @@ sngl.spin2y = opts.spin2y
 sngl.spin2x = opts.spin2x
 
 # generate waveform
-logging.info('Generating waveform at %.3fMpc beginning at %.3fHz', sim.distance, opts.waveform_low_frequency_cutoff)
-h_plus, h_cross = get_td_waveform(sim, approximant=name, phase_order=phase_order,
+logging.info('Generating waveform at %.3fMpc beginning at %.3fHz for SNR calculation', sim.distance, opts.psd_low_frequency_cutoff)
+h_plus, h_cross = get_td_waveform(sim, approximant=name, phase_order=phase_order, f_lower=opts.psd_low_frequency_cutoff,
                       delta_t=1.0/sample_rate)
 
 # zero pad polarizations to get integer second time series
@@ -351,8 +351,8 @@ sim.distance = scale*sim.distance
 network_snr = 0.0
 
 # generate waveform
-logging.info('Generating waveform at %.3fMpc beginning at %.3fHz', sim.distance, opts.waveform_low_frequency_cutoff)
-h_plus, h_cross = get_td_waveform(sim, approximant=name, phase_order=phase_order,
+logging.info('Generating waveform at %.3fMpc beginning at %.3fHz for SNR calculation', sim.distance, opts.psd_low_frequency_cutoff)
+h_plus, h_cross = get_td_waveform(sim, approximant=name, phase_order=phase_order, f_lower=opts.psd_low_frequency_cutoff,
                       delta_t=1.0/sample_rate)
 
 # zero pad polarizations to get integer second time series

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -443,6 +443,7 @@ for ifo in opts.instruments:
     output = TimeSeries(initial_array, delta_t=1.0/sample_rate, epoch=start_time, dtype=strain.dtype)
 
     # inject waveform
+    logging.info('Injecting %s waveform into timeseries of zeroes', ifo)
     injections = InjectionSet(xml_filename)
     injections.apply(output, ifo)
 

--- a/bin/hwinj/pycbc_insert_frame_hwinj
+++ b/bin/hwinj/pycbc_insert_frame_hwinj
@@ -1,0 +1,74 @@
+#! /usr/bin/python
+
+# Copyright (C) 2015 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import argparse
+import logging
+import numpy
+from pycbc.frame import write_frame
+from pycbc import strain as _strain
+
+ifo_list = ['H1', 'L1']
+
+# command line usage
+parser = argparse.ArgumentParser(usage='pycbc_insert_frame_hwinj [--options]',
+             description="Inserts a single-column ASCII file into frame data.")
+
+# injection options
+parser.add_argument('--hwinj-file', type=str, required=True,
+             help='Path to single-column ASCII file.')
+parser.add_argument('--hwinj-start-time', type=int, required=True,
+             help='Start time of the single-column ASCII file.')
+
+# frame options
+parser.add_argument('--ifo', type=str, required=True,
+             choices=ifo_list,
+             help='IFO.')
+parser.add_argument('--output-file', type=str, required=True,
+             help='Path to output frame file.')
+
+# add option groups
+_strain.insert_strain_option_group(parser)
+
+# parse command line
+opts = parser.parse_args()
+
+# setup log
+logging_level = logging.DEBUG
+logging.basicConfig(format='%(asctime)s : %(message)s', level=logging_level)
+
+# get strain
+strain = _strain.from_cli(opts)
+
+# load data
+logging.info('Reading the hardware injection data')
+initial_array = numpy.loadtxt(opts.hwinj_file)
+
+# figure out how much to pad
+start_pad = (opts.hwinj_start_time-opts.gps_start_time) * opts.sample_rate
+
+# add the two time series
+logging.info('Summing the two time series')
+for i in range(len(initial_array)):
+    strain[start_pad+1+i] += initial_array[i]
+
+# write frame
+logging.info('Writing data')
+write_frame(opts.output_file, opts.ifo+':HWINJ_INJECTED', strain)
+
+# exit
+logging.info('Done.')

--- a/docs/hwinj.rst
+++ b/docs/hwinj.rst
@@ -201,6 +201,19 @@ You can print out the recovered SNR and other parameters with ``lwtprint``, for 
 
   lwtprint -t sngl_inspiral -c end_time,snr ${INSPIRAL_FILE}
 
+&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+Recover ASCII file injection with ``pycbc_inspiral``
+&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+
+There is an executable ``pycbc_insert_frame_hwinj`` that will read the single-column ASCII file and insert it into frame data. An example command is here ::
+
+  HWINJ_FILE=H1-HWINJ_CBC-${START}-${DURATION}.txt
+  pycbc_insert_frame_hwinj --frame-type ${FRAME_TYPE} --channel-name H1:${CHANNEL_NAME} --gps-start-time $((${GPS_START_TIME} - 16)) --gps-end-time $((${GPS_END_TIME} + 16)) --pad-data 8 --strain-high-pass 30.0 --sample-rate 16384 --hwinj-file ${HWINJ_FILE} --hwinj-start-time ${START} --ifo H1 --output-file H1-HWINJ.gwf
+
+Where ``${START}`` is the start of the injection and ``${DURATION}`` is the length of the injection.
+
+Then you can run pycbc on the output frame file ``H1-HWINJ.gwf``.
+
 =================================================
 How to query the segment database
 =================================================

--- a/docs/hwinj.rst
+++ b/docs/hwinj.rst
@@ -195,7 +195,7 @@ The analogous software injection command for the example above would be ::
   INSPIRAL_FILE=H1-INSPIRAL_PYCBC-${GPS_START_TIME}-$((${GPS_END_TIME}-${GPS_START_TIME})).xml.gz
   pycbc_inspiral --segment-end-pad 64  --segment-length 256 --segment-start-pad 64 --psd-estimation median --psd-segment-length 16 --psd-segment-stride 8 --psd-inverse-length 16 --pad-data 8 --sample-rate 4096 --low-frequency-cutoff 40 --strain-high-pass 30 --filter-inj-only --processing-scheme cpu --cluster-method template --approximant SEOBNRv2 --order 8 --snr-threshold 5.5 --chisq-bins 16 --channel-name ${CHANNEL_NAME} --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --trig-start-time $(($GEOCENT_END_TIME - 2)) --trig-end-time $(($GEOCENT_END_TIME + 2)) --frame-type ${FRAME_TYPE} --injection-file ${TMPLTBANK_FILE}  --bank-file ${TMPLTBANK_FILE} --output ${INSPIRAL_FILE} --verbose
 
-Where ${START} is the start of the injection and ${DURATION} is the length of the injection. We kept the same PSD options (eg. ``--psd-segment-length``, etc.), data, high-pass filter, and low-frequency-cutoff.
+Where ``${START}`` is the start of the injection and ``${DURATION}`` is the length of the injection. We kept the same PSD options (eg. ``--psd-segment-length``, etc.), data, high-pass filter, and low-frequency-cutoff.
 
 You can print out the recovered SNR and other parameters with ``lwtprint``, for example ::
 

--- a/docs/hwinj.rst
+++ b/docs/hwinj.rst
@@ -28,7 +28,7 @@ Select a time for the injection
 
 First on the command line set a variable for the GPS geocentric end time of the coherent injection ::
 
-  GEOCENT_END_TIME=1126399769
+  GEOCENT_END_TIME=1124381661
 
 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 Select data for PSD estimation
@@ -182,6 +182,24 @@ You can plot the ASCII waveform files with an X11 connection. It's strongly reco
 If you are using ``ssh`` or ``gsissh`` to log into a cluster, you can provide the ``-Y`` option to open an X11 connection. For example ::
 
   gsissh -Y ldas-pcdev1.ligo.caltech.edu
+
+&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+Recover software injection with ``pycbc_inspiral``
+&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
+
+The executable ``pycbc_generate_hwinj`` will create an XML file with both a ``sim_inspiral`` and ``sngl_inspiral`` table. Therefore we can inject the exact waveform parameters and recover them with the exact template.
+
+The analogous software injection command for the example above would be ::
+
+  TMPLTBANK_FILE=H1-HWINJ_CBC-${START}-${DURATION}.xml.gz
+  INSPIRAL_FILE=H1-INSPIRAL_PYCBC-${GPS_START_TIME}-$((${GPS_END_TIME}-${GPS_START_TIME})).xml.gz
+  pycbc_inspiral --segment-end-pad 64  --segment-length 256 --segment-start-pad 64 --psd-estimation median --psd-segment-length 16 --psd-segment-stride 8 --psd-inverse-length 16 --pad-data 8 --sample-rate 4096 --low-frequency-cutoff 40 --strain-high-pass 30 --filter-inj-only --processing-scheme cpu --cluster-method template --approximant SEOBNRv2 --order 8 --snr-threshold 5.5 --chisq-bins 16 --channel-name ${CHANNEL_NAME} --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --trig-start-time $(($GEOCENT_END_TIME - 2)) --trig-end-time $(($GEOCENT_END_TIME + 2)) --frame-type ${FRAME_TYPE} --injection-file ${TMPLTBANK_FILE}  --bank-file ${TMPLTBANK_FILE} --output ${INSPIRAL_FILE} --verbose
+
+We kept the same PSD options (eg. ``--psd-segment-length``, etc.), data, high-pass filter, and low-frequency-cutoff.
+
+You can print out the recovered SNR and other parameters with ``lwtprint``, for example
+
+  lwtprint -t sngl_inspiral -c end_time,snr ${INSPIRAL_FILE}
 
 =================================================
 How to query the segment database

--- a/docs/hwinj.rst
+++ b/docs/hwinj.rst
@@ -195,9 +195,9 @@ The analogous software injection command for the example above would be ::
   INSPIRAL_FILE=H1-INSPIRAL_PYCBC-${GPS_START_TIME}-$((${GPS_END_TIME}-${GPS_START_TIME})).xml.gz
   pycbc_inspiral --segment-end-pad 64  --segment-length 256 --segment-start-pad 64 --psd-estimation median --psd-segment-length 16 --psd-segment-stride 8 --psd-inverse-length 16 --pad-data 8 --sample-rate 4096 --low-frequency-cutoff 40 --strain-high-pass 30 --filter-inj-only --processing-scheme cpu --cluster-method template --approximant SEOBNRv2 --order 8 --snr-threshold 5.5 --chisq-bins 16 --channel-name ${CHANNEL_NAME} --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --trig-start-time $(($GEOCENT_END_TIME - 2)) --trig-end-time $(($GEOCENT_END_TIME + 2)) --frame-type ${FRAME_TYPE} --injection-file ${TMPLTBANK_FILE}  --bank-file ${TMPLTBANK_FILE} --output ${INSPIRAL_FILE} --verbose
 
-We kept the same PSD options (eg. ``--psd-segment-length``, etc.), data, high-pass filter, and low-frequency-cutoff.
+Where ${START} is the start of the injection and ${DURATION} is the length of the injection. We kept the same PSD options (eg. ``--psd-segment-length``, etc.), data, high-pass filter, and low-frequency-cutoff.
 
-You can print out the recovered SNR and other parameters with ``lwtprint``, for example
+You can print out the recovered SNR and other parameters with ``lwtprint``, for example ::
 
   lwtprint -t sngl_inspiral -c end_time,snr ${INSPIRAL_FILE}
 

--- a/setup.py
+++ b/setup.py
@@ -417,6 +417,7 @@ setup (
                'bin/hwinj/pycbc_generate_hwinj',
                'bin/hwinj/pycbc_generate_hwinj_from_xml',
                'bin/hwinj/pycbc_plot_hwinj',
+               'bin/hwinj/pycbc_insert_frame_hwinj',
                'bin/hdfcoinc/pycbc_strip_injections',
                'bin/sngl/pycbc_ligolw_cluster',
                'bin/sngl/pycbc_plot_bank',


### PR DESCRIPTION
This PR:
  * Adds an executable ``pycbc_insert_frame_hwinj`` that inserts the single-column ASCII file for hardware injections into frame data so that it can be recovered by ``pycbc_inspiral``.
  * Updates the hardware injection documentation so that it has examples on how to use ``pycbc_inspiral`` to recover the injection from the XML file or the ASCII file.
  * Changes waveform generation low frequency cutoff for SNR calculation to be the same as the PSD to save time.