### PR TITLE
Implement optimal SNR in inj followups

### DIFF
--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -85,20 +85,28 @@ missed = f['missed/after_vetoes'][:]
 
 num_events = int(workflow.cp.get_opt_tags('workflow-injection_minifollowups', 'num-events', ''))
 
-eff_dist = {'H1': f['injections/eff_dist_h'][:][missed],
-         'L1': f['injections/eff_dist_l'][:][missed],
-         'V1': f['injections/eff_dist_v'][:][missed],
-        }
+try:
+    optimal_snr =[f['injections/optimal_snr_1'][:][missed],
+                  f['injections/optimal_snr_2'][:][missed]]
+    dec_snr = numpy.minimum(optimal_snr[0], optimal_snr[1])
+    sorting = dec_snr.argsort()
+    sorting = sorting[::-1]
+except:
+    # Fall back to effective distance if optimal SNR not available
+    eff_dist = {'H1': f['injections/eff_dist_h'][:][missed],
+               'L1': f['injections/eff_dist_l'][:][missed],
+               'V1': f['injections/eff_dist_v'][:][missed],
+               }
+    dec_dist = numpy.maximum(eff_dist[single_triggers[0].ifo], 
+                             eff_dist[single_triggers[1].ifo])
 
-dec_dist = numpy.maximum(eff_dist[single_triggers[0].ifo], 
-                         eff_dist[single_triggers[1].ifo])
+    mchirp, eta = pycbc.pnutils.mass1_mass2_to_mchirp_eta(\
+                                              f['injections/mass1'][:][missed],
+                                              f['injections/mass2'][:][missed])
 
-mchirp, eta = pycbc.pnutils.mass1_mass2_to_mchirp_eta(f['injections/mass1'][:][missed],
-                                                      f['injections/mass2'][:][missed])
+    dec_chirp_dist = pycbc.pnutils.chirp_distance(dec_dist, mchirp)
 
-dec_chirp_dist = pycbc.pnutils.chirp_distance(dec_dist, mchirp)
-
-sorting = dec_chirp_dist.argsort()
+    sorting = dec_chirp_dist.argsort()
 
 if len(missed) < num_events:
     num_events = len(missed)

--- a/bin/minifollowups/pycbc_page_injinfo
+++ b/bin/minifollowups/pycbc_page_injinfo
@@ -40,18 +40,30 @@ n = args.injection_index
 headers = []
 data = []
 
-keys = ['end_time', 'dec chirp dist', 'eff_dist_h', 'eff_dist_l', 'mass1', 'mass2',
-        'mchirp', 'eta', 'ra', 'dec', 'inc', 'spin1x', 'spin1y',
-        'spin1z', 'spin2x', 'spin2y', 'spin2z']
+keys = ['end_time']
 
 m1, m2 = f['injections']['mass1'][args.injection_index], f['injections']['mass2'][args.injection_index]
 mchirp, eta = pycbc.pnutils.mass1_mass2_to_mchirp_eta(m1, m2)
 
-dec_dist = max(f['injections']['eff_dist_h'][args.injection_index], f['injections']['eff_dist_l'][args.injection_index])
-dec_chirp_dist = pycbc.pnutils.chirp_distance(dec_dist, mchirp)
+if 'optimal_snr_1' in f['injections'].keys():
+    keys += ['optimal_snr_1', 'optimal_snr_2']
+else:
+    keys += ['dec chirp dist', 'eff_dist_h', 'eff_dist_l']
+    dec_dist = max(f['injections']['eff_dist_h'][args.injection_index], f['injections']['eff_dist_l'][args.injection_index])
+    dec_chirp_dist = pycbc.pnutils.chirp_distance(dec_dist, mchirp)
+
+keys += ['mass1', 'mass2',
+        'mchirp', 'eta', 'ra', 'dec', 'inc', 'spin1x', 'spin1y',
+        'spin1z', 'spin2x', 'spin2y', 'spin2z']
 
 for key in keys:
-    headers += [key]
+    if key == 'optimal_snr_1':
+        headers += ['optimal_snr_' + f.attrs['detector_1']]
+    elif key == 'optimal_snr_2':
+        headers += ['optimal_snr_' + f.attrs['detector_2']]
+    else:
+        headers += [key]
+
     if key in f['injections']:
         data += ["%.2f" % f['injections'][key][args.injection_index]]
     elif key == 'mchirp':
@@ -66,6 +78,7 @@ for key in keys:
         data += ["%.2f" % f['injections']['latitude'][args.injection_index]]
     elif key == 'dec chirp dist':
         data += ["%.2f" % dec_chirp_dist]
+
         
 table = numpy.array([data], dtype=str)
 html = str(pycbc.results.static_table(table, headers))

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -218,7 +218,6 @@ with ctx:
      
         snrs.append(snr[stilde.analyze])
         chisqs.append(chisq[stilde.analyze])
-        print snr.start_time
         
     f['snr'] = numpy.concatenate([snr.numpy() for snr in snrs])
     f['snr'].attrs['start_time'] = float(snrs[0].start_time)

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -288,10 +288,10 @@ def make_single_template_plots_new(workflow, segs, seg_name, params,
             # Reanalyze the time around the trigger in each detector
             node = PlotExecutable(workflow.cp, 'single_template', ifos=[ifo],
                               out_dir=out_dir, tags=[tag] + tags).create_node()
-            node.add_opt('--mass1', params['mass1'])
-            node.add_opt('--mass2', params['mass2'])
-            node.add_opt('--spin1z', params['spin1z'])
-            node.add_opt('--spin2z', params['spin2z'])
+            node.add_opt('--mass1', "%.6f" % params['mass1'])
+            node.add_opt('--mass2', "%.6f" % params['mass2'])
+            node.add_opt('--spin1z',"%.6f" % params['spin1z'])
+            node.add_opt('--spin2z',"%.6f" % params['spin2z'])
             # str(numpy.float64) restricts to 2d.p. BE CAREFUL WITH THIS!!!
             str_trig_time = '%.6f' %(params[ifo + '_end_time'])
             node.add_opt('--trigger-time', str_trig_time)


### PR DESCRIPTION
This adds optimal SNR to the injection minifollwups and sorts by decisive optimal SNR the missed injections. Example here:

https://sugar-jobs.phy.syr.edu/~spxiwh/aLIGO/O1/o1_sep26-oct08/with_minifups/run7/5._injections/5.2_followup-BBH02_INJ/

Also fixed:

 * Removed print statement in pycbc_single_template
 * Fixed edge case bug where very small spins could be printed in the .sub file as --spin2x 0.4356E-6 and cause the parser to fail.