### PR TITLE
Use ifo_list and string as section tags

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -214,7 +214,10 @@ class Executable(pegasus_workflow.Executable):
         # this executable
         sections = [name]
         if self.ifo_list is not None
-            sec_tags = tags + [self.ifo_list] + [self.ifo_string]
+            if len(self.ifo_list) > 1:
+                sec_tags = tags + self.ifo_list + [self.ifo_string]
+            else:
+                sec_tags = tags + self.ifo_list
         else:
             sec_tags = tags
         for tag in sec_tags:

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -213,8 +213,8 @@ class Executable(pegasus_workflow.Executable):
         # Determine the sections from the ini file that will configure
         # this executable
         sections = [name]
-        if self.ifo_string:
-            sec_tags = tags + [self.ifo_string]
+        if self.ifo_list is not None
+            sec_tags = tags + [self.ifo_list] + [self.ifo_string]
         else:
             sec_tags = tags
         for tag in sec_tags:


### PR DESCRIPTION
This changes the behaviour of jobs when using ifo_list=['H1','L1','V1'] so that options in [executable-H1], [executable-L1], [executable-V1] and executable-H1L1V1 are picked up. (The last may not be meaningful, and may be removed in the future).

This is needed for the O1 GRB runs and should be considered for the 1.2.5 release.