### PR TITLE
Do not set PSD < flow = 0

### DIFF
--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -76,6 +76,9 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
         elif opt.asd_file:
             psd = from_txt(opt.asd_file, length, 
                            delta_f, f_low, is_asd_file=True)
+        # Set values < flow to the value at flow
+        kmin = int(low_frequency_cutoff / psd.delta_f)
+        psd[0:kmin] = psd[kmin]
 
         psd *= dyn_range_factor ** 2
 

--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -221,10 +221,6 @@ def inverse_spectrum_truncation(psd, max_filter_len, low_frequency_cutoff=None, 
     psd_trunc *= psd_trunc.conj()
     psd_out = 1. / abs(psd_trunc)
 
-    if low_frequency_cutoff:
-        kmin = int(low_frequency_cutoff / psd.delta_f)
-        psd_out[0:kmin] = 0
-
     return psd_out
 
 def interpolate(series, delta_f):
@@ -282,9 +278,4 @@ def bandlimited_interpolate(series, delta_f):
     fft(padded_series_in_time, interpolated_series)
 
     return interpolated_series
-
-
-
-
-
 


### PR DESCRIPTION
Hi Alex,

I identified two places where PSD<flow is set to 0. First when using an analytical PSD or PSD from file, and second when using inverse-psd-length. I didn't really see why the inverse-psd-length sets these value to 0 after shortening the PSD length so I just removed it (although the inverted PSD values < flow are still taking values of 0 before truncating the PSD length , and that is meaningful).

Does this look okay to you? I've tested the returned PSD for these use cases and it does what is expected.