### PR TITLE
Minimal change to collect faithsim results whilst running

### DIFF
--- a/bin/pycbc_make_faithsim
+++ b/bin/pycbc_make_faithsim
@@ -181,7 +181,9 @@ if __name__ == "__main__":
                 btables[bname] = table.get_table(indoc, lsctables.SimInspiralTable.tableName) 
             bt = btables[bname]
             try:      
-                md = loadtxt(part, dtype=dtypem)  
+                md = loadtxt(part, dtype=dtypem)
+                if md.size == 0:
+                    continue  
             except IOError:
                 continue
             pdata = zeros(len(bt), dtype=dtypeo)


### PR DESCRIPTION
This is the minimal change to pycbc_make_faithsim that allows the scr…ipt pycbc_faithsim_collect_results to work while jobs are still running or some of them have failed.

I have tested it and it works.