### PR TITLE
A few improvements to Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ cache:
   directories:
     - $HOME/inst
 install:
-  - ./tools/install_travis.sh
+  - travis_retry ./tools/install_travis.sh
 script:
   - ./tools/run_travis.sh

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -22,8 +22,7 @@ else
     # install the version of swig that for some reason we have to use
 
     cd ${SRC}
-    # FIXME SF mirror hardcoded to heanet to work around occasional failures
-    wget -q http://heanet.dl.sourceforge.net/project/swig/swig/swig-2.0.11/swig-2.0.11.tar.gz
+    wget -q http://download.sourceforge.net/project/swig/swig/swig-2.0.11/swig-2.0.11.tar.gz
     tar -xzf swig-2.0.11.tar.gz
     cd swig-2.0.11
     ./configure -q --prefix=${INST}
@@ -62,6 +61,10 @@ else
         --disable-lalxml --disable-lalburst --disable-lalapps
     make -j
     make install
+
+    # run lalsimulation tests
+    cd lalsimulation
+    make check
 
     touch ${INST}/dep_install.done
 

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -76,6 +76,11 @@ function test_exec_help {
     test $? -ne 0 && RESULT=1
 }
 
+test_exec_help pycbc_banksim
+test_exec_help pycbc_make_banksim
+test_exec_help pycbc_faithsim
+test_exec_help pycbc_make_faithsim
+
 test_exec_help pycbc_inspiral
 test_exec_help pycbc_geom_nonspinbank
 test_exec_help pycbc_aligned_stoch_bank


### PR DESCRIPTION
* Use travis_retry for downloads and don't hardcode the SWIG mirror
* Run lalsimulation unit tests after building lalsuite
* Add banksim and faithsim executables to tests