### PR TITLE
remove duplicate psds

### DIFF
--- a/pycbc/workflow/psd.py
+++ b/pycbc/workflow/psd.py
@@ -58,6 +58,9 @@ def setup_psd_calculate(workflow, frame_files, ifo, segments,
     else:
         num_parts = 1
         
+    # get rid of duplicate segments which happen when splitting the bank
+    segments = segmentlist(frozenset(segments))       
+        
     segment_lists = list(chunks(segments, num_parts)) 
     
     psd_files = FileList([])


### PR DESCRIPTION
This was patched before my removing duplicate psds in the calculate psd exe, but that doesn't quite work if you are pre splitting the bank. You can still end up with boundaries where the same psd will get calculated. 