### PR TITLE
Add -mno-avx2 to weave to enable running on OSG

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -126,6 +126,13 @@ except ImportError as e:
     print e
     HAVE_MKL=False
     
+
+# Check for site-local flags to pass to gcc
+WEAVE_FLAGS = ''
+
+if 'WEAVE_FLAGS' in os.environ:
+    WEAVE_FLAGS = os.environ['WEAVE_FLAGS'] + ' '
+
 def multiprocess_cache_dir():
     import multiprocessing
     cache_dir =  os.path.join(_cache_dir_path,  str(id(multiprocessing.current_process())))

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -138,7 +138,7 @@ def findchirp_cluster_over_window(times, values, window_length):
         k[0] = j;
     """
     inline(code, ['times', 'absvalues', 'window_length', 'indices', 'tlen', 'k'],
-                 extra_compile_args=['-mno-avx2 -march=native -O3 -w'])
+                 extra_compile_args=['-march=native -O3 -w'])
     return indices[0:k[0]+1]
 
 def cluster_reduce(idx, snr, window_size):

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -27,6 +27,7 @@ produces event triggers
 import glue.ligolw.utils.process
 import lal, numpy, copy, os.path
 
+from pycbc import WEAVE_FLAGS
 from pycbc.types import Array
 from pycbc.types import convert_to_process_params_dict
 from pycbc.scheme import schemed
@@ -138,7 +139,7 @@ def findchirp_cluster_over_window(times, values, window_length):
         k[0] = j;
     """
     inline(code, ['times', 'absvalues', 'window_length', 'indices', 'tlen', 'k'],
-                 extra_compile_args=['-march=native -O3 -w'])
+                 extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'])
     return indices[0:k[0]+1]
 
 def cluster_reduce(idx, snr, window_size):

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -138,7 +138,7 @@ def findchirp_cluster_over_window(times, values, window_length):
         k[0] = j;
     """
     inline(code, ['times', 'absvalues', 'window_length', 'indices', 'tlen', 'k'],
-                 extra_compile_args=['-march=native -O3 -w'])
+                 extra_compile_args=['-mno-avx2 -march=native -O3 -w'])
     return indices[0:k[0]+1]
 
 def cluster_reduce(idx, snr, window_size):

--- a/pycbc/events/simd_threshold.py
+++ b/pycbc/events/simd_threshold.py
@@ -709,7 +709,7 @@ class MaxOnlyObject(object):
         nstart = self.nstart
         howmany = self.howmany
         inline(self.code, ['inarr', 'mval', 'norm', 'mloc', 'nstart', 'howmany'],
-               extra_compile_args = ['-march=native -O3 -w'],
+               extra_compile_args = ['-mno-avx2 -march=native -O3 -w'],
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
                #extra_compile_args = ['-msse4.1 -O3 -w'],
                support_code = self.support, auto_downcast = 1, verbose = self.verbose)
@@ -748,7 +748,7 @@ class WindowedMaxObject(object):
         winsize = self.winsize
         startoffset = self.startoffset
         inline(self.code, ['inarr', 'arrlen', 'cvals', 'norms', 'locs', 'winsize', 'startoffset'],
-               extra_compile_args = ['-march=native -O3 -w'],
+               extra_compile_args = ['-mno-avx2 -march=native -O3 -w'],
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
                #extra_compile_args = ['-msse4.1 -O3 -w'],
                support_code = self.support, auto_downcast = 1, verbose = self.verbose)
@@ -801,7 +801,7 @@ class ThreshClusterObject(object):
         window = self.window
         segsize = self.segsize
         nthr = inline(self.code, ['series', 'slen', 'values', 'locs', 'thresh', 'window', 'segsize'],
-                      extra_compile_args = ['-march=native -O3 -w'] + omp_flags,
+                      extra_compile_args = ['-mno-avx2 -march=native -O3 -w'] + omp_flags,
                       #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
                       #extra_compile_args = ['-msse4.1 -O3 -w'],
                       support_code = self.support, libraries = omp_libs,

--- a/pycbc/events/simd_threshold.py
+++ b/pycbc/events/simd_threshold.py
@@ -14,6 +14,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from pycbc import WEAVE_FLAGS
 from pycbc.types import zeros, complex64, float32
 from scipy.weave import inline
 import numpy as _np
@@ -709,7 +710,7 @@ class MaxOnlyObject(object):
         nstart = self.nstart
         howmany = self.howmany
         inline(self.code, ['inarr', 'mval', 'norm', 'mloc', 'nstart', 'howmany'],
-               extra_compile_args = ['-march=native -O3 -w'],
+               extra_compile_args = [WEAVE_FLAGS + '-march=native -O3 -w'],
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
                #extra_compile_args = ['-msse4.1 -O3 -w'],
                support_code = self.support, auto_downcast = 1, verbose = self.verbose)
@@ -748,7 +749,7 @@ class WindowedMaxObject(object):
         winsize = self.winsize
         startoffset = self.startoffset
         inline(self.code, ['inarr', 'arrlen', 'cvals', 'norms', 'locs', 'winsize', 'startoffset'],
-               extra_compile_args = ['-march=native -O3 -w'],
+               extra_compile_args = [WEAVE_FLAGS + '-march=native -O3 -w'],
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
                #extra_compile_args = ['-msse4.1 -O3 -w'],
                support_code = self.support, auto_downcast = 1, verbose = self.verbose)
@@ -801,7 +802,7 @@ class ThreshClusterObject(object):
         window = self.window
         segsize = self.segsize
         nthr = inline(self.code, ['series', 'slen', 'values', 'locs', 'thresh', 'window', 'segsize'],
-                      extra_compile_args = ['-march=native -O3 -w'] + omp_flags,
+                      extra_compile_args = [WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
                       #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
                       #extra_compile_args = ['-msse4.1 -O3 -w'],
                       support_code = self.support, libraries = omp_libs,

--- a/pycbc/events/simd_threshold.py
+++ b/pycbc/events/simd_threshold.py
@@ -709,7 +709,7 @@ class MaxOnlyObject(object):
         nstart = self.nstart
         howmany = self.howmany
         inline(self.code, ['inarr', 'mval', 'norm', 'mloc', 'nstart', 'howmany'],
-               extra_compile_args = ['-mno-avx2 -march=native -O3 -w'],
+               extra_compile_args = ['-march=native -O3 -w'],
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
                #extra_compile_args = ['-msse4.1 -O3 -w'],
                support_code = self.support, auto_downcast = 1, verbose = self.verbose)
@@ -748,7 +748,7 @@ class WindowedMaxObject(object):
         winsize = self.winsize
         startoffset = self.startoffset
         inline(self.code, ['inarr', 'arrlen', 'cvals', 'norms', 'locs', 'winsize', 'startoffset'],
-               extra_compile_args = ['-mno-avx2 -march=native -O3 -w'],
+               extra_compile_args = ['-march=native -O3 -w'],
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
                #extra_compile_args = ['-msse4.1 -O3 -w'],
                support_code = self.support, auto_downcast = 1, verbose = self.verbose)
@@ -801,7 +801,7 @@ class ThreshClusterObject(object):
         window = self.window
         segsize = self.segsize
         nthr = inline(self.code, ['series', 'slen', 'values', 'locs', 'thresh', 'window', 'segsize'],
-                      extra_compile_args = ['-mno-avx2 -march=native -O3 -w'] + omp_flags,
+                      extra_compile_args = ['-march=native -O3 -w'] + omp_flags,
                       #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
                       #extra_compile_args = ['-msse4.1 -O3 -w'],
                       support_code = self.support, libraries = omp_libs,

--- a/pycbc/events/threshold_cpu.py
+++ b/pycbc/events/threshold_cpu.py
@@ -81,7 +81,7 @@ def threshold_inline(series, value):
         count[0] = t;
     """
     inline(code, ['N', 'arr', 'outv', 'outl', 'count', 'threshold'],
-                    extra_compile_args=['-mno-avx2 -march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
                     libraries=omp_libs
           )
     num = count[0]
@@ -113,7 +113,7 @@ class CPUThresholdCluster(_BaseThresholdCluster):
         locs = self.outl
         segsize = self.segsize
         self.count = inline(self.code, ['series', 'slen', 'values', 'locs', 'threshold', 'window', 'segsize'],
-                            extra_compile_args = ['-mno-avx2 -march=native -O3 -w'] + omp_flags,
+                            extra_compile_args = ['-march=native -O3 -w'] + omp_flags,
                             #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'] + omp_flags,
                             #extra_compile_args = ['-msse3 -O3 -w'] + omp_flags,
                             support_code = self.support, libraries = omp_libs,

--- a/pycbc/events/threshold_cpu.py
+++ b/pycbc/events/threshold_cpu.py
@@ -81,7 +81,7 @@ def threshold_inline(series, value):
         count[0] = t;
     """
     inline(code, ['N', 'arr', 'outv', 'outl', 'count', 'threshold'],
-                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=['-mno-avx2 -march=native -O3 -w'] + omp_flags,
                     libraries=omp_libs
           )
     num = count[0]
@@ -113,7 +113,7 @@ class CPUThresholdCluster(_BaseThresholdCluster):
         locs = self.outl
         segsize = self.segsize
         self.count = inline(self.code, ['series', 'slen', 'values', 'locs', 'threshold', 'window', 'segsize'],
-                            extra_compile_args = ['-march=native -O3 -w'] + omp_flags,
+                            extra_compile_args = ['-mno-avx2 -march=native -O3 -w'] + omp_flags,
                             #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'] + omp_flags,
                             #extra_compile_args = ['-msse3 -O3 -w'] + omp_flags,
                             support_code = self.support, libraries = omp_libs,

--- a/pycbc/events/threshold_cpu.py
+++ b/pycbc/events/threshold_cpu.py
@@ -22,6 +22,7 @@
 # =============================================================================
 #
 import numpy
+from pycbc import WEAVE_FLAGS
 from scipy.weave import inline
 from .simd_threshold import thresh_cluster_support, default_segsize
 from .events import _BaseThresholdCluster
@@ -81,7 +82,7 @@ def threshold_inline(series, value):
         count[0] = t;
     """
     inline(code, ['N', 'arr', 'outv', 'outl', 'count', 'threshold'],
-                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
                     libraries=omp_libs
           )
     num = count[0]
@@ -113,7 +114,7 @@ class CPUThresholdCluster(_BaseThresholdCluster):
         locs = self.outl
         segsize = self.segsize
         self.count = inline(self.code, ['series', 'slen', 'values', 'locs', 'threshold', 'window', 'segsize'],
-                            extra_compile_args = ['-march=native -O3 -w'] + omp_flags,
+                            extra_compile_args = [WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
                             #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'] + omp_flags,
                             #extra_compile_args = ['-msse3 -O3 -w'] + omp_flags,
                             support_code = self.support, libraries = omp_libs,

--- a/pycbc/fft/fftw_pruned.py
+++ b/pycbc/fft/fftw_pruned.py
@@ -167,7 +167,7 @@ def second_phase(invec, indices, N1, N2):
         }
     """
     scipy.weave.inline(code, ['N1', 'N2', 'NI', 'indices', 'out', 'invec'],
-                      )
+                       extra_compile_args=['-mno-avx2 -march=native -O3 -w'])
     return out
 
 def fast_second_phase(invec, indices, N1, N2):
@@ -222,7 +222,7 @@ def fast_second_phase(invec, indices, N1, N2):
         }
     """
     scipy.weave.inline(code, ['N1', 'N2', 'NI', 'indices', 'out', 'invec'],
-                       extra_compile_args=['-march=native -O3 -w'])
+                       extra_compile_args=['-mno-avx2 -march=native -O3 -w'])
     return out
 
 _thetransposeplan = None

--- a/pycbc/fft/fftw_pruned.py
+++ b/pycbc/fft/fftw_pruned.py
@@ -12,6 +12,7 @@ I use a similar naming convention here, with minor simplifications to the
 twiddle factors.
 """
 import numpy, scipy.weave, ctypes, pycbc.types
+from pycbc import WEAVE_FLAGS
 from pycbc.libutils import get_ctypes_library
 
 # FFTW constants
@@ -222,7 +223,7 @@ def fast_second_phase(invec, indices, N1, N2):
         }
     """
     scipy.weave.inline(code, ['N1', 'N2', 'NI', 'indices', 'out', 'invec'],
-                       extra_compile_args=['-march=native -O3 -w'])
+                       extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'])
     return out
 
 _thetransposeplan = None

--- a/pycbc/fft/fftw_pruned.py
+++ b/pycbc/fft/fftw_pruned.py
@@ -167,7 +167,7 @@ def second_phase(invec, indices, N1, N2):
         }
     """
     scipy.weave.inline(code, ['N1', 'N2', 'NI', 'indices', 'out', 'invec'],
-                       extra_compile_args=['-mno-avx2 -march=native -O3 -w'])
+                      )
     return out
 
 def fast_second_phase(invec, indices, N1, N2):
@@ -222,7 +222,7 @@ def fast_second_phase(invec, indices, N1, N2):
         }
     """
     scipy.weave.inline(code, ['N1', 'N2', 'NI', 'indices', 'out', 'invec'],
-                       extra_compile_args=['-mno-avx2 -march=native -O3 -w'])
+                       extra_compile_args=['-march=native -O3 -w'])
     return out
 
 _thetransposeplan = None

--- a/pycbc/filter/matchedfilter_cpu.py
+++ b/pycbc/filter/matchedfilter_cpu.py
@@ -65,7 +65,7 @@ def correlate_inline(x, y, z):
     ya = numpy.array(y.data, copy=False)
     N = len(x) 
     inline(the_code, ['xa', 'ya', 'za', 'N'], 
-                    extra_compile_args=['-mno-avx2 -march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
                     support_code = support,
                     libraries=omp_libs
           )
@@ -90,7 +90,7 @@ class CPUCorrelator(_BaseCorrelator):
         arrlen = self.arrlen
         segsize = self.segsize
         inline(self.code, ['htilde', 'stilde', 'qtilde', 'arrlen', 'segsize'],
-               extra_compile_args = ['-mno-avx2 -march=native -O3 -w'] + omp_flags,
+               extra_compile_args = ['-march=native -O3 -w'] + omp_flags,
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'] + omp_flags,
                #extra_compile_args = ['-msse3 -O3 -w'] + omp_flags,
                libraries = omp_libs, support_code = self.support, auto_downcast = 1)

--- a/pycbc/filter/matchedfilter_cpu.py
+++ b/pycbc/filter/matchedfilter_cpu.py
@@ -65,7 +65,7 @@ def correlate_inline(x, y, z):
     ya = numpy.array(y.data, copy=False)
     N = len(x) 
     inline(the_code, ['xa', 'ya', 'za', 'N'], 
-                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=['-mno-avx2 -march=native -O3 -w'] + omp_flags,
                     support_code = support,
                     libraries=omp_libs
           )
@@ -90,7 +90,7 @@ class CPUCorrelator(_BaseCorrelator):
         arrlen = self.arrlen
         segsize = self.segsize
         inline(self.code, ['htilde', 'stilde', 'qtilde', 'arrlen', 'segsize'],
-               extra_compile_args = ['-march=native -O3 -w'] + omp_flags,
+               extra_compile_args = ['-mno-avx2 -march=native -O3 -w'] + omp_flags,
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'] + omp_flags,
                #extra_compile_args = ['-msse3 -O3 -w'] + omp_flags,
                libraries = omp_libs, support_code = self.support, auto_downcast = 1)

--- a/pycbc/filter/matchedfilter_cpu.py
+++ b/pycbc/filter/matchedfilter_cpu.py
@@ -23,6 +23,7 @@
 #
 import numpy
 from pycbc.opt import omp_libs, omp_flags
+from pycbc import WEAVE_FLAGS
 from scipy.weave import inline
 from .simd_correlate import default_segsize, corr_parallel_code, corr_support
 from .matchedfilter import _BaseCorrelator
@@ -65,7 +66,7 @@ def correlate_inline(x, y, z):
     ya = numpy.array(y.data, copy=False)
     N = len(x) 
     inline(the_code, ['xa', 'ya', 'za', 'N'], 
-                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
                     support_code = support,
                     libraries=omp_libs
           )
@@ -90,7 +91,7 @@ class CPUCorrelator(_BaseCorrelator):
         arrlen = self.arrlen
         segsize = self.segsize
         inline(self.code, ['htilde', 'stilde', 'qtilde', 'arrlen', 'segsize'],
-               extra_compile_args = ['-march=native -O3 -w'] + omp_flags,
+               extra_compile_args = [WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'] + omp_flags,
                #extra_compile_args = ['-msse3 -O3 -w'] + omp_flags,
                libraries = omp_libs, support_code = self.support, auto_downcast = 1)

--- a/pycbc/filter/simd_correlate.py
+++ b/pycbc/filter/simd_correlate.py
@@ -424,7 +424,7 @@ def correlate_simd(ht, st, qt):
     qtilde = _np.array(qt.data, copy = False).view(dtype = float32)
     arrlen = len(htilde)
     inline(corr_simd_code, ['htilde', 'stilde', 'qtilde', 'arrlen'],
-           extra_compile_args = ['-march=native -O3 -w'],
+           extra_compile_args = ['-mno-avx2 -march=native -O3 -w'],
            #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
            #extra_compile_args = ['-msse3 -O3 -w'],
            support_code = corr_support, auto_downcast = 1)
@@ -458,7 +458,7 @@ def correlate_parallel(ht, st, qt):
     arrlen = len(htilde)
     segsize = default_segsize
     inline(corr_parallel_code, ['htilde', 'stilde', 'qtilde', 'arrlen', 'segsize'],
-           extra_compile_args = ['-march=native -O3 -w'] + omp_flags, libraries = omp_libs,
+           extra_compile_args = ['-mno-avx2 -march=native -O3 -w'] + omp_flags, libraries = omp_libs,
            #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
            #extra_compile_args = ['-msse3 -O3 -w'],
            support_code = corr_support, auto_downcast = 1)

--- a/pycbc/filter/simd_correlate.py
+++ b/pycbc/filter/simd_correlate.py
@@ -424,7 +424,7 @@ def correlate_simd(ht, st, qt):
     qtilde = _np.array(qt.data, copy = False).view(dtype = float32)
     arrlen = len(htilde)
     inline(corr_simd_code, ['htilde', 'stilde', 'qtilde', 'arrlen'],
-           extra_compile_args = ['-mno-avx2 -march=native -O3 -w'],
+           extra_compile_args = ['-march=native -O3 -w'],
            #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
            #extra_compile_args = ['-msse3 -O3 -w'],
            support_code = corr_support, auto_downcast = 1)
@@ -458,7 +458,7 @@ def correlate_parallel(ht, st, qt):
     arrlen = len(htilde)
     segsize = default_segsize
     inline(corr_parallel_code, ['htilde', 'stilde', 'qtilde', 'arrlen', 'segsize'],
-           extra_compile_args = ['-mno-avx2 -march=native -O3 -w'] + omp_flags, libraries = omp_libs,
+           extra_compile_args = ['-march=native -O3 -w'] + omp_flags, libraries = omp_libs,
            #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
            #extra_compile_args = ['-msse3 -O3 -w'],
            support_code = corr_support, auto_downcast = 1)

--- a/pycbc/filter/simd_correlate.py
+++ b/pycbc/filter/simd_correlate.py
@@ -16,6 +16,7 @@
 
 from pycbc.types import float32
 from scipy.weave import inline
+from pycbc import WEAVE_FLAGS
 import numpy as _np
 import pycbc.opt
 from pycbc.opt import omp_support, omp_libs, omp_flags
@@ -424,7 +425,7 @@ def correlate_simd(ht, st, qt):
     qtilde = _np.array(qt.data, copy = False).view(dtype = float32)
     arrlen = len(htilde)
     inline(corr_simd_code, ['htilde', 'stilde', 'qtilde', 'arrlen'],
-           extra_compile_args = ['-march=native -O3 -w'],
+           extra_compile_args = [WEAVE_FLAGS + '-march=native -O3 -w'],
            #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
            #extra_compile_args = ['-msse3 -O3 -w'],
            support_code = corr_support, auto_downcast = 1)
@@ -458,7 +459,7 @@ def correlate_parallel(ht, st, qt):
     arrlen = len(htilde)
     segsize = default_segsize
     inline(corr_parallel_code, ['htilde', 'stilde', 'qtilde', 'arrlen', 'segsize'],
-           extra_compile_args = ['-march=native -O3 -w'] + omp_flags, libraries = omp_libs,
+           extra_compile_args = [WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags, libraries = omp_libs,
            #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
            #extra_compile_args = ['-msse3 -O3 -w'],
            support_code = corr_support, auto_downcast = 1)

--- a/pycbc/vetoes/chisq_cpu.py
+++ b/pycbc/vetoes/chisq_cpu.py
@@ -24,6 +24,7 @@
 import numpy, pycbc
 from pycbc.types import real_same_precision_as
 from scipy.weave import inline
+from pycbc import WEAVE_FLAGS
 
 if pycbc.HAVE_OMP:
     omp_libs = ['gomp']
@@ -47,7 +48,7 @@ def chisq_accum_bin_inline(chisq, q):
         }
     """
     inline(code, ['chisq', 'q', 'N'], 
-                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
                     libraries=omp_libs
           )
           
@@ -166,7 +167,7 @@ def shift_sum(v1, shifts, bins):
     chisq =  numpy.zeros(n, dtype=real_type)
     
     inline(code, ['v1', 'n', 'chisq', 'slen', 'shifts', 'bins', 'blen'],
-                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
                     libraries=omp_libs
           )
           

--- a/pycbc/vetoes/chisq_cpu.py
+++ b/pycbc/vetoes/chisq_cpu.py
@@ -47,7 +47,7 @@ def chisq_accum_bin_inline(chisq, q):
         }
     """
     inline(code, ['chisq', 'q', 'N'], 
-                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=['-mno-avx2 -march=native -O3 -w'] + omp_flags,
                     libraries=omp_libs
           )
           
@@ -166,7 +166,7 @@ def shift_sum(v1, shifts, bins):
     chisq =  numpy.zeros(n, dtype=real_type)
     
     inline(code, ['v1', 'n', 'chisq', 'slen', 'shifts', 'bins', 'blen'],
-                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=['-mno-avx2 -march=native -O3 -w'] + omp_flags,
                     libraries=omp_libs
           )
           

--- a/pycbc/vetoes/chisq_cpu.py
+++ b/pycbc/vetoes/chisq_cpu.py
@@ -47,7 +47,7 @@ def chisq_accum_bin_inline(chisq, q):
         }
     """
     inline(code, ['chisq', 'q', 'N'], 
-                    extra_compile_args=['-mno-avx2 -march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
                     libraries=omp_libs
           )
           
@@ -166,7 +166,7 @@ def shift_sum(v1, shifts, bins):
     chisq =  numpy.zeros(n, dtype=real_type)
     
     inline(code, ['v1', 'n', 'chisq', 'slen', 'shifts', 'bins', 'blen'],
-                    extra_compile_args=['-mno-avx2 -march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
                     libraries=omp_libs
           )
           

--- a/pycbc/waveform/spa_tmplt_cpu.py
+++ b/pycbc/waveform/spa_tmplt_cpu.py
@@ -193,7 +193,7 @@ def spa_tmplt_engine(htilde,  kmin,  phase_order, delta_f, piM,  pfaN,
                    'piM',  'pfaN', 'amp_factor', 'kfac',
                    'pfa2',  'pfa3',  'pfa4',  'pfa5',  'pfl5',
                    'pfa6',  'pfl6',  'pfa7', 'length'],
-                    extra_compile_args=['-mno-avx2 -march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
                     support_code = support,
                     libraries=omp_libs
                 )

--- a/pycbc/waveform/spa_tmplt_cpu.py
+++ b/pycbc/waveform/spa_tmplt_cpu.py
@@ -193,7 +193,7 @@ def spa_tmplt_engine(htilde,  kmin,  phase_order, delta_f, piM,  pfaN,
                    'piM',  'pfaN', 'amp_factor', 'kfac',
                    'pfa2',  'pfa3',  'pfa4',  'pfa5',  'pfl5',
                    'pfa6',  'pfl6',  'pfa7', 'length'],
-                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=['-mno-avx2 -march=native -O3 -w'] + omp_flags,
                     support_code = support,
                     libraries=omp_libs
                 )

--- a/pycbc/waveform/spa_tmplt_cpu.py
+++ b/pycbc/waveform/spa_tmplt_cpu.py
@@ -193,7 +193,7 @@ def spa_tmplt_engine(htilde,  kmin,  phase_order, delta_f, piM,  pfaN,
                    'piM',  'pfaN', 'amp_factor', 'kfac',
                    'pfa2',  'pfa3',  'pfa4',  'pfa5',  'pfl5',
                    'pfa6',  'pfl6',  'pfa7', 'length'],
-                    extra_compile_args=['-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=[pycbc.WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
                     support_code = support,
                     libraries=omp_libs
                 )

--- a/pycbc/workflow/pegasus_files/nebraska-site-template.xml
+++ b/pycbc/workflow/pegasus_files/nebraska-site-template.xml
@@ -11,4 +11,5 @@
     <profile namespace="env" key="LD_LIBRARY_PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/gmp/6.0.0/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/mpfr/3.1.3/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/mpc/1.0.3/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/gcc/4.9.2/lib64:/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/lib</profile>
     <profile namespace="env" key="LIBRARY_PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/lib</profile>
     <profile namespace="env" key="CPATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/include</profile>
+    <profile namespace="env" key="WEAVE_FLAGS">-mno-avx2</profile>
     <profile namespace="env" key="LAL_DATA_PATH">/mnt/hadoop/user/ligo/frames/O1/ROM/lal-data/lalsimulation</profile>


### PR DESCRIPTION
Addresses https://github.com/ligo-cbc/pycbc/issues/569

This adds -mno-avx2 to all weave calls, which was found to be necessary in order to run on at least some OSG sites.  This has been tested in a full workflow with inspiral jobs sent to UNL, started on sugar-dev2 in /home/lppekows/projects/osg/nebraska-test-003 (I would link to the Pegasus dashboard page, but for some reason jobs I submit from dev2 are not seen by dashboard). 
