### PR TITLE
pycbc_page_foundmissed: fix missing distance choices

### DIFF
--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -14,7 +14,8 @@ parser.add_argument('--axis-type', default='mchirp', choices=['mchirp',
                     'effective_spin', 'time', 'mtotal', 'mass_ratio'])
 parser.add_argument('--distance-type', default='decisive_distance',
                     choices=['decisive_distance', 'dec_chirp_distance',
-                    'chirp_distance'])
+                             'chirp_distance', 'comb_optimal_snr',
+                             'decisive_optimal_snr'])
 parser.add_argument('--verbose', action='count')
 parser.add_argument('--log-distance', action='store_true', default=False)
 parser.add_argument('--dynamic', action='store_true', default=False)


### PR DESCRIPTION
Commit e7bf4ce90d855adefa191c195c8fa3d506687c57 effectively removed the ability to use optimal SNRs, this reenables them.