### PR TITLE
Add missing import to fotonfilter

### DIFF
--- a/pycbc/filter/fotonfilter.py
+++ b/pycbc/filter/fotonfilter.py
@@ -23,7 +23,7 @@ from pycbc import frame
 import ROOT
 ROOT.gSystem.Load('/usr/lib64/libdmtsigp.so')
 ROOT.gSystem.Load('/usr/lib64/libgdsplot.so')
-from foton import FilterFile, Filter
+from foton import FilterFile, Filter, iir2z
 
 def get_swstat_bits(frame_filenames, swstat_channel_name, start_time, end_time):
     ''' This function just checks the first time in the SWSTAT channel


### PR DESCRIPTION
When I cleaned up the conflict from PR #352 I forgot to add back this import.