### PR TITLE
move foreground mini followups into a subdax

### DIFF
--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -325,8 +325,10 @@ for inj_file, tag in zip(inj_files, inj_tags):
                   rdir['injections/%s' % tag],
                    exclude=['all', 'summ', 'sub'], tags=[tag])
                    
-    wf.make_inj_table(workflow, found_inj, 
-                  rdir['injections/%s' % tag], tags=[tag])
+    found_table = wf.make_inj_table(workflow, found_inj, 
+                  rdir['injections/%s' % tag], tags=[tag + 'found'])
+    missed_table = wf.make_inj_table(workflow, found_inj, 
+                  rdir['injections/%s' % tag], missed=True, tags=[tag + 'missed'])
                          
     for inj_insp, trig_insp in zip(insps, full_insps):
         f += wf.make_coinc_snrchi_plot(workflow, found_inj, inj_insp, 
@@ -335,7 +337,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
 
     inj_layout = list(layout.grouper(f, 2)) + [found_table, missed_table]
     if len(s) > 0: layout.group_layout(rdir['search_sensitivity/%s' % tag], s)        
-    if len(f) > 0: layout.group_layout(rdir['injections/%s' % tag], f)  
+    if len(f) > 0: layout.two_column_layout(rdir['injections/%s' % tag], inj_layout)  
     
 # Make combined injection plots
 inj_summ = []

--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -333,6 +333,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
                                   final_bg_file, trig_insp,
                                   rdir['injections/%s' % tag], tags=[tag])
 
+    inj_layout = list(layout.grouper(f, 2)) + [found_table, missed_table]
     if len(s) > 0: layout.group_layout(rdir['search_sensitivity/%s' % tag], s)        
     if len(f) > 0: layout.group_layout(rdir['injections/%s' % tag], f)  
     

--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -216,13 +216,13 @@ layout.two_column_layout(rdir['detector_sensitivity'], det_summ + list(layout.gr
 # run minifollowups on the output of the loudest events 
 wf.setup_foreground_minifollowups(workflow, final_bg_file,
                                   full_insps,  hdfbank[0],
-                                  insp_data_segs, 'INSPIRAL_DATA',
+                                  insp_data_segs, 'INSPIRAL_DATA', 'daxes',
                                   rdir['result/full'], tags=final_bg_file.tags)
     
 for bin_file in bin_files:
     if hasattr(bin_file, 'bin_name'):
         wf.setup_foregroujnd_minifollowups(workflow, bin_file, full_insps, hdfbank[0],
-                                  insp_data_segs, 'INSPIRAL_DATA', 
+                                  insp_data_segs, 'INSPIRAL_DATA', 'daxes',
                                   rdir['result/%s' % bin_file.bin_name],
                                   tags=bin_file.tags)
 

--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -214,20 +214,17 @@ layout.two_column_layout(rdir['detector_sensitivity'], det_summ + list(layout.gr
 
 
 # run minifollowups on the output of the loudest events 
-wf_layout = wf.setup_minifollowups(workflow, final_bg_file,
+wf.setup_foreground_minifollowups(workflow, final_bg_file,
                                   full_insps,  hdfbank[0],
                                   insp_data_segs, 'INSPIRAL_DATA',
-                                  rdir['result'], tags=final_bg_file.tags)
-
-layout.two_column_layout(rdir['result'], results_page + [(table,)] + wf_layout)
+                                  rdir['result/full'], tags=final_bg_file.tags)
     
 for bin_file in bin_files:
     if hasattr(bin_file, 'bin_name'):
-        wf_layout = wf.setup_minifollowups(workflow, bin_file, full_insps, hdfbank[0],
+        wf.setup_foregroujnd_minifollowups(workflow, bin_file, full_insps, hdfbank[0],
                                   insp_data_segs, 'INSPIRAL_DATA', 
                                   rdir['result/%s' % bin_file.bin_name],
                                   tags=bin_file.tags)
-        layout.two_column_layout(rdir['result/%s' % bin_file.bin_name], wf_layout)
 
 ################## Setup segment / veto related plots #########################    
 # do plotting of segments / veto times

--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -165,6 +165,9 @@ wf.make_ifar_plot(workflow, final_bg_file, rdir['result'])
 table = wf.make_foreground_table(workflow, final_bg_file, 
                     hdfbank[0], tag, rdir['result'], singles=insps,
                     extension='.html', tags=["html"])
+results_page += [(table,)]                    
+layout.two_column_layout(rdir['result'], results_page)
+ 
 fore_xmlall = wf.make_foreground_table(workflow, final_bg_file,
                     hdfbank[0], tag, rdir['result'], singles=insps,
                     extension='.xml', tags=["xmlall"])

--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -221,7 +221,7 @@ wf.setup_foreground_minifollowups(workflow, final_bg_file,
     
 for bin_file in bin_files:
     if hasattr(bin_file, 'bin_name'):
-        wf.setup_foregroujnd_minifollowups(workflow, bin_file, full_insps, hdfbank[0],
+        wf.setup_foreground_minifollowups(workflow, bin_file, full_insps, hdfbank[0],
                                   insp_data_segs, 'INSPIRAL_DATA', 'daxes',
                                   rdir['result/%s' % bin_file.bin_name],
                                   tags=bin_file.tags)
@@ -331,7 +331,7 @@ for inj_file, tag in zip(inj_files, inj_tags):
         f += wf.make_coinc_snrchi_plot(workflow, found_inj, inj_insp, 
                                   final_bg_file, trig_insp,
                                   rdir['injections/%s' % tag], tags=[tag])
-                                  
+
     inj_layout = list(layout.grouper(f, 2)) + [(found_table,), (missed_table,)]
     if len(s) > 0: layout.group_layout(rdir['search_sensitivity/%s' % tag], s)        
     if len(f) > 0: layout.two_column_layout(rdir['injections/%s' % tag], inj_layout)  

--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -334,8 +334,8 @@ for inj_file, tag in zip(inj_files, inj_tags):
         f += wf.make_coinc_snrchi_plot(workflow, found_inj, inj_insp, 
                                   final_bg_file, trig_insp,
                                   rdir['injections/%s' % tag], tags=[tag])
-
-    inj_layout = list(layout.grouper(f, 2)) + [found_table, missed_table]
+                                  
+    inj_layout = list(layout.grouper(f, 2)) + [(found_table,), (missed_table,)]
     if len(s) > 0: layout.group_layout(rdir['search_sensitivity/%s' % tag], s)        
     if len(f) > 0: layout.two_column_layout(rdir['injections/%s' % tag], inj_layout)  
     

--- a/bin/hdfcoinc/pycbc_page_injtable
+++ b/bin/hdfcoinc/pycbc_page_injtable
@@ -1,46 +1,59 @@
 #!/usr/bin/python
 """ Make a table of found injection information
 """
-import argparse, h5py, numpy, pycbc.results, pycbc.detector
+import argparse, h5py, numpy, pycbc.results, pycbc.detector, sys
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--injection-file', help='HDF File containing the matched injections')
 parser.add_argument('--verbose', action='count')
+parser.add_argument('--show-missed', action='store_true')
 parser.add_argument('--output-file')
 args = parser.parse_args()
 
 f = h5py.File(args.injection_file)
-found = f['found_after_vetoes']
 inj = f['injections']
-idx = found['injection_index'][:]
+found_cols, found_names, found_formats = [], [], []
 
-tdiff = (found['time1'][:] - found['time2'][:]) * 1000
-tdiff_str = '%s - %s time (ms)' % (f.attrs['detector_1'], f.attrs['detector_2'])
+if args.show_missed:
+    title = "Missed Injections"
+    idx = f['missed/after_vetoes'][:]
+else:
+    title = "Found Injections"
+    found = f['found_after_vetoes']
+    idx = found['injection_index'][:]
+    tdiff = (found['time1'][:] - found['time2'][:]) * 1000
+    tdiff_str = '%s - %s time (ms)' % (f.attrs['detector_1'], f.attrs['detector_2'])
+    
+    found_cols = [tdiff, found['stat'], found['ifar']]
+    found_names = [tdiff_str, 'Ranking Stat.', 'IFAR (years)']
+    found_formats =  ['##.##', '##.##', '##']
 
 columns = [inj['end_time'][:][idx], inj['mass1'][:][idx], inj['mass2'][:][idx],
            inj['spin1x'][:][idx], inj['spin1y'][:][idx], inj['spin1z'][:][idx],
            inj['spin2x'][:][idx], inj['spin2y'][:][idx], inj['spin2z'][:][idx],
            inj['distance'][:][idx],
-           inj['eff_dist_h'][:][idx], inj['eff_dist_l'][:][idx], inj['eff_dist_v'][:][idx],
-           tdiff, found['stat'], found['ifar'],     
-          ]
+           inj['eff_dist_h'][:][idx], inj['eff_dist_l'][:][idx], inj['eff_dist_v'][:][idx], 
+           ] + found_cols
+         
 names = ['Inj Time', 'Mass1', 'Mass2',
          's1x', 's1y', 's1z',
          's2x', 's2y', 's2z', 
          'Dist',
          'Eff Dist (H)', '(L)', '(V)',
-         tdiff_str, 'Ranking Stat.', 'IFAR (years)',
-        ]
+        ] + found_names
 format_strings = ['##.##', '##.##', '##.##',
                   '##.##', '##.##', '##.##',
                   '##.##', '##.##', '##.##',
                   '##.##',
                   '##.##', '##.##', '##.##',
-                  '##.##', '##.##', '##',
-                 ]
+                 ] + found_formats
 
 html_table = pycbc.results.table(columns, names, 
                                  format_strings=format_strings, 
                                  page_size=20)
-f = open(args.output_file, 'w')
-f.write(html_table)
+                                 
+kwds = { 'title' : title, 
+        'caption' : "A table of %s and their coincident statistic information." % title.lower(),
+        'cmd' :' '.join(sys.argv), }
+pycbc.results.save_fig_with_metadata(str(html_table), args.output_file, **kwds)
+

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -86,6 +86,9 @@ stat = stat[sorting][0:num_events]
 times = {f.attrs['detector_1']: f['foreground/time1'][:][sorting][0:num_events],
          f.attrs['detector_2']: f['foreground/time2'][:][sorting][0:num_events],
         }
+tids = {f.attrs['detector_1']: f['foreground/trigger_id1'][:][sorting][0:num_events],
+         f.attrs['detector_2']: f['foreground/trigger_id2'][:][sorting][0:num_events],
+        }
 
 # loop over number of loudest events to be followed up
 for num_event in range(num_events):
@@ -93,12 +96,15 @@ for num_event in range(num_events):
     
     ifo_times = '%s:%s %s:%s' % (times.keys()[0], times[times.keys()[0]][num_event],
                                  times.keys()[1], times[times.keys()[1]][num_event])
+
+    ifo_tids = '%s:%s %s:%s' % (tids.keys()[0], tids[tids.keys()[0]][num_event],
+                                 tids.keys()[1], tids[tids.keys()[1]][num_event])
     
     layouts += (mini.make_coinc_info(workflow, single_triggers, tmpltbank_file,
                               coinc_file, num_event, 
                               args.output_dir, tags=args.tags + [str(num_event)]),)        
     files += mini.make_trigger_timeseries(workflow, single_triggers,
-                              ifo_times, args.output_dir,
+                              ifo_times, args.output_dir, special_tids=ifo_tids,
                               tags=args.tags + [str(num_event)])
     files += mini.make_single_template_plots(workflow, insp_segs,
                               args.inspiral_segment_name, coinc_file, tmpltbank_file,

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -22,9 +22,9 @@ import pycbc.workflow.minifollowups as mini
 import pycbc.workflow.pegasus_workflow as wdax
 import pycbc.version
 
-def to_file(path):
-    print "PATH ", path
+def to_file(path, ifo=None):
     fil = wdax.File(os.path.basename(path))
+    fil.ifo = ifo
     fil.PFN(path, 'local')
     return fil
 
@@ -65,31 +65,41 @@ coinc_file = to_file(args.statmap_file)
 single_triggers = []
 for name in args.single_detector_triggers:
     ifo, fname = name.split(':')
-    single_triggers.append(to_file(fname))
+    single_triggers.append(to_file(fname, ifo=ifo))
     
 insp_segs = {}
 for name in args.inspiral_segments:
     ifo, fname = name.split(':')
-    insp_segs[ifo] = to_file(fname)
+    insp_segs[ifo] = to_file(fname, ifo=ifo)
 
 num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
 f = h5py.File(args.statmap_file, 'r')
 stat = f['foreground/stat'][:]
+
 sorting = stat.argsort()[::-1]
-stat = stat[sorting]
 
 if len(stat) < num_events:
     num_events = len(stat)
 
+stat = stat[sorting][0:num_events]
+
+times = {f.attrs['detector_1']: f['foreground/time1'][:][sorting][0:num_events],
+         f.attrs['detector_2']: f['foreground/time2'][:][sorting][0:num_events],
+        }
+
 # loop over number of loudest events to be followed up
 for num_event in range(num_events):
     files = wf.FileList([])
+    
+    ifo_times = '%s:%s %s:%s' % (times.keys()[0], times[times.keys()[0]][num_event],
+                                 times.keys()[1], times[times.keys()[1]][num_event])
+    
     layouts += (mini.make_coinc_info(workflow, single_triggers, tmpltbank_file,
                               coinc_file, num_event, 
                               args.output_dir, tags=args.tags + [str(num_event)]),)        
     files += mini.make_trigger_timeseries(workflow, single_triggers,
-                              coinc_file, num_event, 
-                              args.output_dir, tags=args.tags + [str(num_event)])
+                              ifo_times, args.output_dir,
+                              tags=args.tags + [str(num_event)])
     files += mini.make_single_template_plots(workflow, insp_segs,
                               args.inspiral_segment_name, coinc_file, tmpltbank_file,
                               num_event, args.output_dir, tags=args.tags + [str(num_event)])

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -19,9 +19,16 @@
 import os, argparse, logging, pycbc.workflow as wf
 from pycbc.results import layout
 import pycbc.workflow.minifollowups as mini
+import pycbc.workflow.pegasus_workflow as wdax
+import pycbc.version
+
+def to_file(path):
+    fil = wdax.File(os.path.basename(path))
+    fil.PFN(path, 'local')
+    return fil
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
-parser.add_argument('--version', action='version', version=__version__) 
+parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg) 
 parser.add_argument('--workflow-name', default='my_unamed_run')
 parser.add_argument("-d", "--output-dir", default=None,
                     help="Path to output directory.")
@@ -36,6 +43,7 @@ parser.add_argument('--inspiral-segments', nargs='+',
 parser.add_argument('--inspiral-segment-name',
                     help="Name of inspiral segmentlist to read from segment files")
 parser.add_argument('--output-map')
+parser.add_argument('--tags', nargs='+', default=[])
 wf.add_workflow_command_line_group(parser)
 args = parser.parse_args()
 
@@ -49,19 +57,32 @@ wf.makedir(args.output_dir)
 # create a FileList that will contain all output files
 layout = []
 
+tmpltbank_file = to_file(args.bank_file)
+coinc_file = to_file(args.statmap_file)
+
+single_triggers = []
+for name in args.single_detector_triggers:
+    ifo, fname = name.split(':')
+    single_triggers.append(to_file(fname))
+    
+insp_segs = {}
+for name in args.inspiral_segments:
+    ifo, fname = name.split(':')
+    insp_segs[ifo] = to_file(fname)
+
 # loop over number of loudest events to be followed up
 num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
 for num_event in range(num_events):
     files = FileList([])
     layout += (mini.make_coinc_info(workflow, single_triggers, tmpltbank_file,
                               coinc_file, num_event, 
-                              out_dir, tags=tags + [str(num_event)]),)        
+                              args.output_dir, tags=args.tags + [str(num_event)]),)        
     files += mini.make_trigger_timeseries(workflow, single_triggers,
                               coinc_file, num_event, 
-                              out_dir, tags=tags + [str(num_event)])
+                              args.output_dir, tags=args.tags + [str(num_event)])
     files += mini.make_single_template_plots(workflow, insp_segs,
-                              insp_seg_name, coinc_file, tmpltbank_file,
-                              num_event, out_dir, tags=tags + [str(num_event)])
+                              args.inspiral_segment_name, coinc_file, tmpltbank_file,
+                              num_event, args.output_dir, tags=args.tags + [str(num_event)])
     layout += list(grouper(files, 2))
     num_event += 1
 

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -1,0 +1,69 @@
+#!/bin/env python
+# Copyright (C) 2015 Alexander Harvey Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+""" Followup foreground events
+"""
+import os, argparse, logging, pycbc.workflow as wf
+from pycbc.results import layout
+import pycbc.workflow.minifollowups as mini
+
+parser = argparse.ArgumentParser(description=__doc__[1:])
+parser.add_argument('--version', action='version', version=__version__) 
+parser.add_argument('--workflow-name', default='my_unamed_run')
+parser.add_argument("-d", "--output-dir", default=None,
+                    help="Path to output directory.")
+parser.add_argument('--bank-file',
+                    help="HDF format template bank file")
+parser.add_argument('--statmap-file',
+                    help="HDF format clustered coincident trigger result file")
+parser.add_argument('--single-detector-triggers', nargs='+', 
+                    help="HDF format merged single detector trigger files")
+parser.add_argument('--inspiral-segments', nargs='+',
+                    help="xml segment files containing the inspiral analysis times")
+parser.add_argument('--inspiral-segment-name',
+                    help="Name of inspiral segmentlist to read from segment files")
+parser.add_argument('--output-map')
+wf.add_workflow_command_line_group(parser)
+args = parser.parse_args()
+
+logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s', 
+                    level=logging.INFO)
+
+workflow = wf.Workflow(args, args.workflow_name)
+
+wf.makedir(args.output_dir)
+             
+# create a FileList that will contain all output files
+layout = []
+
+# loop over number of loudest events to be followed up
+num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
+for num_event in range(num_events):
+    files = FileList([])
+    layout += (mini.make_coinc_info(workflow, single_triggers, tmpltbank_file,
+                              coinc_file, num_event, 
+                              out_dir, tags=tags + [str(num_event)]),)        
+    files += mini.make_trigger_timeseries(workflow, single_triggers,
+                              coinc_file, num_event, 
+                              out_dir, tags=tags + [str(num_event)])
+    files += mini.make_single_template_plots(workflow, insp_segs,
+                              insp_seg_name, coinc_file, tmpltbank_file,
+                              num_event, out_dir, tags=tags + [str(num_event)])
+    layout += list(grouper(files, 2))
+    num_event += 1
+
+workflow.save(output_map=output_map)
+layout.two_column_layout(args.output_dir, layout)

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -23,6 +23,7 @@ import pycbc.workflow.pegasus_workflow as wdax
 import pycbc.version
 
 def to_file(path):
+    print "PATH ", path
     fil = wdax.File(os.path.basename(path))
     fil.PFN(path, 'local')
     return fil
@@ -43,6 +44,7 @@ parser.add_argument('--inspiral-segments', nargs='+',
 parser.add_argument('--inspiral-segment-name',
                     help="Name of inspiral segmentlist to read from segment files")
 parser.add_argument('--output-map')
+parser.add_argument('--output-file')
 parser.add_argument('--tags', nargs='+', default=[])
 wf.add_workflow_command_line_group(parser)
 args = parser.parse_args()
@@ -55,7 +57,7 @@ workflow = wf.Workflow(args, args.workflow_name)
 wf.makedir(args.output_dir)
              
 # create a FileList that will contain all output files
-layout = []
+layouts = []
 
 tmpltbank_file = to_file(args.bank_file)
 coinc_file = to_file(args.statmap_file)
@@ -73,8 +75,8 @@ for name in args.inspiral_segments:
 # loop over number of loudest events to be followed up
 num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
 for num_event in range(num_events):
-    files = FileList([])
-    layout += (mini.make_coinc_info(workflow, single_triggers, tmpltbank_file,
+    files = wf.FileList([])
+    layouts += (mini.make_coinc_info(workflow, single_triggers, tmpltbank_file,
                               coinc_file, num_event, 
                               args.output_dir, tags=args.tags + [str(num_event)]),)        
     files += mini.make_trigger_timeseries(workflow, single_triggers,
@@ -83,8 +85,8 @@ for num_event in range(num_events):
     files += mini.make_single_template_plots(workflow, insp_segs,
                               args.inspiral_segment_name, coinc_file, tmpltbank_file,
                               num_event, args.output_dir, tags=args.tags + [str(num_event)])
-    layout += list(grouper(files, 2))
+    layouts += list(layout.grouper(files, 2))
     num_event += 1
 
-workflow.save(output_map=output_map)
-layout.two_column_layout(args.output_dir, layout)
+workflow.save(filename=args.output_file, output_map=args.output_map)
+layout.two_column_layout(args.output_dir, layouts)

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -16,7 +16,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """ Followup foreground events
 """
-import os, argparse, logging, pycbc.workflow as wf
+import os, argparse, logging, h5py, pycbc.workflow as wf
 from pycbc.results import layout
 import pycbc.workflow.minifollowups as mini
 import pycbc.workflow.pegasus_workflow as wdax
@@ -72,8 +72,16 @@ for name in args.inspiral_segments:
     ifo, fname = name.split(':')
     insp_segs[ifo] = to_file(fname)
 
-# loop over number of loudest events to be followed up
 num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
+f = h5py.File(args.statmap_file, 'r')
+stat = f['foreground/stat'][:]
+sorting = stat.argsort()[::-1]
+stat = stat[sorting]
+
+if len(stat) < num_events:
+    num_events = len(stat)
+
+# loop over number of loudest events to be followed up
 for num_event in range(num_events):
     files = wf.FileList([])
     layouts += (mini.make_coinc_info(workflow, single_triggers, tmpltbank_file,

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -59,14 +59,7 @@ pycbc.init_logging(args.verbose)
 
 # Get the nth loudest trigger from the output of pycbc_coinc_statmap
 f = h5py.File(args.statmap_file, 'r')
-try:
-    n = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
-except:
-    f = open(args.output_file, 'w')
-    f.write("<h1>Event %s, no triggers found</h1>" % (args.n_loudest + 1))
-    f.close()
-    sys.exit()
-
+n = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
 d = f['foreground']
 
 # JavaScript for searching the aLOG

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -23,15 +23,9 @@ def get_time_from_cli(args):
     coincident trigger """
     if args.statmap_file:
         f = h5py.File(args.statmap_file, 'r')
-        try:
-            stat = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
-        except:
-            pylab.text(0.5, 0.5, 'no triggers found'); pylab.savefig(args.output_file)
-            sys.exit()
-            
+        stat = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]           
         id1 = f['foreground/trigger_id1'][:][stat]
-        id2 = f['foreground/trigger_id2'][:][stat]
-        
+        id2 = f['foreground/trigger_id2'][:][stat]        
         ifo1, ifo2 = f.attrs['detector_1'], f.attrs['detector_2']
         return ({ifo1:(f['foreground/time1'][:][stat], id1), 
                 ifo2:(f['foreground/time2'][:][stat], id2)})

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -33,6 +33,9 @@ parser.add_argument('--times', nargs='+', type=float,
     action=MultiDetOptionAction, metavar="IFO:GPS_TIME",
     help="The gps times to plot around in multi-ifo argument format, "
          "H1:132341323 L1:132423422")
+parser.add_argument('--special-trigger-ids', nargs='+', type=int, 
+    action=MultiDetOptionAction, metavar="IFO:GPS_TIME",
+    help="The set of special trigger ids to plot a star at")
 parser.add_argument('--plot-type', choices=['snr', 'newsnr'], default='snr',
     help="Which plot to make; an 'snr' or a newsnr' plot.")
 parser.add_argument('--output-file')
@@ -45,7 +48,9 @@ pycbc.init_logging(args.verbose)
 fig = pylab.figure()
 for ifo in args.single_trigger_files.keys():
     t = args.times[ifo]
-    #id_loud = 0
+    
+    if args.special_trigger_ids:
+        id_loud = args.special_trigger_ids[ifo]
     
     data = h5py.File(args.single_trigger_files[ifo], 'r')[ifo]
     times = data['end_time'][:]
@@ -57,28 +62,34 @@ for ifo in args.single_trigger_files.keys():
     times = times[idx] - t
     
     if args.plot_type == 'snr':
-        data = data['snr'][:][idx]   
-        #top = data['snr'][:][id_loud]
+        val = data['snr'][:][idx] 
+        
+        if args.special_trigger_ids:
+            top = data['snr'][:][id_loud]
+            
     if args.plot_type == 'newsnr':                                         
         snr = data['snr'][:][idx]
         chisq = data['chisq'][:][idx]
         chisq_dof = data['chisq_dof'][:][idx]
-        data = pycbc.events.newsnr(snr, chisq / (2 * chisq_dof - 2))
+        val = pycbc.events.newsnr(snr, chisq / (2 * chisq_dof - 2))
         
         # Get the newnsr of the loudest trigger so we can plot a star there
-        #rchisq = data['chisq'][:][id_loud] / (data['chisq_dof'][:][id_loud] * 2 - 2)
-        #top = pycbc.events.newsnr(data['snr'][:][id_loud], rchisq)
+        if args.special_trigger_ids:
+            rchisq = data['chisq'][:][id_loud] / (data['chisq_dof'][:][id_loud] * 2 - 2)
+            top = pycbc.events.newsnr(data['snr'][:][id_loud], rchisq)
         
-    pylab.scatter(times, data, color=pycbc.results.ifo_color(ifo), marker='x',
+    pylab.scatter(times, val, color=pycbc.results.ifo_color(ifo), marker='x',
                   label=ifo)
-    #pylab.scatter([0], [top], marker='*', s=50, color='yellow')
+                  
+    if args.special_trigger_ids:
+        pylab.scatter([0], [top], marker='*', s=50, color='yellow')
  
 if args.log_y_axis:
     pylab.yscale('log')
      
 pylab.xlabel('time (s)')
 pylab.ylabel(args.plot_type)                                
-pylab.ylim(ymin=data.min())
+pylab.ylim(ymin=val.min())
 pylab.xlim(xmin=-args.window, xmax=args.window)
 pylab.legend()
 pylab.grid()

--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -16,56 +16,39 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """ Plot the single detector trigger timeseries """
 import h5py, argparse, logging, pycbc.version, pycbc.events, pycbc.results, sys
+from pycbc.types import MultiDetOptionAction
 import matplotlib; matplotlib.use('Agg'); import pylab
-
-def get_time_from_cli(args):
-    """ Return the time and single detector trigger ids for the nth loudest
-    coincident trigger """
-    if args.statmap_file:
-        f = h5py.File(args.statmap_file, 'r')
-        stat = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]           
-        id1 = f['foreground/trigger_id1'][:][stat]
-        id2 = f['foreground/trigger_id2'][:][stat]        
-        ifo1, ifo2 = f.attrs['detector_1'], f.attrs['detector_2']
-        return ({ifo1:(f['foreground/time1'][:][stat], id1), 
-                ifo2:(f['foreground/time2'][:][stat], id2)})
     
 parser = argparse.ArgumentParser()
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--verbose', action='store_true')
-parser.add_argument('--single-trigger-files', nargs='+', 
-    help="The HDF format single detector merged trigger files")
+parser.add_argument('--single-trigger-files', nargs='+',
+    action=MultiDetOptionAction, metavar="IFO:FILE",
+    help="The HDF format single detector merged trigger files, in "
+         "multi-ifo argument format, H1:file1.hdf L1:fil2.hdf, etc")
 parser.add_argument('--window', type=float, default=10,
     help="Time in seconds around the coincident trigger to plot")
+parser.add_argument('--times', nargs='+', type=float,
+    action=MultiDetOptionAction, metavar="IFO:GPS_TIME",
+    help="The gps times to plot around in multi-ifo argument format, "
+         "H1:132341323 L1:132423422")
 parser.add_argument('--plot-type', choices=['snr', 'newsnr'], default='snr',
     help="Which plot to make; an 'snr' or a newsnr' plot.")
 parser.add_argument('--output-file')
 parser.add_argument('--log-y-axis', action='store_true')
 
-# These options help choose the GPS time to examine, add more options to pull
-# from different file types (injections, etc)    
-parser.add_argument('--statmap-file',
-    help="The HDF format clustered coincident statmap file containing the result "
-         "triggers. ")
-parser.add_argument('--n-loudest', type=int,
-    help="The trigger Nth loudest trigger to examine, use with statmap file")
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 
 # organize the single detector triggers files by ifo in a dict
-time = get_time_from_cli(args)
-files = {}
-for fname in args.single_trigger_files:
-    f = h5py.File(fname, 'r')
-    ifos = f.keys()
-    for ifo in ifos:
-        files[ifo] = f[ifo]
-
 fig = pylab.figure()
-for ifo in files.keys():
-    t, id_loud = time[ifo]
-    times = files[ifo]['end_time'][:]
+for ifo in args.single_trigger_files.keys():
+    t = args.times[ifo]
+    #id_loud = 0
+    
+    data = h5py.File(args.single_trigger_files[ifo], 'r')[ifo]
+    times = data['end_time'][:]
     
     idx = pycbc.events.indices_within_times(times, [t - args.window],
                                                    [t + args.window])
@@ -74,21 +57,21 @@ for ifo in files.keys():
     times = times[idx] - t
     
     if args.plot_type == 'snr':
-        data = files[ifo]['snr'][:][idx]   
-        top = files[ifo]['snr'][:][id_loud]
+        data = data['snr'][:][idx]   
+        #top = data['snr'][:][id_loud]
     if args.plot_type == 'newsnr':                                         
-        snr = files[ifo]['snr'][:][idx]
-        chisq = files[ifo]['chisq'][:][idx]
-        chisq_dof = files[ifo]['chisq_dof'][:][idx]
+        snr = data['snr'][:][idx]
+        chisq = data['chisq'][:][idx]
+        chisq_dof = data['chisq_dof'][:][idx]
         data = pycbc.events.newsnr(snr, chisq / (2 * chisq_dof - 2))
         
         # Get the newnsr of the loudest trigger so we can plot a star there
-        rchisq = files[ifo]['chisq'][:][id_loud] / (files[ifo]['chisq_dof'][:][id_loud] * 2 - 2)
-        top = pycbc.events.newsnr(files[ifo]['snr'][:][id_loud], rchisq)
+        #rchisq = data['chisq'][:][id_loud] / (data['chisq_dof'][:][id_loud] * 2 - 2)
+        #top = pycbc.events.newsnr(data['snr'][:][id_loud], rchisq)
         
     pylab.scatter(times, data, color=pycbc.results.ifo_color(ifo), marker='x',
                   label=ifo)
-    pylab.scatter([0], [top], marker='*', s=50, color='yellow')
+    #pylab.scatter([0], [top], marker='*', s=50, color='yellow')
  
 if args.log_y_axis:
     pylab.yscale('log')

--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -36,15 +36,9 @@ pycbc.init_logging(args.verbose)
 # The event is chosen from the input of pycbc_single template, so we
 # just extract the parameters here
 f = h5py.File(args.single_template_file)
-
-try:
-    delta_t = f['snr'].attrs['delta_t']
-    start_time = f['snr'].attrs['start_time']
-    time = f.attrs['event_time']
-except:
-    pylab.text(0.5, 0.5, 'no triggers found')
-    pylab.savefig(args.output_file)
-    sys.exit()
+delta_t = f['snr'].attrs['delta_t']
+start_time = f['snr'].attrs['start_time']
+time = f.attrs['event_time']
 
 ifo = f.attrs['ifo']
 center = int((time - start_time) / delta_t)

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -23,16 +23,10 @@ from pycbc.types import zeros, float32, complex64, TimeSeries
 
 def get_time(statmap, n_loudest, ifo):
      f = h5py.File(statmap, 'r')
-     
-     try:
-        n = f['foreground/stat'][:].argsort()[::-1][n_loudest]
-     except:
-        return None, None
-     
+     n = f['foreground/stat'][:].argsort()[::-1][n_loudest]
      t = {f.attrs['detector_1']: f['foreground/time1'][:][n],
           f.attrs['detector_2']: f['foreground/time2'][:][n],
           }
-     
      return t[ifo], f['foreground/template_id'][:][n]
 
 def select_segment(fname, segment, ifo, time, start_pad, end_pad):

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -562,7 +562,7 @@ class Node(pegasus_workflow.Node):
         for infile in inputs:
             self.add_raw_arg(infile.ifo)
             self.add_raw_arg(':')
-            self.add_raw_arg(infile)
+            self.add_raw_arg(infile.name)
             self.add_raw_arg(' ')
             self._add_input(infile)
 
@@ -573,12 +573,12 @@ class Node(pegasus_workflow.Node):
         """
         # NOTE: Here we have to use the raw arguments functionality as the
         #       file and ifo are not space separated.
-        self.add_raw_arg('--' +opt)
+        self.add_raw_arg(opt)
         self.add_raw_arg(' ')
         for outfile in outputs:
             self.add_raw_arg(outfile.ifo)
             self.add_raw_arg(':')
-            self.add_raw_arg(outfile)
+            self.add_raw_arg(outfile.name)
             self.add_raw_arg(' ')
             self._add_output(outfile)
 

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -449,7 +449,7 @@ class Workflow(pegasus_workflow.Workflow):
         job.addArguments('--cleanup inplace')
         job.addArguments('--cluster label,horizontal')
             
-    def save(self, name=None, output_map=None):
+    def save(self, filename=None, output_map=None):
         if output_map is None:
             output_map = self.output_map
             
@@ -464,7 +464,7 @@ class Workflow(pegasus_workflow.Workflow):
             fil.insert_into_dax(self._adag)
             
         # save the dax file
-        super(Workflow, self).save()
+        super(Workflow, self).save(filename=filename)
         
         # add workflow storage locations to the output mapper
         f = open(output_map, 'w')

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -557,7 +557,7 @@ class Node(pegasus_workflow.Node):
         """
         # NOTE: Here we have to use the raw arguments functionality as the
         #       file and ifo are not space separated.
-        self.add_raw_arg('--' + opt)
+        self.add_raw_arg(opt)
         self.add_raw_arg(' ')
         for infile in inputs:
             self.add_raw_arg(infile.ifo)
@@ -573,7 +573,7 @@ class Node(pegasus_workflow.Node):
         """
         # NOTE: Here we have to use the raw arguments functionality as the
         #       file and ifo are not space separated.
-        self.add_raw_arg('--' + opt)
+        self.add_raw_arg('--' +opt)
         self.add_raw_arg(' ')
         for outfile in outputs:
             self.add_raw_arg(outfile.ifo)

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -440,7 +440,7 @@ class Workflow(pegasus_workflow.Workflow):
             fil.node = None
             fil.PFN(fil.storage_path, site='local')
     
-    @classmethod
+    @staticmethod
     def set_job_properties(job, output_map):
         job.addArguments('-Dpegasus.dir.storage.mapper.replica.file=%s' % output_map) 
         job.addArguments('-Dpegasus.dir.storage.mapper.replica=File') 
@@ -453,7 +453,7 @@ class Workflow(pegasus_workflow.Workflow):
         if output_map is None:
             output_map = self.output_map
             
-        self.set_job_poperties(self.as_job, output_map)
+        Workflow.set_job_properties(self.as_job, output_map)
 
         # add executable pfns for local site to dax
         for exe in self._executables:

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -449,7 +449,7 @@ class Workflow(pegasus_workflow.Workflow):
         job.addArguments('--cleanup inplace')
         job.addArguments('--cluster label,horizontal')
             
-    def save(self, output_map=None):
+    def save(self, name=None, output_map=None):
         if output_map is None:
             output_map = self.output_map
             

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -154,7 +154,7 @@ def make_coinc_info(workflow, singles, bank, coinc, num, out_dir,
     files += node.output_files
     return files
     
-def make_trigger_timeseries(workflow, singles, coinc, num, out_dir,
+def make_trigger_timeseries(workflow, singles, ifo_times, out_dir,
                             exclude=None, require=None, tags=None):
     tags = [] if tags is None else tags
     makedir(out_dir)
@@ -165,9 +165,8 @@ def make_trigger_timeseries(workflow, singles, coinc, num, out_dir,
     for tag in secs:
         node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
                               out_dir=out_dir, tags=[tag] + tags).create_node()
-        node.add_input_list_opt('--single-trigger-files', singles)
-        node.add_input_opt('--statmap-file', coinc)
-        node.add_opt('--n-loudest', str(num))
+        node.add_multiifo_input_list_opt('--single-trigger-files', singles)
+        node.add_opt('--times', ifo_times)
         node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
         workflow += node
         files += node.output_files

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -97,7 +97,7 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers, tmpltb
     
     ## FIXME not clear why I have to set the id here, pegasus should do this!
     job = dax.DAX(fil)
-    job.addArguments('--basename %s' % name)
+    job.addArguments('--basename %s' % os.path.splitext(os.path.basename(name))[0])
     Workflow.set_job_properties(job, map_loc)
     workflow._adag.addJob(job)
     dep = dax.Dependency(parent=node._dax_node, child=job)

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -154,7 +154,7 @@ def make_coinc_info(workflow, singles, bank, coinc, num, out_dir,
     files += node.output_files
     return files
     
-def make_trigger_timeseries(workflow, singles, ifo_times, out_dir,
+def make_trigger_timeseries(workflow, singles, ifo_times, out_dir, special_tids,
                             exclude=None, require=None, tags=None):
     tags = [] if tags is None else tags
     makedir(out_dir)
@@ -168,6 +168,10 @@ def make_trigger_timeseries(workflow, singles, ifo_times, out_dir,
         node.add_multiifo_input_list_opt('--single-trigger-files', singles)
         node.add_opt('--times', ifo_times)
         node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
+        
+        if special_tids is not None:
+            node.add_opt('--special-trigger-ids', special_tids)
+        
         workflow += node
         files += node.output_files
     return files

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -67,7 +67,7 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers, tmpltb
     makedir(dax_output)
     
     # turn the config file into a File class
-    config_path = dax_output + '/' + '_'.join(tags) + 'foreground_minifollowup.ini'
+    config_path = os.path.abspath(dax_output + '/' + '_'.join(tags) + 'foreground_minifollowup.ini')
     workflow.cp.write(open(config_path, 'w'))
     
     config_file = wdax.File(os.path.basename(config_path))
@@ -96,11 +96,12 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers, tmpltb
     fil = node.output_files[0]
     
     ## FIXME not clear why I have to set the id here, pegasus should do this!
-    job = dax.DAX(fil, id=id(node))
+    job = dax.DAX(fil)
+    job.addArguments('--basename %s' % name)
     Workflow.set_job_properties(job, map_loc)
-    workflow._adag.addJob(job)    
+    workflow._adag.addJob(job)
     dep = dax.Dependency(parent=node._dax_node, child=job)
-    
+    workflow._adag.addDependency(dep)
     logging.info('Leaving minifollowups module')
 
 def make_single_template_plots(workflow, segs, seg_name, coinc, bank, num, out_dir, 

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -345,13 +345,16 @@ class Workflow(object):
             raise TypeError('Cannot add type %s to this workflow' % type(other))
             
       
-    def save(self):
+    def save(self, filename=None):
         """ Write this workflow to DAX file 
         """        
+        if filename is None:
+            filename = self.filename
+        
         for sub in self.sub_workflows:
             sub.save()
         
-        f = open(self.filename, "w")
+        f = open(filename, "w")
         self._adag.writeXML(f)
 
 class DataStorage(object):

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -146,13 +146,16 @@ def make_coinc_snrchi_plot(workflow, inj_file, inj_trig, stat_file, trig_file, o
         files += node.output_files
     return files
 
-def make_inj_table(workflow, inj_file, out_dir, tags=[]):
+def make_inj_table(workflow, inj_file, out_dir, missed=False, tags=[]):
     makedir(out_dir)
     node = PlotExecutable(workflow.cp, 'page_injections', ifos=workflow.ifos,
                     out_dir=out_dir, tags=tags).create_node()
     node.add_input_opt('--injection-file', inj_file)
+    if missed:
+        node.add_opt('--show-missed')
     node.new_output_file_opt(inj_file.segment, '.html', '--output-file')
     workflow += node   
+    return node.output_files[0]
 
 def make_seg_table(workflow, seg_files, seg_names, out_dir, tags=None, title_text=None, description=None):
     """ Creates a node in the workflow for writing the segment summary

--- a/setup.py
+++ b/setup.py
@@ -350,6 +350,7 @@ setup (
     install_requires = install_requires,
     dependency_links = links,
     scripts  = [
+               'bin/minifollowups/pycbc_foreground_minifollowup',
                'bin/minifollowups/pycbc_single_template_plot',
                'bin/minifollowups/pycbc_page_coincinfo',
                'bin/minifollowups/pycbc_plot_trigger_timeseries',


### PR DESCRIPTION
Depends on #424 

Move the foreground followup code into a subdax, and remove some of the special arguments originally required by each plotting code to read from statmap files, as they can now get the information on the command line. This should allow for more plots to be added without requiring to reach be able to read whatever special file type we would like to run mini followups on, and for these plotting codes to be used for other followups (injections, background, etc). 

This also moves the combined minifollowups that were below the main results to a sub-page, as currently making a self-contained sub-page is much easier to do for  sub-dax. 

Here is an example output. 
https://sugar-jobs.phy.syr.edu/~ahnitz/projects/bigdog_rerun/plots/gw15/html/