### PR TITLE
multiifo args temporary fix

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -562,7 +562,7 @@ class Node(pegasus_workflow.Node):
         for infile in inputs:
             self.add_raw_arg(infile.ifo)
             self.add_raw_arg(':')
-            self.add_raw_arg(infile)
+            self.add_raw_arg(infile.name)
             self.add_raw_arg(' ')
             self._add_input(infile)
 
@@ -573,12 +573,12 @@ class Node(pegasus_workflow.Node):
         """
         # NOTE: Here we have to use the raw arguments functionality as the
         #       file and ifo are not space separated.
-        self.add_raw_arg('--' +opt)
+        self.add_raw_arg(opt)
         self.add_raw_arg(' ')
         for outfile in outputs:
             self.add_raw_arg(outfile.ifo)
             self.add_raw_arg(':')
-            self.add_raw_arg(outfile)
+            self.add_raw_arg(outfile.name)
             self.add_raw_arg(' ')
             self._add_output(outfile)
 

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -557,7 +557,7 @@ class Node(pegasus_workflow.Node):
         """
         # NOTE: Here we have to use the raw arguments functionality as the
         #       file and ifo are not space separated.
-        self.add_raw_arg('--' + opt)
+        self.add_raw_arg(opt)
         self.add_raw_arg(' ')
         for infile in inputs:
             self.add_raw_arg(infile.ifo)
@@ -573,7 +573,7 @@ class Node(pegasus_workflow.Node):
         """
         # NOTE: Here we have to use the raw arguments functionality as the
         #       file and ifo are not space separated.
-        self.add_raw_arg('--' + opt)
+        self.add_raw_arg('--' +opt)
         self.add_raw_arg(' ')
         for outfile in outputs:
             self.add_raw_arg(outfile.ifo)

--- a/pycbc/workflow/psd.py
+++ b/pycbc/workflow/psd.py
@@ -115,7 +115,7 @@ def make_average_psd(workflow, psd_files, out_dir, tags=None,
     node.new_output_file_opt(workflow.analysis_time, output_fmt,
                              '--detector-avg-file')
 
-    node.new_multiifo_output_list_opt('time-avg-file', workflow.ifos,
+    node.new_multiifo_output_list_opt('--time-avg-file', workflow.ifos,
                                  workflow.analysis_time, output_fmt, tags=tags)
 
     workflow += node


### PR DESCRIPTION
This applies  temporary fix to the multiifo argument so that they can be used in the current pegasus version. The hope if that future pegasus versions might have a way to respect whitespace, but currently they do not. Also included is a change to the argument so it does not preprend a ('--') which is consistent with the other argument handlers. This also allows giving short options ('-'). 

