### PR TITLE
PyGRB: Single IFO running

### DIFF
--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -91,8 +91,14 @@ else:
                                                               sciSegs,
                                                               single_ifo)
 
-# Update analysis time after coherent segment calculation
+# How many IFOs do we have in the search?
 wflow.ifos = sciSegs.keys()
+if len(wflow.ifos) == 1:
+    mf_tag = "sngl"
+else:
+    mf_tag = "coherent"
+
+# Update analysis time after coherent segment calculation
 ifo = sciSegs.keys()[0]
 padding = int(wflow.cp.get("inspiral", "pad-data"))
 deadtime = int(wflow.cp.get("inspiral", "segment-duration")) / 4
@@ -188,7 +194,7 @@ if wflow.cp.has_section("workflow-injections"):
     # Generate injection matched filter workflow
     inj_insp_files = _workflow.setup_matchedfltr_workflow(wflow, sciSegs,
             datafind_veto_files, inj_splitbank_files, injDir, injs,
-            tags=["injections"])
+            tags=[mf_tag + "_injections"])
     for inj_insp_file in inj_insp_files:
         split_str = [s for s in inj_insp_file.name.split("_") \
                      if ("SPLIT" in s and s[-1].isdigit())]
@@ -225,9 +231,8 @@ if wflow.cp.has_section("workflow-injections"):
 # MAIN MATCHED FILTERING
 inspDir = os.path.join(currDir, "inspiral")
 inspiral_files = _workflow.setup_matchedfltr_workflow(wflow, sciSegs,
-                                                      datafind_veto_files,
-                                                      splitbank_files, inspDir,
-                                                      tags=["no_injections"])
+        datafind_veto_files, splitbank_files, inspDir,
+        tags=[mf_tag + "_no_injections"])
 all_files.extend(inspiral_files)
 inspiral_cache = _workflow.File(ifos, "inspiral", sciSegs[ifo][0],
                                 extension="lcf", directory=inspDir)

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -37,7 +37,6 @@ from glue.segments import segment
 workflow_name = "pygrb_offline"
 logging.basicConfig(format="%(asctime)s:%(levelname)s : %(message)s",
                     level=logging.INFO)
-logging.info("Generating %s workflow" % workflow_name)
 
 # Parse command line options and instantiate pycbc workflow object
 parser = argparse.ArgumentParser()
@@ -48,6 +47,8 @@ wflow = _workflow.Workflow(args, workflow_name)
 all_files = _workflow.FileList([])
 tags = []
 initDir = os.getcwd()
+
+logging.info("Generating %s workflow" % workflow_name)
 
 # Setup run directory
 if wflow.cp.has_option("workflow", "output-directory"):
@@ -74,10 +75,24 @@ segDir = os.path.join(currDir, "segments")
 sciSegs, segsFileList = _workflow.setup_segment_generation(wflow, segDir)
 
 # Make coherent network segments
-onSrc, sciSegs = _workflow.get_triggered_coherent_segment(wflow, segDir,
-                                                          sciSegs)
+single_ifo = wflow.cp.has_option("workflow", "allow-single-ifo-search")
+if len(sciSegs.keys()) < 2 and not single_ifo:
+    msg = "Science segments exist only for %s. " % sciSegs.keys()[0]
+    msg += "If you wish to enable single IFO running add the option "
+    msg += "'allow-single-ifo-search' to the [workflow] section of your "
+    msg += "configuration file." 
+    raise RuntimeError(msg)
+elif len(sciSegs.keys()) < 2:
+    logging.info("Generating a single IFO search.")
+    onSrc, sciSegs = _workflow.get_triggered_single_ifo_segment(wflow, segDir,
+                                                                sciSegs)
+else:
+    onSrc, sciSegs = _workflow.get_triggered_coherent_segment(wflow, segDir,
+                                                              sciSegs,
+                                                              single_ifo)
 
 # Update analysis time after coherent segment calculation
+wflow.ifos = sciSegs.keys()
 ifo = sciSegs.keys()[0]
 padding = int(wflow.cp.get("inspiral", "pad-data"))
 deadtime = int(wflow.cp.get("inspiral", "segment-duration")) / 4

--- a/examples/workflow/pygrb/ER8/er8_injections_offline.ini
+++ b/examples/workflow/pygrb/ER8/er8_injections_offline.ini
@@ -32,7 +32,7 @@ splitinjtable-interval = 800
 [injections]
 
 [injections-detectionfullinj]
-waveform      = SpinTaylorthreePointFivePN
+waveform      = SpinTaylorT2threePointFivePN
 i-distr       = uniform
 l-distr       = exttrig
 d-distr       = uniform
@@ -55,7 +55,7 @@ f-lower       = 30.0
 disable-milkyway =
 
 [injections-nsns30inj]
-waveform      = SpinTaylorthreePointFivePN
+waveform      = SpinTaylorT2threePointFivePN
 i-distr       = uniform
 max-inc       = 30
 l-distr       = exttrig
@@ -82,7 +82,7 @@ f-lower       = 30.0
 disable-milkyway =
 
 [injections-nsbh30inj]
-waveform      = SpinTaylorthreePointFivePN
+waveform      = SpinTaylorT2threePointFivePN
 i-distr       = uniform
 max-inc       = 30
 l-distr       = exttrig

--- a/examples/workflow/pygrb/ER8/er8_injections_online.ini
+++ b/examples/workflow/pygrb/ER8/er8_injections_online.ini
@@ -32,7 +32,7 @@ splitinjtable-interval = 800
 [injections]
 
 [injections-detectionfullinj]
-waveform      = SpinTaylorthreePointFivePN
+waveform      = SpinTaylorT2threePointFivePN
 i-distr       = uniform
 l-distr       = exttrig
 d-distr       = uniform
@@ -55,7 +55,7 @@ f-lower       = 30.0
 disable-milkyway =
 
 [injections-nsns30inj]
-waveform      = SpinTaylorthreePointFivePN
+waveform      = SpinTaylorT2threePointFivePN
 i-distr       = uniform
 max-inc       = 30
 l-distr       = exttrig
@@ -82,7 +82,7 @@ f-lower       = 30.0
 disable-milkyway =
 
 [injections-nsbh30inj]
-waveform      = SpinTaylorthreePointFivePN
+waveform      = SpinTaylorT2threePointFivePN
 i-distr       = uniform
 max-inc       = 30
 l-distr       = exttrig

--- a/examples/workflow/pygrb/ER8/er8_main_offline.ini
+++ b/examples/workflow/pygrb/ER8/er8_main_offline.ini
@@ -7,7 +7,6 @@
 file-retention-level = all_files
 h1-channel-name = H1:GDS-CALIB_STRAIN
 l1-channel-name = L1:GDS-CALIB_STRAIN
-allow-single-ifo-search =
 
 [workflow-ifos]
 ; This is the list of ifos to analyse
@@ -103,7 +102,7 @@ strain-data =
 sample-rate = 4096
 segment-duration = 256
 block-duration = 5248
-do-sngl-chi-tests =
+;do-sngl-chi-tests =
 do-trace-snr =
 ;do-null-stream
 do-bank-veto =
@@ -124,8 +123,8 @@ face-on-analysis =
 face-away-analysis =
 
 [inspiral-no_injections]
-;do-short-slides =
-;short-slide-offset = 6
+do-short-slides =
+short-slide-offset = 6
 
 [inspiral-injections]
 inj-search-window = 1

--- a/examples/workflow/pygrb/ER8/er8_main_offline.ini
+++ b/examples/workflow/pygrb/ER8/er8_main_offline.ini
@@ -102,7 +102,6 @@ strain-data =
 sample-rate = 4096
 segment-duration = 256
 block-duration = 5248
-;do-sngl-chi-tests =
 do-trace-snr =
 ;do-null-stream
 do-bank-veto =
@@ -112,24 +111,29 @@ num-auto-chisq-points = 40
 auto-veto-time-step = 0.001
 num-chi-square-bins = 16
 chi-square-threshold = 6
-approximant = SpinTaylorFrameless
+approximant = SpinTaylorT4
 order = threePointFivePN
 sngl-snr-threshold = 4
 psd-segment-duration = 256
 do-clustering =
 cluster-window = 0.1
 inverse-spec-length = 32
-face-on-analysis =
-face-away-analysis =
 
-[inspiral-no_injections]
+[inpiral-sngl_no_injections&inspiral-sngl_injections]
+do-sngl-chi-tests =
+
+[inspiral-coherent_no_injections]
 do-short-slides =
 short-slide-offset = 6
 
-[inspiral-injections]
+[inspiral-sngl_injections&inspiral-coherent_injections]
 inj-search-window = 1
 inj-mchirp-window = 0.05
 analyze-inj-segs-only =
+
+[inspiral-coherent_no_injections&inspiral-coherent_injections]
+face-on-analysis =
+face-away-analysis =
 
 [inspiral-h1]
 ; h1 specific inspiral parameters

--- a/examples/workflow/pygrb/ER8/er8_main_online.ini
+++ b/examples/workflow/pygrb/ER8/er8_main_online.ini
@@ -103,7 +103,6 @@ strain-data =
 sample-rate = 4096
 segment-duration = 256
 block-duration = 5248
-;do-sngl-chi-tests =
 do-trace-snr =
 ;do-null-stream
 do-bank-veto =
@@ -113,24 +112,29 @@ num-auto-chisq-points = 40
 auto-veto-time-step = 0.001
 num-chi-square-bins = 16
 chi-square-threshold = 6
-approximant = SpinTaylorFrameless
+approximant = SpinTaylorT4
 order = threePointFivePN
 sngl-snr-threshold = 4
 psd-segment-duration = 256
 do-clustering =
 cluster-window = 0.1
 inverse-spec-length = 32
-face-on-analysis =
-face-away-analysis =
 
-[inspiral-no_injections]
+[inpiral-sngl_no_injections&inspiral-sngl_injections]
+do-sngl-chi-tests =
+
+[inspiral-coherent_no_injections]
 do-short-slides =
 short-slide-offset = 6
 
-[inspiral-injections]
+[inspiral-sngl_injections&inspiral-coherent_injections]
 inj-search-window = 1
 inj-mchirp-window = 0.05
 analyze-inj-segs-only =
+
+[inspiral-coherent_no_injections&inspiral-coherent_injections]
+face-on-analysis =
+face-away-analysis =
 
 [inspiral-h1]
 ; h1 specific inspiral parameters

--- a/examples/workflow/pygrb/ER8/er8_main_online.ini
+++ b/examples/workflow/pygrb/ER8/er8_main_online.ini
@@ -103,7 +103,7 @@ strain-data =
 sample-rate = 4096
 segment-duration = 256
 block-duration = 5248
-do-sngl-chi-tests =
+;do-sngl-chi-tests =
 do-trace-snr =
 ;do-null-stream
 do-bank-veto =
@@ -124,8 +124,8 @@ face-on-analysis =
 face-away-analysis =
 
 [inspiral-no_injections]
-;do-short-slides =
-;short-slide-offset = 6
+do-short-slides =
+short-slide-offset = 6
 
 [inspiral-injections]
 inj-search-window = 1

--- a/pycbc/workflow/legacy_ihope.py
+++ b/pycbc/workflow/legacy_ihope.py
@@ -270,37 +270,9 @@ class LegacyCohPTFInspiralExecutable(LegacyAnalysisExecutable):
         if len(self.ifo_list) < 2 and \
                 ('--do-short-slides' in node._options or \
                  '--short-slide-offset' in node._options):
-            idcs = [i for i, x in enumerate(node._options) \
-                    if x == '--short-slide-offset']
-            idcs.sort(reverse=True)
-            for id in idcs:
-                del node._options[id + 1]
-                del node._options[id]
-            idcs = [i for i, x in enumerate(node._options) \
-                    if x == '--do-short-slides']
-            idcs.sort(reverse=True)
-            for id in idcs:
-                del node._options[id]
-
-        # If doing single IFO search, ensure face-on/-off options are disabled
-        if len(self.ifo_list) < 2 and \
-                ('--face-on-analysis' in node._options or \
-                 '--face-away-analysis' in node._options):
-            idcs = [i for i, x in enumerate(node._options) \
-                    if (x == '--face-on-analysis' or \
-                        x == '--face-away-analysis')]
-            idcs.sort(reverse=True)
-            for id in idcs:
-                del node._options[id]
- 
-        # If doing single IFO search with any chi tests, ensure
-        # '--do-sngl-chi-tests' option is added to jobs
-        if len(self.ifo_list) < 2 and \
-                '--do-sngl-chi-tests' not in node._options and \
-                ('--do-bank-veto' in node._options or \
-                 '--do-chi-square' in node._options or \
-                 '--do-auto-veto' in node._options):
-            node._options.append('--do-sngl-chi-tests')
+            raise ValueError("Cannot run with time slides in a single IFO "
+                             "configuration! Please edit your configuration "
+                             "file accordingly.")
 
         pad_data = self.get_opt('pad-data')
         if pad_data is None:

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1069,11 +1069,10 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
     snglsegs = segments.segmentlistdict()
     for key in sciencesegs.keys():
         if triggertime in sciencesegs[key]:
-            ifo = key
-            snglsegs[ifo] = sciencesegs[ifo]
-            logging.info("Trigger is within %s segments." % ifo)
+            snglsegs[key] = sciencesegs[key]
+            logging.info("Trigger is within %s segments." % key)
     
-    if not snglsegs:
+    if len(snglsegs.keys()) == 0:
         logging.error("Trigger is not contained within any available segment. "
                       "Exiting.")
         sys.exit()
@@ -1110,7 +1109,9 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
                       "duration. Exiting.")
         sys.exit()
     elif len(offsrc.keys()) > 1:
-        logging.error("Something has gone wrong!")
+        logging.error("Something is broken! At this point there should only "
+                      "be 1 IFO in play, but there are %d."
+                      % len(offsrc.keys()))
         sys.exit()
     else:
         ifo = offsrc.keys()[0]

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -807,24 +807,24 @@ def find_playground_segments(segs):
 
     return outlist
 
-def get_triggered_coherent_segment(workflow, out_dir, sciencesegs, tag=None):
+def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
+                                   sngl_ifo=False):
     """
-    Construct the coherent network on and off source segments.
+    Construct the coherent network on and off source segments. Can switch to
+    construction of segments for a single IFO search when coherent segments
+    are insufficient for a search.
 
     Parameters
     -----------
     workflow : pycbc.workflow.core.Workflow
-        The workflow instance that the coincidence jobs will be added to.
-        This instance also contains the ifos for which to attempt to obtain
-        segments for this analysis and the start and end times to search for
-        segments over.
-    out_dir : path
+        The workflow instance that the calculated segments belong to.
+    out_dir : str
         The directory in which output will be stored.
-    sciencesegs : dictionary
-        Dictionary of science segments produced by
-        ahope.setup_segment_generation()
-    tag : string, optional (default=None)
-        Use this to specify a tag.
+    sciencesegs : dict
+        Dictionary of all science segments within analysis time.
+    sngl_ifo : bool, optional (default=False)
+        If true, will fall back on single IFO segments if coherent segments
+        do not match the required criteria.
 
     Returns
     --------
@@ -838,10 +838,7 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs, tag=None):
 
     # Load parsed workflow config options
     cp = workflow.cp
-    ra = float(os.path.basename(cp.get('workflow', 'ra')))
-    dec = float(os.path.basename(cp.get('workflow', 'dec')))
     triggertime = int(os.path.basename(cp.get('workflow', 'trigger-time')))
-    
     minbefore = int(os.path.basename(cp.get('workflow-exttrig_segments',
                                             'min-before')))
     minafter = int(os.path.basename(cp.get('workflow-exttrig_segments',
@@ -863,13 +860,27 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs, tag=None):
 
     # Check available data segments meet criteria specified in arguments
     sciencesegs = segments.segmentlistdict(sciencesegs)
-    sciencesegs = sciencesegs.extract_common(sciencesegs.keys())
-    if triggertime not in sciencesegs[sciencesegs.keys()[0]]:
-        logging.error("Trigger is not contained within any available segment."
-                      " Exiting.")
-        sys.exit()
+    commonsegs = sciencesegs.extract_common(sciencesegs.keys())
+    if triggertime not in commonsegs[commonsegs.keys()[0]]:
+        if sngl_ifo:
+            snglsegs = segments.segmentlistdict()
+            for key in sciencesegs.keys():
+                if triggertime in sciencesegs[key]:
+                    snglsegs[key] = sciencesegs[key]
+                    logging.warning("Trigger is only found in %s segments. "
+                                    "Falling back on single IFO data." % key)
+                    return get_triggered_single_ifo_segment(workflow, out_dir,
+                                                            snglsegs)
+            if len(snglsegs.keys()) == 0:
+                logging.error("Trigger is not contained within any available "
+                              "science segment. Exiting.")
+                sys.exit()
+        else:
+            logging.error("Trigger is not contained within any available "
+                          "coherent science segment. Exiting.")
+            sys.exit()
 
-    offsrclist = sciencesegs[sciencesegs.keys()[0]]
+    offsrclist = commonsegs[commonsegs.keys()[0]]
     if len(offsrclist) > 1:
         logging.info("Removing network segments that do not contain trigger "
                      "time")
@@ -881,13 +892,28 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs, tag=None):
 
     if (triggertime - minbefore - padding not in offsrc) or (
             triggertime + minafter + padding not in offsrc):
-        logging.error("Not enough data either side of trigger time. Exiting.")
-        sys.exit()
+        if sngl_ifo:
+            logging.warning("Not enough data either side of trigger time in "
+                            "coherent segment. Falling back on single IFO "
+                            "data.")
+            return get_triggered_single_ifo_segment(workflow, out_dir,
+                                                    sciencesegs)
+        else:
+            logging.error("Not enough data either side of trigger time. "
+                          "Exiting.")
+            sys.exit()
 
     if abs(offsrc) < minduration + 2 * padding:
-        logging.error("Available network segment shorter than minimum allowed "
-                      "duration. Exiting.")
-        sys.exit()
+        if sngl_ifo:
+            logging.warning("Available coherent segment shorter than minimum "
+                            "allowed duration. Falling back on single IFO "
+                            "data.")
+            return get_triggered_single_ifo_segment(workflow, out_dir,
+                                                    sciencesegs)
+        else:
+            logging.error("Available network segment shorter than minimum "
+                          "allowed duration. Exiting.")
+            sys.exit()
 
     # Will segment duration be the maximum desired length or not?
     if abs(offsrc) >= maxduration + 2 * padding:
@@ -975,13 +1001,209 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs, tag=None):
                            "%s-COH_OFFSOURCE_SEGMENT.xml" % ifos.upper())
     currUrl = urlparse.urlunparse(['file', 'localhost', XmlFile, None, None,
                                    None])
-    currFile = OutSegFile(ifos, 'COH-OFFSOURCE', offsource[iifo], currUrl,
+    currFile = OutSegFile(ifos, 'COH_OFFSOURCE', offsource[iifo], currUrl,
                           offsource[iifo])
     currFile.toSegmentXml()
     logging.info("Optimal coherent segment calculated.")
 
-    #FIXME: For legacy coh_PTF_post_processing we must write out the segments
-    #       to segwizard files (with hardcoded names!)
+    offsourceSegfile = os.path.join(out_dir, "offSourceSeg.txt")
+    segmentsUtils.tosegwizard(open(offsourceSegfile, "w"), offsrc)
+
+    onsourceSegfile = os.path.join(out_dir, "onSourceSeg.txt")
+    segmentsUtils.tosegwizard(file(onsourceSegfile, "w"), onsrc)
+
+    onlen = abs(onsrc[0])
+    bufferSegment = segments.segment(onstart - bufferleft * onlen,
+                                     onend + bufferright * onlen)
+    bufferSegfile = os.path.join(out_dir, "bufferSeg.txt")
+    segmentsUtils.tosegwizard(file(bufferSegfile, "w"),
+                              segments.segmentlist([bufferSegment]))
+
+    return onsource, offsource
+
+def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
+    """
+    Construct a single IFO segment for a triggered search.
+
+    Parameters
+    -----------
+    workflow : pycbc.workflow.core.Workflow
+        The workflow instance that the calculated segments belong to.
+    out_dir : str
+        The directory in which output will be stored.
+    sciencesegs : dict
+        Dictionary of interesting science segments within analysis time.
+
+    Returns
+    --------
+    onsource : glue.segments.segmentlistdict
+        A dictionary containing the on source segment for a single IFO
+
+    offsource : glue.segments.segmentlistdict
+        A dictionary containing the off source segment for a single IFO
+    """
+
+    # Load parsed workflow config options
+    cp = workflow.cp
+    triggertime = int(os.path.basename(cp.get('workflow', 'trigger-time')))
+    minbefore = int(os.path.basename(cp.get('workflow-exttrig_segments',
+                                            'min-before')))
+    minafter = int(os.path.basename(cp.get('workflow-exttrig_segments',
+                                           'min-after')))
+    minduration = int(os.path.basename(cp.get('workflow-exttrig_segments',
+                                              'min-duration')))
+    maxduration = int(os.path.basename(cp.get('workflow-exttrig_segments',
+                                              'max-duration')))
+    onbefore = int(os.path.basename(cp.get('workflow-exttrig_segments',
+                                           'on-before')))
+    onafter = int(os.path.basename(cp.get('workflow-exttrig_segments',
+                                          'on-after')))
+    padding = int(os.path.basename(cp.get('workflow-exttrig_segments',
+                                          'pad-data')))
+    quanta = int(os.path.basename(cp.get('workflow-exttrig_segments',
+                                         'quanta')))
+    bufferleft = int(cp.get('workflow-exttrig_segments', 'num-buffer-before'))
+    bufferright = int(cp.get('workflow-exttrig_segments', 'num-buffer-after'))
+
+    # Check available data segments meet criteria specified in arguments
+    snglsegs = segments.segmentlistdict()
+    for key in sciencesegs.keys():
+        if triggertime in sciencesegs[key]:
+            ifo = key
+            snglsegs[ifo] = sciencesegs[ifo]
+            logging.info("Trigger is within %s segments." % ifo)
+    
+    if not snglsegs:
+        logging.error("Trigger is not contained within any available segment. "
+                      "Exiting.")
+        sys.exit()
+
+    offsrc = segments.segmentlistdict()
+    for key in snglsegs.keys():
+        if len(snglsegs[key]) > 1:
+            logging.info("Removing network segments that do not contain "
+                         "trigger time.")
+            for seg in snglsegs[key]:
+                if triggertime in seg:
+                    offsrc[key] = seg
+        else:
+            offsrc[key] = snglsegs[key][0]
+
+    for key in offsrc.keys():
+        if (triggertime - minbefore - padding not in offsrc[key]) or \
+                (triggertime + minafter + padding not in offsrc[key]):
+            logging.info("Not enough data either side of trigger time in %s."
+                         % key)
+            offsrc.pop(key)
+    if len(offsrc.keys()) == 0:
+        logging.error("Not enough data either side of trigger time in any "
+                      "IFO. Exiting.")
+        sys.exit()
+
+    for key in offsrc.keys():
+        if abs(offsrc[key]) < minduration + 2 * padding:
+            logging.info("%s segment shorter than minimum allowed duration."
+                         % key)
+            offsrc.pop(key)
+    if len(offsrc.keys()) == 0:
+        logging.error("All available segments shorter than minimum allowed "
+                      "duration. Exiting.")
+        sys.exit()
+    elif len(offsrc.keys()) > 1:
+        logging.error("Something has gone wrong!")
+        sys.exit()
+    else:
+        ifo = offsrc.keys()[0]
+
+    # Will segment duration be the maximum desired length or not?
+    if abs(offsrc[ifo]) >= maxduration + 2 * padding:
+        logging.info("Available network science segment duration (%ds) is "
+                     "greater than the maximum allowed segment length (%ds). "
+                     "Truncating..." % (abs(offsrc[ifo]), maxduration))
+    else:
+        logging.info("Available network science segment duration (%ds) is "
+                     "less than the maximum allowed segment length (%ds)."
+                     % (abs(offsrc[ifo]), maxduration))
+
+    logging.info("%ds of padding applied at beginning and end of segment."
+                 % padding)
+
+
+    # Construct on-source
+    onstart = triggertime - onbefore
+    onend = triggertime + onafter
+    oncentre = onstart + ((onbefore + onafter) / 2)
+    onsrc = segments.segment(onstart, onend)
+    logging.info("Constructed ON-SOURCE: duration %ds (%ds before to %ds after"
+                 " trigger)."
+                 % (abs(onsrc), triggertime - onsrc[0],
+                    onsrc[1] - triggertime))
+    onsrc = segments.segmentlist([onsrc])
+
+    # Maximal, centred coherent network segment
+    idealsegment = segments.segment(int(oncentre - padding -
+                                    0.5 * maxduration),
+                                    int(oncentre + padding +
+                                    0.5 * maxduration))
+
+    # Construct off-source
+    offsrc = offsrc[ifo]
+    if (idealsegment in offsrc):
+        offsrc = idealsegment
+
+    elif idealsegment[1] not in offsrc:
+        offsrc &= segments.segment(offsrc[1] - maxduration - 2 * padding,
+                                   offsrc[1])
+
+    elif idealsegment[0] not in offsrc:
+        offsrc &= segments.segment(offsrc[0],
+                                   offsrc[0] + maxduration + 2 * padding)
+
+    # Trimming off-source
+    excess = (abs(offsrc) - 2 * padding) % quanta
+    if excess != 0:
+        logging.info("Trimming %ds excess time to make OFF-SOURCE duration a "
+                     "multiple of %ds" % (excess, quanta))
+        offset = (offsrc[0] + abs(offsrc) / 2.) - oncentre
+        if 2 * abs(offset) > excess:
+            if offset < 0:
+                offsrc &= segments.segment(offsrc[0] + excess,
+                                           offsrc[1])
+            elif offset > 0:
+                offsrc &= segments.segment(offsrc[0],
+                                           offsrc[1] - excess)
+            assert abs(offsrc) % quanta == 2 * padding
+        else:
+            logging.info("This will make OFF-SOURCE symmetrical about "
+                         "ON-SOURCE.")
+            start = int(offsrc[0] - offset + excess / 2)
+            end = int(offsrc[1] - offset - round(float(excess) / 2))
+            offsrc = segments.segment(start, end)
+            assert abs(offsrc) % quanta == 2 * padding
+
+    logging.info("Constructed OFF-SOURCE: duration %ds (%ds before to %ds "
+                 "after trigger)."
+                 % (abs(offsrc) - 2 * padding,
+                    triggertime - offsrc[0] - padding,
+                    offsrc[1] - triggertime - padding))
+    offsrc = segments.segmentlist([offsrc])
+
+    # Put segments into segmentlistdicts
+    onsource = segments.segmentlistdict()
+    offsource = segments.segmentlistdict()
+    onsource[ifo] = onsrc
+    offsource[ifo] = offsrc
+
+    # Write off-source to xml file
+    XmlFile = os.path.join(out_dir,
+                           "%s-SINGLE_IFO_OFFSOURCE_SEGMENT.xml" % ifo.upper())
+    currUrl = urlparse.urlunparse(['file', 'localhost', XmlFile, None, None,
+                                   None])
+    currFile = OutSegFile(ifo, 'SINGLE_IFO_OFFSOURCE', offsource[ifo], currUrl,
+                          offsource[ifo])
+    currFile.toSegmentXml()
+    logging.info("Optimal single IFO segment calculated for %s." % ifo)
+
     offsourceSegfile = os.path.join(out_dir, "offSourceSeg.txt")
     segmentsUtils.tosegwizard(open(offsourceSegfile, "w"), offsrc)
 


### PR DESCRIPTION
These commits will allow the pygrb workflow generator to fall back to a single IFO search if there isn't enough data for a coherent search. All that is required for this to happen is to include the option 'allow-single-ifo-search' in the [workflow] section of the configuration file. If this isn't given, the code will exit in the case of insufficient coherent data, which was the previous behaviour.

Since this functionality was designed with the online search in mind, where a single set of static config files are desired, the LegacyCohPTFInspiralExecutable class will check for any options that have been passed to it that aren't compatible with single IFO running. These include face-on/-away options and short timeslide options. It will also add the --do-sngl-chi-tests argument if there is only 1 IFO.