### PR TITLE
Multi ifo methods in pycbc.workflow

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -549,7 +549,66 @@ class Node(pegasus_workflow.Node):
                    use_tmp_subdirs=use_tmp_subdirs)
         self.add_output_opt(option_name, fil)
         return fil
-        
+
+    def add_multiifo_input_list_opt(self, opt, inputs):
+        """ Add an option that determines a list of inputs from multiple
+            detectors. Files will be supplied as --opt ifo1:input1 ifo2:input2
+            .....
+        """
+        # NOTE: Here we have to use the raw arguments functionality as the
+        #       file and ifo are not space separated.
+        self.add_raw_arg('--' + opt)
+        self.add_raw_arg(' ')
+        for infile in inputs:
+            self.add_raw_arg(infile.ifo)
+            self.add_raw_arg(':')
+            self.add_raw_arg(infile)
+            self.add_raw_arg(' ')
+            self._add_input(infile)
+
+    def add_multiifo_output_list_opt(self, opt, outputs):
+        """ Add an option that determines a list of outputs from multiple
+            detectors. Files will be supplied as --opt ifo1:input1 ifo2:input2
+            .....
+        """
+        # NOTE: Here we have to use the raw arguments functionality as the
+        #       file and ifo are not space separated.
+        self.add_raw_arg('--' + opt)
+        self.add_raw_arg(' ')
+        for outfile in outputs:
+            self.add_raw_arg(outfile.ifo)
+            self.add_raw_arg(':')
+            self.add_raw_arg(outfile)
+            self.add_raw_arg(' ')
+            self._add_output(outfile)
+
+    def new_multiifo_output_list_opt(self, opt, ifos, analysis_time, extension,
+                                     tags=[], store_file=None,
+                                     use_tmp_subdirs=False):
+        """ Add an option that determines a list of outputs from multiple
+            detectors. Files will be supplied as --opt ifo1:input1 ifo2:input2
+            .....
+            File names are created internally from the provided extension and
+            analysis time.
+        """
+        all_tags = copy.deepcopy(self.executable.tags)
+        for tag in tags:
+            if tag not in all_tags:
+                all_tags.append(tag)
+
+        output_files = FileList([])
+        store_file = store_file if store_file is not None \
+                                              else self.executable.retain_files
+
+        for ifo in ifos:
+            curr_file = File(ifo, self.executable.name, analysis_time,
+                             extension=extension, store_file=store_file,
+                             directory=self.executable.out_dir, tags=all_tags,
+                             use_tmp_subdirs=use_tmp_subdirs)
+            output_files.append(curr_file)
+        self.add_multiifo_output_list_opt(opt, output_files)
+
+
     @property    
     def output_files(self):
         return FileList(self._outputs)

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -108,7 +108,13 @@ class Node(ProfileShortcuts):
                                  version = executable.version, 
                                  namespace=executable.namespace)
         self._args = []
+        # Each value in _options is added separated with whitespace
+        # so ['--option','value'] --> "--option value"
         self._options = []
+        # For _raw_options *NO* whitespace is added.
+        # so ['--option','value'] --> "--optionvalue"
+        # and ['--option',' ','value'] --> "--option value"
+        self._raw_options = []
         
     def add_arg(self, arg):
         """ Add an argument
@@ -117,7 +123,17 @@ class Node(ProfileShortcuts):
             arg = str(arg)
         
         self._args += [arg]
-        
+
+    def add_raw_arg(self, arg):
+        """ Add an argument to the command line of this job, but do *NOT* add
+            white space between arguments. This can be added manually by adding
+            ' ' if needed
+        """
+        if not isinstance(arg, File):
+            arg = str(arg)
+
+        self._raw_options += [arg]
+
     def add_opt(self, opt, value=None):
         """ Add a option
         """
@@ -203,6 +219,9 @@ class Node(ProfileShortcuts):
     def _finalize(self):
         args = self._args + self._options
         self._dax_node.addArguments(*args)
+        if len(self._raw_options):
+            raw_args = [' '] + self._raw_options
+            self._dax_node.addRawArguments(*raw_args)
         
 class Workflow(object):
     """ 

--- a/pycbc/workflow/psd.py
+++ b/pycbc/workflow/psd.py
@@ -106,7 +106,6 @@ class AvgPSDExecutable(Executable):
     current_retention_level = Executable.FINAL_RESULT
 
 def make_average_psd(workflow, psd_files, out_dir, tags=None,
-                     gate_files=None,
                      output_fmt='.txt'):
     make_analysis_dir(out_dir)
     tags = [] if tags is None else tags
@@ -116,25 +115,8 @@ def make_average_psd(workflow, psd_files, out_dir, tags=None,
     node.new_output_file_opt(workflow.analysis_time, output_fmt,
                              '--detector-avg-file')
 
-    # FIXME should Node have a public method for handling
-    # multidetector output options of type --option H1:foo L1:bar?
-    node.add_opt('--time-avg-file')
-    for ifo in workflow.ifos:
-        time_avg_file = File(ifo, node.executable.name, workflow.analysis_time,
-                             extension=output_fmt, directory=out_dir,
-                             tags=tags)
-        multi_ifo_string = ifo + ':' + time_avg_file.name
-        node.add_opt(multi_ifo_string)
-        node._add_output(time_avg_file)
-    
-        if gate_files is not None:
-            ifo_gate = None
-            for gate_file in gate_files:
-                if gate_file.ifo == ifo:
-                    ifo_gate = gate_file
-            
-            if ifo_gate is not None:
-                node.add_input_opt('--gating-file', ifo_gate)
+    node.new_multiifo_output_list_opt('time-avg-file', workflow.ifos,
+                                 workflow.analysis_time, output_fmt, tags=tags)
 
     workflow += node
     return node.output_files


### PR DESCRIPTION
This is still being tested, do not merge this please until I can finish testing this.

This patch addresses #266 by adding methods to add multi-ifo format options directly to pycbc.workflow. I had stated in #266 that this was not possible due to a pegasus bug. That bug appears to have been fixed in the version of pegasus we are currently using (but of course this will not work with the older version)!

Basically, previously a job with multi ifo options would look something like this:

```
        <job id="ID0000003" name="average_psd-H1L1_ID8">
                <argument>--input-files <file name="H1-CALCULATE_PSD-1123858817-1358905.hdf"/> <file name="L1-CALCULATE_PSD-1123858817-1358905.hdf"/> --detector-avg-file <file name="H1L1-AVERAGE_PSD-1123858817-1358905.txt"/> --time-avg-file H1:H1-AVERAGE_PSD-1123858817-1358905.txt L1:L1-AVERAGE_PSD-1123858817-1358905.txt</argument>
                <profile namespace="dagman" key="category">average_psd</profile>
                <profile namespace="condor" key="getenv">True</profile>
                <uses name="L1-CALCULATE_PSD-1123858817-1358905.hdf" link="input" register="false" transfer="true"/>
                <uses name="H1-CALCULATE_PSD-1123858817-1358905.hdf" link="input" register="false" transfer="true"/>
                <uses name="H1-AVERAGE_PSD-1123858817-1358905.txt" link="output" register="false" transfer="true"/>
                <uses name="H1L1-AVERAGE_PSD-1123858817-1358905.txt" link="output" register="false" transfer="true"/>
                <uses name="L1-AVERAGE_PSD-1123858817-1358905.txt" link="output" register="false" transfer="true"/>
        </job>
```

Note the explicit file names in the arguments. This now becomes

```
        <job id="ID0000003" name="average_psd-H1L1_ID8">
                <argument>--input-files <file name="H1-CALCULATE_PSD-1123858817-1358905.hdf"/> <file name="L1-CALCULATE_PSD-1123858817-1358905.hdf"/> --detector-avg-file <file name="H1L1-AVERAGE_PSD-1123858817-1358905.txt"/> --time-avg-file H1:<file name="H1-AVERAGE_PSD-1123858817-1358905.txt"/> L1:<file name="L1-AVERAGE_PSD-1123858817-1358905.txt"/> </argument>
                <profile namespace="dagman" key="category">average_psd</profile>
                <profile namespace="condor" key="getenv">True</profile>
                <uses name="L1-CALCULATE_PSD-1123858817-1358905.hdf" link="input" register="false" transfer="true"/>
                <uses name="H1-CALCULATE_PSD-1123858817-1358905.hdf" link="input" register="false" transfer="true"/>
                <uses name="H1-AVERAGE_PSD-1123858817-1358905.txt" link="output" register="false" transfer="true"/>
                <uses name="H1L1-AVERAGE_PSD-1123858817-1358905.txt" link="output" register="false" transfer="true"/>
                <uses name="L1-AVERAGE_PSD-1123858817-1358905.txt" link="output" register="false" transfer="true"/>
        </job>
```

To do this I need to make use of the toRawArguments function of the underlying pegasus workflow. I think this is the only way to supply arguments in this form, but it does mean spaces need to be specified explicitly.

A full test of the PSD estimation workflow with this is currently running. I'll update when that completes, but I post this now for feedback while that is running. This will also be needed for multi-ifo analysis code like the python reimplementation of coh_PTF_inspiral and pycbc_multi_inspiral.

I also remove gate_files from the make_average_psd function as this executable *cannot* take gating files, and the logic block there was broken anyway!