### PR TITLE
Closed box sngl minifollowups

### DIFF
--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -234,7 +234,9 @@ for insp_file in full_insps:
     curr_ifo = insp_file.ifo
     wf.setup_single_det_minifollowups(workflow, insp_file, hdfbank[0],
                                   insp_data_segs, 'INSPIRAL_DATA', 'daxes',
-                                  rdir['result/sngl_%s' %(curr_ifo,)],
+                                  rdir['single_triggers/sngl_%s' %(curr_ifo,)],
+                                  veto_file=censored_veto,
+                                  veto_segment_name='closed_box',
                                   tags=insp_file.tags)
 
 ################## Setup segment / veto related plots #########################    

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -74,7 +74,7 @@ parser.add_argument('--statmap-file',
          "result triggers. ")
 parser.add_argument('--veto-file',
     help="The veto file to be used if vetoing triggers (optional).")
-parser.add_argument('--segment-name',
+parser.add_argument('--veto-segment-name',
     help="If using veto file must also provide the name of the segment to use "
          "as a veto.")
 parser.add_argument('--instrument', help="Name of ifo (e.g. H1)")
@@ -88,7 +88,7 @@ pycbc.init_logging(args.verbose)
 
 # Get the nth loudest trigger from the output of pycbc_coinc_statmap
 sngl_file = hdf.SingleDetTriggers(args.single_trigger_file, args.bank_file,
-                args.veto_file, args.segment_name, None, args.instrument)
+                args.veto_file, args.veto_segment_name, None, args.instrument)
 
 sngl_file.mask_to_n_loudest_clustered_events(n_loudest=args.n_loudest+1,
                                       ranking_statistic=args.ranking_statistic)

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -72,6 +72,7 @@ layouts = []
 
 tmpltbank_file = to_file(args.bank_file)
 sngl_file = to_file(args.single_detector_file, ifo=args.instrument)
+veto_file = to_file(args.veto_file, ifo=args.instrument)
 #insp_segs = to_file(args.inspiral_segments)
 
 num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups',
@@ -101,8 +102,8 @@ for num_event in range(num_events):
     layouts += (mini.make_sngl_ifo(workflow, sngl_file, tmpltbank_file,
                               num_event, args.output_dir, args.instrument,
                               tags = args.tags + [str(num_event)],
-                              veto_file=args.veto_file,
-                              segment_name=args.veto_segment_name),)
+                              veto_file=veto_file,
+                              veto_segment_name=args.veto_segment_name),)
     files += mini.make_trigger_timeseries(workflow, [sngl_file],
                               ifo_time, args.output_dir, special_tids=ifo_tid,
                               tags=args.tags + [str(num_event)])

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -41,6 +41,11 @@ parser.add_argument('--bank-file',
 parser.add_argument('--single-detector-file',
                     help="HDF format merged single detector trigger files")
 parser.add_argument('--instrument', help="Name of interferometer e.g. H1") 
+parser.add_argument('--veto-file',
+    help="The veto file to be used if vetoing triggers (optional).")
+parser.add_argument('--veto-segment-name',
+    help="If using veto file must also provide the name of the segment to use "
+         "as a veto.")
 parser.add_argument('--inspiral-segments',
                     help="xml segment file containing the inspiral analysis "
                          "times")
@@ -72,10 +77,9 @@ sngl_file = to_file(args.single_detector_file, ifo=args.instrument)
 num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups',
                  'num-sngl-events', ''))
 
-veto_file=None
-segment_name=None
 trigs = hdf.SingleDetTriggers(args.single_detector_file, args.bank_file,
-                              veto_file, segment_name, None, args.instrument)
+                              args.veto_file, args.veto_segment_name,
+                              None, args.instrument)
 
 trigs.mask_to_n_loudest_clustered_events(n_loudest=num_events,
                                       ranking_statistic=args.ranking_statistic)
@@ -97,7 +101,8 @@ for num_event in range(num_events):
     layouts += (mini.make_sngl_ifo(workflow, sngl_file, tmpltbank_file,
                               num_event, args.output_dir, args.instrument,
                               tags = args.tags + [str(num_event)],
-                              veto_file=veto_file, segment_name=segment_name),)
+                              veto_file=args.veto_file,
+                              segment_name=args.veto_segment_name),)
     files += mini.make_trigger_timeseries(workflow, [sngl_file],
                               ifo_time, args.output_dir, special_tids=ifo_tid,
                               tags=args.tags + [str(num_event)])

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -264,6 +264,8 @@ class SingleDetTriggers(object):
             logging.info('Applying veto segments')
             # veto_mask is an array of indices into the trigger arrays
             # giving the surviving triggers 
+            logging.info('%i triggers before vetoes',
+                          len(self.trigs['end_time'][:]))
             self.veto_mask, segs = events.veto.indices_outside_segments(
                 self.trigs['end_time'][:], [veto_file],
                 ifo=detector, segment_name=segment_name)
@@ -330,12 +332,9 @@ class SingleDetTriggers(object):
                 new_times.append(curr_time)
             if len(new_index) >= n_loudest:
                 break
-        print new_times
-        print new_index
         index = np.array(new_index)
         self.stat = stat[index]
-        self.mask = index  
-
+        self.mask = self.mask[index]
 
     @property
     def template_id(self):

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -107,7 +107,8 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers, tmpltb
 
 def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
                                   insp_segs, insp_seg_name, dax_output,
-                                  out_dir, tags=None):
+                                  out_dir, veto_file=None,
+                                  veto_segment_name=None, tags=None):
     """ Create plots that followup the Nth loudest clustered single detector
     triggers from a merged single detector trigger HDF file.
     
@@ -164,6 +165,10 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     node.add_input_opt('--inspiral-segments', insp_segs[curr_ifo])
     node.add_opt('--inspiral-segment-name', insp_seg_name)
     node.add_opt('--instrument', curr_ifo)
+    if veto_file is not None:
+        assert(veto_segment_name is not None)
+        node.add_input_opt('--veto-file', veto_file)
+        node.add_opt('--veto-segment-name', veto_segment_name)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file',
                              tags=tags)
 

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -327,7 +327,7 @@ def make_coinc_info(workflow, singles, bank, coinc, num, out_dir, tags=None):
     return files
 
 def make_sngl_ifo(workflow, sngl_file, bank_file, num, out_dir, ifo,
-                  tags=None, veto_file=None, segment_name=None):
+                  veto_file=None, veto_segment_name=None, tags=None):
     """Setup a job to create sngl detector sngl ifo html summary snippet.
     """
     tags = [] if tags is None else tags
@@ -338,6 +338,10 @@ def make_sngl_ifo(workflow, sngl_file, bank_file, num, out_dir, ifo,
                               out_dir=out_dir, tags=tags).create_node()
     node.add_input_opt('--single-trigger-file', sngl_file)
     node.add_input_opt('--bank-file', bank_file)
+    if veto_file is not None:
+        assert(veto_segment_name is not None)
+        node.add_input_opt('--veto-file', veto_file)
+        node.add_opt('--veto-segment-name', veto_segment_name)
     node.add_opt('--n-loudest', str(num))
     node.add_opt('--instrument', ifo)
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')


### PR DESCRIPTION
This converts the single trigger minifollowups into closed-box plots by using the foreground censor veto file. This has been tested:

https://sugar-jobs.phy.syr.edu/~spxiwh/aLIGO/O1/o1_sep26-oct08/with_minifups/run1

and seems to work as intended.

As an aside, I was, of course, using the re-use cache file functionality when doing this. This included some of Soumi's followup dax files in the input.map. The planner failed completely when trying to plan Soumi's dax files that had been copied over. Probably we should not reuse these sub-dax files? If that is the case then should/can we stop them appearing in the output.map files?