### PR TITLE
Add sngls minifup to workflow

### DIFF
--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -229,6 +229,14 @@ for bin_file in bin_files:
                                   rdir['result/%s' % bin_file.bin_name],
                                   tags=bin_file.tags)
 
+# Also run minifollowups on loudest sngl detector events
+for insp_file in full_insps:
+    curr_ifo = insp_file.ifo
+    wf.setup_single_det_minifollowups(workflow, insp_file, hdfbank[0],
+                                  insp_data_segs, 'INSPIRAL_DATA', 'daxes',
+                                  rdir['result/sngl_%s' %(curr_ifo,)],
+                                  tags=insp_file.tags)
+
 ################## Setup segment / veto related plots #########################    
 # do plotting of segments / veto times
 for ifo, files in zip(*ind_cats.categorize_by_attr('ifo')):

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -1,0 +1,128 @@
+#!/bin/env python
+# Copyright (C) 2015 Alexander Harvey Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+""" Make tables describing a sngl event"""
+import sys, h5py, matplotlib, numpy, datetime, argparse
+matplotlib.use('Agg')
+import pylab
+import lal
+import pycbc.version, pycbc.events, pycbc.results, pycbc.pnutils
+from pycbc.io import hdf
+
+# JavaScript for searching the aLOG
+html = """<script type="text/javascript">
+function redirect(form,way)
+{
+        // Set location to form and submit.
+        if(form != '')
+        {
+                document.forms[form].action=way;
+                document.forms[form].submit();
+        }
+        else
+        {
+                window.top.location = way;
+        }
+}
+</script>"""
+
+def get_summary_page_link(ifo, utc_time):
+    """ Return a string that links to the summary page for this ifo """
+    search_form = """<form name="%s_alog_search" id="%s_alog_search" method="post">
+<input type="hidden" name="srcDateFrom" id="srcDateFrom" value="%s" size="20" />
+<input type="hidden" name="srcDateTo" id="srcDateTo" value="%s" size="20" />
+</form>
+"""
+    data = {'H1':"""H1&nbsp;<a href=https://ldas-jobs.ligo-wa.caltech.edu/~detchar/summary/day/%s>Summary</a>&nbsp;<a onclick="redirect('h1_alog_search','https://alog.ligo-wa.caltech.edu/aLOG/includes/search.php?adminType=search'); return true;">aLOG</a>""",
+            'L1':"""L1&nbsp;<a href=https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day/%s>Summary</a>&nbsp;<a onclick="redirect('l1_alog_search','https://alog.ligo-la.caltech.edu/aLOG/includes/search.php?adminType=search'); return true;">aLOG</a>""" }
+    if ifo not in data:
+        return ifo
+    else:
+        euro_utc = '%02d-%02d-%4d' % (utc_time[1], utc_time[2], utc_time[0])
+        ext = '%4d%02d%02d' % (utc_time[0], utc_time[1], utc_time[2]) 
+        return_string = search_form % (ifo.lower(), ifo.lower(), euro_utc, euro_utc)
+        return_string += data[ifo] % ext
+        return return_string
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--version', action='version',
+    version=pycbc.version.git_verbose_msg)
+parser.add_argument('--verbose', action='store_true')
+parser.add_argument('--single-trigger-file',
+              help="HDF format single detector trigger files for the full "
+                   "data run")
+parser.add_argument('--bank-file',
+              help="HDF format template bank file")
+parser.add_argument('--output-file')
+# CURRENTLY UNUSED, but may be needed if using foreground censor
+parser.add_argument('--statmap-file',
+    help="The HDF format clustered coincident statmap file containing the "
+         "result triggers. ")
+parser.add_argument('--veto-file',
+    help="The veto file to be used if vetoing triggers (optional).")
+parser.add_argument('--segment-name',
+    help="If using veto file must also provide the name of the segment to use "
+         "as a veto.")
+parser.add_argument('--instrument', help="Name of ifo (e.g. H1)")
+parser.add_argument('--n-loudest', type=int,
+    help="The trigger Nth loudest trigger to examine, use with statmap file")
+parser.add_argument('--ranking-statistic',
+                help="How to rank triggers when determining loudest triggers.")
+
+args = parser.parse_args()
+pycbc.init_logging(args.verbose)
+
+# Get the nth loudest trigger from the output of pycbc_coinc_statmap
+sngl_file = hdf.SingleDetTriggers(args.single_trigger_file, args.bank_file,
+                args.veto_file, args.segment_name, None, args.instrument)
+
+sngl_file.mask_to_n_loudest_clustered_events(n_loudest=args.n_loudest+1,
+                                      ranking_statistic=args.ranking_statistic)
+# Restrict to only the nth loudest, instead of all triggers up to nth loudest
+stat = sngl_file.stat[-1]
+sngl_file.mask = sngl_file.mask[-1]
+
+# make a table for the single detector information ############################
+headers = ["Detector&nbsp;Status", "UTC", "Time", "SNR", sngl_file.stat_name,
+           "Chisq", "Bins", "Phase", "M1", "M2", "Mc", "S1z", "S2z",
+           "Duration"]
+
+time = sngl_file.end_time 
+utc = lal.GPSToUTC(int(time))[0:6]
+data = [[get_summary_page_link(args.instrument, utc),
+        str(datetime.datetime(*utc)),
+        time,
+        '%5.2f' % sngl_file.snr,
+        '%5.2f' % stat,
+        '%5.2f' % sngl_file.rchisq,            
+        '%5.2f' % sngl_file.get_column('chisq_dof'),
+        '%5.2f' % sngl_file.get_column('coa_phase'),
+        '%5.2f' % sngl_file.mass1,
+        '%5.2f' % sngl_file.mass2,
+        '%5.2f' % sngl_file.mchirp,
+        '%5.2f' % sngl_file.spin1z,
+        '%5.2f' % sngl_file.spin2z,
+        '%5.2f' % sngl_file.template_duration,
+           ]]
+
+html += str(pycbc.results.static_table(data, headers))
+###############################################################################
+
+pycbc.results.save_fig_with_metadata(html, args.output_file, {},
+                        cmd = ' '.join(sys.argv),
+                        title = 'Parameters of Single detector Event Ranked %s' % (args.n_loudest + 1),
+                        caption = 'Parameters of the single detector event ranked number %s by %s. The figures below show the mini-followup data for this event.' % (args.n_loudest + 1, sngl_file.stat_name))

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -1,0 +1,118 @@
+#!/bin/env python
+# Copyright (C) 2015 Alexander Harvey Nitz, Ian Harry
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+""" Followup foreground events
+"""
+import os, argparse, logging, h5py
+from pycbc.results import layout
+import pycbc.workflow.minifollowups as mini
+import pycbc.workflow.pegasus_workflow as wdax
+import pycbc.version
+import pycbc.workflow as wf
+from pycbc.io import hdf
+
+def to_file(path, ifo=None):
+    fil = wdax.File(os.path.basename(path))
+    fil.ifo = ifo
+    path = os.path.abspath(path)
+    fil.PFN(path, 'local')
+    return fil
+
+parser = argparse.ArgumentParser(description=__doc__[1:])
+parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg) 
+parser.add_argument('--workflow-name', default='my_unamed_run')
+parser.add_argument("-d", "--output-dir", default=None,
+                    help="Path to output directory.")
+parser.add_argument('--bank-file',
+                    help="HDF format template bank file")
+parser.add_argument('--single-detector-file',
+                    help="HDF format merged single detector trigger files")
+parser.add_argument('--instrument', help="Name of interferometer e.g. H1") 
+parser.add_argument('--inspiral-segments',
+                    help="xml segment file containing the inspiral analysis "
+                         "times")
+parser.add_argument('--inspiral-segment-name',
+                    help="Name of inspiral segmentlist to read from segment "
+                         "file")
+parser.add_argument('--ranking-statistic',
+                help="How to rank triggers when determining loudest triggers.")
+parser.add_argument('--output-map')
+parser.add_argument('--output-file')
+parser.add_argument('--tags', nargs='+', default=[])
+wf.add_workflow_command_line_group(parser)
+args = parser.parse_args()
+
+logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s', 
+                    level=logging.INFO)
+
+workflow = wf.Workflow(args, args.workflow_name)
+
+wf.makedir(args.output_dir)
+             
+# create a FileList that will contain all output files
+layouts = []
+
+tmpltbank_file = to_file(args.bank_file)
+sngl_file = to_file(args.single_detector_file, ifo=args.instrument)
+#insp_segs = to_file(args.inspiral_segments)
+
+num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups',
+                 'num-sngl-events', ''))
+
+veto_file=None
+segment_name=None
+trigs = hdf.SingleDetTriggers(args.single_detector_file, args.bank_file,
+                              veto_file, segment_name, None, args.instrument)
+
+trigs.mask_to_n_loudest_clustered_events(n_loudest=num_events,
+                                      ranking_statistic=args.ranking_statistic)
+
+if len(trigs.stat) < num_events:
+    num_events = len(trigs.stat)
+
+times = trigs.end_time
+tids = trigs.template_id
+
+# loop over number of loudest events to be followed up
+for num_event in range(num_events):
+    files = wf.FileList([])
+    time = times[num_event]
+    ifo_time = '%s:%s' %(args.instrument, str(time))
+    tid = trigs.mask[num_event]
+    ifo_tid = '%s:%s' %(args.instrument, str(tid))
+    
+    layouts += (mini.make_sngl_ifo(workflow, sngl_file, tmpltbank_file,
+                              num_event, args.output_dir, args.instrument,
+                              tags = args.tags + [str(num_event)],
+                              veto_file=veto_file, segment_name=segment_name),)
+    files += mini.make_trigger_timeseries(workflow, [sngl_file],
+                              ifo_time, args.output_dir, special_tids=ifo_tid,
+                              tags=args.tags + [str(num_event)])
+    # Would be nice to have this, but is not yet supported
+    #files += mini.make_single_template_plots(workflow, insp_segs,
+    #                          args.inspiral_segment_name, coinc_file,
+    #                          tmpltbank_file, num_event, args.output_dir,
+    #                          tags=args.tags + [str(num_event)])
+    
+    files += mini.make_singles_timefreq(workflow, sngl_file, tmpltbank_file, 
+                            time - 10, time + 10, args.output_dir,
+                            tags=args.tags + [str(num_event), args.instrument])                 
+    
+    layouts += list(layout.grouper(files, 2))
+    num_event += 1
+
+workflow.save(filename=args.output_file, output_map=args.output_map)
+layout.two_column_layout(args.output_dir, layouts)

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -252,6 +252,7 @@ class SingleDetTriggers(object):
     """
     Provides easy access to the parameters of single-detector CBC triggers.
     """
+    # FIXME: Some of these are optional and should be kwargs.
     def __init__(self, trig_file, bank_file, veto_file, segment_name, filter_func, detector):
         logging.info('Loading triggers')
         self.trigs_f = h5py.File(trig_file, 'r')
@@ -299,6 +300,42 @@ class SingleDetTriggers(object):
         "Returns a list of plottable CBC parameter variables."
         return [m[0] for m in inspect.getmembers(cls) \
             if type(m[1]) == property]
+
+    def mask_to_n_loudest_clustered_events(self, n_loudest=10,
+                                           ranking_statistic='newsnr',
+                                           cluster_window=10):
+        """Edits the mask property of the class to point to the N loudest
+        single detector events as ranked by ranking statistic. Events are
+        clustered so that no more than 1 event within +/- cluster-window will
+        be considered."""
+        # If this becomes memory intensive we can optimize
+        if ranking_statistic == 'newsnr':
+            stat = self.newsnr
+            self.stat_name = "New SNR"
+        else:
+            err_msg = "Don't recognize statistic %s." %(ranking_statistic,)
+            raise ValueError(err_msg)
+        times = self.end_time
+        index = stat.argsort()[::-1]
+        new_times = []
+        new_index = []
+        for curr_idx in index:
+            curr_time = times[curr_idx] 
+            for time in new_times:
+                if abs(curr_time - time) < cluster_window:
+                    break
+            else:
+                # Only get here if no other triggers within cluster window
+                new_index.append(curr_idx)
+                new_times.append(curr_time)
+            if len(new_index) >= n_loudest:
+                break
+        print new_times
+        print new_index
+        index = np.array(new_index)
+        self.stat = stat[index]
+        self.mask = index  
+
 
     @property
     def template_id(self):

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -105,6 +105,89 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers, tmpltb
     workflow._adag.addDependency(dep)
     logging.info('Leaving minifollowups module')
 
+def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
+                                  insp_segs, insp_seg_name, dax_output,
+                                  out_dir, tags=None):
+    """ Create plots that followup the Nth loudest clustered single detector
+    triggers from a merged single detector trigger HDF file.
+    
+    Parameters
+    ----------
+    workflow: pycbc.workflow.Workflow
+        The core workflow instance we are populating
+    single_trig_file: pycbc.workflow.File
+        The File class holding the single detector triggers.
+    tmpltbank_file: pycbc.workflow.File
+        The file object pointing to the HDF format template bank
+    insp_segs: dict
+        A dictionary, keyed by ifo name, of the data read by each inspiral job.
+    insp_segs_name: str 
+        The name of the segmentlist to read from the inspiral segment file
+    out_dir: path
+        The directory to store minifollowups result plots and files
+    tags: {None, optional}
+        Tags to add to the minifollowups executables    
+    Returns
+    -------
+    layout: list
+        A list of tuples which specify the displayed file layout for the 
+        minifollops plots.
+    """
+    logging.info('Entering minifollowups module')
+
+    if not workflow.cp.has_section('workflow-minifollowups'):
+        msg = 'There is no [workflow-minifollowups] section in '
+        msg += 'configuration file'
+        logging.info(msg)
+        logging.info('Leaving minifollowups')
+        return
+
+    tags = [] if tags is None else tags
+    makedir(dax_output)
+
+    # turn the config file into a File class
+    curr_ifo = single_trig_file.ifo
+    config_path = os.path.abspath(dax_output + '/' + curr_ifo + \
+                                   '_'.join(tags) + 'singles_minifollowup.ini')
+    workflow.cp.write(open(config_path, 'w'))
+
+    config_file = wdax.File(os.path.basename(config_path))
+    config_file.PFN(config_path, 'local')
+
+    exe = Executable(workflow.cp, 'singles_minifollowup',
+                     ifos=curr_ifo, out_dir=dax_output)
+
+    node = exe.create_node()
+    node.add_input_opt('--config-files', config_file)
+    node.add_input_opt('--bank-file', tmpltbank_file)
+    node.add_input_opt('--single-detector-file', single_trig_file)
+    node.add_input_opt('--inspiral-segments', insp_segs[curr_ifo])
+    node.add_opt('--inspiral-segment-name', insp_seg_name)
+    node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file',
+                             tags=tags)
+
+    name = node.output_files[0].name
+    map_loc = name + '.map'
+    node.add_opt('--workflow-name', name)
+    node.add_opt('--output-dir', out_dir)
+    node.add_opt('--output-map', map_loc)
+
+    workflow += node
+
+    # execute this is a sub-workflow
+    fil = node.output_files[0]
+
+    ## FIXME not clear why I have to set the id here, pegasus should do this!
+    job = dax.DAX(fil)
+    job.addArguments('--basename %s' \
+                     % os.path.splitext(os.path.basename(name))[0])
+    Workflow.set_job_properties(job, map_loc)
+    workflow._adag.addJob(job)
+    dep = dax.Dependency(parent=node._dax_node, child=job)
+    workflow._adag.addDependency(dep)
+    logging.info('Leaving minifollowups module')
+
+
 def setup_injection_minifollowups(workflow, injection_file, single_triggers, tmpltbank_file, 
                                   dax_output, out_dir, tags=None):
     """ Create plots that followup the closest missed injections
@@ -241,7 +324,27 @@ def make_coinc_info(workflow, singles, bank, coinc, num, out_dir, tags=None):
     workflow += node
     files += node.output_files
     return files
-    
+
+def make_sngl_ifo(workflow, sngl_file, bank_file, num, out_dir, ifo,
+                  tags=None, veto_file=None, segment_name=None):
+    """Setup a job to create sngl detector sngl ifo html summary snippet.
+    """
+    tags = [] if tags is None else tags
+    makedir(out_dir)
+    name = 'page_snglinfo'
+    files = FileList([])
+    node = PlotExecutable(workflow.cp, name, ifos=[ifo],
+                              out_dir=out_dir, tags=tags).create_node()
+    node.add_input_opt('--single-trigger-file', sngl_file)
+    node.add_input_opt('--bank-file', bank_file)
+    node.add_opt('--n-loudest', str(num))
+    node.add_opt('--instrument', ifo)
+    node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
+    workflow += node
+    files += node.output_files
+    return files
+
+
 def make_trigger_timeseries(workflow, singles, ifo_times, out_dir, special_tids=None,
                             exclude=None, require=None, tags=None):
     tags = [] if tags is None else tags

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -163,6 +163,7 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     node.add_input_opt('--single-detector-file', single_trig_file)
     node.add_input_opt('--inspiral-segments', insp_segs[curr_ifo])
     node.add_opt('--inspiral-segment-name', insp_seg_name)
+    node.add_opt('--instrument', curr_ifo)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file',
                              tags=tags)
 

--- a/setup.py
+++ b/setup.py
@@ -352,9 +352,11 @@ setup (
     scripts  = [
                'bin/minifollowups/pycbc_injection_minifollowup',
                'bin/minifollowups/pycbc_foreground_minifollowup',
+               'bin/minifollowups/pycbc_sngl_minifollowup',
                'bin/minifollowups/pycbc_single_template_plot',
                'bin/minifollowups/pycbc_page_coincinfo',
                'bin/minifollowups/pycbc_page_injinfo',
+               'bin/minifollowups/pycbc_page_snglinfo',
                'bin/minifollowups/pycbc_plot_trigger_timeseries',
                'bin/lalapps/lalapps_inspiral_ahope',
                'bin/lalapps/lalapps_tmpltbank_ahope',


### PR DESCRIPTION
This patch adds followup of the loudest single detector triggers to the workflow. This is still very much a first-stage cut at this, but I think getting this in early let's people think about, and add, information that is missing.

Currently this uses open-box triggers (does not use foreground censor) and therefore is written only to the open box page. This can maybe be changed if people want to, some of the stuff that would be needed to do this is kind of in place already. I also leave some of the stuff in place that will be needed to do the single_trigger plots, even though currently that is unused.

@ahnitz if you want to test this on your end to make sure everything is working fine, that would be good!

My example page is here:

https://galahad.aei.mpg.de/~spxiwh/LVC/ER8/analyses/uberbank/highmtotal_bank_run1p5/8._test_run/