### PR TITLE
modified inspiral + omicron follow-up plots to use SEOBNRv2 for waveform generation

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_Nth_loudest_coinc_omicron.py
+++ b/bin/hdfcoinc/pycbc_plot_Nth_loudest_coinc_omicron.py
@@ -121,6 +121,7 @@ for era in eras:
                 omicron_freq.append(row.peak_frequency)
 
 
+# Generate inspiral waveform and calculate f(t) to plot on top of Omicron triggers
 hp, hc = get_td_waveform(approximant='SEOBNRv2', mass1=m1, mass2=m2,
                  spin1x=0, spin1y=0, spin1z=s1z,
                  spin2x=0, spin2y=0, spin2z=s2z,


### PR DESCRIPTION
This executable has been modified to generate SEOBNRv2 waveforms for plotting f(t) of a given signal, which is a better representation of the templates used in the offline coincident search and includes spin effects. The f(t) trace is plotted up to the point of maximum amplitude of h(t). Previously the code generated an analytic 3.5 PN waveform that only calculated up to f_ISCO.

Tested on same commands as old executable and it seems to work fine.