### PR TITLE
change dir before making workflow

### DIFF
--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -45,12 +45,13 @@ args = parser.parse_args()
 logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s', 
                     level=logging.INFO)
 
+wf.makedir(args.output_dir)
+os.chdir(args.output_dir)
+
 container = wf.Workflow(args, args.workflow_name)
 workflow = wf.Workflow(args, 'main')
 finalize_workflow = wf.Workflow(args, 'finalization')
 
-wf.makedir(args.output_dir)
-os.chdir(args.output_dir)
              
 rdir = layout.SectionNumber('results', ['configuration',
                                  'analysis_time',


### PR DESCRIPTION
Change directory in the workflow before creating the workflow objects so that the parsed configuration files get placed in the output directory and not the cwd. 