### PR TITLE
Add pycbc_plot_singles_timefreq to foreground minifollowups

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_singles_timefreq
+++ b/bin/hdfcoinc/pycbc_plot_singles_timefreq
@@ -29,7 +29,6 @@ matplotlib.use('agg')
 import pylab as pl
 import matplotlib.mlab as mlab
 import h5py
-import lalinspiral
 import pycbc.events
 import pycbc.pnutils
 import pycbc.strain

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -109,6 +109,13 @@ for num_event in range(num_events):
     files += mini.make_single_template_plots(workflow, insp_segs,
                               args.inspiral_segment_name, coinc_file, tmpltbank_file,
                               num_event, args.output_dir, tags=args.tags + [str(num_event)])
+    
+    for single in single_triggers:
+        time = times[single.ifo][num_event]
+        files += mini.make_singles_timefreq(workflow, single, tmpltbank_file, 
+                                time - 10, time + 10, args.output_dir,
+                                tags=args.tags + [str(num_event), single.ifo])                 
+    
     layouts += list(layout.grouper(files, 2))
     num_event += 1
 

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -176,5 +176,26 @@ def make_trigger_timeseries(workflow, singles, ifo_times, out_dir, special_tids,
         files += node.output_files
     return files
 
+    
+def make_singles_timefreq(workflow, single, bank_file, start, end, out_dir,
+                          veto_file=None, tags=None):
+    tags = [] if tags is None else tags
+    makedir(out_dir)
+    name = 'plot_singles_timefreq'
+
+    node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
+                          out_dir=out_dir, tags=tags).create_node()
+    node.add_input_opt('--trig-file', single)
+    node.add_input_opt('--bank-file', bank_file)
+    node.add_opt('--gps-start-time', int(start))
+    node.add_opt('--gps-end-time', int(end))
+    
+    if veto_file:
+        node.add_input_opt('--veto-file', veto_file)
+        
+    node.add_opt('--detector', single.ifo)
+    node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
+    workflow += node
+    return node.output_files
 
 


### PR DESCRIPTION
This depends on #427 as it is hard to add new plots without it.

Example result page

https://sugar-jobs.phy.syr.edu/~ahnitz/projects/bigdog_rerun/plots/gw16/html/7._result/7.1_full/

Should not break current ini files, but will not show up without changes. I'll propose the needed configuration change if this patch is accepted. 