### PR TITLE
Short-term kludge to avoid race condition in weave

### DIFF
--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -86,6 +86,16 @@ segments = segmentlist(frozenset(segments))
 logging.info('%d psds to calculate', len(segments))
 p = multiprocessing.Pool(args.cores)
 
+# KLUDGE! Run the first segment to esure that the weave cache is
+# populated.  This is a short-term fix until the issues with
+# https://github.com/ligo-cbc/pycbc/issues/501
+# can be resolved.  This will wastefully run the first segment
+# twice which could be avoided, but since this is a short-term
+# kludge anyway I'd prefer to be minimally invasive.
+# TODO: Remove this when 501 is resolved.
+# FIXME: https://www.youtube.com/watch?v=DtRNg5uSKQ0
+get_psd( (segments[0], 0) )
+
 psds = p.map_async(get_psd, zip(segments, range(len(segments))))
 psds = psds.get()
 


### PR DESCRIPTION
Per the description, this is a short-term workaround until https://github.com/ligo-cbc/pycbc/issues/501 can be resolved properly.  I've tested this by building a static executable and running a job that had failed on the command line on a head node.  It appeared to work; one process was busy for a while, the weave cache was populated, and then all four processes became busy.