### PR TITLE
Set correct end time in merge_psds

### DIFF
--- a/bin/hdfcoinc/pycbc_merge_psds
+++ b/bin/hdfcoinc/pycbc_merge_psds
@@ -1,4 +1,20 @@
 #!/usr/bin/env python
+# Copyright (C) 2015 Alex Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 """ Merge hdf psd files
 """
 import logging, argparse, numpy, h5py, pycbc.types
@@ -24,6 +40,7 @@ for psd_file in args.psd_files:
         start[ifo], end[ifo] = [], []
     
     for rkey in f['%s/psds' % ifo].keys():
+        int_key = int(rkey)
         rkey = '%s/psds/%s' % (ifo, rkey)
         psd = pycbc.types.load_frequencyseries(psd_file, group=rkey)
     
@@ -31,13 +48,13 @@ for psd_file in args.psd_files:
         outf.create_dataset(key, data=psd,
                          compression='gzip', compression_opts=9, shuffle=True)
                          
-        s = int(psd.epoch)
-        e = int(s + 1.0 / psd.delta_f)
+        s = f['%s/start_time' % ifo][int_key]
+        e = f['%s/end_time' % ifo][int_key]
                          
-        outf[key].attrs['epoch'] = s
+        outf[key].attrs['epoch'] = int(psd.epoch)
         outf[key].attrs['delta_f'] = float(psd.delta_f)
         start[ifo].append(s)
-        end[ifo].append(s)
+        end[ifo].append(e)
         
         inc[ifo] += 1
 
@@ -47,4 +64,3 @@ for ifo in start:
 
 outf.attrs['low_frequency_cutoff'] = f.attrs['low_frequency_cutoff']
 logging.info('Done!')
-


### PR DESCRIPTION
pycbc_merge_psds currently stores the wrong value in the end_time group. It actually writes the start time there and the end time is anyway miscalculated.

This fixes this by taking the correct end times from the input combine psds files.

BTW, Alex, I am concerned by file pointer management here. At no point are .close() operations ever performed, and every file is actually opened a second time when calling pycbc.types.load_frequencyseries. Could this cause problems if a large number of files are read in?

I also notice that some PSDs appear duplicated in this merged file. Is this intentional? I am using Sam's ER8b run on sugar as my example and test case.