### PR TITLE
Parallel build

### DIFF
--- a/tools/static/build_dag.sh
+++ b/tools/static/build_dag.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+if [ ! -e ../../bin/pycbc_inspiral ]
+then
+	echo "Please run this script from the tools/static directory of your source installation"
+	exit 1
+fi
+
+cat > build_one.sub <<EOT
+universe = vanilla
+priority = 100
+request_memory = 32000
+executable = ${PWD}/build_one.sh
+arguments = \$(prog)
+output = pyinstaller_build.\$(cluster).\$(process).out
+error = pyinstaller_build.\$(cluster).\$(process).err
+log = /usr1/${USER}/log/pyinstaller_build_1.log
+getenv = True
+accounting_group = ligo.dev.o1.cbc.nsbh.pycbcoffline 
+queue
+EOT
+
+
+for prog in `find ../../bin -type f `
+do
+	# don't try to pyinstall shell scripts
+	if `head -1 ${prog} | grep -q python`
+	then
+		exename=`basename ${prog}`
+
+		# Some programs can't be compiled.  At the moment these are
+		# not needed in any workflow, but this list may need to be
+		# revisited
+		if ! grep -q ${exename} cant_be_built
+		then
+			NEW_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+
+			echo "JOB ${NEW_UUID} ${PWD}/build_one.sub DIR ${PWD}"
+			echo "VARS ${NEW_UUID} prog=\"${prog}\""
+			echo
+		fi
+	fi
+done > build_static.dag
+
+

--- a/tools/static/build_one.sh
+++ b/tools/static/build_one.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+source ../../../../bin/activate
+export PYINSTALLER_CONFIG_DIR=/usr1/${USER}/`hostname`/${BASHPID}
+
+prog=$1
+
+exename=`basename ${prog}`
+
+if grep -q ^${exename}$ needs_full_build 
+then
+	# This will be used by hooks/hook-pycbc.py to
+	# determine what needs to be included
+	export NOW_BUILDING=${exename}
+
+	pyinstaller ${prog} \
+	  --additional-hooks-dir ./hooks/ \
+	  --runtime-hook runtime-scipy.py \
+	  --name ${exename} \
+	  --strip \
+	  --onefile
+else
+	pyinstaller ${prog} --name ${exename} --strip --onefile
+fi
+
+if ! dist/${exename} --help
+then
+	echo "Build of ${exename} failed"
+	exit 1
+fi

--- a/tools/static/needs_full_build
+++ b/tools/static/needs_full_build
@@ -66,3 +66,7 @@ pycbc_insert_frame_hwinj
 pycbc_generate_hwinj_from_xml
 pycbc_plot_trigger_timeseries
 pycbc_single_template
+pycbc_sngl_minifollowup
+pycbc_page_injinfo
+pycbc_page_snglinfo
+pycbc_injection_minifollowup


### PR DESCRIPTION
This adds a script which generates a dag and a sub file, which performs the pyinstaller bundling in parallel.  It sets
```
export PYINSTALLER_CONFIG_DIR=/usr1/${USER}/`hostname`/${BASHPID}
```
which ensures that the pyinstaller cache is unique even if jobs end up on the same node, to prevent corruption of the intermediate stripped and compressed libraries (this also means the cache isn't actually caching and total compute cost will be larger, but throughput will be much higher).