### PR TITLE
add minifollowups v1

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -174,16 +174,17 @@ fore_xmlall = wf.make_foreground_table(workflow, final_bg_file,
 fore_xmlloudest = wf.make_foreground_table(workflow, final_bg_file,
                     hdfbank[0], tag, rdir['result'], singles=insps,
                     extension='.xml', tags=["xmlloudest"])
-layout(rdir['result'], results_page + [(table,)])
 
 snrchi = wf.make_snrchi_plot(workflow, insps, censored_veto, 
                     'closed_box', rdir['single_triggers'], tags=[tag])
 group_layout(rdir['single_triggers'], snrchi)
 
 # run minifollowups on the output of the loudest events
-mf_results = wf.setup_minifollowups(workflow, final_bg_file, hdfbank[0],
-                                              full_insps, rdir['result'],
-                                              tags=final_bg_file.tags)
+mf_results = wf.setup_minifollowups(workflow, final_bg_file,
+                                  full_insps,  hdfbank[0], rdir['result'],
+                                  tags=final_bg_file.tags)
+
+layout(rdir['result'], results_page + [(table,)] + list(groupby(mf_results, 2)))
 
 hist_summ = []
 for insp in full_insps:

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -163,10 +163,6 @@ for bin_file in bin_files:
                     rdir['result'], tags=bin_file.tags)
     results_page += [(snrifar, ifar)]
 
-    # run minifollowups for each mass bin
-    mf_results = wf.setup_minifollowups(workflow, rdir, datafind_files,
-                    bin_file, hdfbank[0], 'foreground', tags=bin_file.tags)
-
 wf.make_ifar_plot(workflow, final_bg_file, rdir['result'])
 
 table = wf.make_foreground_table(workflow, final_bg_file, 
@@ -183,6 +179,11 @@ layout(rdir['result'], results_page + [(table,)])
 snrchi = wf.make_snrchi_plot(workflow, insps, censored_veto, 
                     'closed_box', rdir['single_triggers'], tags=[tag])
 group_layout(rdir['single_triggers'], snrchi)
+
+# run minifollowups on the output of the loudest events
+mf_results = wf.setup_minifollowups(workflow, final_bg_file, hdfbank[0],
+                                              full_insps, rdir['result'],
+                                              tags=final_bg_file.tags)
 
 hist_summ = []
 for insp in full_insps:

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -119,7 +119,7 @@ bank_plot = [(wf.make_template_plot(workflow, hdfbank[0], rdir['coincident_trigg
 inj_files, inj_tags = wf.setup_injection_workflow(workflow, 
                                                      output_dir="inj_files")
                                                                                                                                                         
-######################## Setup the FULL DATA run
+######################## Setup the FULL DATA run ##############################
 tag = output_dir = "full_data"
 ctags = [tag, 'full']
 
@@ -179,13 +179,6 @@ snrchi = wf.make_snrchi_plot(workflow, insps, censored_veto,
                     'closed_box', rdir['single_triggers'], tags=[tag])
 group_layout(rdir['single_triggers'], snrchi)
 
-# run minifollowups on the output of the loudest events
-wf_layout = wf.setup_minifollowups(workflow, final_bg_file,
-                                  full_insps,  hdfbank[0], rdir['result'],
-                                  tags=final_bg_file.tags)
-
-layout(rdir['result'], results_page + [(table,)] + wf_layout)
-
 hist_summ = []
 for insp in full_insps:
     wf.make_singles_plot(workflow, [insp], hdfbank[0], censored_veto, 
@@ -199,7 +192,7 @@ for insp in full_insps:
     hist_summ += list(grouper(hists, 2))
 
 # Calculate the inspiral psds and make plots
-full_segs, psd_files, insp_segs, insp_data_segs = [], [], {}, {}                            
+full_segs, psd_files, insp_segs, insp_data_segs = [], [], {}, {}                      
 for ifo, files in zip(*ind_insps.categorize_by_attr('ifo')):
     name = 'INSPIRAL_SEGMENTS'
     fname = 'segments/%s-' % ifo + name + '.xml'
@@ -207,12 +200,12 @@ for ifo, files in zip(*ind_insps.categorize_by_attr('ifo')):
     full_segs.append(pycbc.events.segments_to_file(insp_segs[ifo], fname, name, ifo=ifo))
 
     insp_data_segs[ifo] = glue.segments.segmentlist([f.metadata['data_seg'] for f in files])
-    data_seg = pycbc.events.segments_to_file(insp_data_segs[ifo],
+    insp_data_segs[ifo] = pycbc.events.segments_to_file(insp_data_segs[ifo],
                    'segments/%s-INSP_DATA.xml' % ifo, 'INSPIRAL_DATA', ifo=ifo)
 
     psd_files += [wf.make_psd_file(workflow, datafind_files.find_output_with_ifo(ifo), 
-                                data_seg, 'INSPIRAL_DATA', 'psds')]
-                           
+                                data_seg[ifo], 'INSPIRAL_DATA', 'psds')]
+
 s = wf.make_spectrum_plot(workflow, psd_files, rdir['detector_sensitivity'])
 r = wf.make_range_plot(workflow, psd_files, rdir['detector_sensitivity'], require='summ')
 r2 = wf.make_range_plot(workflow, psd_files, rdir['detector_sensitivity'], exclude='summ')
@@ -220,6 +213,17 @@ r2 = wf.make_range_plot(workflow, psd_files, rdir['detector_sensitivity'], exclu
 det_summ = [(s, r[0] if len(r) != 0 else None)]
 layout(rdir['detector_sensitivity'], det_summ + list(grouper(r2, 2)))    
 
+
+# run minifollowups on the output of the loudest events
+wf_layout = wf.setup_minifollowups(workflow, final_bg_file,
+                                  full_insps,  hdfbank[0],
+                                  insp_data_segs, 'INSPIRAL_DATA',
+                                  rdir['result'], tags=final_bg_file.tags)
+
+layout(rdir['result'], results_page + [(table,)] + wf_layout)
+    
+################## Setup segment / veto related plots #########################    
+# do plotting of segments / veto times
 for ifo, files in zip(*ind_cats.categorize_by_attr('ifo')):
     wf.make_segments_plot(workflow, files, rdir['analysis_time/segments'], 
                           tags=['%s_VETO_SEGMENTS' % ifo])
@@ -262,7 +266,7 @@ seg_summ_plot = wf.make_seg_plot(workflow, [seg_summ_file],
 # make veto definer table
 vetodef_table = wf.make_veto_table(workflow, rdir['analysis_time/veto_definer'])
 
-############################## Setup the injection runs                                                                           
+############################## Setup the injection runs #######################                                                                   
 inj_coincs = wf.FileList()
 for inj_file, tag in zip(inj_files, inj_tags):
     ctags = [tag, 'inj']

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -180,11 +180,11 @@ snrchi = wf.make_snrchi_plot(workflow, insps, censored_veto,
 group_layout(rdir['single_triggers'], snrchi)
 
 # run minifollowups on the output of the loudest events
-mf_results = wf.setup_minifollowups(workflow, final_bg_file,
+wf_layout = wf.setup_minifollowups(workflow, final_bg_file,
                                   full_insps,  hdfbank[0], rdir['result'],
                                   tags=final_bg_file.tags)
 
-layout(rdir['result'], results_page + [(table,)] + list(groupby(mf_results, 2)))
+layout(rdir['result'], results_page + [(table,)] + wf_layout)
 
 hist_summ = []
 for insp in full_insps:

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -204,7 +204,7 @@ for ifo, files in zip(*ind_insps.categorize_by_attr('ifo')):
                    'segments/%s-INSP_DATA.xml' % ifo, 'INSPIRAL_DATA', ifo=ifo)
 
     psd_files += [wf.make_psd_file(workflow, datafind_files.find_output_with_ifo(ifo), 
-                                data_seg[ifo], 'INSPIRAL_DATA', 'psds')]
+                                insp_data_segs[ifo], 'INSPIRAL_DATA', 'psds')]
 
 s = wf.make_spectrum_plot(workflow, psd_files, rdir['detector_sensitivity'])
 r = wf.make_range_plot(workflow, psd_files, rdir['detector_sensitivity'], require='summ')

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -1,5 +1,5 @@
 #!/bin/env python
-""" Plot the single detector trigger timeseries """
+""" Make tables describing a coincident foreground event"""
 import h5py, argparse, logging, pycbc.version, pycbc.events, pycbc.results, sys
 import matplotlib; matplotlib.use('Agg'); import pylab
 import numpy, pycbc.pnutils
@@ -8,8 +8,10 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--verbose', action='store_true')
-parser.add_argument('--single-trigger-files', nargs='+')
+parser.add_argument('--single-trigger-files', nargs='+', 
+              help="HDF format single detector trigger files for the full data run")
 parser.add_argument('--bank-file')
+              help="HDF format template bank file")
 parser.add_argument('--output-file')
 parser.add_argument('--statmap-file',
     help="The HDF format clustered coincident statmap file containing the result "
@@ -20,10 +22,12 @@ parser.add_argument('--n-loudest', type=int,
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 
+# Get the nth loudest trigger from the output of pycbc_coinc_statmap
 f = h5py.File(args.statmap_file, 'r')
 n = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
 d = f['foreground']
 
+# make a table for the coincident information #################################
 headers = ["Combined Ranking Stat.", "Inc. IFAR (yrs)","Inc. FAP (yrs)", 
                       "exc. IFAR (yrs)", "exc. FAP (yrs)", "Time Delay (s)"]
 
@@ -38,12 +42,15 @@ table = numpy.array([
 
 html = str(pycbc.results.static_table(table, headers))
 
+# make a table for the single detector information ############################
 headers = ["IFO", "Time", "SNR", "NewSNR", "Chisq", "Bins",
            "Phase", "M1", "M2", "Mc", "S1z", "S2z", "Duration"]
 
 ifo1, ifo2 = f.attrs['detector_1'], f.attrs['detector_2']
 idx = {ifo1:d['trigger_id1'][:][n], ifo2:d['trigger_id2'][:][n]}
 
+
+# Store the single detector trigger files keyed by ifo in a dictionary
 table = []
 files = {}
 for fname in args.single_trigger_files:
@@ -58,16 +65,19 @@ for ifo in files.keys():
     d = files[ifo]
     i = idx[ifo]
     tid = d['template_id'][:][i]
+    rchisq =  d['chisq'][:][i] / (d['chisq_dof'][:][i] * 2 - 2)
+    mchirp = (pycbc.pnutils.mass1_mass2_to_mchirp_eta(bank['mass1'][:][tid], 
+                                                      bank['mass2'][:][tid]))[0]  
     data = [ifo,
             d['end_time'][:][i],
             '%5.2f' % d['snr'][:][i],
-            '%5.2f' %  pycbc.events.newsnr(d['snr'][:][i], d['chisq'][:][i]/ (d['chisq_dof'][:][i] * 2 - 2)),
-            '%5.2f' %  (d['chisq'][:][i] / (d['chisq_dof'][:][i] * 2 - 2)),            
+            '%5.2f' %  pycbc.events.newsnr(d['snr'][:][i], rchisq),
+            '%5.2f' %  rchisq,            
             '%5.2f' %  d['chisq_dof'][:][i],
             '%5.2f' % d['coa_phase'][:][i],
             '%5.2f' % bank['mass1'][:][tid],
             '%5.2f' % bank['mass2'][:][tid],
-            '%5.2f' % (pycbc.pnutils.mass1_mass2_to_mchirp_eta(bank['mass1'][:][tid], bank['mass2'][:][tid],))[0],
+            '%5.2f' % mchirp,
             '%5.2f' % bank['spin1z'][:][tid],
             '%5.2f' % bank['spin2z'][:][tid],
             '%5.2f' % d['template_duration'][:][i],
@@ -75,6 +85,7 @@ for ifo in files.keys():
     table.append(data)    
 
 html += str(pycbc.results.static_table(table, headers))
+###############################################################################
 
 pycbc.results.save_fig_with_metadata(html, args.output_file, {},
                         cmd = ' '.join(sys.argv),

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -10,7 +10,7 @@ parser.add_argument('--version', action='version',
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--single-trigger-files', nargs='+', 
               help="HDF format single detector trigger files for the full data run")
-parser.add_argument('--bank-file')
+parser.add_argument('--bank-file',
               help="HDF format template bank file")
 parser.add_argument('--output-file')
 parser.add_argument('--statmap-file',

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -2,15 +2,15 @@
 """ Plot the single detector trigger timeseries """
 import h5py, argparse, logging, pycbc.version, pycbc.events, pycbc.results, sys
 import matplotlib; matplotlib.use('Agg'); import pylab
-import numpy
+import numpy, pycbc.pnutils
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--single-trigger-files', nargs='+')
-parser.add_argument('--coinc-output-file')
-parser.add_argument('--single-output-file')
+parser.add_argument('--bank-file')
+parser.add_argument('--output-file')
 parser.add_argument('--statmap-file',
     help="The HDF format clustered coincident statmap file containing the result "
          "triggers. ")
@@ -24,8 +24,8 @@ f = h5py.File(args.statmap_file, 'r')
 n = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
 d = f['foreground']
 
-headers = ["Combined Ranking Stat.", "IFAR (inc.)","FAP(inc.)", 
-                      "IFAR (exc.)", "FAP(exc.)", "Time Delay (s)"]
+headers = ["Combined Ranking Stat.", "Inc. IFAR (yrs)","Inc. FAP (yrs)", 
+                      "exc. IFAR (yrs)", "exc. FAP (yrs)", "Time Delay (s)"]
 
 table = numpy.array([
                      ['%5.2f' % d['stat'][:][n], 
@@ -38,6 +38,44 @@ table = numpy.array([
 
 html = str(pycbc.results.static_table(table, headers))
 
-pycbc.results.save_html_with_metadata(html, args.coinc_output_file, {}, {})
+headers = ["IFO", "Time", "SNR", "NewSNR", "Chisq", "Bins",
+           "Phase", "M1", "M2", "Mc", "S1z", "S2z", "Duration"]
 
+ifo1, ifo2 = f.attrs['detector_1'], f.attrs['detector_2']
+idx = {ifo1:d['trigger_id1'][:][n], ifo2:d['trigger_id2'][:][n]}
 
+table = []
+files = {}
+for fname in args.single_trigger_files:
+    f = h5py.File(fname, 'r')
+    ifos = f.keys()
+    for ifo in ifos:
+        files[ifo] = f[ifo]
+
+bank = h5py.File(args.bank_file, 'r')
+
+for ifo in files.keys():
+    d = files[ifo]
+    i = idx[ifo]
+    tid = d['template_id'][:][i]
+    data = [ifo,
+            d['end_time'][:][i],
+            '%5.2f' % d['snr'][:][i],
+            '%5.2f' %  pycbc.events.newsnr(d['snr'][:][i], d['chisq'][:][i]/ (d['chisq_dof'][:][i] * 2 - 2)),
+            '%5.2f' %  (d['chisq'][:][i] / (d['chisq_dof'][:][i] * 2 - 2)),            
+            '%5.2f' %  d['chisq_dof'][:][i],
+            '%5.2f' % d['coa_phase'][:][i],
+            '%5.2f' % bank['mass1'][:][tid],
+            '%5.2f' % bank['mass2'][:][tid],
+            '%5.2f' % (pycbc.pnutils.mass1_mass2_to_mchirp_eta(bank['mass1'][:][tid], bank['mass2'][:][tid],))[0],
+            '%5.2f' % bank['spin1z'][:][tid],
+            '%5.2f' % bank['spin2z'][:][tid],
+            '%5.2f' % d['template_duration'][:][i],
+           ]
+    table.append(data)    
+
+html += str(pycbc.results.static_table(table, headers))
+
+pycbc.results.save_fig_with_metadata(html, args.output_file, {},
+                        cmd = ' '.join(sys.argv),
+                        title = 'Coincident event %s' % args.n_loudest)

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -24,7 +24,12 @@ pycbc.init_logging(args.verbose)
 
 # Get the nth loudest trigger from the output of pycbc_coinc_statmap
 f = h5py.File(args.statmap_file, 'r')
-n = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
+try:
+    n = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
+except:
+    pylab.text(0.5, 0.5, 'no trigger found'); pylab.savefig(args.output_file)
+    exit()
+
 d = f['foreground']
 
 # make a table for the coincident information #################################

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -1,4 +1,19 @@
 #!/bin/env python
+# Copyright (C) 2015 Alexander Harvey Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """ Make tables describing a coincident foreground event"""
 import h5py, argparse, logging, pycbc.version, pycbc.events, pycbc.results, sys
 import matplotlib; matplotlib.use('Agg'); import pylab
@@ -27,7 +42,7 @@ f = h5py.File(args.statmap_file, 'r')
 try:
     n = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
 except:
-    pylab.text(0.5, 0.5, 'no trigger found'); pylab.savefig(args.output_file)
+    pylab.text(0.5, 0.5, 'no triggers found'); pylab.savefig(args.output_file)
     exit()
 
 d = f['foreground']

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -1,0 +1,43 @@
+#!/bin/env python
+""" Plot the single detector trigger timeseries """
+import h5py, argparse, logging, pycbc.version, pycbc.events, pycbc.results, sys
+import matplotlib; matplotlib.use('Agg'); import pylab
+import numpy
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--version', action='version',
+    version=pycbc.version.git_verbose_msg)
+parser.add_argument('--verbose', action='store_true')
+parser.add_argument('--single-trigger-files', nargs='+')
+parser.add_argument('--coinc-output-file')
+parser.add_argument('--single-output-file')
+parser.add_argument('--statmap-file',
+    help="The HDF format clustered coincident statmap file containing the result "
+         "triggers. ")
+parser.add_argument('--n-loudest', type=int,
+    help="The trigger Nth loudest trigger to examine, use with statmap file")
+
+args = parser.parse_args()
+pycbc.init_logging(args.verbose)
+
+f = h5py.File(args.statmap_file, 'r')
+n = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
+d = f['foreground']
+
+headers = ["Combined Ranking Stat.", "IFAR (inc.)","FAP(inc.)", 
+                      "IFAR (exc.)", "FAP(exc.)", "Time Delay (s)"]
+
+table = numpy.array([
+                     ['%5.2f' % d['stat'][:][n], 
+                      '%5.2f' % d['ifar'][:][n], 
+                      '%5.2e' % d['fap'][:][n],
+                      '%5.2f' % d['ifar_exc'][:][n], 
+                      '%5.2e' % d['fap_exc'][:][n],
+                      '%5.4f' % (d['time1'][:][n] - d['time2'][:][n])]
+                    ], dtype=str)
+
+html = str(pycbc.results.static_table(table, headers))
+
+pycbc.results.save_html_with_metadata(html, args.coinc_output_file, {}, {})
+
+

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -33,7 +33,7 @@ table = numpy.array([
                       '%5.2e' % d['fap'][:][n],
                       '%5.2f' % d['ifar_exc'][:][n], 
                       '%5.2e' % d['fap_exc'][:][n],
-                      '%5.4f' % (d['time1'][:][n] - d['time2'][:][n])]
+                      '%5.4f' % (d['time2'][:][n] - d['time1'][:][n])]
                     ], dtype=str)
 
 html = str(pycbc.results.static_table(table, headers))

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -8,8 +8,12 @@ def get_time_from_cli(args):
     coincident trigger """
     if args.statmap_file:
         f = h5py.File(args.statmap_file, 'r')
-        stat = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
-        
+        try:
+            stat = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
+        except:
+            pylab.text(0.5, 0.5, 'no trigger found'); pylab.savefig(args.output_file)
+            exit()
+            
         id1 = f['foreground/trigger_id1'][:][stat]
         id2 = f['foreground/trigger_id2'][:][stat]
         

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -18,7 +18,7 @@ parser.add_argument('--version', action='version',
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--single-trigger-files', nargs='+', 
     help="The HDF format single detector merged trigger files")
-parser.add_argument('--window', type=float)
+parser.add_argument('--window', type=float, default=10)
 parser.add_argument('--plot-type', choices=['snr', 'newsnr'], default='snr')
 parser.add_argument('--output-file')
 

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -23,6 +23,7 @@ parser.add_argument('--single-trigger-files', nargs='+',
 parser.add_argument('--window', type=float, default=10)
 parser.add_argument('--plot-type', choices=['snr', 'newsnr'], default='snr')
 parser.add_argument('--output-file')
+parser.add_argument('--log-y-axis', action='store_true')
 
 # These options help choose the GPS time to examine, add more options to pull
 # from different file types (injections, etc)    
@@ -67,9 +68,11 @@ for ifo in files.keys():
         
     pylab.scatter(times, data, color=pycbc.results.ifo_color(ifo), marker='x',
                   label=ifo)
-    print top
     pylab.scatter([0], [top], marker='*', s=50, color='yellow')
-    
+ 
+if args.log_y_axis:
+    pylab.yscale('log')
+     
 pylab.xlabel('time (s)')
 pylab.ylabel(args.plot_type)                                
 pylab.ylim(ymin=data.min())

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -1,0 +1,75 @@
+#!/bin/env python
+""" Plot the single detector trigger timeseries """
+import h5py, argparse, logging, pycbc.version, pycbc.events, pycbc.results, sys
+import matplotlib; matplotlib.use('Agg'); import pylab
+
+def get_time_from_cli(args):
+    if args.statmap_file:
+        f = h5py.File(args.statmap_file, 'r')
+        stat = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
+        
+        ifo1, ifo2 = f.attrs['detector_1'], f.attrs['detector_2']
+        return ({ifo1:f['foreground/time1'][:][stat], 
+                ifo2:f['foreground/time2'][:][stat]})
+    
+parser = argparse.ArgumentParser()
+parser.add_argument('--version', action='version',
+    version=pycbc.version.git_verbose_msg)
+parser.add_argument('--verbose', action='store_true')
+parser.add_argument('--single-trigger-files', nargs='+', 
+    help="The HDF format single detector merged trigger files")
+parser.add_argument('--window', type=float)
+parser.add_argument('--plot-type', choices=['snr', 'newsnr'], default='snr')
+parser.add_argument('--output-file')
+
+# These options help choose the GPS time to examine, add more options to pull
+# from different file types (injections, etc)    
+parser.add_argument('--statmap-file',
+    help="The HDF format clustered coincident statmap file containing the result "
+         "triggers. ")
+parser.add_argument('--n-loudest', type=int,
+    help="The trigger Nth loudest trigger to examine, use with statmap file")
+args = parser.parse_args()
+pycbc.init_logging(args.verbose)
+
+time = get_time_from_cli(args)
+files = {}
+for fname in args.single_trigger_files:
+    f = h5py.File(fname, 'r')
+    ifos = f.keys()
+    for ifo in ifos:
+        files[ifo] = f[ifo]
+
+fig = pylab.figure()
+for ifo in files.keys():
+    t = time[ifo]
+    times = files[ifo]['end_time'][:]
+    
+    idx = pycbc.events.indices_within_times(times, [t - args.window],
+                                                   [t + args.window])
+                                                   
+    # center times on the trigger/chosen time
+    times = times[idx] - t
+    
+    if args.plot_type == 'snr':
+        data = files[ifo]['snr'][:][idx]   
+    if args.plot_type == 'newsnr':                                         
+        snr = files[ifo]['snr'][:]
+        chisq = files[ifo]['chisq'][:]
+        chisq_dof = files[ifo]['chisq_dof'][:]
+        data = pycbc.events.newsnr(snr, chisq / (2 * chisq_dof - 2))
+    
+    pylab.scatter(times, data, color=pycbc.results.ifo_color(ifo), marker='x',
+                  label=ifo)
+    
+pylab.xlabel('time (s)')
+pylab.ylabel(args.plot_type)                                
+pylab.ylim(ymin=data.min())
+pylab.xlim(xmin=-args.window, xmax=args.window)
+pylab.legend()
+pylab.grid()
+pycbc.results.save_fig_with_metadata(fig, args.output_file,
+            cmd = ' '.join(sys.argv),
+            title = 'Single Detector Trigger Timeseries (%s)' % args.plot_type,
+            caption = '',           
+         )

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -4,11 +4,14 @@ import h5py, argparse, logging, pycbc.version, pycbc.events, pycbc.results, sys
 import matplotlib; matplotlib.use('Agg'); import pylab
 
 def get_time_from_cli(args):
+    """ Return the time and single detector trigger ids for the nth loudest
+    coincident trigger """
     if args.statmap_file:
         f = h5py.File(args.statmap_file, 'r')
         stat = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
         
-        id1, id2 = f['foreground/trigger_id1'][:][stat], f['foreground/trigger_id2'][:][stat]
+        id1 = f['foreground/trigger_id1'][:][stat]
+        id2 = f['foreground/trigger_id2'][:][stat]
         
         ifo1, ifo2 = f.attrs['detector_1'], f.attrs['detector_2']
         return ({ifo1:(f['foreground/time1'][:][stat], id1), 
@@ -20,8 +23,10 @@ parser.add_argument('--version', action='version',
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--single-trigger-files', nargs='+', 
     help="The HDF format single detector merged trigger files")
-parser.add_argument('--window', type=float, default=10)
-parser.add_argument('--plot-type', choices=['snr', 'newsnr'], default='snr')
+parser.add_argument('--window', type=float, default=10,
+    help="Time in seconds around the coincident trigger to plot")
+parser.add_argument('--plot-type', choices=['snr', 'newsnr'], default='snr',
+    help="Which plot to make; an 'snr' or a newsnr' plot.")
 parser.add_argument('--output-file')
 parser.add_argument('--log-y-axis', action='store_true')
 
@@ -35,6 +40,7 @@ parser.add_argument('--n-loudest', type=int,
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 
+# organize the single detector triggers files by ifo in a dict
 time = get_time_from_cli(args)
 files = {}
 for fname in args.single_trigger_files:
@@ -62,9 +68,10 @@ for ifo in files.keys():
         chisq = files[ifo]['chisq'][:][idx]
         chisq_dof = files[ifo]['chisq_dof'][:][idx]
         data = pycbc.events.newsnr(snr, chisq / (2 * chisq_dof - 2))
-        top = pycbc.events.newsnr(files[ifo]['snr'][:][id_loud],
-                                  (files[ifo]['chisq'][:][id_loud] / (files[ifo]['chisq_dof'][:][id_loud] * 2 - 2))
-                                  )
+        
+        # Get the newnsr of the loudest trigger so we can plot a star there
+        rchisq = files[ifo]['chisq'][:][id_loud] / (files[ifo]['chisq_dof'][:][id_loud] * 2 - 2)
+        top = pycbc.events.newsnr(files[ifo]['snr'][:][id_loud], rchisq)
         
     pylab.scatter(times, data, color=pycbc.results.ifo_color(ifo), marker='x',
                   label=ifo)

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -1,4 +1,19 @@
 #!/bin/env python
+# Copyright (C) 2015 Alexander Harvey Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """ Plot the single detector trigger timeseries """
 import h5py, argparse, logging, pycbc.version, pycbc.events, pycbc.results, sys
 import matplotlib; matplotlib.use('Agg'); import pylab
@@ -11,7 +26,7 @@ def get_time_from_cli(args):
         try:
             stat = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
         except:
-            pylab.text(0.5, 0.5, 'no trigger found'); pylab.savefig(args.output_file)
+            pylab.text(0.5, 0.5, 'no triggers found'); pylab.savefig(args.output_file)
             exit()
             
         id1 = f['foreground/trigger_id1'][:][stat]

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -8,9 +8,11 @@ def get_time_from_cli(args):
         f = h5py.File(args.statmap_file, 'r')
         stat = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
         
+        id1, id2 = f['foreground/trigger_id1'][:][stat], f['foreground/trigger_id2'][:][stat]
+        
         ifo1, ifo2 = f.attrs['detector_1'], f.attrs['detector_2']
-        return ({ifo1:f['foreground/time1'][:][stat], 
-                ifo2:f['foreground/time2'][:][stat]})
+        return ({ifo1:(f['foreground/time1'][:][stat], id1), 
+                ifo2:(f['foreground/time2'][:][stat], id2)})
     
 parser = argparse.ArgumentParser()
 parser.add_argument('--version', action='version',
@@ -42,7 +44,7 @@ for fname in args.single_trigger_files:
 
 fig = pylab.figure()
 for ifo in files.keys():
-    t = time[ifo]
+    t, id_loud = time[ifo]
     times = files[ifo]['end_time'][:]
     
     idx = pycbc.events.indices_within_times(times, [t - args.window],
@@ -53,14 +55,20 @@ for ifo in files.keys():
     
     if args.plot_type == 'snr':
         data = files[ifo]['snr'][:][idx]   
+        top = files[ifo]['snr'][:][id_loud]
     if args.plot_type == 'newsnr':                                         
         snr = files[ifo]['snr'][:][idx]
         chisq = files[ifo]['chisq'][:][idx]
         chisq_dof = files[ifo]['chisq_dof'][:][idx]
         data = pycbc.events.newsnr(snr, chisq / (2 * chisq_dof - 2))
-    
+        top = pycbc.events.newsnr(files[ifo]['snr'][:][id_loud],
+                                  (files[ifo]['chisq'][:][id_loud] / (files[ifo]['chisq_dof'][:][id_loud] * 2 - 2))
+                                  )
+        
     pylab.scatter(times, data, color=pycbc.results.ifo_color(ifo), marker='x',
                   label=ifo)
+    print top
+    pylab.scatter([0], [top], marker='*', s=50, color='yellow')
     
 pylab.xlabel('time (s)')
 pylab.ylabel(args.plot_type)                                

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -54,9 +54,9 @@ for ifo in files.keys():
     if args.plot_type == 'snr':
         data = files[ifo]['snr'][:][idx]   
     if args.plot_type == 'newsnr':                                         
-        snr = files[ifo]['snr'][:]
-        chisq = files[ifo]['chisq'][:]
-        chisq_dof = files[ifo]['chisq_dof'][:]
+        snr = files[ifo]['snr'][:][idx]
+        chisq = files[ifo]['chisq'][:][idx]
+        chisq_dof = files[ifo]['chisq_dof'][:][idx]
         data = pycbc.events.newsnr(snr, chisq / (2 * chisq_dof - 2))
     
     pylab.scatter(times, data, color=pycbc.results.ifo_color(ifo), marker='x',

--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -7,7 +7,7 @@ import pylab
 parser = argparse.ArgumentParser()
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--verbose')
-parser.add_argument('--single-template-input')
+parser.add_argument('--single-template-file')
 parser.add_argument('--window', type=float)
 parser.add_argument('--output-file')
 
@@ -15,11 +15,11 @@ args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 
 
-f = h5py.File(args.single_template_input)
+f = h5py.File(args.single_template_file)
 delta_t = f['snr'].attrs['delta_t']
 start_time = f['snr'].attrs['start_time']
 time = f.attrs['event_time']
-ifo = f.attrs['ifo]
+ifo = f.attrs['ifo']
 center = int((time - start_time) / delta_t)
 
 

--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -1,20 +1,25 @@
 #!/bin/env python
-
+""" Plot the output of pycbc_single_template """
 import argparse, pycbc.results, pycbc.events, pycbc.events, sys, h5py, numpy
 import matplotlib; matplotlib.use('Agg')
 import pylab
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
+parser.add_argument('--version', action='version',
+    version=pycbc.version.git_verbose_msg)
 parser.add_argument('--verbose')
-parser.add_argument('--single-template-file')
-parser.add_argument('--window', type=float)
+parser.add_argument('--single-template-file', 
+    help="HDF file containing the SNR and CHISQ timeseries. "
+         " The output of pycbc_single_template")
+parser.add_argument('--window', type=float
+    help="The time in seconds to plot")
 parser.add_argument('--output-file')
 
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 
-
+# The event is chosen from the input of pycbc_single template, so we
+# just extract the parameters here
 f = h5py.File(args.single_template_file)
 delta_t = f['snr'].attrs['delta_t']
 start_time = f['snr'].attrs['start_time']
@@ -22,17 +27,14 @@ time = f.attrs['event_time']
 ifo = f.attrs['ifo']
 center = int((time - start_time) / delta_t)
 
-
+# Determine where in the timeseries we need to plot
 left = center - int(args.window / delta_t)
 right = center + int(args.window / delta_t)
-
-
 
 snr = abs(f['snr'][left:right][:])
 chisq = f['chisq'][left:right][:]
 
 rang = (numpy.arange(0, len(snr), 1) - (center - left)) * delta_t
-
 newsnr = pycbc.events.newsnr(snr, chisq)
 
 fig, ax1 = pylab.subplots()
@@ -46,7 +48,6 @@ ax2 = ax1.twinx()
 ax2.plot(rang, chisq, color='green', label='chisq')
 ax2.set_ylabel('CHISQ')
 ax2.legend(loc="upper right")
-
 
 pycbc.results.save_fig_with_metadata(fig, args.output_file, 
                              cmd=' '.join(sys.argv), fig_kwds={'dpi': 150},

--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -11,7 +11,7 @@ parser.add_argument('--verbose')
 parser.add_argument('--single-template-file', 
     help="HDF file containing the SNR and CHISQ timeseries. "
          " The output of pycbc_single_template")
-parser.add_argument('--window', type=float
+parser.add_argument('--window', type=float,
     help="The time in seconds to plot")
 parser.add_argument('--output-file')
 

--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -1,0 +1,53 @@
+#!/bin/env python
+
+import argparse, pycbc.results, pycbc.events, pycbc.events, sys, h5py, numpy
+import matplotlib; matplotlib.use('Agg')
+import pylab
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
+parser.add_argument('--verbose')
+parser.add_argument('--single-template-input')
+parser.add_argument('--window', type=float)
+parser.add_argument('--output-file')
+
+args = parser.parse_args()
+pycbc.init_logging(args.verbose)
+
+
+f = h5py.File(args.single_template_input)
+delta_t = f['snr'].attrs['delta_t']
+start_time = f['snr'].attrs['start_time']
+time = f.attrs['event_time']
+ifo = f.attrs['ifo]
+center = int((time - start_time) / delta_t)
+
+
+left = center - int(args.window / delta_t)
+right = center + int(args.window / delta_t)
+
+
+
+snr = abs(f['snr'][left:right][:])
+chisq = f['chisq'][left:right][:]
+
+rang = (numpy.arange(0, len(snr), 1) - (center - left)) * delta_t
+
+newsnr = pycbc.events.newsnr(snr, chisq)
+
+fig, ax1 = pylab.subplots()
+ax1.plot(rang, snr, color='blue', label='snr')
+ax1.plot(rang, newsnr, color='purple', label='newsnr')
+ax1.set_ylabel('SNR')
+ax1.legend(loc="upper left")
+ax1.set_xlabel('Time (s)')
+
+ax2 = ax1.twinx()
+ax2.plot(rang, chisq, color='green', label='chisq')
+ax2.set_ylabel('CHISQ')
+ax2.legend(loc="upper right")
+
+
+pycbc.results.save_fig_with_metadata(fig, args.output_file, 
+                             cmd=' '.join(sys.argv), fig_kwds={'dpi': 150},
+                             title='%s: SNR and CHISQ TimeSeries' % ifo)

--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -21,9 +21,14 @@ pycbc.init_logging(args.verbose)
 # The event is chosen from the input of pycbc_single template, so we
 # just extract the parameters here
 f = h5py.File(args.single_template_file)
-delta_t = f['snr'].attrs['delta_t']
-start_time = f['snr'].attrs['start_time']
-time = f.attrs['event_time']
+
+try:
+    delta_t = f['snr'].attrs['delta_t']
+    start_time = f['snr'].attrs['start_time']
+    time = f.attrs['event_time']
+except:
+    pylab.text(0.5, 0.5, 'no trigger found'); pylab.savefig(args.output_file)
+
 ifo = f.attrs['ifo']
 center = int((time - start_time) / delta_t)
 

--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -1,4 +1,19 @@
 #!/bin/env python
+# Copyright (C) 2015 Alexander Harvey Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """ Plot the output of pycbc_single_template """
 import argparse, pycbc.results, pycbc.events, pycbc.events, sys, h5py, numpy
 import matplotlib; matplotlib.use('Agg')
@@ -27,7 +42,7 @@ try:
     start_time = f['snr'].attrs['start_time']
     time = f.attrs['event_time']
 except:
-    pylab.text(0.5, 0.5, 'no trigger found'); pylab.savefig(args.output_file)
+    pylab.text(0.5, 0.5, 'no triggers found'); pylab.savefig(args.output_file)
 
 ifo = f.attrs['ifo']
 center = int((time - start_time) / delta_t)

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -8,7 +8,11 @@ from pycbc.types import zeros, float32, complex64, TimeSeries
 
 def get_time(statmap, n_loudest, ifo):
      f = h5py.File(statmap, 'r')
-     n = f['foreground/stat'][:].argsort()[::-1][n_loudest]
+     
+     try:
+        n = f['foreground/stat'][:].argsort()[::-1][n_loudest]
+     except:
+        return None, None
      
      t = {f.attrs['detector_1']: f['foreground/time1'][:][n],
           f.attrs['detector_2']: f['foreground/time2'][:][n],
@@ -90,6 +94,10 @@ ifo = opt.channel_name[0:2]
 # If we are reading from the coinc files ######################################
 if opt.statmap_file:
     time, tid = get_time(opt.statmap_file, opt.n_loudest, ifo)
+    
+    if time is None:
+        exit()
+    
     b = h5py.File(opt.bank_file, 'r')
     opt.mass1 = float(b['mass1'][:][tid])
     opt.mass2 = float(b['mass2'][:][tid])

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -52,7 +52,7 @@ parser.add_argument("--taper-template", choices=["start","end","startend"],
 
 # alternate option set to pull from statmap file
 parser.add_argument("--statmap-file")
-parser.add_argument("--n-loudest")
+parser.add_argument("--n-loudest", type=int)
 parser.add_argument("--bank-file")
 parser.add_argument("--inspiral-segments")
 parser.add_argument("--segment-name")

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+""" Calculate the SNR and CHIQ timeseries for either a chosen template, or 
+a specific Nth loudest coincident event.
+"""
 import sys, logging, argparse, numpy, itertools, pycbc, h5py
 from pycbc import vetoes, psd, waveform, version, strain, scheme, fft, filter, events
 from pycbc.types import zeros, float32, complex64, TimeSeries
@@ -37,10 +40,18 @@ parser.add_argument("--psd-recalculate-segments", type=int,
                     help="Number of segments to use before recalculating the PSD", default=0)
 parser.add_argument("--approximant", type=str,
                   help="The name of the approximant to use for filtering. ")
-parser.add_argument("--mass1", type=float)
-parser.add_argument("--mass2", type=float)
-parser.add_argument("--spin1z", type=float, default=0)
-parser.add_argument("--spin2z", type=float, default=0)
+parser.add_argument("--mass1", type=float, 
+                  help="The mass of the first component object. "
+                       "Do not use if giving a statmap file")
+parser.add_argument("--mass2", type=float,
+                  help="The mass of the second component object. "
+                    "Do not use if giving a statmap file.")
+parser.add_argument("--spin1z", type=float, default=0,
+                  help="The aligned spin of the first component object. "
+                    "Do not use if giving a statmap file.")
+parser.add_argument("--spin2z", type=float, default=0,
+                  help="The aligned pin of the second component object. "
+                    "Do not use if giving a statmap file.")
 parser.add_argument("--order", type=int,
                   help="The integer half-PN order at which to generate"
                        " the approximant. Default is -1 which indicates to use"
@@ -51,11 +62,19 @@ parser.add_argument("--taper-template", choices=["start","end","startend"],
                     " end of the waveform before FFTing.")
 
 # alternate option set to pull from statmap file
-parser.add_argument("--statmap-file")
-parser.add_argument("--n-loudest", type=int)
-parser.add_argument("--bank-file")
-parser.add_argument("--inspiral-segments")
-parser.add_argument("--segment-name")
+parser.add_argument("--statmap-file",
+        help="Alternative to giving mass/spin parameters. The HDF file "
+             "containing the clustered coincident triggers")
+parser.add_argument("--n-loudest", type=int,
+        help="An integer to choose which coincident trigger is followed up"
+             ", only used with --statmap-file")
+parser.add_argument("--bank-file",
+        help="HDF format template bank file, only used with --statmap-file")
+parser.add_argument("--inspiral-segments",
+        help="XML file containing the inspiral analysis segments. "
+             "Only used with the --statmap-file option")
+parser.add_argument("--segment-name", 
+        help="name of the segmentlist to read from the inspiral segment file")
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -66,7 +85,6 @@ fft.insert_fft_option_group(parser)
 opt = parser.parse_args()
 
 f = h5py.File(opt.output_file, 'w')          
-
 ifo = opt.channel_name[0:2]
 
 # If we are reading from the coinc files ######################################

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -3,10 +3,15 @@ import sys, logging, argparse, numpy, itertools, pycbc, h5py
 from pycbc import vetoes, psd, waveform, version, strain, scheme, fft, filter, events
 from pycbc.types import zeros, float32, complex64, TimeSeries
 
-def get_time(statmap, n_loudest):
+def get_time(statmap, n_loudest, ifo):
      f = h5py.File(statmap, 'r')
      n = f['foreground/stat'][:].argsort()[::-1][n_loudest]
-     return f['foreground/time1'][:][n], f['foreground/template_id'][:][n]
+     
+     t = {f.attrs['detector_1']: f['foreground/time1'][:][n],
+          f.attrs['detector_2']: f['foreground/time2'][:][n],
+          }
+     
+     return t[ifo], f['foreground/template_id'][:][n]
 
 def select_segment(fname, segment, ifo, time):
     segs = events.select_segments_by_definer(fname, segment, ifo)
@@ -60,19 +65,22 @@ scheme.insert_processing_option_group(parser)
 fft.insert_fft_option_group(parser)
 opt = parser.parse_args()
 
+f = h5py.File(opt.output_file, 'w')          
+
+ifo = opt.channel_name[0:2]
+
 # If we are reading from the coinc files ######################################
 if opt.statmap_file:
-    time, tid = get_time(opt.statmap_file, opt.n_loudest)
-    f = h5py.File(opt.bank_file)
-    opt.mass1 = float(f['mass1'][:][tid])
-    opt.mass2 = float(f['mass2'][:][tid])
-    opt.spin1z = float(f['spin1z'][:][tid])
-    opt.spin2z = float(f['spin2z'][:][tid])
-    ifo = opt.channel_name[0:2]
+    time, tid = get_time(opt.statmap_file, opt.n_loudest, ifo)
+    b = h5py.File(opt.bank_file, 'r')
+    opt.mass1 = float(b['mass1'][:][tid])
+    opt.mass2 = float(b['mass2'][:][tid])
+    opt.spin1z = float(b['spin1z'][:][tid])
+    opt.spin2z = float(b['spin2z'][:][tid])
     seg = select_segment(opt.inspiral_segments, opt.segment_name, ifo, time)
     opt.gps_start_time, opt.gps_end_time = seg[0] + opt.pad_data, seg[1] - opt.pad_data
+    f.attrs['event_time'] = time
 
-print opt.gps_start_time, opt.gps_end_time
 ###############################################################################
 
 # Check that the values returned for the options make sense
@@ -144,8 +152,8 @@ with ctx:
                                     taper=opt.taper_template, 
                                     f_lower=flow, delta_f=delta_f,
                                     delta_t=gwstrain.delta_t)
-                                    
-    f = h5py.File(opt.output_file, 'w')                               
+                  
+    snrs, chisqs = [], []                                       
     for s_num, stilde in enumerate(segments):
         logging.info("Filtering segment %s" % s_num)
         snr, corr, norm = filter.matched_filter_core(template, stilde, 
@@ -155,13 +163,19 @@ with ctx:
         logging.info("calculating chisq")
         chisq = vetoes.power_chisq(template, stilde, chisq_bins, stilde.psd, 
                                     low_frequency_cutoff = flow)
-        chisq /= chisq_bins * 2 - 2  
+        chisq /= chisq_bins * 2 - 2
+     
+        snrs.append(snr[stilde.analyze])
+        chisqs.append(chisq[stilde.analyze])
         
-        f['snr/%s' % s_num] = snr.numpy() 
-        f['snr/%s' % s_num].attrs['start_time'] = numpy.float64(stilde.epoch)
-        f['snr/%s' % s_num].attrs['delta_t'] = snr.delta_t
-        f['chisq/%s' % s_num] = chisq.numpy() 
-        f['chisq/%s' % s_num].attrs['start_time'] = numpy.float64(stilde.epoch)
-        f['chisq/%s' % s_num].attrs['delta_t'] = snr.delta_t 
+    f['snr'] = numpy.concatenate([snr.numpy() for snr in snrs])
+    f['snr'].attrs['start_time'] = float(snrs[0].start_time)
+    f['snr'].attrs['delta_t'] = snr.delta_t
+    
+    f['chisq'] = numpy.concatenate([chisq.numpy() for chisq in chisqs])
+    f['chisq'].attrs['start_time'] = float(snrs[0].start_time)
+    f['chisq'].attrs['delta_t'] = snr.delta_t 
     f.attrs['approximant'] = opt.approximant
+    f.attrs['ifo'] = ifo
+    
 logging.info("Finished")

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
-""" Calculate the SNR and CHIQ timeseries for either a chosen template, or 
+# Copyright (C) 2015 Alexander Harvey Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+""" Calculate the SNR and CHISQ timeseries for either a chosen template, or 
 a specific Nth loudest coincident event.
 """
 import sys, logging, argparse, numpy, itertools, pycbc, h5py

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -31,6 +31,12 @@ parser.add_argument("--taper-template", choices=["start","end","startend"],
                     help="For time-domain approximants, taper the start and/or"
                     " end of the waveform before FFTing.")
 
+# alternate option set to pull from statmap file
+parser.add_argument("--statmap-file")
+parser.add_argument("--n-loudest")
+parser.add_argument("--inspiral-segments")
+parser.add_argument("--segment-name")
+
 # Add options groups
 psd.insert_psd_option_group(parser)
 strain.insert_strain_option_group(parser)
@@ -119,6 +125,12 @@ with ctx:
         chisq = vetoes.power_chisq(template, stilde, chisq_bins, stilde.psd, 
                                     low_frequency_cutoff = flow)
         chisq /= opt.chisq_bins * 2 - 2  
-         
-    
+        
+        f['snr/%s' % s_num] = snr.numpy() 
+        f['snr/%s' % s_num].attrs['start_time'] = numpy.float64(stilde.epoch)
+        f['snr/%s' % s_num].attrs['delta_t'] = snr.delta_t
+        f['chisq/%s' % s_num] = chisq.numpy() 
+        f['chisq/%s' % s_num].attrs['start_time'] = numpy.float64(stilde.epoch)
+        f['chisq/%s' % s_num].attrs['delta_t'] = snr.delta_t 
+        
 logging.info("Finished")

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import sys, logging, argparse, numpy, itertools, pycbc
+import sys, logging, argparse, numpy, itertools, pycbc, h5py
 from pycbc import vetoes, psd, waveform, version, strain, scheme, fft, filter, events
 from pycbc.types import zeros, float32, complex64, TimeSeries
 
@@ -73,6 +73,18 @@ ctx = scheme.from_cli(opt)
 gwstrain = strain.from_cli(opt, pycbc.DYN_RANGE_FAC)
 strain_segments = strain.StrainSegments.from_cli(opt, gwstrain)
 
+class t(object):
+    pass
+ 
+row = t()
+row.mass1 = opt.mass1
+row.mass2 = opt.mass2
+row.spin1z = opt.spin1z
+row.spin2z = opt.spin2z
+
+chisq_bins = vetoes.SingleDetPowerChisq.parse_option(row, opt.chisq_bins)
+approximant = waveform.FilterBank.parse_option(row, opt.approximant)
+
 with ctx:
     fft.from_cli(opt)
     flow = opt.low_frequency_cutoff
@@ -89,13 +101,14 @@ with ctx:
 
     logging.info("Making template: %s" % opt.approximant)
     template = waveform.get_waveform_filter(zeros(flen, dtype=complex64), 
-                                    approximant=opt.approximant,
+                                    approximant=approximant,
                                     mass1=opt.mass1, mass2=opt.mass2,
                                     spin1z=opt.spin1z, spin2z=opt.spin2z,
                                     taper=opt.taper_template, 
                                     f_lower=flow, delta_f=delta_f,
                                     delta_t=gwstrain.delta_t)
                                     
+    f = h5py.File(args.output_file, 'w')                               
     for s_num, stilde in enumerate(segments):
         logging.info("Filtering segment %s" % s_num)
         snr, corr, norm = filter.matched_filter_core(template, stilde, 
@@ -103,14 +116,9 @@ with ctx:
                                     low_frequency_cutoff=flow)
         snr *= norm
         logging.info("calculating chisq")
-        chisq = vetoes.power_chisq(template, stilde, opt.chisq_bins, stilde.psd, 
+        chisq = vetoes.power_chisq(template, stilde, chisq_bins, stilde.psd, 
                                     low_frequency_cutoff = flow)
-        chisq /= opt.chisq_bins * 2 - 2   
-        newsnr = TimeSeries(events.newsnr(abs(snr).numpy(), chisq.numpy()), 
-                            delta_t=snr.delta_t, epoch=snr.start_time)
-        #import pylab # example plot segment by segment
-        #pylab.plot(snr.sample_times.numpy(), abs(snr).numpy(), label='SNR')
-        #pylab.plot(chisq.sample_times.numpy(), chisq.numpy(), label='CHISQ')
-        #pylab.plot(newsnr.sample_times.numpy(), newsnr.numpy(), label='NewSNR')
-        #pylab.show()
+        chisq /= opt.chisq_bins * 2 - 2  
+         
+    
 logging.info("Finished")

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -3,6 +3,17 @@ import sys, logging, argparse, numpy, itertools, pycbc, h5py
 from pycbc import vetoes, psd, waveform, version, strain, scheme, fft, filter, events
 from pycbc.types import zeros, float32, complex64, TimeSeries
 
+def get_time(statmap, n_loudest):
+     f = h5py.File(statmap, 'r')
+     n = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
+     return f['foreground/time1'][:][n], f['foreground/template_id'][:][n]
+
+def select_segment(fname, segment, ifo, time):
+    segs = events.select_segments_by_definer(fname, segment, ifo)
+    s, e = events.segments_to_start_end(segs)
+    idx = numpy.searchsorted(s, time) - 1
+    reutrn (s[idx], e[idx])
+
 parser = argparse.ArgumentParser(usage='',
     description="Single template gravitational-wave followup")
 parser.add_argument('--version', action='version', 
@@ -34,6 +45,7 @@ parser.add_argument("--taper-template", choices=["start","end","startend"],
 # alternate option set to pull from statmap file
 parser.add_argument("--statmap-file")
 parser.add_argument("--n-loudest")
+parser.add_argument("--bank-file")
 parser.add_argument("--inspiral-segments")
 parser.add_argument("--segment-name")
 
@@ -44,6 +56,20 @@ strain.StrainSegments.insert_segment_option_group(parser)
 scheme.insert_processing_option_group(parser)
 fft.insert_fft_option_group(parser)
 opt = parser.parse_args()
+
+# If we are reading from the coinc files ######################################
+if args.statmap_file:
+    time, tid = get_time(opt.statmap_file, opt.n_loudest)
+    f = h5py.File(opt.bank_file)
+    opt.mass1 = f['mass1'][:][tid]
+    opt.mass2 = f['mass2'][:][tid]    
+    opt.spin1z = f['spin1z'][:][tid]
+    opt.spin2z = f['spin2z'][:][tid]
+    ifo = opt.channel_name[0:2]
+    seg = select_segment(opt.inspiral_segments, opt.segment_name, ifo, time)
+    opt.gps_start_time, opt.gps_end_time = seg[0], seg[1]
+    
+###############################################################################
 
 # Check that the values returned for the options make sense
 psd.verify_psd_options(opt, parser)

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -5,14 +5,17 @@ from pycbc.types import zeros, float32, complex64, TimeSeries
 
 def get_time(statmap, n_loudest):
      f = h5py.File(statmap, 'r')
-     n = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
+     n = f['foreground/stat'][:].argsort()[::-1][n_loudest]
      return f['foreground/time1'][:][n], f['foreground/template_id'][:][n]
 
 def select_segment(fname, segment, ifo, time):
     segs = events.select_segments_by_definer(fname, segment, ifo)
-    s, e = events.segments_to_start_end(segs)
+
+    s = numpy.array([t[0] for t in segs])
+    e = numpy.array([t[1] for t in segs])    
+    
     idx = numpy.searchsorted(s, time) - 1
-    reutrn (s[idx], e[idx])
+    return (s[idx], e[idx])
 
 parser = argparse.ArgumentParser(usage='',
     description="Single template gravitational-wave followup")
@@ -23,7 +26,7 @@ parser.add_argument("-V", "--verbose", action="store_true",
                   help="print extra debugging information", default=False )
 parser.add_argument("--low-frequency-cutoff", type=float,
                   help="The low frequency cutoff to use for filtering (Hz)")
-parser.add_argument("--chisq-bins", default=0, type=int, help=
+parser.add_argument("--chisq-bins", default="0", type=str, help=
                     "Number of frequency bins to use for power chisq.")
 parser.add_argument("--psd-recalculate-segments", type=int, 
                     help="Number of segments to use before recalculating the PSD", default=0)
@@ -58,17 +61,18 @@ fft.insert_fft_option_group(parser)
 opt = parser.parse_args()
 
 # If we are reading from the coinc files ######################################
-if args.statmap_file:
+if opt.statmap_file:
     time, tid = get_time(opt.statmap_file, opt.n_loudest)
     f = h5py.File(opt.bank_file)
-    opt.mass1 = f['mass1'][:][tid]
-    opt.mass2 = f['mass2'][:][tid]    
-    opt.spin1z = f['spin1z'][:][tid]
-    opt.spin2z = f['spin2z'][:][tid]
+    opt.mass1 = float(f['mass1'][:][tid])
+    opt.mass2 = float(f['mass2'][:][tid])
+    opt.spin1z = float(f['spin1z'][:][tid])
+    opt.spin2z = float(f['spin2z'][:][tid])
     ifo = opt.channel_name[0:2]
     seg = select_segment(opt.inspiral_segments, opt.segment_name, ifo, time)
-    opt.gps_start_time, opt.gps_end_time = seg[0], seg[1]
-    
+    opt.gps_start_time, opt.gps_end_time = seg[0] + opt.pad_data, seg[1] - opt.pad_data
+
+print opt.gps_start_time, opt.gps_end_time
 ###############################################################################
 
 # Check that the values returned for the options make sense
@@ -115,7 +119,8 @@ row.spin1z = opt.spin1z
 row.spin2z = opt.spin2z
 
 chisq_bins = vetoes.SingleDetPowerChisq.parse_option(row, opt.chisq_bins)
-approximant = waveform.FilterBank.parse_option(row, opt.approximant)
+if 'params' in opt.approximant:
+    opt.approximant = waveform.FilterBank.parse_option(row, opt.approximant)
 
 with ctx:
     fft.from_cli(opt)
@@ -133,14 +138,14 @@ with ctx:
 
     logging.info("Making template: %s" % opt.approximant)
     template = waveform.get_waveform_filter(zeros(flen, dtype=complex64), 
-                                    approximant=approximant,
+                                    approximant=opt.approximant,
                                     mass1=opt.mass1, mass2=opt.mass2,
                                     spin1z=opt.spin1z, spin2z=opt.spin2z,
                                     taper=opt.taper_template, 
                                     f_lower=flow, delta_f=delta_f,
                                     delta_t=gwstrain.delta_t)
                                     
-    f = h5py.File(args.output_file, 'w')                               
+    f = h5py.File(opt.output_file, 'w')                               
     for s_num, stilde in enumerate(segments):
         logging.info("Filtering segment %s" % s_num)
         snr, corr, norm = filter.matched_filter_core(template, stilde, 
@@ -150,7 +155,7 @@ with ctx:
         logging.info("calculating chisq")
         chisq = vetoes.power_chisq(template, stilde, chisq_bins, stilde.psd, 
                                     low_frequency_cutoff = flow)
-        chisq /= opt.chisq_bins * 2 - 2  
+        chisq /= chisq_bins * 2 - 2  
         
         f['snr/%s' % s_num] = snr.numpy() 
         f['snr/%s' % s_num].attrs['start_time'] = numpy.float64(stilde.epoch)
@@ -158,5 +163,5 @@ with ctx:
         f['chisq/%s' % s_num] = chisq.numpy() 
         f['chisq/%s' % s_num].attrs['start_time'] = numpy.float64(stilde.epoch)
         f['chisq/%s' % s_num].attrs['delta_t'] = snr.delta_t 
-        
+    f.attrs['approximant'] = opt.approximant
 logging.info("Finished")

--- a/pycbc/frame.py
+++ b/pycbc/frame.py
@@ -285,7 +285,7 @@ def query_and_read_frame(frame_type, channels, start_time, end_time):
     >>>                               968995968, 968995968+2048)
     """
     logging.info('querying datafind server')
-    paths = frame_paths(frame_type, start_time, end_time)
+    paths = frame_paths(frame_type, int(start_time), int(end_time))
     logging.info('found files: %s' % (' '.join(paths)))
     return read_frame(paths, channels, 
                       start_time=start_time, 

--- a/pycbc/results/table.py
+++ b/pycbc/results/table.py
@@ -100,3 +100,46 @@ def table(columns, names, page_size=None, format_strings=None):
                                 data=data,
                                 format_strings=format_strings,
                                )
+
+static_table_template = mako.template.Template("""
+    <table class="table">
+        % if titles is not None:
+            <tr>
+            % for i in range(len(titles)):
+                <th>
+                    ${titles[i]}
+                </th>
+            % endfor
+            </tr>
+        % endif
+    
+        % for i in range(len(data)):
+            <tr>
+            % for j in range(len(data[i])):
+                <td>
+                    ${data[i][j]}
+                </td>
+            % endfor
+            </tr>
+        % endfor
+    </table>
+""")
+                               
+def static_table(data, titles=None):
+    """ Return an html tableo of this data
+    
+    Parameters
+    ----------
+    data : two-dimensional numpy string array
+        Array containing the cell values
+    titles : numpy array 
+        Vector str of titles
+    
+    Returns
+    -------
+    html_table : str
+        A string containing the html table.
+    """
+    return static_table_template.render(data=data, titles=titles)
+    
+    

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -16,75 +16,41 @@
 
 import logging
 from pycbc.workflow.core import Executable, FileList, Node
+from pycbc.workflow.plotting import PlotExecutable
 
-def setup_minifollowups(workflow, out_dir, frame_files,
-                             coinc_file, tmpltbank_file, data_type, tags=None):
-    ''' This performs a series of followup jobs on the num_events-th loudest
+def setup_minifollowups(workflow, coinc_file, 
+                                  single_triggers,
+                                  tmpltbank_file, 
+                             out_dir, tags=None):
+    """ This performs a series of followup jobs on the num_events-th loudest
     events.
-    '''
-
+    """
     logging.info('Entering minifollowups module')
-
-    if tags == None: tags = []
-
-    # create a FileList that will contain all output files
-    output_filelist = FileList([])
 
     # check if minifollowups section exists
     # if not then do not do add minifollowup jobs to the workflow
     if not workflow.cp.has_section('workflow-minifollowups'):
-      logging.info('There is no [workflow-minifollowups] section in configuration file')
-      logging.info('Leaving minifollowups')
-      return output_filelist
+        logging.info('There is no [workflow-minifollowups] section in configuration file')
+        logging.info('Leaving minifollowups')
+        return output_filelist
+    
+    
+    tags = [] if tags is None else tags
+    makedir(out_dir)
+
+    # create a FileList that will contain all output files
+    output_filelist = FileList([])
 
     # loop over number of loudest events to be followed up
     num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
     for num_event in range(num_events):
-
-        # increment by 1 for human readability
         num_event += 1
-
-        # get output directory for this event
-        tag_str = '_'.join(tags)
-        output_dir = out_dir['result/loudest_event_%d_of_%d_%s'%(num_event, num_events, tag_str)]
-
-        # make a pycbc_mf_table node for this event
-        table_exe = MinifollowupsTableExecutable(workflow.cp, 'mf_table',
-                        workflow.ifo_string, output_dir, tags=tags)
-        table_node = table_exe.create_node(workflow.analysis_time, coinc_file,
-                        tmpltbank_file, data_type, num_event)
-        workflow.add_node(table_node)
-        output_filelist.extend(table_node.output_files)
+        
+        
 
     logging.info('Leaving minifollowups module')
 
     return output_filelist
 
-class MinifollowupsTableExecutable(Executable):
-    ''' The class responsible for creating jobs for pycbc_mf_table.'''
 
-    current_retention_level = Executable.FINAL_RESULT
-    def __init__(self, cp, exe_name,
-                 ifo=None, out_dir=None, tags=[], universe=None):
-        super(MinifollowupsTableExecutable, self).__init__(cp, exe_name, universe, ifo, out_dir, tags=tags)
 
-    def create_node(self, segment, coinc_file, tmpltbank_file, data_type, loudest_event_number):
-        ''' Creates a node for the loudest_event_number-th loudest event in the
-        coinc_file. '''
-
-        # make a node
-        node = Node(self)
-
-        # add input files
-        node.add_input_opt('--coinc-file', coinc_file)
-        node.add_input_opt('--tmpltbank-file', tmpltbank_file)
-
-        # add options
-        node.add_opt('--data-type', data_type)
-        node.add_opt('--loudest-event-number', loudest_event_number)
-
-        # add output file
-        node.new_output_file_opt(segment, '.html', '--output-file',
-                                 store_file=self.retain_files)
-
-        return node

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -53,7 +53,7 @@ def setup_minifollowups(workflow, coinc_file,
                                   out_dir, tags=tags + [str(num_event)]),)        
         files += make_trigger_timeseries(workflow, single_triggers, coinc_file, num_event, 
                                   out_dir, tags=tags + [str(num_event)])
-        layout += list(grouper(files, 2))]
+        layout += list(grouper(files, 2))
         num_event += 1
     logging.info('Leaving minifollowups module')
 

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -39,7 +39,7 @@ def setup_minifollowups(workflow, coinc_file,
     if not workflow.cp.has_section('workflow-minifollowups'):
         logging.info('There is no [workflow-minifollowups] section in configuration file')
         logging.info('Leaving minifollowups')
-        return output_filelist
+        return []
         
     tags = [] if tags is None else tags
     makedir(out_dir)

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -23,14 +23,35 @@ def grouper(iterable, n, fillvalue=None):
     args = [iter(iterable)] * n
     return izip_longest(*args, fillvalue=fillvalue)
 
-def setup_minifollowups(workflow, coinc_file, 
-                                  single_triggers,
-                                  tmpltbank_file, 
-                                  insp_segs,
-                                  insp_seg_name,
-                             out_dir, tags=None):
+def setup_minifollowups(workflow, coinc_file, single_triggers, tmpltbank_file, 
+                       insp_segs, insp_seg_name, out_dir, tags=None):
     """ This performs a series of followup jobs on the num_events-th loudest
-    events.
+    foreground events.
+    
+    Parameters
+    ----------
+    workflow: pycbc.workflow.Workflow
+        The core workflow instance we are populating
+    coinc_file: 
+    single_triggers: list of pycbc.workflow.File
+        A list cointaining the file objects associated with the merged
+        single detector trigger files for each ifo.
+    tmpltbank_file: pycbc.workflow.File
+        The file object pointing to the HDF format template bank
+    insp_segs: dict
+        A dictionary, keyed by ifo name, of the data read by each inspiral job.
+    insp_segs_name: str 
+        The name of the segmentlist to read from the inspiral segment file
+    out_dir: path
+        The directory to store minifollowups result plots and files
+    tags: {None, optional}
+        Tags to add to the minifollowups executables
+    
+    Returns
+    -------
+    layout: list
+        A list of tuples which specify the displayed file layout for the 
+        minifollops plots.
     """
     logging.info('Entering minifollowups module')
 
@@ -51,11 +72,14 @@ def setup_minifollowups(workflow, coinc_file,
     num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
     for num_event in range(num_events):
         files = FileList([])
-        layout += (make_coinc_info(workflow, single_triggers, tmpltbank_file, coinc_file, num_event, 
+        layout += (make_coinc_info(workflow, single_triggers, tmpltbank_file,
+                                  coinc_file, num_event, 
                                   out_dir, tags=tags + [str(num_event)]),)        
-        files += make_trigger_timeseries(workflow, single_triggers, coinc_file, num_event, 
+        files += make_trigger_timeseries(workflow, single_triggers,
+                                  coinc_file, num_event, 
                                   out_dir, tags=tags + [str(num_event)])
-        files += make_single_template_plots(workflow, insp_segs, insp_seg_name, coinc_file, tmpltbank_file,
+        files += make_single_template_plots(workflow, insp_segs,
+                                  insp_seg_name, coinc_file, tmpltbank_file,
                                   num_event, out_dir, tags=tags + [str(num_event)])
         layout += list(grouper(files, 2))
         num_event += 1
@@ -94,7 +118,8 @@ def make_single_template_plots(workflow, segs, seg_name, coinc, bank, num, out_d
             files += node.output_files
     return files      
 
-def make_coinc_info(workflow, singles, bank, coinc, num, out_dir, exclude=None, require=None, tags=None):
+def make_coinc_info(workflow, singles, bank, coinc, num, out_dir,
+                    exclude=None, require=None, tags=None):
     tags = [] if tags is None else tags
     makedir(out_dir)
     name = 'page_coincinfo'
@@ -112,7 +137,8 @@ def make_coinc_info(workflow, singles, bank, coinc, num, out_dir, exclude=None, 
     files += node.output_files
     return files
     
-def make_trigger_timeseries(workflow, singles, coinc, num, out_dir, exclude=None, require=None, tags=None):
+def make_trigger_timeseries(workflow, singles, coinc, num, out_dir,
+                            exclude=None, require=None, tags=None):
     tags = [] if tags is None else tags
     makedir(out_dir)
     name = 'plot_trigger_timeseries'

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -55,7 +55,7 @@ def setup_minifollowups(workflow, coinc_file,
                                   out_dir, tags=tags + [str(num_event)]),)        
         files += make_trigger_timeseries(workflow, single_triggers, coinc_file, num_event, 
                                   out_dir, tags=tags + [str(num_event)])
-        files += make_single_template_plots(workflow, insp_segs, insp_seg_name, coinc_file,
+        files += make_single_template_plots(workflow, insp_segs, insp_seg_name, coinc_file, tmpltbank_file,
                                   num_event, out_dir, tags=tags + [str(num_event)])
         layout += list(grouper(files, 2))
         num_event += 1
@@ -63,7 +63,7 @@ def setup_minifollowups(workflow, coinc_file,
 
     return layout
 
-def make_single_template_plots(workflow, segs, seg_name, coinc, num, out_dir, 
+def make_single_template_plots(workflow, segs, seg_name, coinc, bank, num, out_dir, 
                                exclude=None, require=None, tags=None):
     tags = [] if tags is None else tags
     makedir(out_dir)
@@ -77,9 +77,10 @@ def make_single_template_plots(workflow, segs, seg_name, coinc, num, out_dir,
             node = PlotExecutable(workflow.cp, 'single_template', ifos=[ifo],
                                  out_dir=out_dir, tags=[tag] + tags).create_node()
             node.add_input_opt('--statmap-file', coinc)
-            node.add_opt('--n-loudest', num)
+            node.add_opt('--n-loudest', str(num))
             node.add_input_opt('--inspiral-segments', segs[ifo])
             node.add_opt('--segment-name', seg_name)
+            node.add_input_opt('--bank-file', bank)
             node.new_output_file_opt(workflow.analysis_time, '.hdf', '--output-file')
             data = node.output_files[0]
             workflow += node
@@ -87,7 +88,7 @@ def make_single_template_plots(workflow, segs, seg_name, coinc, num, out_dir,
             # Make the plot for this trigger and detector
             node = PlotExecutable(workflow.cp, name, ifos=[ifo],
                                   out_dir=out_dir, tags=[tag] + tags).create_node()
-            node.add_input_list_opt('--single-template-file', data)
+            node.add_input_opt('--single-template-file', data)
             node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
             workflow += node
             files += node.output_files

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -49,17 +49,17 @@ def setup_minifollowups(workflow, coinc_file,
     num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
     for num_event in range(num_events):
         files = FileList([])
-        layout += (make_coinc_info(workflow, single_triggers, coinc_file, num_event, 
+        layout += (make_coinc_info(workflow, single_triggers, tmpltbank_file, coinc_file, num_event, 
                                   out_dir, tags=tags + [str(num_event)]),)        
         files += make_trigger_timeseries(workflow, single_triggers, coinc_file, num_event, 
                                   out_dir, tags=tags + [str(num_event)])
-        layout += list(grouper(files, 2))
+        layout += list(grouper(files, 2))]
         num_event += 1
     logging.info('Leaving minifollowups module')
 
     return layout
 
-def make_coinc_info(workflow, singles, coinc, num, out_dir, exclude=None, require=None, tags=None):
+def make_coinc_info(workflow, singles, bank, coinc, num, out_dir, exclude=None, require=None, tags=None):
     tags = [] if tags is None else tags
     makedir(out_dir)
     name = 'page_coincinfo'
@@ -70,8 +70,9 @@ def make_coinc_info(workflow, singles, coinc, num, out_dir, exclude=None, requir
                               out_dir=out_dir, tags=tags).create_node()
     node.add_input_list_opt('--single-trigger-files', singles)
     node.add_input_opt('--statmap-file', coinc)
+    node.add_input_opt('--bank-file', bank)
     node.add_opt('--n-loudest', str(num))
-    node.new_output_file_opt(workflow.analysis_time, '.html', '--coinc-output-file')
+    node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow += node
     files += node.output_files
     return files

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Christopher M. Biwer
+# Copyright (C) 2015 Christopher M. Biwer, Alexander Harvey Nitz
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -20,13 +20,15 @@ from pycbc.workflow.plotting import PlotExecutable, requirestr, excludestr
 from itertools import izip_longest
 
 def grouper(iterable, n, fillvalue=None):
+    """ Create a list of n length tuples
+    """
     args = [iter(iterable)] * n
     return izip_longest(*args, fillvalue=fillvalue)
 
 def setup_minifollowups(workflow, coinc_file, single_triggers, tmpltbank_file, 
                        insp_segs, insp_seg_name, out_dir, tags=None):
-    """ This performs a series of followup jobs on the num_events-th loudest
-    foreground events.
+    """ Create plots that followup the Nth loudest coincident injection
+    from a statmap produced HDF file.
     
     Parameters
     ----------

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -42,7 +42,7 @@ def requirestr(tags, substr):
     return [tag for tag in tags if substr in tag]
  
 class PlotExecutable(Executable):
-    """ This converts xml tmpltbank to an hdf format
+    """ plot executable
     """
     current_retention_level = Executable.FINAL_RESULT
 

--- a/setup.py
+++ b/setup.py
@@ -350,6 +350,7 @@ setup (
     install_requires = install_requires,
     dependency_links = links,
     scripts  = [
+               'bin/minifollowups/pycbc_single_template_plot',
                'bin/minifollowups/pycbc_page_coincinfo',
                'bin/minifollowups/pycbc_plot_trigger_timeseries',
                'bin/lalapps/lalapps_inspiral_ahope',

--- a/setup.py
+++ b/setup.py
@@ -350,6 +350,8 @@ setup (
     install_requires = install_requires,
     dependency_links = links,
     scripts  = [
+               'bin/minifollowups/pycbc_page_coincinfo',
+               'bin/minifollowups/pycbc_plot_trigger_timeseries',
                'bin/lalapps/lalapps_inspiral_ahope',
                'bin/lalapps/lalapps_tmpltbank_ahope',
                'bin/pycbc_banksim',


### PR DESCRIPTION
This adds followup plots for the top X foreground events. It's at the point that I think it is worth recommitting to master. 

The following features are implemented
* trigger time series plots
* snr/chisq plots (created from a pycbc_inspiral based single template followup code)
* tables with the easiest to extrac coinc / single trigger information. 

If need be I can split this into separate pull requests for each script, followed by the changes to the workflow. 

Example page using the latest code.
https://sugar-jobs.phy.syr.edu/~ahnitz/projects/bigdog_rerun/plots/gw12/html/7._result/