### PR TITLE
Small bug fixes

### DIFF
--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -134,7 +134,7 @@ def make_coinc_info(workflow, singles, bank, coinc, num, out_dir,
     node.add_input_opt('--statmap-file', coinc)
     node.add_input_opt('--bank-file', bank)
     node.add_opt('--n-loudest', str(num))
-    node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
+    node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
     workflow += node
     files += node.output_files
     return files

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -134,7 +134,7 @@ def make_coinc_info(workflow, singles, bank, coinc, num, out_dir,
     node.add_input_opt('--statmap-file', coinc)
     node.add_input_opt('--bank-file', bank)
     node.add_opt('--n-loudest', str(num))
-    node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
+    node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow += node
     files += node.output_files
     return files

--- a/tools/static/hooks/hook-pycbc.py
+++ b/tools/static/hooks/hook-pycbc.py
@@ -14,7 +14,7 @@ from PyInstaller.hooks.hookutils import (collect_data_files, collect_submodules)
 needs_assets = ['pycbc_make_html_page', 'pycbc_make_hdf_coinc_workflow']
 
 # Executables that need MKL
-needs_mkl = ['pycbc_inspiral']
+needs_mkl = ['pycbc_inspiral','pycbc_single_template']
 
 #Some of our libaries are not being picked up automatically (need to invest.)
 #In the meantime we can pull them manually, in the same way we normally


### PR DESCRIPTION
This fixes two minor unrelated problems
  * pycbc_single_template needs the MKL libraries
  * The output to pycbc_page_coincinfo was specified as  "html" instead of "png", causing it to fail with "unsupported format."