### PR TITLE
make the mass/spin parameters accessible as the chisq_bins and templa…

### DIFF
--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -162,10 +162,11 @@ class t(object):
     pass
  
 row = t()
-row.mass1 = opt.mass1
-row.mass2 = opt.mass2
-row.spin1z = opt.spin1z
-row.spin2z = opt.spin2z
+row.params = t()
+row.params.mass1 = opt.mass1
+row.params.mass2 = opt.mass2
+row.params.spin1z = opt.spin1z
+row.params.spin2z = opt.spin2z
 
 chisq_bins = vetoes.SingleDetPowerChisq.parse_option(row, opt.chisq_bins)
 if 'params' in opt.approximant:


### PR DESCRIPTION
This is a fix needed for the single template snr/chisq followup code to work with the chisq bins and approximant choices we use for the uberbank (with the eval of a string). 

I've tested that this works on a rerun of Tito's chunk 2 analysis. 