### PR TITLE
Issue #306, support remote executables at workflow-generation time.

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -415,7 +415,7 @@ class Workflow(pegasus_workflow.Workflow):
         """ Execute this node immediately on the local machine
         """
         node.executed = True
-        cmd_list = node.get_command_line(verbatim_exe)
+        cmd_list = node.get_command_line(verbatim_exe=verbatim_exe)
         
         # Must execute in output directory.
         curr_dir = os.getcwd()

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -26,7 +26,7 @@ This module provides the worker functions and classes that are used when
 creating a workflow. For details about the workflow module see here:
 https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope.html
 """
-import os, subprocess, logging, math, string, urllib2, urlparse, ConfigParser, copy
+import os, stat, subprocess, logging, math, string, urllib2, urlparse, ConfigParser, copy
 import numpy, cPickle, random
 from itertools import combinations, groupby
 from operator import attrgetter
@@ -411,11 +411,11 @@ class Workflow(pegasus_workflow.Workflow):
         return path
         
 
-    def execute_node(self, node):
+    def execute_node(self, node, verbatim_exe = False):
         """ Execute this node immediately on the local machine
         """
         node.executed = True
-        cmd_list = node.get_command_line()
+        cmd_list = node.get_command_line(verbatim_exe)
         
         # Must execute in output directory.
         curr_dir = os.getcwd()
@@ -475,7 +475,7 @@ class Node(pegasus_workflow.Node):
             
         self._options += self.executable.common_options
     
-    def get_command_line(self):
+    def get_command_line(self, verbatim_exe=False):
         self._finalize()
         arglist = self._dax_node.arguments
         
@@ -490,8 +490,14 @@ class Node(pegasus_workflow.Node):
         arglist = [a for a in arglist if a != '']
         
         arglist = [a.storage_path if isinstance(a, File) else a for a in arglist]
-                        
-        exe_path = urlparse.urlsplit(self.executable.get_pfn()).path
+       
+        # This allows the pfn to be an http(s) URL, which will be
+        # downloaded by resolve_url
+        if verbatim_exe:
+            exe_path = self.executable.get_pfn()
+        else:
+            exe_path = urlparse.urlsplit(self.executable.get_pfn()).path
+
         return [exe_path] + arglist
         
     def new_output_file_opt(self, valid_seg, extension, option_name, tags=[],
@@ -1232,6 +1238,11 @@ def make_external_call(cmdList, out_dir=None, out_basename='external_call',
     exitCode : int
         The code returned by the process.
     """
+    resolvedExe = resolve_url(cmdList[0])
+    if resolvedExe != cmdList[0]:
+        os.chmod(resolvedExe, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+        cmdList[0] = resolvedExe
+
     if out_dir:
         outBase = os.path.join(out_dir,out_basename)
         errFile = outBase + '.err'

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -500,7 +500,7 @@ def get_veto_segs(workflow, ifo, category, start_time, end_time, out_dir,
     
     if execute_now:
         if file_needs_generating(vetoXmlFile.cache_entry.path):
-            workflow.execute_node(node)
+            workflow.execute_node(node, verbatim_exe = True)
         else:
             node.executed = True
             for fil in node._outputs:
@@ -618,7 +618,7 @@ def get_cumulative_segs(workflow, currSegFile, categories,
         cum_node = cum_job.create_node(valid_segment, inputs, segment_name)
         if execute_now:
             if file_needs_generating(cum_node.output_files[0].cache_entry.path):
-                workflow.execute_node(cum_node)
+                workflow.execute_node(cum_node, verbatim_exe = True)
             else:
                 cum_node.executed = True
                 for fil in cum_node._outputs:
@@ -634,7 +634,7 @@ def get_cumulative_segs(workflow, currSegFile, categories,
                                    output=currSegFile)   
     if execute_now:
         if file_needs_generating(add_node.output_files[0].cache_entry.path):
-            workflow.execute_node(add_node)
+            workflow.execute_node(add_node, verbatim_exe = True)
         else:
             add_node.executed = True
             for fil in add_node._outputs:
@@ -672,7 +672,7 @@ def add_cumulative_files(workflow, output_file, input_files, out_dir,
                                    output=output_file)
     if execute_now:
         if file_needs_generating(add_node.output_files[0].cache_entry.path):
-            workflow.execute_node(add_node)
+            workflow.execute_node(add_node, verbatim_exe = True)
         else:
             add_node.executed = True
             for fil in add_node._outputs:


### PR DESCRIPTION
This calls reolve_url in make_external_call, which allows executables be be specified as URLs.  

get_command_line strips the protocol out of the PFN on assumption that if there is one its file:, so this path also adds an additional parameter to bypass that.