### PR TITLE
handle case where newsnr returns a number

### DIFF
--- a/bin/minifollowups/pycbc_plot_trigger_timeseries
+++ b/bin/minifollowups/pycbc_plot_trigger_timeseries
@@ -95,8 +95,11 @@ if args.log_y_axis:
 pylab.xlabel('time (s)')
 pylab.ylabel(args.plot_type)
 
-if len(val) > 0:                                
-    pylab.ylim(ymin=val.min())
+try:
+    if len(val) > 0:                                
+        pylab.ylim(ymin=val.min())
+except TypeError:
+    pylab.ylim(ymin=val)
 
 pylab.xlim(xmin=-args.window, xmax=args.window)
 pylab.legend()


### PR DESCRIPTION
pycbc.events returns an array for the newsnr if there is more than one event, but a number otherwise:

https://github.com/ligo-cbc/pycbc/blob/master/pycbc/events/events.py#L178

pycbc_plot_trigger_timeseries always assumes that this is an array. This adds a try/except to handle the case where there is only one.