### PR TITLE
Fix for case where workflow doesn't have a psd section

### DIFF
--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -84,7 +84,7 @@ def make_spectrum_plot(workflow, psd_files, out_dir, tags=None, precalc_psd_file
     node.add_input_list_opt('--psd-files', psd_files)
     node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
 
-    if precalc_psd_files is not None:
+    if precalc_psd_files is not None and len(precalc_psd_files) > 0:
         node.add_input_list_opt('--psd-file', precalc_psd_files)
 
     workflow += node


### PR DESCRIPTION
If the ini file doesn't contain a workflow-psd section the plotting code is passed an empty FileList, which was resulting in a call to pycbc_plot_psd_file with an empty --psd-file argument, resulting in a runtime error.  I have confirmed (by checking the DAX) that this patch does the right thing both when the section is present and missing.