### PR TITLE
Add a section at the workflow level for pregenerated PSDs.

### DIFF
--- a/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
+++ b/bin/hdfcoinc/pycbc_make_hdf_coinc_workflow
@@ -120,9 +120,15 @@ cum_veto_files, veto_names, ind_cats = wf.get_cumulative_veto_group_files(workfl
 final_veto_file, final_veto_name, ind_cats = wf.get_cumulative_veto_group_files(workflow, 
                                         'segments-final-veto-group', "segments")
 
+# Precalculated PSDs
+precalc_psd_files = wf.setup_psd_workflow(workflow, science_segs,
+                                            datafind_files, "psdfiles")
+
 # Template bank stuff
 bank_files = wf.setup_tmpltbank_workflow(workflow, science_segs, 
-                                            datafind_files, "bank")                                            
+                                            datafind_files, 
+                                            "bank",
+                                            psd_files=precalc_psd_files)
 hdfbank = wf.convert_bank_to_hdf(workflow, bank_files, "bank")
 splitbank_files = wf.setup_splittable_workflow(workflow, bank_files, "bank") 
 
@@ -224,7 +230,8 @@ for ifo, files in zip(*ind_insps.categorize_by_attr('ifo')):
     psd_files += [wf.make_psd_file(workflow, datafind_files.find_output_with_ifo(ifo), 
                         insp_data_segs[ifo], 'INSPIRAL_DATA', 'psds', gate_files=gate_files)]
 
-s = wf.make_spectrum_plot(workflow, psd_files, rdir['detector_sensitivity'])
+s = wf.make_spectrum_plot(workflow, psd_files, rdir['detector_sensitivity'],
+                          precalc_psd_files=precalc_psd_files)
 r = wf.make_range_plot(workflow, psd_files, rdir['detector_sensitivity'], require='summ')
 r2 = wf.make_range_plot(workflow, psd_files, rdir['detector_sensitivity'], exclude='summ')
 

--- a/pycbc/workflow/__init__.py
+++ b/pycbc/workflow/__init__.py
@@ -39,6 +39,7 @@ from pycbc.workflow.datafind import *
 from pycbc.workflow.segment import *
 from pycbc.workflow.tmpltbank import *
 from pycbc.workflow.gatefiles import *
+from pycbc.workflow.psdfiles import *
 from pycbc.workflow.splittable import *
 from pycbc.workflow.coincidence import *
 from pycbc.workflow.injection import *

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -836,11 +836,12 @@ class PyCBCTmpltbankExecutable(Executable):
     
     current_retention_level = Executable.CRITICAL
     def __init__(self, cp, exe_name, ifo=None, out_dir=None,
-                 tags=[], write_psd=False):
+                 tags=[], write_psd=False, psd_files=None):
         super(PyCBCTmpltbankExecutable, self).__init__(cp, exe_name, 'vanilla', ifo, out_dir, tags=tags)
         self.cp = cp
         self.set_memory(2000)
         self.write_psd = write_psd
+        self.psd_files = psd_files
 
     def create_node(self, data_seg, valid_seg, parent=None, dfParents=None, tags=[]):
         node = Node(self)
@@ -895,6 +896,20 @@ class PyCBCTmpltbankExecutable(Executable):
 
         node.new_output_file_opt(valid_seg, '.xml.gz', '--output-file',
                                  store_file=self.retain_files)
+
+        if self.psd_files is not None:
+            should_add = False
+
+            # If any of the ifos for this job are in the set
+            # of ifos for which a static psd was provided.
+            for ifo in self.ifo_list:
+                for psd_file in self.psd_files:
+                    if ifo in psd_file.ifo_list:
+                        should_add = True
+
+            if should_add:
+                node.add_input_opt('--psd-file', psd_file)
+
         return node
 
     def get_valid_times(self):

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -76,13 +76,17 @@ def make_range_plot(workflow, psd_files, out_dir, exclude=None, require=None, ta
         files += node.output_files
     return files
 
-def make_spectrum_plot(workflow, psd_files, out_dir, tags=None):
+def make_spectrum_plot(workflow, psd_files, out_dir, tags=None, precalc_psd_files=None):
     tags = [] if tags is None else tags
     makedir(out_dir)
     node = PlotExecutable(workflow.cp, 'plot_spectrum', ifos=workflow.ifos,
                           out_dir=out_dir, tags=tags).create_node()
     node.add_input_list_opt('--psd-files', psd_files)
     node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
+
+    if precalc_psd_files is not None:
+        node.add_input_list_opt('--psd-file', precalc_psd_files)
+
     workflow += node
     return node.output_files[0]
  

--- a/pycbc/workflow/psdfiles.py
+++ b/pycbc/workflow/psdfiles.py
@@ -1,0 +1,148 @@
+# Copyright (C) 2015 Larne Pekowsky
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+
+"""
+This module is responsible for setting up the psd files used by CBC
+workflows. 
+"""
+
+from __future__ import division
+
+import os
+import ConfigParser
+import urlparse, urllib
+import logging
+from pycbc.workflow.core import File, FileList, make_analysis_dir, resolve_url
+
+def setup_psd_workflow(workflow, science_segs, datafind_outs,
+                             output_dir=None, tags=[]):
+    '''
+    Setup static psd section of CBC workflow. At present this only supports pregenerated
+    psd files, in the future these could be created within the workflow.
+
+    Parameters
+    ----------
+    workflow: pycbc.workflow.core.Workflow
+        An instanced class that manages the constructed workflow.
+    science_segs : Keyed dictionary of glue.segmentlist objects
+        scienceSegs[ifo] holds the science segments to be analysed for each
+        ifo. 
+    datafind_outs : pycbc.workflow.core.FileList
+        The file list containing the datafind files.
+    output_dir : path string
+        The directory where data products will be placed. 
+    tags : list of strings
+        If given these tags are used to uniquely name and identify output files
+        that would be produced in multiple calls to this function.
+
+    Returns
+    --------
+    psd_files : pycbc.workflow.core.FileList
+        The FileList holding the psd files, 0 or 1 per ifo
+    '''
+    logging.info("Entering static psd module.")
+    make_analysis_dir(output_dir)
+    cp = workflow.cp
+    
+    # Parse for options in ini file.  
+    try:
+        psdMethod = cp.get_opt_tags("workflow-psd", "psd-method",
+                                     tags)
+    except:
+        # Predefined PSD sare optional, just return an empty list if not
+        # provided.
+        return FileList([])
+
+    if psdMethod == "PREGENERATED_FILE":
+        logging.info("Setting psd from pre-generated file(s).")
+        psd_files = setup_psd_pregenerated(workflow, tags=tags)
+    else:
+        errMsg = "PSD method not recognized. Only "
+        errMsg += "PREGENERATED_FILE is currently supported."
+        raise ValueError(errMsg)
+    
+    logging.info("Leaving psd module.")
+    return psd_files
+
+
+def setup_psd_pregenerated(workflow, tags=[]):
+    '''
+    Setup CBC workflow to use pregenerated psd files.
+    The file given in cp.get('workflow','pregenerated-psd-file-(ifo)') will 
+    be used as the --psd-file argument to geom_nonspinbank, geom_aligned_bank
+    and pycbc_plot_psd_file.
+
+    Parameters
+    ----------
+    workflow: pycbc.workflow.core.Workflow
+        An instanced class that manages the constructed workflow.
+    tags : list of strings
+        If given these tags are used to uniquely name and identify output files
+        that would be produced in multiple calls to this function.
+
+    Returns
+    --------
+    psd_files : pycbc.workflow.core.FileList
+        The FileList holding the gating files
+    '''
+    psd_files = FileList([])
+
+    cp = workflow.cp
+    global_seg = workflow.analysis_time
+    user_tag = "PREGEN_PSD"
+
+    # Check for one psd for all ifos
+    try:
+        pre_gen_file = cp.get_opt_tags('workflow-psd',
+                        'psd-pregenerated-file', tags)
+        pre_gen_file = resolve_url(pre_gen_file)
+        file_url = urlparse.urljoin('file:',
+                                     urllib.pathname2url(pre_gen_file))
+        curr_file = File(workflow.ifos, user_tag, global_seg, file_url,
+                                                    tags=tags)
+        curr_file.PFN(file_url, site='local')
+        psd_files.append(curr_file)
+    except ConfigParser.Error:
+        # Check for one psd per ifo
+        for ifo in workflow.ifos:
+            try:
+                pre_gen_file = cp.get_opt_tags('workflow-psd',
+                                'psd-pregenerated-file-%s' % ifo.lower(),
+                                tags)
+                pre_gen_file = resolve_url(pre_gen_file)
+                file_url = urlparse.urljoin('file:',
+                                             urllib.pathname2url(pre_gen_file))
+                curr_file = File(ifo, user_tag, global_seg, file_url,
+                                                            tags=tags)
+                curr_file.PFN(file_url, site='local')
+                psd_files.append(curr_file)
+
+            except ConfigParser.Error:
+                # It's unlikely, but not impossible, that only some ifos
+                # will have pregenerated PSDs
+                logging.warn("No psd file specified for IFO %s." % (ifo,))
+                pass
+            
+    return psd_files
+


### PR DESCRIPTION
This adds a new section to the workflow
```
[workflow-psd]
psd-method = PREGENERATED_FILE
psd-pregenerated-file = (file or URL)
```

Any file specified here will be passed to the template jobs as well as to plot_psd with the --psd-file argument.  I have verified this results in a correct DAX and that the plotting command works when run by hand.