### PR TITLE
Improve presentation of injection minifollowup SNR/chi2 time series

### DIFF
--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -137,7 +137,8 @@ for num_event in range(num_events):
     files += mini.make_single_template_plots_new(workflow, insp_segs,
                             args.inspiral_segment_name, inj_params,
                             args.output_dir, inj_file=injection_xml_file,
-                            tags=args.tags+['INJ_PARAMS',str(num_event)])
+                            tags=args.tags+['INJ_PARAMS',str(num_event)],
+                            params_str='injection parameters.')
 
     for curr_ifo, single_fname in \
                          [l.split(':') for l in args.single_detector_triggers]:
@@ -161,7 +162,8 @@ for num_event in range(num_events):
         files += mini.make_single_template_plots_new(workflow, insp_segs,
                                 args.inspiral_segment_name, curr_params,
                                 args.output_dir, inj_file=injection_xml_file,
-                                tags=args.tags+curr_tags)
+                                tags=args.tags+curr_tags,
+                                params_str='loudest template in %s' %curr_ifo )
 
     layouts += list(layout.grouper(files, 2))
     num_event += 1

--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -33,6 +33,10 @@ parser.add_argument('--event-time', type=float,
 parser.add_argument('--output-file', required=True)
 parser.add_argument('--log-y', action='store_true',
                     help='Use log scale for y-axis')
+parser.add_argument('--plot-title',
+                    help="If given, use this as the plot title")
+parser.add_argument('--plot-caption',
+                    help="If given, use this as the plot caption")
 
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
@@ -85,6 +89,12 @@ if args.log_y:
     ax2.set_yscale('log')
 ax2.legend(loc="upper right")
 
+if args.plot_title is None:
+    args.plot_title = '%s: SNR and chi^2 time series' % ifo
+if args.plot_caption is None:
+    args.plot_caption = ''
+
 pycbc.results.save_fig_with_metadata(fig, args.output_file, 
                              cmd=' '.join(sys.argv), fig_kwds={'dpi': 150},
-                             title='%s: SNR and chi^2 time series' % ifo)
+                             title=args.plot_title,
+                             caption=args.plot_caption)

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -276,7 +276,7 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
 
 def make_single_template_plots_new(workflow, segs, seg_name, params,
                                    out_dir, inj_file=None, exclude=None,
-                                   require=None, tags=None):
+                                   require=None, tags=None, params_str=None):
     tags = [] if tags is None else tags
     makedir(out_dir)
     name = 'single_template_plot'
@@ -292,7 +292,9 @@ def make_single_template_plots_new(workflow, segs, seg_name, params,
             node.add_opt('--mass2', params['mass2'])
             node.add_opt('--spin1z', params['spin1z'])
             node.add_opt('--spin2z', params['spin2z'])
-            node.add_opt('--trigger-time', params[ifo + '_end_time'])
+            # str(numpy.float64) restricts to 2d.p. BE CAREFUL WITH THIS!!!
+            str_trig_time = '%.6f' %(params[ifo + '_end_time'])
+            node.add_opt('--trigger-time', str_trig_time)
             node.add_input_opt('--inspiral-segments', segs[ifo])
             if inj_file is not None:
                 node.add_input_opt('--injection-file', inj_file)
@@ -307,6 +309,19 @@ def make_single_template_plots_new(workflow, segs, seg_name, params,
             node.add_input_opt('--single-template-file', data)
             node.new_output_file_opt(workflow.analysis_time, '.png',
                                      '--output-file')
+            title="'%s SNR and chi^2 timeseries" %(ifo) 
+            if params_str is not None:
+                title+= " using %s" %(params_str)
+            title+="'"
+            node.add_opt('--plot-title', title)
+            caption = "'The SNR and chi^2 timeseries around the injection"
+            if params_str is not None:
+                caption += " using %s" %(params_str)
+            caption += ". The template used has the following parameters: "
+            caption += "mass1=%s, mass2=%s, spin1z=%s, spin2z=%s'"\
+                       %(params['mass1'], params['mass2'], params['spin1z'],
+                         params['spin2z'])
+            node.add_opt('--plot-caption', caption)
             workflow += node
             files += node.output_files
     return files


### PR DESCRIPTION
This edits the title of the injection SNR/chi2 time series plots by making the title clearer and adding a caption. The caption includes masses and spins of the template that was used.

Example here:

https://sugar-jobs.phy.syr.edu/~spxiwh/aLIGO/O1/o1_sep26-oct08/with_minifups/run4/5._injections/5.10_followup-BBH01_INJ/