### PR TITLE
Check for case where --help works but cython_blas is missing

### DIFF
--- a/tools/static/build_one.sh
+++ b/tools/static/build_one.sh
@@ -23,8 +23,17 @@ else
 	pyinstaller ${prog} --name ${exename} --strip --onefile
 fi
 
-if ! dist/${exename} --help
+dist/${exename} --help >&  ${exename}.out
+
+if [ $? != 0 ]
 then
 	echo "Build of ${exename} failed"
 	exit 1
 fi
+
+if grep -q 'No module named cython_blas' ${exename}.out
+then
+	echo "Build of ${exename} is missing hidden dependancies"
+	exit 1
+fi
+


### PR DESCRIPTION
Addresses https://github.com/ligo-cbc/pycbc/issues/502

I had thought this was just a matter of rearranging import statements, but in fact something more subtle is going on.  In some programs, for example pycbc_plot_gating, all the imports are correctly at the top of the program but something down the tree of imports is pulling in cython_blas, printing the error if it's not available, but then catching the exception and continuing.  Finding the root cause may require substantial  digging.

As a simpler fix I've modified the build script to check for the error message.  This will catch every instance of this problem that I've seen.  I've tested it by removing pycbc_plot_gating from the needs_full_build list and confirming that the build script fails with the "missing dependancies" message, then returning pycbc_plot_gating to the list and confirming that the build succeeds.