### PR TITLE
Restrict output files of pycbc_generate_hwinj_from_xml to one waveform per file

### DIFF
--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -250,7 +250,7 @@ sim.latitude = opts.ra
 sim.longitude = opts.dec
 sim.mass1 = opts.mass1
 sim.mass2 = opts.mass2
-sim.mchirp, sim.eta = pnutils.mass1_mass2_to_mtotal_eta(sim.mass1, sim.mass2)
+sim.mchirp, sim.eta = pnutils.mass1_mass2_to_mchirp_eta(sim.mass1, sim.mass2)
 sim.spin1z = opts.spin1z
 sim.spin1y = opts.spin1y
 sim.spin1x = opts.spin1x
@@ -278,7 +278,7 @@ outdoc.childNodes[0].appendChild(sngl_table)
 sngl = _empty_row(lsctables.SnglInspiral)
 sngl.mass1 = opts.mass1
 sngl.mass2 = opts.mass2
-sngl.mchirp, sngl.eta = pnutils.mass1_mass2_to_mtotal_eta(sngl.mass1, sngl.mass2)
+sngl.mchirp, sngl.eta = pnutils.mass1_mass2_to_mchirp_eta(sngl.mass1, sngl.mass2)
 sngl.mtotal = sngl.mass1 + sngl.mass2
 sngl.spin1z = opts.spin1z
 sngl.spin1y = opts.spin1y

--- a/bin/hwinj/pycbc_generate_hwinj_from_xml
+++ b/bin/hwinj/pycbc_generate_hwinj_from_xml
@@ -99,7 +99,7 @@ for sim in injections.table:
 
         # inject waveform into time series of zeroes
         logging.info('Injecting %s waveform into timeseries of zeroes', ifo)
-        injections.apply(output, ifo)
+        injections.apply(output, ifo, simulation_ids=[sim.simulation_id])
 
         # set output filename
         txt_filename = ifo + '-' + 'HWINJ_CBC_FROM_SIMULATION_ID_' + str(sim_id) + '-' + str(start_time) + '-' + str(end_time-start_time) + '.txt'


### PR DESCRIPTION
This PR:
  * Fixes the issue John V. was having where ``pycbc_generate_hwinj_from_xml`` will generate all waveforms at a GPS time into the same file. Instead now it checks for the ``simulation_id`` column and will only inject one waveform per file. Wasn't a problem with ``lalapps_inspinj`` since ``lalapps_inspinj`` spaces injections out in time.
  * Corrects the value of chirp mass stored in the XML table. This didn't have an affect on the waveform generation since ``mass1`` and ``mass2`` are used. For a double check, here is before PR h(t) plot https://ldas-jobs.ligo-wa.caltech.edu/~cbiwer/hwinj_check/hwinj1_patch/H1-TIMESERIES_HWINJ_ORIG_CBC_2.png and after PR h(t) plot https://ldas-jobs.ligo-wa.caltech.edu/~cbiwer/hwinj_check/hwinj1_patch/H1-TIMESERIES_HWINJ_CBC_2.png ... they are the same.