### PR TITLE
Implement automatic gating in strain module

### DIFF
--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -44,6 +44,9 @@ def detect_loud_glitches(strain, psd_duration=16, psd_stride=8,
     if output_intermediates:
         strain.save_to_wav('strain_conditioned.wav')
 
+    # don't waste time trying to optimize a single FFT
+    pycbc.fft.fftw.set_measure_level(0)
+
     logging.info('Autogating: estimating PSD')
     psd = pycbc.psd.welch(strain, seg_len=psd_duration*strain.sample_rate,
                           seg_stride=psd_stride*strain.sample_rate,
@@ -66,6 +69,8 @@ def detect_loud_glitches(strain, psd_duration=16, psd_stride=8,
 
     logging.info('Autogating: frequency -> time')
     pycbc.fft.ifft(strain_tilde, strain)
+
+    pycbc.fft.fftw.set_measure_level(pycbc.fft.fftw._default_measurelvl)
 
     logging.info('Autogating: stdev of whitened strain is %.4f', numpy.std(strain))
 


### PR DESCRIPTION
This patch introduces a poor-man transient search which looks for spikes in the whitened strain time series. The resulting list of times is turned into gating information which is then applied to the strain, and optionally saved. This should free us from depending on Omicron and also enable us to test the effect of gating on injections (and ultimately to tune gating parameters) in a straightforward way.

This is still crude and a work in progress. I'm testing it and there's room for making the FFTs faster and exposing more parameters to the CLI.