### PR TITLE
split psd generation into multiple jobs

### DIFF
--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -229,11 +229,12 @@ for ifo, files in zip(*ind_insps.categorize_by_attr('ifo')):
     full_segs.append(pycbc.events.segments_to_file(insp_segs[ifo], fname, name, ifo=ifo))
 
     insp_data_segs[ifo] = glue.segments.segmentlist([f.metadata['data_seg'] for f in files])
+
+    psd_files += wf.setup_psd_calculate(workflow, datafind_files.find_output_with_ifo(ifo), 
+                  ifo, insp_data_segs[ifo], 'INSPIRAL_DATA', 'psds', gate_files=gate_files)
+
     insp_data_segs[ifo] = pycbc.events.segments_to_file(insp_data_segs[ifo],
                    'segments/%s-INSP_DATA.xml' % ifo, 'INSPIRAL_DATA', ifo=ifo)
-
-    psd_files += [wf.make_psd_file(workflow, datafind_files.find_output_with_ifo(ifo), 
-                        insp_data_segs[ifo], 'INSPIRAL_DATA', 'psds', gate_files=gate_files)]
 
 s = wf.make_spectrum_plot(workflow, psd_files, rdir['detector_sensitivity'],
                           precalc_psd_files=precalc_psd_files)

--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -230,8 +230,8 @@ for ifo, files in zip(*ind_insps.categorize_by_attr('ifo')):
 
     insp_data_segs[ifo] = glue.segments.segmentlist([f.metadata['data_seg'] for f in files])
 
-    psd_files += wf.setup_psd_calculate(workflow, datafind_files.find_output_with_ifo(ifo), 
-                  ifo, insp_data_segs[ifo], 'INSPIRAL_DATA', 'psds', gate_files=gate_files)
+    psd_files += [wf.setup_psd_calculate(workflow, datafind_files.find_output_with_ifo(ifo), 
+                  ifo, insp_data_segs[ifo], 'INSPIRAL_DATA', 'psds', gate_files=gate_files)]
 
     insp_data_segs[ifo] = pycbc.events.segments_to_file(insp_data_segs[ifo],
                    'segments/%s-INSP_DATA.xml' % ifo, 'INSPIRAL_DATA', ifo=ifo)

--- a/bin/hdfcoinc/pycbc_merge_psds
+++ b/bin/hdfcoinc/pycbc_merge_psds
@@ -23,7 +23,8 @@ for psd_file in args.psd_files:
         inc[ifo] = 0
         start[ifo], end[ifo] = [], []
     
-    for rkey in f[ifo].keys():
+    for rkey in f['%s/psds' % ifo].keys():
+        rkey = '%s/psds/%s' % (ifo, rkey)
         psd = pycbc.types.load_frequencyseries(psd_file, group=rkey)
     
         key = ifo + '/psds/' + str(inc[ifo])
@@ -45,6 +46,5 @@ for ifo in start:
     outf[ifo + '/end_time'] = numpy.array(end[ifo], dtype=numpy.uint32)
 
 outf.attrs['low_frequency_cutoff'] = f.attrs['low_frequency_cutoff']
-
 logging.info('Done!')
 

--- a/bin/hdfcoinc/pycbc_merge_psds
+++ b/bin/hdfcoinc/pycbc_merge_psds
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+""" Merge hdf psd files
+"""
+import logging, argparse, numpy, h5py, pycbc.types
+from pycbc.version import git_verbose_msg as version
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--version', action='version', version=version)
+parser.add_argument('--verbose', action="store_true")
+parser.add_argument('--psd-files', nargs='+')
+parser.add_argument("--output-file", required=True)
+
+args = parser.parse_args()
+pycbc.init_logging(args.verbose)
+
+outf = h5py.File(args.output_file, 'w')
+inc = {}
+start, end = {}, {}
+for psd_file in args.psd_files:
+    f = h5py.File(psd_file, 'r')
+    ifo = f.keys()[0]
+    if ifo not in inc:
+        inc[ifo] = 0
+        start[ifo], end[ifo] = [], []
+    
+    for rkey in f[ifo].keys():
+        psd = pycbc.types.load_frequencyseries(psd_file, group=rkey)
+    
+        key = ifo + '/psds/' + str(inc[ifo])
+        outf.create_dataset(key, data=psd,
+                         compression='gzip', compression_opts=9, shuffle=True)
+                         
+        s = int(psd.epoch)
+        e = int(s + 1.0 / psd.delta_f)
+                         
+        outf[key].attrs['epoch'] = s
+        outf[key].attrs['delta_f'] = float(psd.delta_f)
+        start[ifo].append(s)
+        end[ifo].append(s)
+        
+        inc[ifo] += 1
+
+for ifo in start:    
+    outf[ifo + '/start_time'] = numpy.array(start[ifo], dtype=numpy.uint32)
+    outf[ifo + '/end_time'] = numpy.array(end[ifo], dtype=numpy.uint32)
+
+outf.attrs['low_frequency_cutoff'] = f.attrs['low_frequency_cutoff']
+
+logging.info('Done!')
+

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -84,7 +84,7 @@ def make_spectrum_plot(workflow, psd_files, out_dir, tags=None, precalc_psd_file
     node.add_input_list_opt('--psd-files', psd_files)
     node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
 
-    if precalc_psd_files is not None and len(precalc_psd_files) > 0:
+    if precalc_psd_files is not None and len(precalc_psd_files) == 1:
         node.add_input_list_opt('--psd-file', precalc_psd_files)
 
     workflow += node

--- a/pycbc/workflow/psd.py
+++ b/pycbc/workflow/psd.py
@@ -18,6 +18,8 @@
 """
 
 from pycbc.workflow.core import FileList, make_analysis_dir, Executable, File
+from pycbc.events import segments_to_file
+from glue.segments import segmentlist
 
 class CalcPSDExecutable(Executable):
     current_retention_level = Executable.CRITICAL
@@ -39,31 +41,32 @@ def merge_psds(workflow, files, ifo, out_dir, tags=None):
     node = MergePSDFiles(workflow.cp, 'merge_psds',
                          ifos=ifo, out_dir=out_dir,
                          tags=tags).create_node()
-    node.add_input_opt('--psd-files', segment_file)
+    node.add_input_list_opt('--psd-files', files)
     node.new_output_file_opt(workflow.analysis_time, '.hdf', '--output-file')
     workflow += node
     return node.output_files[0]        
 
 def setup_psd_calculate(workflow, frame_files, ifo, segments,
                         segment_name, out_dir,
-                        gate_files=None, tags=None)
-    
+                        gate_files=None, tags=None):
+    make_analysis_dir(out_dir)
+    tags = [] if not tags else tags
     if workflow.cp.has_option_tags('workflow-psd', 'parallelization-factor', tags=tags):
-        num_parts = int(workflow.cp.get_option_tags('workflow-psd', 
+        num_parts = int(workflow.cp.get_opt_tags('workflow-psd', 
                                                  'parallelization-factor',
                                                  tags=tags))
     else:
         num_parts = 1
         
-    segment_lists = list(cunks(segments, num_parts)) 
+    segment_lists = list(chunks(segments, num_parts)) 
     
     psd_files = FileList([])
     for i, segs in enumerate(segment_lists):
-        seg_file = pycbc.events.segments_to_file(segs, 
+        seg_file = segments_to_file(segmentlist(segs), 
                                out_dir + '/%s-INSPIRAL_DATA-%s.xml' % (ifo, i), 
                                'INSPIRAL_DATA', ifo=ifo)
 
-        psd_files += [make_psd_file(frame_files, seg_file,
+        psd_files += [make_psd_file(workflow, frame_files, seg_file,
                                     segment_name, out_dir, 
                                     gate_files=gate_files, 
                                     tags=tags + ['PART%s' % i])]
@@ -77,9 +80,10 @@ def make_psd_file(workflow, frame_files, segment_file, segment_name, out_dir,
                   gate_files=None, tags=None):
     make_analysis_dir(out_dir)
     tags = [] if not tags else tags
-    node = CalcPSDExecutable(workflow.cp, 'calculate_psd',
+    exe = CalcPSDExecutable(workflow.cp, 'calculate_psd',
                              ifos=segment_file.ifo, out_dir=out_dir,
-                             tags=tags).create_node()
+                             tags=tags)
+    node = exe.create_node()
     node.add_input_opt('--analysis-segment-file', segment_file)
     node.add_opt('--segment-name', segment_name)
     
@@ -91,8 +95,9 @@ def make_psd_file(workflow, frame_files, segment_file, segment_name, out_dir,
         
         if ifo_gate is not None:
             node.add_input_opt('--gating-file', ifo_gate)
-
-    node.add_input_list_opt('--frame-files', frame_files)
+    
+    if not exe.has_opt('frame-type'):
+        node.add_input_list_opt('--frame-files', frame_files)
     node.new_output_file_opt(workflow.analysis_time, '.hdf', '--output-file')
     workflow += node
     return node.output_files[0]
@@ -135,4 +140,4 @@ def make_average_psd(workflow, psd_files, out_dir, tags=None,
     return node.output_files
 
 # keep namespace clean
-__all__ = ['make_psd_file', 'make_average_psd']
+__all__ = ['make_psd_file', 'make_average_psd', 'setup_psd_calculate', 'merge_psds']

--- a/setup.py
+++ b/setup.py
@@ -445,6 +445,7 @@ setup (
                'bin/hdfcoinc/pycbc_plot_bank_bins',
                'bin/pygrb/pycbc_make_offline_grb_workflow',
                'bin/pygrb/pycbc_make_grb_summary_page',
+               'bin/hdfcoinc/pycbc_merge_psds',
                ],
     packages = [
                'pycbc',


### PR DESCRIPTION
This splits the psd generation into multiple jobs. Current ini files should have the standard behavior. To activate, add the following to the configuration file. 

[workflow-psd]
parallelization-factor = XX