### PR TITLE
exit() -> sys.exit() for pyinstaller

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -4,6 +4,7 @@ The program combines coincident output files generated
 by pycbc_coinc_findtrigs to generated a mapping between SNR and FAP, along
 with producing the combined foreground and background triggers
 """
+import sys
 import argparse, h5py, logging, itertools, numpy
 import lal
 from pycbc.events import veto, coinc
@@ -78,7 +79,7 @@ back_locs = d.timeslide_id != 0
 if (back_locs.sum()) == 0:
     logging.warn("There were no background events, so we could not assign "
                  "any statistic values")
-    exit()
+    sys.exit()
     
 logging.info("Dumping background triggers (inclusive of zerolag)")
 for k in d.data:

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -58,7 +58,7 @@ except:
     f = open(args.output_file, 'w')
     f.write("<h1>Event %s, no triggers found</h1>" % (args.n_loudest + 1))
     f.close()
-    exit()
+    sys.exit()
 
 d = f['foreground']
 

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -27,7 +27,7 @@ def get_time_from_cli(args):
             stat = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
         except:
             pylab.text(0.5, 0.5, 'no triggers found'); pylab.savefig(args.output_file)
-            exit()
+            sys.exit()
             
         id1 = f['foreground/trigger_id1'][:][stat]
         id2 = f['foreground/trigger_id2'][:][stat]

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -111,7 +111,7 @@ if opt.statmap_file:
     time, tid = get_time(opt.statmap_file, opt.n_loudest, ifo)
     
     if time is None:
-        exit()
+        sy.exit()
     
     b = h5py.File(opt.bank_file, 'r')
     opt.mass1 = float(b['mass1'][:][tid])

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -111,7 +111,7 @@ if opt.statmap_file:
     time, tid = get_time(opt.statmap_file, opt.n_loudest, ifo)
     
     if time is None:
-        sy.exit()
+        sys.exit()
     
     b = h5py.File(opt.bank_file, 'r')
     opt.mass1 = float(b['mass1'][:][tid])


### PR DESCRIPTION
Programs built by pyinstaller run as if given the -S flag

```
[lppekows@sugar-dev3 ~]$ python -S
Python 2.6.6 (r266:84292, Nov 21 2013, 12:39:37) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-3)] on linux2
>>> exit()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'exit' is not defined
```

so these programs could appear to have failed to condor.