### PR TITLE
Short-term kludge to avoid race condition in weave for pycbc_optimal_snr

### DIFF
--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -94,8 +94,7 @@ p = multiprocessing.Pool(args.cores)
 # kludge anyway I'd prefer to be minimally invasive.
 # TODO: Remove this when 501 is resolved.
 # FIXME: https://www.youtube.com/watch?v=DtRNg5uSKQ0
-if len(segments) > 0:
-    get_psd( (segments[0], 0) )
+get_psd( (segments[0], 0) )
 
 psds = p.map_async(get_psd, zip(segments, range(len(segments))))
 psds = psds.get()

--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -94,7 +94,8 @@ p = multiprocessing.Pool(args.cores)
 # kludge anyway I'd prefer to be minimally invasive.
 # TODO: Remove this when 501 is resolved.
 # FIXME: https://www.youtube.com/watch?v=DtRNg5uSKQ0
-get_psd( (segments[0], 0) )
+if len(segments) > 0:
+    get_psd( (segments[0], 0) )
 
 psds = p.map_async(get_psd, zip(segments, range(len(segments))))
 psds = psds.get()

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -172,7 +172,7 @@ if __name__ == '__main__':
                          simulation_ids=[simulation_id])
         return make_frequency_series(strain)
 
-    def compute_optimal_snr(inj):
+    def compute_optimal_snr(inj, return_found=False):
         for det, column in opts.snr_columns.items():
             injection_time = inj.get_end(det[0])
             psd = psds[det](injection_time)
@@ -187,6 +187,15 @@ if __name__ == '__main__':
                 continue
             sval = sigma(wave, psd=psd, low_frequency_cutoff=f_low)
             setattr(inj, column, sval)
+
+            if return_found:
+                # No need to do any other dets if we just
+                # want to trigger weave
+                return (inj, True)
+
+        if return_found:
+            return (inj, False)
+
         return inj
 
     logging.info("Loading injections")
@@ -196,17 +205,22 @@ if __name__ == '__main__':
     out_sim_inspiral = lsctables.New(lsctables.SimInspiralTable,
                                      columns=injections.table.columnnames)
 
-    logging.info('Starting workers')
-    pool = multiprocessing.Pool(processes=opts.cores)
-    # KLUDGE! Run the first segment to esure that the weave cache is
-    # populated.  This is a short-term fix until the issues with
+    # KLUDGE! Loop through the injections until we find one that 
+    # will be processed, in order to populate the weave cache.
+    # This is a short-term fix until the issues with
     # https://github.com/ligo-cbc/pycbc/issues/501
-    # can be resolved.  This will wastefully run the first segment
+    # can be resolved.  This will wastefully run the first injection
     # twice which could be avoided, but since this is a short-term
     # kludge anyway I'd prefer to be minimally invasive.
     # TODO: Remove this when 501 is resolved.
     # FIXME: https://www.youtube.com/watch?v=DtRNg5uSKQ0
-    compute_optimal_snr(inj_table[0])
+    for inj in inj_table:
+        ignore, found = compute_optimal_snr(inj, True)
+        if found:
+            break
+
+    logging.info('Starting workers')
+    pool = multiprocessing.Pool(processes=opts.cores)
 
     proc_injs = pool.map(compute_optimal_snr, inj_table)
     for inj in proc_injs:

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -206,8 +206,7 @@ if __name__ == '__main__':
     # kludge anyway I'd prefer to be minimally invasive.
     # TODO: Remove this when 501 is resolved.
     # FIXME: https://www.youtube.com/watch?v=DtRNg5uSKQ0
-    if len(inj_table) > 0:
-        compute_optimal_snr(inj_table[0])
+    compute_optimal_snr(inj_table[0])
 
     proc_injs = pool.map(compute_optimal_snr, inj_table)
     for inj in proc_injs:

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -198,6 +198,16 @@ if __name__ == '__main__':
 
     logging.info('Starting workers')
     pool = multiprocessing.Pool(processes=opts.cores)
+    # KLUDGE! Run the first segment to esure that the weave cache is
+    # populated.  This is a short-term fix until the issues with
+    # https://github.com/ligo-cbc/pycbc/issues/501
+    # can be resolved.  This will wastefully run the first segment
+    # twice which could be avoided, but since this is a short-term
+    # kludge anyway I'd prefer to be minimally invasive.
+    # TODO: Remove this when 501 is resolved.
+    # FIXME: https://www.youtube.com/watch?v=DtRNg5uSKQ0
+    compute_optimal_snr(inj_table[0])
+
     proc_injs = pool.map(compute_optimal_snr, inj_table)
     for inj in proc_injs:
         out_sim_inspiral.append(inj)

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -206,7 +206,8 @@ if __name__ == '__main__':
     # kludge anyway I'd prefer to be minimally invasive.
     # TODO: Remove this when 501 is resolved.
     # FIXME: https://www.youtube.com/watch?v=DtRNg5uSKQ0
-    compute_optimal_snr(inj_table[0])
+    if len(inj_table) > 0:
+        compute_optimal_snr(inj_table[0])
 
     proc_injs = pool.map(compute_optimal_snr, inj_table)
     for inj in proc_injs:


### PR DESCRIPTION
Addresses https://github.com/ligo-cbc/pycbc/issues/501

This runs the first instance outside Pool.map in order to force the generation of the weave cache to be single-threaded.  This is the same short-term fix that was used in pycbc_calculate_psd.


