### PR TITLE
Adding SNR timeseries to minifups page

### DIFF
--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -360,8 +360,10 @@ for inj_file, tag in zip(inj_files, inj_tags):
     if len(f) > 0: layout.two_column_layout(rdir['injections/%s' % tag], inj_layout)  
 
     # run minifollowups on nearest missed injections
-    wf.setup_injection_minifollowups(workflow, found_inj, insps,  hdfbank[0],
-                                     'daxes', rdir['injections/followup-%s' % tag],
+    wf.setup_injection_minifollowups(workflow, found_inj, small_inj_file,
+                                     insps,  hdfbank[0],
+                                     insp_data_segs, 'INSPIRAL_DATA', 'daxes',
+                                     rdir['injections/followup-%s' % tag],
                                      tags=[tag])
         
 # Make combined injection plots

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -16,12 +16,14 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """ Followup foreground events
 """
-import os, argparse, numpy, logging, h5py, pycbc.workflow as wf
+import os, argparse, numpy, logging, h5py, copy
+import pycbc.workflow as wf
 from pycbc.results import layout
 from pycbc.detector import Detector
 import pycbc.workflow.minifollowups as mini
 import pycbc.workflow.pegasus_workflow as wdax
 import pycbc.version, pycbc.pnutils
+from pycbc.io.hdf import SingleDetTriggers
 
 def to_file(path, ifo=None):
     fil = wdax.File(os.path.basename(path))
@@ -38,8 +40,16 @@ parser.add_argument('--bank-file',
                     help="HDF format template bank file")
 parser.add_argument('--injection-file',
                     help="HDF format injection results file")
+parser.add_argument('--injection-xml-file',
+                    help="XML format injection file")
 parser.add_argument('--single-detector-triggers', nargs='+', 
                     help="HDF format merged single detector trigger files")
+parser.add_argument('--inspiral-segments', nargs='+',
+                    help="xml segment files containing the inspiral analysis times")
+parser.add_argument('--inspiral-segment-name',
+                    help="Name of inspiral segmentlist to read from segment files")
+parser.add_argument('--inj-window', type=int, default=0.5,
+                    help="Time window in which to look for injection triggers")
 parser.add_argument('--output-map')
 parser.add_argument('--output-file')
 parser.add_argument('--tags', nargs='+', default=[])
@@ -58,11 +68,17 @@ layouts = []
 
 tmpltbank_file = to_file(args.bank_file)
 injection_file = to_file(args.injection_file)
+injection_xml_file = to_file(args.injection_xml_file)
 
 single_triggers = []
 for name in args.single_detector_triggers:
     ifo, fname = name.split(':')
     single_triggers.append(to_file(fname, ifo=ifo))
+
+insp_segs = {}
+for name in args.inspiral_segments:
+    ifo, fname = name.split(':')
+    insp_segs[ifo] = to_file(fname, ifo=ifo)
 
 f = h5py.File(args.injection_file, 'r')
 missed = f['missed/after_vetoes'][:]
@@ -95,6 +111,9 @@ for num_event in range(num_events):
     time = f['injections/end_time'][injection_index]
     
     ifo_times = ''
+    inj_params = {}
+    for val in ['mass1', 'mass2', 'spin1z', 'spin2z', 'end_time']:
+        inj_params[val] = f['injections/%s' %(val,)][injection_index]
     for single in single_triggers:
         ifo = single.ifo
         det = Detector(ifo)
@@ -102,6 +121,7 @@ for num_event in range(num_events):
         lat = f['injections/latitude'][injection_index]
         ifo_time = time + det.time_delay_from_earth_center(lon, lat, time)
         ifo_times += ' %s:%s ' % (ifo, ifo_time) 
+        inj_params[ifo+'_end_time'] = ifo_time
           
     layouts += [(mini.make_inj_info(workflow, injection_file, injection_index, num_event,
                                args.output_dir, tags=args.tags + [str(num_event)])[0],)]   
@@ -113,7 +133,36 @@ for num_event in range(num_events):
         files += mini.make_singles_timefreq(workflow, single, tmpltbank_file, 
                                 time - 10, time + 10, args.output_dir,
                                 tags=args.tags + [str(num_event), single.ifo])                 
-    
+
+    files += mini.make_single_template_plots_new(workflow, insp_segs,
+                            args.inspiral_segment_name, inj_params,
+                            args.output_dir, inj_file=injection_xml_file,
+                            tags=args.tags+['INJ_PARAMS',str(num_event)])
+
+    for curr_ifo, single_fname in \
+                         [l.split(':') for l in args.single_detector_triggers]:
+        hd_sngl = SingleDetTriggers(single_fname, args.bank_file, None, None,
+                                    None, curr_ifo)
+        end_times = hd_sngl.end_time
+        # Use SNR here or NewSNR??
+        snr = hd_sngl.snr
+        lgc_mask = abs(end_times - inj_params['end_time']) < args.inj_window
+        if len(snr[lgc_mask]) == 0:
+            continue
+        snr_idx = hd_sngl.mask[lgc_mask][snr[lgc_mask].argmax()]
+        hd_sngl.mask = hd_sngl.mask[snr_idx]
+        curr_params = copy.deepcopy(inj_params)
+        curr_params['mass1'] = hd_sngl.mass1
+        curr_params['mass2'] = hd_sngl.mass2
+        curr_params['spin1z'] = hd_sngl.spin1z
+        curr_params['spin2z'] = hd_sngl.spin2z
+        curr_tags = ['TMPLT_PARAMS_%s' %(curr_ifo,)]
+        curr_tags += [str(num_event)]
+        files += mini.make_single_template_plots_new(workflow, insp_segs,
+                                args.inspiral_segment_name, curr_params,
+                                args.output_dir, inj_file=injection_xml_file,
+                                tags=args.tags+curr_tags)
+
     layouts += list(layout.grouper(files, 2))
     num_event += 1
 

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -70,6 +70,8 @@ parser.add_argument("--spin1z", type=float, default=0,
 parser.add_argument("--spin2z", type=float, default=0,
                   help="The aligned pin of the second component object. "
                     "Do not use if giving a statmap file.")
+parser.add_argument("--trigger-time", type=float, default=0,
+                  help="The central time of the trigger to use.")
 parser.add_argument("--order", type=int,
                   help="The integer half-PN order at which to generate"
                        " the approximant. Default is -1 which indicates to use"
@@ -88,6 +90,7 @@ parser.add_argument("--n-loudest", type=int,
              ", only used with --statmap-file")
 parser.add_argument("--bank-file",
         help="HDF format template bank file, only used with --statmap-file")
+# These options can be used to identify start/end times
 parser.add_argument("--inspiral-segments",
         help="XML file containing the inspiral analysis segments. "
              "Only used with the --statmap-file option")
@@ -107,9 +110,9 @@ ifo = opt.channel_name[0:2]
 
 # If we are reading from the coinc files ######################################
 if opt.statmap_file:
-    time, tid = get_time(opt.statmap_file, opt.n_loudest, ifo)
+    opt.trigger_time, tid = get_time(opt.statmap_file, opt.n_loudest, ifo)
     
-    if time is None:
+    if opt.trigger_time is None:
         sys.exit()
     
     b = h5py.File(opt.bank_file, 'r')
@@ -117,11 +120,16 @@ if opt.statmap_file:
     opt.mass2 = float(b['mass2'][:][tid])
     opt.spin1z = float(b['spin1z'][:][tid])
     opt.spin2z = float(b['spin2z'][:][tid])
+
+# If we are choosing start/end times from XML file ############################
+if opt.inspiral_segments:
     start_pad = opt.pad_data + opt.segment_start_pad
     end_pad = opt.pad_data + opt.segment_end_pad
-    seg = select_segment(opt.inspiral_segments, opt.segment_name, ifo, time, start_pad, end_pad)
-    opt.gps_start_time, opt.gps_end_time = seg[0] + opt.pad_data, seg[1] - opt.pad_data
-    f.attrs['event_time'] = time
+    seg = select_segment(opt.inspiral_segments, opt.segment_name, ifo,
+                         opt.trigger_time, start_pad, end_pad)
+    opt.gps_start_time, opt.gps_end_time = \
+                                   seg[0] + opt.pad_data, seg[1] - opt.pad_data
+    f.attrs['event_time'] = opt.trigger_time
 
 ###############################################################################
 
@@ -210,6 +218,7 @@ with ctx:
      
         snrs.append(snr[stilde.analyze])
         chisqs.append(chisq[stilde.analyze])
+        print snr.start_time
         
     f['snr'] = numpy.concatenate([snr.numpy() for snr in snrs])
     f['snr'].attrs['start_time'] = float(snrs[0].start_time)

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -194,7 +194,9 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     logging.info('Leaving minifollowups module')
 
 
-def setup_injection_minifollowups(workflow, injection_file, single_triggers, tmpltbank_file, 
+def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
+                                  single_triggers, 
+                                  tmpltbank_file, insp_segs, insp_seg_name,
                                   dax_output, out_dir, tags=None):
     """ Create plots that followup the closest missed injections
     
@@ -246,7 +248,10 @@ def setup_injection_minifollowups(workflow, injection_file, single_triggers, tmp
     node.add_input_opt('--config-files', config_file)
     node.add_input_opt('--bank-file', tmpltbank_file)
     node.add_input_opt('--injection-file', injection_file)
+    node.add_input_opt('--injection-xml-file', inj_xml_file)
     node.add_multiifo_input_list_opt('--single-detector-triggers', single_triggers)
+    node.add_multiifo_input_list_opt('--inspiral-segments', insp_segs.values())
+    node.add_opt('--inspiral-segment-name', insp_seg_name)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file', tags=tags)
     
     name = node.output_files[0].name
@@ -268,6 +273,43 @@ def setup_injection_minifollowups(workflow, injection_file, single_triggers, tmp
     dep = dax.Dependency(parent=node._dax_node, child=job)
     workflow._adag.addDependency(dep)
     logging.info('Leaving injection minifollowups module')
+
+def make_single_template_plots_new(workflow, segs, seg_name, params,
+                                   out_dir, inj_file=None, exclude=None,
+                                   require=None, tags=None):
+    tags = [] if tags is None else tags
+    makedir(out_dir)
+    name = 'single_template_plot'
+    secs = requirestr(workflow.cp.get_subsections(name), require)
+    secs = excludestr(secs, exclude)
+    files = FileList([])
+    for tag in secs:
+        for ifo in workflow.ifos:
+            # Reanalyze the time around the trigger in each detector
+            node = PlotExecutable(workflow.cp, 'single_template', ifos=[ifo],
+                              out_dir=out_dir, tags=[tag] + tags).create_node()
+            node.add_opt('--mass1', params['mass1'])
+            node.add_opt('--mass2', params['mass2'])
+            node.add_opt('--spin1z', params['spin1z'])
+            node.add_opt('--spin2z', params['spin2z'])
+            node.add_opt('--trigger-time', params[ifo + '_end_time'])
+            node.add_input_opt('--inspiral-segments', segs[ifo])
+            if inj_file is not None:
+                node.add_input_opt('--injection-file', inj_file)
+            node.add_opt('--segment-name', seg_name)
+            node.new_output_file_opt(workflow.analysis_time, '.hdf',
+                                     '--output-file')
+            data = node.output_files[0]
+            workflow += node
+            # Make the plot for this trigger and detector
+            node = PlotExecutable(workflow.cp, name, ifos=[ifo],
+                              out_dir=out_dir, tags=[tag] + tags).create_node()
+            node.add_input_opt('--single-template-file', data)
+            node.new_output_file_opt(workflow.analysis_time, '.png',
+                                     '--output-file')
+            workflow += node
+            files += node.output_files
+    return files
 
 def make_single_template_plots(workflow, segs, seg_name, coinc, bank, num, out_dir, 
                                exclude=None, require=None, tags=None):
@@ -300,7 +342,8 @@ def make_single_template_plots(workflow, segs, seg_name, coinc, bank, num, out_d
             files += node.output_files
     return files      
 
-def make_inj_info(workflow, injection_file, injection_index, num, out_dir, tags=None):
+def make_inj_info(workflow, injection_file, injection_index, num, out_dir,
+                  tags=None):
     tags = [] if tags is None else tags
     makedir(out_dir)
     name = 'page_injinfo'


### PR DESCRIPTION
The presentation of these plots still needs improvement. But this patch adds in SNR timeseries to the minifups page, and adding a new code block in minifollowups.py to interact with this code not using the statmap file.

An example of this is here:

https://sugar-jobs.phy.syr.edu/~spxiwh/aLIGO/O1/o1_sep26-oct08/with_minifups/run3/5._injections/5.10_followup-BBH01_INJ/