### PR TITLE
Dtype of empty arrays should be correct

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -71,7 +71,7 @@ else:
     f['segments/foreground_veto/start'] = numpy.array([0])
     f['segments/foreground_veto/end'] = numpy.array([0])
     for k in d.data:
-        f['foreground/' + k] = numpy.array([])
+        f['foreground/' + k] = numpy.array([], dtype=d.data[k].dtype)
 
 back_locs = d.timeslide_id != 0
 

--- a/bin/hdfcoinc/pycbc_coinc_statmap_inj
+++ b/bin/hdfcoinc/pycbc_coinc_statmap_inj
@@ -70,7 +70,7 @@ if len(zdata) > 0:
         f['foreground/%s' % key] = zdata.data[key]
 else:
     for key in zdata.data:
-        f['foreground/%s' % key] = numpy.array([])
+        f['foreground/%s' % key] = numpy.array([], dtype=zdata.data[key].dtype)
 
 logging.info('calculating statistics excluding zerolag')
 fb = h5py.File(args.full_data_background, "r")


### PR DESCRIPTION
This should address the issue in #340. Specifically the dtype of empty arrays is important if they are going to be numpy.concatenate[d] later. I'm about to add a second part to this to also do this in statmap_inj, is there anywhere else where this should be done?

@stevereyes01 can you verify that this works for you? You will need to rerun parts of your workflow to test this, you do *not* need to rerun inspiral jobs, but I would rerun everything after that.