### PR TITLE
Improve pycbc_single_template_plot

### DIFF
--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -23,22 +23,38 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--version', action='version',
     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--verbose')
-parser.add_argument('--single-template-file', 
+parser.add_argument('--single-template-file', required=True,
     help="HDF file containing the SNR and CHISQ timeseries. "
          " The output of pycbc_single_template")
-parser.add_argument('--window', type=float,
+parser.add_argument('--window', type=float, required=True,
     help="The time in seconds to plot")
-parser.add_argument('--output-file')
+parser.add_argument('--event-time', type=float,
+                    help='GPS time to use as the center of the plot')
+parser.add_argument('--output-file', required=True)
+parser.add_argument('--log-y', action='store_true',
+                    help='Use log scale for y-axis')
 
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 
 # The event is chosen from the input of pycbc_single template, so we
 # just extract the parameters here
-f = h5py.File(args.single_template_file)
-delta_t = f['snr'].attrs['delta_t']
-start_time = f['snr'].attrs['start_time']
-time = f.attrs['event_time']
+f = h5py.File(args.single_template_file, 'r')
+
+try:
+    delta_t = f['snr'].attrs['delta_t']
+    start_time = f['snr'].attrs['start_time']
+except:
+    pylab.text(0.5, 0.5, 'no triggers found')
+    pylab.savefig(args.output_file)
+    sys.exit()
+
+if args.event_time is not None:
+    time = args.event_time
+elif 'event_time' in f.attrs:
+    time = f.attrs['event_time']
+else:
+    raise ValueError('Event time is neither specified nor found in the HDF file')
 
 ifo = f.attrs['ifo']
 center = int((time - start_time) / delta_t)
@@ -54,17 +70,21 @@ rang = (numpy.arange(0, len(snr), 1) - (center - left)) * delta_t
 newsnr = pycbc.events.newsnr(snr, chisq)
 
 fig, ax1 = pylab.subplots()
-ax1.plot(rang, snr, color='blue', label='snr')
-ax1.plot(rang, newsnr, color='purple', label='newsnr')
+ax1.plot(rang, snr, color='blue', label='SNR')
+ax1.plot(rang, newsnr, color='purple', label='NewSNR')
 ax1.set_ylabel('SNR')
+if args.log_y:
+    ax1.set_yscale('log')
 ax1.legend(loc="upper left")
-ax1.set_xlabel('Time (s)')
+ax1.set_xlabel('Time - %.3f (s)' % time)
 
 ax2 = ax1.twinx()
-ax2.plot(rang, chisq, color='green', label='chisq')
-ax2.set_ylabel('CHISQ')
+ax2.plot(rang, chisq, color='green', label='$\\chi^2_{\\rm r}$')
+ax2.set_ylabel('Reduced $\\chi^2$')
+if args.log_y:
+    ax2.set_yscale('log')
 ax2.legend(loc="upper right")
 
 pycbc.results.save_fig_with_metadata(fig, args.output_file, 
                              cmd=' '.join(sys.argv), fig_kwds={'dpi': 150},
-                             title='%s: SNR and CHISQ TimeSeries' % ifo)
+                             title='%s: SNR and chi^2 time series' % ifo)

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -114,5 +114,7 @@ test_exec_help pycbc_plot_psd_file
 test_exec_help pycbc_plot_range
 test_exec_help pycbc_average_psd
 #test_exec_help pycbc_make_html_page
+test_exec_help pycbc_single_template
+test_exec_help pycbc_single_template_plot
 
 exit ${RESULT}


### PR DESCRIPTION
Add ability to plot HDF file generated by manually supplying template
parameters, show center time on the plot, add log-y option and minor
fixes. Also add single-template executables to Travis tests.