### PR TITLE
Add gating files at the workflow level, allow them to be URLs

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -222,7 +222,7 @@ for ifo, files in zip(*ind_insps.categorize_by_attr('ifo')):
                    'segments/%s-INSP_DATA.xml' % ifo, 'INSPIRAL_DATA', ifo=ifo)
 
     psd_files += [wf.make_psd_file(workflow, datafind_files.find_output_with_ifo(ifo), 
-                                insp_data_segs[ifo], 'INSPIRAL_DATA', 'psds')]
+                        insp_data_segs[ifo], 'INSPIRAL_DATA', 'psds', gate_files=gate_files)]
 
 s = wf.make_spectrum_plot(workflow, psd_files, rdir['detector_sensitivity'])
 r = wf.make_range_plot(workflow, psd_files, rdir['detector_sensitivity'], require='summ')

--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -132,6 +132,10 @@ bank_plot = [(wf.make_template_plot(workflow, hdfbank[0], rdir['coincident_trigg
 inj_files, inj_tags = wf.setup_injection_workflow(workflow, 
                                                      output_dir="inj_files")
                                                                                                                                                         
+# setup gating files if provided
+gate_files = wf.setup_gating_workflow(workflow, science_segs,
+                                            datafind_files, "gating")
+
 ######################## Setup the FULL DATA run ##############################
 tag = output_dir = "full_data"
 ctags = [tag, 'full']
@@ -139,7 +143,8 @@ ctags = [tag, 'full']
 # setup the matchedfilter jobs                                                     
 ind_insps = insps = wf.setup_matchedfltr_workflow(workflow, science_segs, 
                                    datafind_files, splitbank_files, 
-                                   output_dir, tags = [tag])
+                                   output_dir, gate_files=gate_files,
+                                   tags = [tag])
 
 insps = wf.merge_single_detector_hdf_files(workflow, hdfbank[0], 
                                            insps, output_dir, tags=[tag])
@@ -303,6 +308,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
     insps = wf.setup_matchedfltr_workflow(workflow, science_segs, 
                                        datafind_files, splitbank_files, 
                                        output_dir, injection_file=small_inj_file,
+                                       gate_files=gate_files,
                                        tags = [tag])
    
     insps = wf.merge_single_detector_hdf_files(workflow, hdfbank[0], 

--- a/pycbc/workflow/__init__.py
+++ b/pycbc/workflow/__init__.py
@@ -38,6 +38,7 @@ from pycbc.workflow.matched_filter import *
 from pycbc.workflow.datafind import *
 from pycbc.workflow.segment import *
 from pycbc.workflow.tmpltbank import *
+from pycbc.workflow.gatefiles import *
 from pycbc.workflow.splittable import *
 from pycbc.workflow.coincidence import *
 from pycbc.workflow.injection import *

--- a/pycbc/workflow/gatefiles.py
+++ b/pycbc/workflow/gatefiles.py
@@ -1,0 +1,134 @@
+# Copyright (C) 2015 Larne Pekowsky
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+
+"""
+This module is responsible for setting up the gating files used by CBC
+workflows. 
+"""
+
+from __future__ import division
+
+import os
+import ConfigParser
+import urlparse, urllib
+import logging
+from pycbc.workflow.core import File, FileList, make_analysis_dir, resolve_url
+
+def setup_gating_workflow(workflow, science_segs, datafind_outs,
+                             output_dir=None, tags=[]):
+    '''
+    Setup gating section of CBC workflow. At present this only supports pregenerated
+    gating files, in the future these could be created within the workflow.
+
+    Parameters
+    ----------
+    workflow: pycbc.workflow.core.Workflow
+        An instanced class that manages the constructed workflow.
+    science_segs : Keyed dictionary of glue.segmentlist objects
+        scienceSegs[ifo] holds the science segments to be analysed for each
+        ifo. 
+    datafind_outs : pycbc.workflow.core.FileList
+        The file list containing the datafind files.
+    output_dir : path string
+        The directory where data products will be placed. 
+    tags : list of strings
+        If given these tags are used to uniquely name and identify output files
+        that would be produced in multiple calls to this function.
+
+    Returns
+    --------
+    gate_files : pycbc.workflow.core.FileList
+        The FileList holding the gate files, 0 or 1 per ifo
+    '''
+    logging.info("Entering gating module.")
+    make_analysis_dir(output_dir)
+    cp = workflow.cp
+    
+    # Parse for options in ini file.  
+    try:
+        gateMethod = cp.get_opt_tags("workflow-gating", "gating-method",
+                                     tags)
+    except:
+        # Gating is optional, just return an empty list if not
+        # provided.
+        return FileList([])
+
+    if gateMethod == "PREGENERATED_FILE":
+        logging.info("Setting gating from pre-generated file(s).")
+        gate_files = setup_gate_pregenerated(workflow, tags=tags)
+    else:
+        errMsg = "Gating method not recognized. Only "
+        errMsg += "PREGENERATED_FILE is currently supported."
+        raise ValueError(errMsg)
+    
+    logging.info("Leaving gating module.")
+    return gate_files
+
+
+def setup_gate_pregenerated(workflow, tags=[]):
+    '''
+    Setup CBC workflow to use pregenerated gating files.
+    The file given in cp.get('workflow','pregenerated-gating-file-(ifo)') will 
+    be used as the --gating-file for all matched-filtering jobs for that ifo.
+
+    Parameters
+    ----------
+    workflow: pycbc.workflow.core.Workflow
+        An instanced class that manages the constructed workflow.
+    tags : list of strings
+        If given these tags are used to uniquely name and identify output files
+        that would be produced in multiple calls to this function.
+
+    Returns
+    --------
+    gate_files : pycbc.workflow.core.FileList
+        The FileList holding the gating files
+    '''
+    gate_files = FileList([])
+
+    cp = workflow.cp
+    global_seg = workflow.analysis_time
+    user_tag = "PREGEN_GATE"
+
+    for ifo in workflow.ifos:
+        try:
+            pre_gen_file = cp.get_opt_tags('workflow-gating',
+                            'gating-pregenerated-file-%s' % ifo.lower(),
+                            tags)
+            pre_gen_file = resolve_url(pre_gen_file)
+            file_url = urlparse.urljoin('file:',
+                                         urllib.pathname2url(pre_gen_file))
+            curr_file = File(ifo, user_tag, global_seg, file_url,
+                                                                 tags=tags)
+            curr_file.PFN(file_url, site='local')
+            gate_files.append(curr_file)
+
+        except ConfigParser.Error:
+            # It's unlikely, but not impossible, that only some ifos
+            # will be gated
+            logging.warn("No gating file specified for IFO %s." % (ifo,))
+            pass
+        
+    return gate_files
+

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -704,11 +704,13 @@ class PyCBCInspiralExecutable(Executable):
     """ The class used to create jobs for pycbc_inspiral Executable. """
     
     current_retention_level = Executable.CRITICAL
-    def __init__(self, cp, exe_name, ifo=None, out_dir=None, injection_file=None, tags=[]):
+    def __init__(self, cp, exe_name, ifo=None, out_dir=None, injection_file=None, 
+                 gate_files=None, tags=[]):
         super(PyCBCInspiralExecutable, self).__init__(cp, exe_name, None, ifo, out_dir, tags=tags)
         self.cp = cp
         self.set_memory(2000)
         self.injection_file = injection_file
+        self.gate_files = gate_files
         
         try:
             outtype = cp.get('workflow-matchedfilter', 'output-type')
@@ -750,6 +752,14 @@ class PyCBCInspiralExecutable(Executable):
 
         if self.injection_file is not None:
             node.add_input_opt('--injection-file', self.injection_file)
+
+        if self.gate_files is not None:
+            ifo_gate = None
+            for gate_file in self.gate_files:
+                if gate_file.ifo == self.ifo:
+                    ifo_gate = gate_file
+            if ifo_gate is not None:
+                node.add_input_opt('--gating-file', ifo_gate)
 
         # set the input and output files        
         fil = node.new_output_file_opt(valid_seg, self.ext, '--output', tags=tags,

--- a/pycbc/workflow/legacy_ihope.py
+++ b/pycbc/workflow/legacy_ihope.py
@@ -155,7 +155,7 @@ class LegacyInspiralExecutable(LegacyAnalysisExecutable):
     """
     current_retention_level = Executable.CRITICAL
     def __init__(self, cp, name, universe=None, ifo=None, injection_file=None, 
-                       out_dir=None, tags=[]):
+                       gate_files=None, out_dir=None, tags=[]):
         super(LegacyInspiralExecutable, self).__init__(cp, name, universe, ifo, 
                                     out_dir=out_dir, tags=tags)
         self.injection_file = injection_file 
@@ -250,7 +250,7 @@ class LegacyCohPTFInspiralExecutable(LegacyAnalysisExecutable):
     """
     current_retention_level = Executable.CRITICAL
     def __init__(self, cp, name, universe=None, ifo=None, injection_file=None,
-                 out_dir=None, tags=[]):
+                 gate_files=None, out_dir=None, tags=[]):
         super(LegacyCohPTFInspiralExecutable, self).__init__(cp, name, universe,
                 ifo, out_dir=out_dir, tags=tags)
         self.cp = cp

--- a/pycbc/workflow/matched_filter.py
+++ b/pycbc/workflow/matched_filter.py
@@ -38,7 +38,7 @@ from pycbc.workflow.jobsetup import (select_matchedfilter_class,
 
 def setup_matchedfltr_workflow(workflow, science_segs, datafind_outs,
                                tmplt_banks, output_dir=None,
-                               injection_file=None, tags=[]):
+                               injection_file=None, gate_files=None, tags=[]):
     '''
     This function aims to be the gateway for setting up a set of matched-filter
     jobs in a workflow. This function is intended to support multiple
@@ -116,7 +116,8 @@ def setup_matchedfltr_workflow(workflow, science_segs, datafind_outs,
     
         inspiral_outs = setup_matchedfltr_dax_generated(workflow, science_segs, 
                                       datafind_outs, tmplt_banks, output_dir,
-                                      injection_file=injection_file, tags=tags,
+                                      injection_file=injection_file, 
+                                      gate_files=gate_files, tags=tags,
                                       link_to_tmpltbank=linkToTmpltbank,
                                       compatibility_mode=compatibility_mode)
     elif mfltrMethod == "WORKFLOW_MULTIPLE_IFOS":
@@ -124,7 +125,7 @@ def setup_matchedfltr_workflow(workflow, science_segs, datafind_outs,
         inspiral_outs = setup_matchedfltr_dax_generated_multi(workflow,
                                       science_segs, datafind_outs, tmplt_banks,
                                       output_dir, injection_file=injection_file,
-                                      tags=tags)
+                                      gate_files=gate_files, tags=tags)
     else:
         errMsg = "Matched filter method not recognized. Must be one of "
         errMsg += "WORKFLOW_INDEPENDENT_IFOS (currently only one option)."
@@ -135,7 +136,7 @@ def setup_matchedfltr_workflow(workflow, science_segs, datafind_outs,
 
 def setup_matchedfltr_dax_generated(workflow, science_segs, datafind_outs,
                                     tmplt_banks, output_dir,
-                                    injection_file=None,
+                                    injection_file=None, gate_files=None,
                                     tags=[], link_to_tmpltbank=False,
                                     compatibility_mode=False):
     '''
@@ -215,6 +216,7 @@ def setup_matchedfltr_dax_generated(workflow, science_segs, datafind_outs,
         job_instance = exe_class(workflow.cp, 'inspiral', ifo=ifo, 
                                                out_dir=output_dir, 
                                                injection_file=injection_file, 
+                                               gate_files=gate_files,
                                                tags=tags)
         if link_exe_instance:
             link_job_instance = link_exe_instance(cp, 'tmpltbank', ifo=ifo,
@@ -300,14 +302,16 @@ def setup_matchedfltr_dax_generated_multi(workflow, science_segs, datafind_outs,
 
         job_instance = exe_class(workflow.cp, 'inspiral', ifo=ifos,
                                  out_dir=output_dir,
-                                 injection_file=injection_file, tags=tags)
+                                 injection_file=injection_file, 
+                                 gate_files=gate_files, tags=tags)
         multi_ifo_coherent_job_setup(workflow, inspiral_outs, job_instance,
                                      science_segs, datafind_outs, output_dir,
                                      parents=tmplt_banks)
     else:
         job_instance = exe_class(workflow.cp, 'inspiral', ifo=ifos,
                                  out_dir=output_dir,
-                                 injection_file=injection_file, tags=tags)
+                                 injection_file=injection_file,
+                                 gate_files=gate_files, tags=tags)
         multi_ifo_job_setup(workflow, inspiral_outs, job_instance,
                             science_segs, datafind_outs, output_dir,
                             parents=tmplt_banks)

--- a/pycbc/workflow/psd.py
+++ b/pycbc/workflow/psd.py
@@ -24,7 +24,7 @@ class CalcPSDExecutable(Executable):
     current_retention_level = Executable.CRITICAL
 
 def make_psd_file(workflow, frame_files, segment_file, segment_name, out_dir,
-                  tags=None):
+                  gate_files=None, tags=None):
     make_analysis_dir(out_dir)
     tags = [] if not tags else tags
     node = CalcPSDExecutable(workflow.cp, 'calculate_psd',
@@ -32,6 +32,16 @@ def make_psd_file(workflow, frame_files, segment_file, segment_name, out_dir,
                              tags=tags).create_node()
     node.add_input_opt('--analysis-segment-file', segment_file)
     node.add_opt('--segment-name', segment_name)
+    
+    if gate_files is not None:
+        ifo_gate = None
+        for gate_file in gate_files:
+            if gate_file.ifo == segment_file.ifo:
+                ifo_gate = gate_file
+        
+        if ifo_gate is not None:
+            node.add_input_opt('--gating-file', ifo_gate)
+
     node.add_input_list_opt('--frame-files', frame_files)
     node.new_output_file_opt(workflow.analysis_time, '.hdf', '--output-file')
     workflow += node
@@ -41,6 +51,7 @@ class AvgPSDExecutable(Executable):
     current_retention_level = Executable.FINAL_RESULT
 
 def make_average_psd(workflow, psd_files, out_dir, tags=None,
+                     gate_files=None,
                      output_fmt='.txt'):
     make_analysis_dir(out_dir)
     tags = [] if tags is None else tags
@@ -60,6 +71,15 @@ def make_average_psd(workflow, psd_files, out_dir, tags=None,
         multi_ifo_string = ifo + ':' + time_avg_file.name
         node.add_opt(multi_ifo_string)
         node._add_output(time_avg_file)
+    
+        if gate_files is not None:
+            ifo_gate = None
+            for gate_file in gate_files:
+                if gate_file.ifo == ifo:
+                    ifo_gate = gate_file
+            
+            if ifo_gate is not None:
+                node.add_input_opt('--gating-file', ifo_gate)
 
     workflow += node
     return node.output_files


### PR DESCRIPTION
This adds a new section to the workflow
```
[workflow-gating]
gating-method = PREGENERATED_FILE
gating-pregenerated-file-h1 = (file or URL)
gating-pregenerated-file-l1 = (file or URL)
```

I've confirmed that
  * This section is optional, no error is caused by omitting it
  * Each ifo is optional, in the unlikely case where we only having gating files for one
  * Remote URLs work
  * When provided, the files are added to workflow and the --gating-file argument is added to full data and injection jobs