### PR TITLE
Adding segment plot to and cleaning up result page

### DIFF
--- a/bin/pygrb/pycbc_make_grb_summary_page
+++ b/bin/pygrb/pycbc_make_grb_summary_page
@@ -60,13 +60,13 @@ def parse_command_line():
                         help="Declination of external trigger")
     
     parser.add_argument("-o", "--output-path", type=str, default=os.getcwd(),
-                        help="output directory")
+                        help="Post processing output directory")
 
     parser.add_argument("-w", "--html-path", type=str, default=None,
-                        help="final web directory")
+                        help="Final web directory")
 
-    parser.add_argument("-s", "--seg_plot", type=str, default=None,
-                        help="segment plot")
+    parser.add_argument("-s", "--seg-plot", type=str, default=None,
+                        help="Path to segments plot")
 
     parser.add_argument("-D", "--exclusion-injections", type=str, default=None,
                         help="A comma seperated list of the detection injection"
@@ -209,16 +209,13 @@ def build_grb_results_page(args, inifile, outdir, htmldir, ifoTag,
         webpage = write_antenna(webpage, args, grid, None)
 
     # add links
-    seglink = 'segment_plot_%s.png' % GRBnum
     inilink = os.path.basename(inifile)
-    linktext = {seglink:   'Segments availability',
-                inilink:   'ini-file used'}
-    for link in [seglink, inilink]:
-        webpage.add(linktext[link])
-        webpage.a(href=link)
-        webpage.add('here')
-        webpage.a.close()
-        webpage.br()
+    inilinktext = 'ini-file used'
+    webpage.add(inilinktext)
+    webpage.a(href=link)
+    webpage.add('here')
+    webpage.a.close()
+    webpage.br()
 
     webpage.div.close()
 

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -57,7 +57,7 @@ else:
     baseDir = os.getcwd()
 runDir = os.path.join(baseDir, "GRB%s" % str(wflow.cp.get("workflow",
                                                           "trigger-name")))
-logging.info("Workflow will be generated in %s" % baseDir)
+logging.info("Workflow will be generated in %s" % runDir)
 if not os.path.exists(runDir):
     os.makedirs(runDir)
 os.chdir(runDir)
@@ -84,12 +84,12 @@ if len(sciSegs.keys()) < 2 and not single_ifo:
     raise RuntimeError(msg)
 elif len(sciSegs.keys()) < 2:
     logging.info("Generating a single IFO search.")
-    onSrc, sciSegs = _workflow.get_triggered_single_ifo_segment(wflow, segDir,
-                                                                sciSegs)
+    onSrc, sciSegs, segs_plot = _workflow.get_triggered_single_ifo_segment(\
+            wflow, segDir, sciSegs)
 else:
-    onSrc, sciSegs = _workflow.get_triggered_coherent_segment(wflow, segDir,
-                                                              sciSegs,
-                                                              single_ifo)
+    onSrc, sciSegs, segs_plot = _workflow.get_triggered_coherent_segment(wflow,
+            segDir, sciSegs, single_ifo)
+all_files.extend(_workflow.FileList([segs_plot]))
 
 # How many IFOs do we have in the search?
 if len(sciSegs.keys()) == 1:
@@ -264,7 +264,7 @@ if post_proc_method == "COH_PTF_WORKFLOW":
             injection_trigger_files=inj_insp_files, injection_files=injs,
             injection_trigger_caches=inj_insp_caches,
             injection_caches=inj_caches, config_file=cp_file, web_dir=html_dir,
-            ifos=ifos, inj_tags=inj_tags)
+            segments_plot=segs_plot, ifos=ifos, inj_tags=inj_tags)
 
     # Retrieve style files for webpage
     summary_files = _workflow.get_coh_PTF_files(wflow.cp, ifos, ppDir,

--- a/pycbc/results/legacy_grb.py
+++ b/pycbc/results/legacy_grb.py
@@ -24,9 +24,14 @@ from __future__ import division
 
 import re
 from argparse import ArgumentParser
-from glue import markup
-from pylal import antenna,git_version
-from lal.gpstime import gps_to_utc,LIGOTimeGPS
+import matplotlib.pyplot as plt
+from glue import markup, segments
+from pylal import antenna, git_version
+from lal.gpstime import gps_to_utc, LIGOTimeGPS
+from matplotlib.patches import Rectangle
+from matplotlib.lines import Line2D
+from matplotlib.ticker import ScalarFormatter
+from pycbc.results.color import ifo_color
 
 __author__  = "Andrew Williamson <andrew.williamson@ligo.org>"
 __version__ = "git id %s" % git_version.id
@@ -253,13 +258,13 @@ def write_antenna(page, args, grid=False, ipn=False):
 
     page = write_table(page, th, td)
 
-    plot = markup.page()
-    p = "projtens.png"
-    plot.a(href=p, title="Detector response and polarization")
-    plot.img(src=p)
-    plot.a.close()
-    th2 = ['Response Diagram']
-    td2 = [plot() ]
+#    plot = markup.page()
+#    p = "projtens.png"
+#    plot.a(href=p, title="Detector response and polarization")
+#    plot.img(src=p)
+#    plot.a.close()
+#    th2 = ['Response Diagram']
+#    td2 = [plot() ]
 
         # FIXME: Add these in!!
 #    plot = markup.page()
@@ -281,6 +286,14 @@ def write_antenna(page, args, grid=False, ipn=False):
 #    td2.append(plot())
 
     plot = markup.page()
+    p = args.seg_plot
+    plot.a(href=p, title="Science Segments")
+    plot.img(src=p)
+    plot.a.close()
+    th2.append('Science Segments')
+    td2.append(plot())
+
+    plot = markup.page()
     p = "ALL_TIMES/plots_clustered/GRB%s_sky_grid.png"\
             % args.grb_name
     plot.a(href=p, title="Sky Grid")
@@ -289,14 +302,14 @@ def write_antenna(page, args, grid=False, ipn=False):
     th2.append('Sky Grid')
     td2.append(plot())
 
-    plot = markup.page()
-    p = "GRB%s_inspiral_horizon_distance.png"\
-            % args.grb_name
-    plot.a(href=p, title="Inspiral Horizon Distance")
-    plot.img(src=p)
-    plot.a.close()
-    th2.append('Inspiral Horizon Distance')
-    td2.append(plot())
+#    plot = markup.page()
+#    p = "GRB%s_inspiral_horizon_distance.png"\
+#            % args.grb_name
+#    plot.a(href=p, title="Inspiral Horizon Distance")
+#    plot.img(src=p)
+#    plot.a.close()
+#    th2.append('Inspiral Horizon Distance')
+#    td2.append(plot())
 
     page = write_table(page, th2, td2)
 
@@ -632,4 +645,76 @@ def write_exclusion_distances(page , trial, injList, massbins, reduced=False,
     page.h3.close()
 
     return page
+
+
+def make_grb_segments_plot(ifos, science_segs, trigger_time, trigger_name,
+                           out_dir, coherent_seg=None, fail_criterion=None):
+    ifo_colors = {}
+    for ifo in ifos:
+        ifo_colors[ifo] = ifo_color(ifo)
+        if ifo not in science_segs.keys():
+            science_segs[ifo] = segments.segmentlist([])
+
+    extent = science_segs.union(ifos)[0]
+
+    # Make plot
+    fig, subs = plt.subplots(len(ifos), sharey=True)
+    plt.xticks(rotation=20, ha='right')
+    plt.subplots_adjust(bottom=0.15)
+    for sub, ifo in zip(subs, ifos):
+        for seg in science_segs[ifo]:
+            sub.add_patch(Rectangle((seg[0], 0.1), abs(seg), 0.8,
+                                    facecolor=ifo_colors[ifo], edgecolor='none'))
+        
+        if len(science_segs[ifo]) > 0:
+            sub.plot([trigger_time, trigger_time], [0, 1], '-',
+                     c='orange')
+            if coherent_seg:
+                sub.add_patch(Rectangle((coherent_seg[0], 0),
+                                        abs(coherent_seg), 1, alpha=0.5,
+                                        facecolor='orange', edgecolor='none'))
+            if fail_criterion:
+                sub.add_patch(Rectangle((fail_criterion[0], 0),
+                                        abs(fail_criterion), 1, alpha=0.5,
+                                        facecolor='red', edgecolor='none'))
+        else:
+            sub.plot([trigger_time, trigger_time], [0, 1], ':',
+                     c='orange')
+            if coherent_seg:
+                sub.plot([coherent_seg[0], coherent_seg[0]], [0, 1], '--',
+                         c='orange', alpha=0.5)
+                sub.plot([coherent_seg[1], coherent_seg[1]], [0, 1], '--',
+                         c='orange', alpha=0.5)
+            if fail_criterion:
+                sub.plot([fail_criterion[0], fail_criterion[0]], [0, 1], '--',
+                         c='red', alpha=0.5)
+                sub.plot([fail_criterion[1], fail_criterion[1]], [0, 1], '--',
+                         c='red', alpha=0.5)
+        
+        sub.set_frame_on(False)
+        sub.set_yticks([])
+        sub.set_ylabel(ifo, rotation=45)
+        sub.set_xlim([float(extent[0]), float(extent[1])])
+        sub.get_xaxis().get_major_formatter().set_useOffset(False)
+        sub.get_xaxis().get_major_formatter().set_scientific(False)
+        sub.get_xaxis().tick_bottom()
+        if not sub is subs[-1]:
+            sub.get_xaxis().set_ticks([])
+            sub.get_xaxis().set_ticklabels([])
+        else:
+            sub.tick_params(labelsize=10, pad=1)
+
+    xmin, xmax = fig.axes[-1].get_xaxis().get_view_interval()
+    ymin, ymax = fig.axes[-1].get_yaxis().get_view_interval()
+    fig.axes[-1].add_artist(Line2D((xmin, xmax), (ymin, ymin), color='black',
+                                linewidth=2))
+    fig.axes[-1].set_xlabel('GPS Time')
+
+    fig.axes[0].set_title('Science Segments for GRB%s' % trigger_name)
+    fig.subplots_adjust(hspace=0)
     
+    plot_name = 'GRB%s_segments.png' % trigger_name
+    plot_url = 'file://localhost%s/%s' % (out_dir, plot_name)
+    fig.savefig('%s/%s' % (out_dir, plot_name))
+
+    return [ifos, plot_name, extent, plot_url]

--- a/pycbc/workflow/legacy_ihope.py
+++ b/pycbc/workflow/legacy_ihope.py
@@ -617,8 +617,8 @@ class PyGRBMakeSummaryPage(LegacyAnalysisExecutable):
         self.num_threads = 1
 
     def create_node(self, parent=None, c_file=None, open_box=False,
-                    tuning_tags=None, exclusion_tags=None, html_dir=None,
-                    tags=[]):
+                    seg_plot=None, tuning_tags=None, exclusion_tags=None,
+                    html_dir=None, tags=[]):
         node = Node(self)
 
         node.add_opt('--grb-name', self.cp.get('workflow', 'trigger-name'))
@@ -632,6 +632,9 @@ class PyGRBMakeSummaryPage(LegacyAnalysisExecutable):
 
         if exclusion_tags is not None:
             node.add_opt('--exclusion-injections', ','.join(exclusion_tags))
+
+        if seg_plot is not None:
+            node.add_opt('--seg-plot', seg_plot.storage_path)
 
         if open_box:
             node.add_opt('--open-box')

--- a/pycbc/workflow/postprocessing_cohptf.py
+++ b/pycbc/workflow/postprocessing_cohptf.py
@@ -43,7 +43,7 @@ def setup_coh_PTF_post_processing(workflow, trigger_files, trigger_cache,
         output_dir, segment_dir, injection_trigger_files=None,
         injection_files=None, injection_trigger_caches=None,
         injection_caches=None, config_file=None, run_dir=None, ifos=None,
-        web_dir=None, inj_tags=[], tags=[], **kwargs):
+        web_dir=None, segments_plot=None, inj_tags=[], tags=[], **kwargs):
     """
     This function aims to be the gateway for running postprocessing in CBC
     offline workflows. Post-processing generally consists of calculating the
@@ -87,8 +87,8 @@ def setup_coh_PTF_post_processing(workflow, trigger_files, trigger_cache,
         post_proc_files = setup_postproc_coh_PTF_workflow(workflow,
                 trigger_files, trigger_cache, injection_trigger_files,
                 injection_files, injection_trigger_caches, injection_caches,
-                config_file, output_dir, web_dir, segment_dir, ifos=ifos,
-                inj_tags=inj_tags, tags=tags, **kwargs)
+                config_file, output_dir, web_dir, segment_dir, segments_plot,
+                ifos=ifos, inj_tags=inj_tags, tags=tags, **kwargs)
     else:
         errMsg = "Post-processing method not recognized. Must be "
         errMsg += "COH_PTF_WORKFLOW."
@@ -102,8 +102,8 @@ def setup_coh_PTF_post_processing(workflow, trigger_files, trigger_cache,
 def setup_postproc_coh_PTF_workflow(workflow, trig_files, trig_cache,
                                     inj_trig_files, inj_files, inj_trig_caches,
                                     inj_caches, config_file, output_dir,
-                                    html_dir, segment_dir, ifos, inj_tags=[],
-                                    tags=[]):
+                                    html_dir, segment_dir, segs_plot, ifos,
+                                    inj_tags=[], tags=[]):
     """
     This module sets up the post-processing stage in the workflow, using a
     coh_PTF style set up. This consists of running trig_combiner to find
@@ -449,10 +449,10 @@ def setup_postproc_coh_PTF_workflow(workflow, trig_files, trig_cache,
                           if "DETECTION" not in inj_tag]
         html_summary_node = html_summary_jobs.create_node(c_file=config_file,
                 tuning_tags=tuning_tags, exclusion_tags=exclusion_tags,
-                html_dir=html_dir)
+                seg_plot=segs_plot, html_dir=html_dir)
     else:
         html_summary_node = html_summary_jobs.create_node(c_file=config_file,
-                                                          html_dir=html_dir)
+                seg_plot=segs_plot, html_dir=html_dir)
     workflow.add_node(html_summary_node)
     for pp_node in pp_nodes:
         dep = dax.Dependency(parent=pp_node._dax_node,


### PR DESCRIPTION
A segment availability plot is now generated at run-time and will show the offsource segment in the context of all search IFOs' science segments. If no workflow is generated due to lack of data this is also shown on this plot.

If we have sufficient science data, the plot is passed through to the results page, which has been cleaned up slightly.