### PR TITLE
Add option to choose variable low frequency cutoff for waveforms

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -40,7 +40,12 @@ parser.add_argument("--snr-threshold",
 parser.add_argument("--newsnr-threshold", type=float, metavar='THRESHOLD',
                     help="Cut triggers with NewSNR less than THRESHOLD")
 parser.add_argument("--low-frequency-cutoff", type=float,
-                  help="The low frequency cutoff to use for filtering (Hz)")
+                  help="The low freqeuncy cutoff to use for waveform generation (Hz)")
+parser.add_argument("--waveform-low-frequency-cutoff", type=str,
+                  help="The low frequency cutoff to use for waveform generation (Hz)"
+                       "One may choose a variable lower freqeuncy cutoff"
+                       " by using math functions and the params keys as "
+                       "follows : 30 if (params.mass1 + params.mass2) < 4 else 20)")
 parser.add_argument("--approximant", type=str,
                   help="The name of the approximant to use for filtering. "
                        "One may choose a single approximant by simple assignment. "
@@ -195,10 +200,14 @@ strain_segments = strain.StrainSegments.from_cli(opt, gwstrain)
 with ctx:
     fft.from_cli(opt)
 
+
     flow = opt.low_frequency_cutoff
     flen = strain_segments.freq_len
     tlen = strain_segments.time_len
     delta_f = strain_segments.delta_f
+
+    waveform_flow = str(opt.waveform_low_frequency_cutoff \
+                    if opt.waveform_low_frequency_cutoff is not None else flow)
 
     logging.info("Making frequency-domain data segments")
     segments = strain_segments.fourier_segments()
@@ -245,7 +254,7 @@ with ctx:
     else:
         use_cluster = True
 
-    matched_filter = MatchedFilterControl(opt.low_frequency_cutoff, None,
+    matched_filter = MatchedFilterControl(None, None,
                                    opt.snr_threshold, tlen, delta_f, complex64,
                                    segments, template_mem, use_cluster,
                                    downsample_factor=opt.downsample_factor,
@@ -274,7 +283,7 @@ with ctx:
 
     logging.info("Read in template bank")
     bank = waveform.FilterBank(opt.bank_file, flen, delta_f,
-                    flow, dtype = complex64, phase_order = opt.order,
+                    waveform_flow, dtype = complex64, phase_order = opt.order,
                     taper = opt.taper_template, approximant = opt.approximant,
                     out = template_mem)
 
@@ -296,7 +305,9 @@ with ctx:
                          (t_num + 1, len(bank), s_num + 1, len(segments)))
 
             snr, norm, corr, idx, snrv = \
-               matched_filter.matched_filter_and_cluster(s_num, template.sigmasq(stilde.psd), cluster_window)
+               matched_filter.matched_filter_and_cluster(s_num, 
+                                                  template.sigmasq(stilde.psd),
+                                                  cluster_window)
 
             if not len(idx):
                 continue

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -74,7 +74,6 @@ class FilterBank(object):
         self.N = (filter_length - 1 ) * 2
         self.delta_t = 1.0 / (self.N * self.delta_f)
         self.filter_length = filter_length
-        self.kmin = int(f_lower / delta_f)
 
         self.indoc = ligolw_utils.load_filename(
             filename, False, contenthandler=LIGOLWContentHandler)
@@ -103,9 +102,11 @@ class FilterBank(object):
         if self.approximant is not None:
             if 'params' in self.approximant:
                 t = type('t', (object,), {'params' : self.table[index]})
-                approximant = str(self.parse_option(t, self.approximant)) 
+                approximant = str(self.parse_option(t, self.approximant))
+                f_lower = float(self.parse_option(t, self.f_lower))
             else:
                 approximant = self.approximant
+                f_lower = float(self.f_lower)
         else:
             raise ValueError("Reading approximant from template bank not yet supported")
 
@@ -124,7 +125,7 @@ class FilterBank(object):
         distance = 1.0 / DYN_RANGE_FAC
         htilde = pycbc.waveform.get_waveform_filter(
             tempout[0:self.filter_length], self.table[index],
-            approximant=approximant, f_lower=self.f_lower, f_final=f_end,
+            approximant=approximant, f_lower=f_lower, f_final=f_end,
             delta_f=self.delta_f, delta_t=self.delta_t, distance=distance,
             **self.extra_args)
 
@@ -141,7 +142,7 @@ class FilterBank(object):
                 self.table[index].template_duration = htilde.chirp_length
 
         htilde = htilde.astype(self.dtype)
-        htilde.f_lower = self.f_lower
+        htilde.f_lower = f_lower
         htilde.end_frequency = f_end
         htilde.end_idx = int(htilde.end_frequency / htilde.delta_f)
         htilde.params = self.table[index]


### PR DESCRIPTION
I'm making this available for comment and suggestions.

This addes another argument to pycbc_inspiral to set the waveform's lower frequency cutoff separately from the general filtering, PSD estimation, etc. It can be given as a string that uses a math expression and the params object of the template. 

--waveform-low-frequency-cutoff 30
--waveform-low-frequency-cutoff "30 if (params.mass1 + params.mass2) < 10 else 20" 

The argument is currently optional if the same as the low-frequency-cutoff. 

Questions:
    * Can we modify the correlator to take kmin/kmax for each template. Is this really needed in the initialization? That would allow me to make it much clearer at the top level what is happening.
    * Any ideas for a better argument format than the one I've implemented? 