### PR TITLE
Solving issue #436 and allowing for two frame conventions in pycbc_dark_vs_bright_injections

### DIFF
--- a/bin/pycbc_dark_vs_bright_injections
+++ b/bin/pycbc_dark_vs_bright_injections
@@ -56,6 +56,8 @@ parser.add_argument('--remnant-mass-threshold', type=float, required=True,
                        "remnant disk mass does not exceed this value, the NS-BH"
                        "binary is dropped from the bank.  UNITS=Solar mass")
 parser.add_argument("-z", "--write-compress", action="store_true", help="Write compressed xml.gz files.")
+parser.add_argument("--frame-axis-view", action="store_true",
+                  help="The x, y, z spin components are wrt the line of site.")
 parser.add_argument("-v", "--verbose", action="store_true", default=False,
                     help="Extended standard output.")
 
@@ -110,15 +112,25 @@ for i, inj in enumerate(injections.table):
         if m1 < m2:
             NSmass = m1
             bh_spin_magnitude = numpy.sqrt(s2x*s2x + s2y*s2y + s2z*s2z)
-            # Scalar product between spin and orbital angular momentum 
-            bh_spin_para = s2x*numpy.sin(incl)+s2z*numpy.cos(incl)
+            if opts.frame_axis_view:
+                # Scalar product between spin and orbital angular momentum 
+                # (the x, y, z spin components are wrt the line of site)
+                bh_spin_para = s2x*numpy.sin(incl)+s2z*numpy.cos(incl)
+            else:
+                # The x, y, z spin components are wrt the orbital angular momentum
+                bh_spin_para = s2z
             bh_spin_inclination = numpy.arccos(bh_spin_para/bh_spin_magnitude)
         # 2 = NS, 1 = BH
         else:
             NSmass = m2
             bh_spin_magnitude = numpy.sqrt(s1x*s1x + s1y*s1y + s1z*s1z)
-            # Scalar product between spin and orbital angular momentum 
-            bh_spin_para = s1x*numpy.sin(incl)+s1z*numpy.cos(incl)
+            if opts.frame_axis_view:
+                # Scalar product between spin and orbital angular momentum 
+                # (the x, y, z spin components are wrt the line of site)
+                bh_spin_para = s1x*numpy.sin(incl)+s1z*numpy.cos(incl)
+            else:
+                # The x, y, z spin components are wrt the orbital angular momentum
+                bh_spin_para = s1z
             bh_spin_inclination = numpy.arccos(bh_spin_para/bh_spin_magnitude)
         # remnant_mass is the remnant disk mass - the threshold set by the user to discriminate dim and bright
         remnant_mass = pycbc.tmpltbank.em_progenitors.remnant_mass(eta, NSmass, ns_sequence, bh_spin_magnitude, bh_spin_inclination, opts.remnant_mass_threshold)

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1452,15 +1452,6 @@ class PycbcDarkVsBrightInjectionsExecutable(Executable):
         node.new_output_file_opt(segment,
                                  ext, '--output-dim',
                                  store_file=self.retain_files, tags=tag)
-
-        eos_name = self.get_opt('eos')
-        if not eos_name == '2H':
-            raise ValueError('2H is the only equation of state that can be handled currently')
-        ns_bh_boundary = self.get_opt('ns-bh-boundary') 
-        remnant_mass_threshold = self.get_opt('remnant-mass-threshold') 
-        node.add_opt('--eos', eos_name)
-        node.add_opt('--ns-bh-boundary', ns_bh_boundary)
-        node.add_opt('--remnant-mass-threshold', remnant_mass_threshold)
         return node
 
 class LigolwCBCJitterSkylocExecutable(Executable):

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1452,16 +1452,15 @@ class PycbcDarkVsBrightInjectionsExecutable(Executable):
         node.new_output_file_opt(segment,
                                  ext, '--output-dim',
                                  store_file=self.retain_files, tags=tag)
-        # The following options are hard-coded because these values are the
-        # only ones currently available for them and correspond to the most
-        # conservatitve choices (i.e. they all disfavour tagging and
-        # injection as dim).  Having ini-file options which are necessary but
-        # not flexible would just be confusing.  When and if the use of these
-        # three options becomes more flexible, one can remove the hard-coded
-        # values.
-        node.add_opt('--eos', '2H')
-        node.add_opt('--ns-bh-boundary', '2.8346480922')
-        node.add_opt('--remnant-mass-threshold', '0.')
+
+        eos_name = self.get_opt('eos')
+        if not eos_name == '2H':
+            raise ValueError('2H is the only equation of state that can be handled currently')
+        ns_bh_boundary = self.get_opt('ns-bh-boundary') 
+        remnant_mass_threshold = self.get_opt('remnant-mass-threshold') 
+        node.add_opt('--eos', eos_name)
+        node.add_opt('--ns-bh-boundary', ns_bh_boundary)
+        node.add_opt('--remnant-mass-threshold', remnant_mass_threshold)
         return node
 
 class LigolwCBCJitterSkylocExecutable(Executable):


### PR DESCRIPTION
@sfairhur This solves the issue you raised (#436) and also allows dark/bright injections to be separated by interpreting the spin components in the sim_inspiral table in two different frame conventions:
(1) L=(0,0,1) [default], where L is the orbital angular momentum direction
(2) N=(0,0,1) [activated by the --frame-axis-view flag], where N is the line of site direction