### PR TITLE
Add html assets to everything, mark a few programs that need full builds

### DIFF
--- a/tools/static/cant_be_built
+++ b/tools/static/cant_be_built
@@ -3,3 +3,4 @@ pycbc_calculate_likelihood
 pycbc_plot_hwinj
 pycbc_mvsc_dag
 pycbc_inspinjfind
+pycbc_get_loudest_params

--- a/tools/static/hooks/hook-pycbc.py
+++ b/tools/static/hooks/hook-pycbc.py
@@ -10,9 +10,6 @@
 import os
 from PyInstaller.hooks.hookutils import (collect_data_files, collect_submodules)
 
-# Executables that need the html assets
-needs_assets = ['pycbc_make_html_page', 'pycbc_make_coinc_search_workflow']
-
 # Executables that need MKL
 needs_mkl = ['pycbc_inspiral','pycbc_single_template']
 
@@ -61,18 +58,18 @@ hiddenimports = ['pycbc.fft.fft_cpu',
 
 datas = [] 
 
-if os.environ["NOW_BUILDING"] in needs_assets:
-    cwd     = os.getcwd()
-    basedir = cwd.replace('tools/static','')
-    rootdir = basedir + 'pycbc/results'
+# Add html assets to all executables
+cwd     = os.getcwd()
+basedir = cwd.replace('tools/static','')
+rootdir = basedir + 'pycbc/results'
 
-    for root, subdirs, files in os.walk(rootdir):
-        for filename in files:
-            if not filename.endswith('.py') and not filename.endswith('.pyc'):
-                file_path  = os.path.join(root, filename)
-                store_path = '/'.join(file_path.split('/')[:-1])
-                store_path = store_path.replace(basedir, '')
-                datas.append( (file_path, store_path) )
+for root, subdirs, files in os.walk(rootdir):
+    for filename in files:
+        if not filename.endswith('.py') and not filename.endswith('.pyc'):
+            file_path  = os.path.join(root, filename)
+            store_path = '/'.join(file_path.split('/')[:-1])
+            store_path = store_path.replace(basedir, '')
+            datas.append( (file_path, store_path) )
 
 if os.environ["NOW_BUILDING"] in needs_mkl:
     # pull in all the mkl .so files

--- a/tools/static/needs_full_build
+++ b/tools/static/needs_full_build
@@ -70,3 +70,17 @@ pycbc_sngl_minifollowup
 pycbc_page_injinfo
 pycbc_page_snglinfo
 pycbc_injection_minifollowup
+pycbc_coinc_trig2hdf
+pycbc_coinc_bank2hdf
+pycbc_page_segments
+pycbc_page_ifar
+pycbc_coinc_mergetrigs
+pycbc_sqlite_simplify
+pycbc_splitbank
+pycbc_timeslides
+pycbc_combine_likelihood
+pycbc_pickle_horizon_distances
+pycbc_pipedown_plots
+pycbc_run_sqlite
+pycbc_page_foreground
+


### PR DESCRIPTION
This patch incorporates some changes that were needed to build 1.2.2
  * Include html assets in all programs (no reason not to, they're small)
  * mark a few programs as needing a full build (these completed successfully when run with --help, but failed at later imports)
