### PR TITLE
Allow commas in value when parsing config object

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -184,6 +184,11 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
                 parsedOverrides.append(tuple(splitOverride))
             elif len(splitOverride) == 2:
                 parsedOverrides.append(tuple(splitOverride + [""]))
+            elif len(splitOverride) > 3:
+                # Cannot have colons in either section name or variable name
+                # but the value may contain colons
+                rec_value = ':'.join(splitOverride[2:])
+                parsedOverrides.append(tuple(splitOverride[:2] + [rec_value]))
             else:
                 raise ValueError(
                     "Overrides must be of format section:option:value "


### PR DESCRIPTION
Here's my attempt to fix the issue Duncan reports in #375. @duncan-brown can you let me know if this solves the issue and merge if it does. This shouldn't cause any problems as it would only get raised if a ValueError was about to be encountered anyway!