### PR TITLE
Add XML option when outputting FrequencySeries

### DIFF
--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -301,7 +301,7 @@ class FrequencySeries(Array):
 
         return lal_data
 
-    def save(self, path, group=None):
+    def save(self, path, group=None, ifo='P1'):
         """
         Save frequency series to a Numpy .npy, hdf, or text file. The first column
         contains the sample frequencies, the second contains the values.
@@ -350,7 +350,7 @@ class FrequencySeries(Array):
             first_idx = _numpy.argmax(data_lal>0)
             if not first_idx == 0:
                 data_lal[:first_idx] = data_lal[first_idx]
-            psddict = {'P1': output}
+            psddict = {ifo: output}
             utils.write_filename(lalseries.make_psd_xmldoc(psddict), path,
                                  gz=path.endswith(".gz"))
         elif ext =='.hdf':

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -350,7 +350,7 @@ class FrequencySeries(Array):
             first_idx = _numpy.argmax(data_lal>0)
             if not first_idx == 0:
                 data_lal[:first_idx] = data_lal[first_idx]
-            psddict = {'G1': output}
+            psddict = {'P1': output}
             utils.write_filename(lalseries.make_psd_xmldoc(psddict), path,
                                  gz=path.endswith(".gz"))
         elif ext =='.hdf':

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -338,6 +338,21 @@ class FrequencySeries(Array):
                                         self.numpy().real,
                                         self.numpy().imag)).T
             _numpy.savetxt(path, output)
+        elif ext == '.xml' or path.endswith('.xml.gz'):
+            from pylal import series as lalseries
+            from glue.ligolw import utils
+            assert(self.kind == 'real')
+            output = self.lal()
+            # When writing in this format we must *not* have the 0 values at
+            # frequencies less than flow. To resolve this we set the first
+            # non-zero value < flow.
+            data_lal = output.data.data
+            first_idx = _numpy.argmax(data_lal>0)
+            if not first_idx == 0:
+                data_lal[:first_idx] = data_lal[first_idx]
+            psddict = {'G1': output}
+            utils.write_filename(lalseries.make_psd_xmldoc(psddict), path,
+                                 gz=path.endswith(".gz"))
         elif ext =='.hdf':
             key = 'data' if group is None else group
             d = h5py.File(path)


### PR DESCRIPTION
Add the ability to write XML format frequency series when saving a PSD. This has been tested with the bank generation codes (ie. the PSD module) and verified to work with sBank (although sBank demands that we do *not* prepend the data with 0s). To resolve #313 this now needs to be tied into pycbc_average_psd, maybe @titodalcanton can take this on, or provide me an example for testing? Basically I think all is needed is to convert to FrequencySeries and then use the built in .save function of the class instead of rewriting this in the executable.

For some reason an instrument is required when writing these files. I think this is meaningless in general as we might be writing some design PSD, or some multi-ifo PSD, and I do *not* think this quantity is relevant (nor the f0 value in the file). Therefore I use f0=0 and ifo='G1', but sbank does need to know about the instrument choice.

As an aside, if we adopt the convention here of prepending PSDs with non-zero values before f-lower it will resolve the warnings that many people are complaining about recently. Should we do this?