### PR TITLE
Use iir2z to get the gain of a gain-only foton module

### DIFF
--- a/examples/cal/foton_filter_esd_saturation/pycbc_foton_filter
+++ b/examples/cal/foton_filter_esd_saturation/pycbc_foton_filter
@@ -79,14 +79,10 @@ parser.add_argument("--sample-rate", type=int, required=True,
 opts = parser.parse_args()
 
 # import dependencies that are not standard to pycbc
-try:
-    import ROOT
-    ROOT.gSystem.Load('/usr/lib64/libdmtsigp.so')
-    ROOT.gSystem.Load('/usr/lib64/libgdsplot.so')
-    from foton import FilterFile, Filter
-except ImportError as e:
-    print e
-    sys.exit()
+import ROOT
+ROOT.gSystem.Load('/usr/lib64/libdmtsigp.so')
+ROOT.gSystem.Load('/usr/lib64/libgdsplot.so')
+from foton import FilterFile, Filter
 
 # setup log
 logging_level = logging.DEBUG

--- a/pycbc/filter/fotonfilter.py
+++ b/pycbc/filter/fotonfilter.py
@@ -84,10 +84,11 @@ def filter_data(data, filter_name, filter_file, bits, filterbank_off=False,
 
             # else it is a filter with only gain so apply the gain
             else:
-                try:
-                    gain = float(filter.design.design.split(')')[0].strip('gain(')) 
-                except ValueError as e:
-                    print 'ValueError', e, 'using gain of 1'
+                coeffs = iir2z(filter_file[filter_name][i])
+                if len(coeffs) > 1:
+                    logging.info('Gain-only filter module return more than one number')
+                    sys.exit()
+                gain = coeffs[0]
                 data = gain * data
 
     return  data


### PR DESCRIPTION
This is a more robust way to get the gain from a gain-only filter module using the foton python package.