### PR TITLE
Fix minifollowup module to return if no [workflow-minifollowups] section

### DIFF
--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -62,6 +62,7 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers, tmpltb
     if not workflow.cp.has_section('workflow-minifollowups'):
         logging.info('There is no [workflow-minifollowups] section in configuration file')
         logging.info('Leaving minifollowups')
+        return
     
     tags = [] if tags is None else tags
     makedir(dax_output)


### PR DESCRIPTION
Fix ``minifollowups`` module to return if no ``[workflow-minifollowups]`` section.