### PR TITLE
Revert the recent changes to add the GRB segment plots

### DIFF
--- a/bin/pygrb/pycbc_make_grb_summary_page
+++ b/bin/pygrb/pycbc_make_grb_summary_page
@@ -60,13 +60,13 @@ def parse_command_line():
                         help="Declination of external trigger")
     
     parser.add_argument("-o", "--output-path", type=str, default=os.getcwd(),
-                        help="Post processing output directory")
+                        help="output directory")
 
     parser.add_argument("-w", "--html-path", type=str, default=None,
-                        help="Final web directory")
+                        help="final web directory")
 
-    parser.add_argument("-s", "--seg-plot", type=str, default=None,
-                        help="Path to segments plot")
+    parser.add_argument("-s", "--seg_plot", type=str, default=None,
+                        help="segment plot")
 
     parser.add_argument("-D", "--exclusion-injections", type=str, default=None,
                         help="A comma seperated list of the detection injection"
@@ -209,13 +209,16 @@ def build_grb_results_page(args, inifile, outdir, htmldir, ifoTag,
         webpage = write_antenna(webpage, args, grid, None)
 
     # add links
+    seglink = 'segment_plot_%s.png' % GRBnum
     inilink = os.path.basename(inifile)
-    inilinktext = 'ini-file used'
-    webpage.add(inilinktext)
-    webpage.a(href=link)
-    webpage.add('here')
-    webpage.a.close()
-    webpage.br()
+    linktext = {seglink:   'Segments availability',
+                inilink:   'ini-file used'}
+    for link in [seglink, inilink]:
+        webpage.add(linktext[link])
+        webpage.a(href=link)
+        webpage.add('here')
+        webpage.a.close()
+        webpage.br()
 
     webpage.div.close()
 

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -32,8 +32,7 @@ import os
 import argparse
 import logging
 import pycbc.workflow as _workflow
-from glue.segments import segment, segmentlistdict
-from pycbc.results.legacy_grb import make_grb_segments_plot
+from glue.segments import segment
 
 workflow_name = "pygrb_offline"
 logging.basicConfig(format="%(asctime)s:%(levelname)s : %(message)s",
@@ -56,19 +55,18 @@ if wflow.cp.has_option("workflow", "output-directory"):
     baseDir = wflow.cp.get("workflow", "output-directory")
 else:
     baseDir = os.getcwd()
-triggername = str(wflow.cp.get("workflow", "trigger-name"))
-runDir = os.path.join(baseDir, "GRB%s" % triggername)
+runDir = os.path.join(baseDir, "GRB%s" % str(wflow.cp.get("workflow",
+                                                          "trigger-name")))
 logging.info("Workflow will be generated in %s" % runDir)
 if not os.path.exists(runDir):
     os.makedirs(runDir)
 os.chdir(runDir)
 
 # SEGMENTS
-triggertime = int(wflow.cp.get("workflow", "trigger-time"))
-start = triggertime - int(wflow.cp.get("workflow-exttrig_segments",
-                                       "max-duration"))
-end = triggertime + int(wflow.cp.get("workflow-exttrig_segments",
-                                     "max-duration"))
+start = int(wflow.cp.get("workflow", "trigger-time")) - int(wflow.cp.get(
+        "workflow-exttrig_segments", "max-duration"))
+end = int(wflow.cp.get("workflow", "trigger-time")) + int(wflow.cp.get(
+        "workflow-exttrig_segments", "max-duration"))
 wflow.cp = _workflow.set_grb_start_end(wflow.cp, start, end)
 
 # Retrieve segments ahope-style
@@ -78,11 +76,7 @@ sciSegs, segsFileList = _workflow.setup_segment_generation(wflow, segDir)
 
 # Make coherent network segments
 single_ifo = wflow.cp.has_option("workflow", "allow-single-ifo-search")
-if len(sciSegs.keys()) == 0:
-    raise RuntimeError("No science segments available.")
-elif len(sciSegs.keys()) < 2 and not single_ifo:
-    plot_met = make_grb_segments_plot(wflow.ifos, segmentlistdict(sciSegs),
-            triggertime, triggername, segDir)
+if len(sciSegs.keys()) < 2 and not single_ifo:
     msg = "Science segments exist only for %s. " % sciSegs.keys()[0]
     msg += "If you wish to enable single IFO running add the option "
     msg += "'allow-single-ifo-search' to the [workflow] section of your "
@@ -90,25 +84,12 @@ elif len(sciSegs.keys()) < 2 and not single_ifo:
     raise RuntimeError(msg)
 elif len(sciSegs.keys()) < 2:
     logging.info("Generating a single IFO search.")
-    onSrc, offSrc = _workflow.get_triggered_single_ifo_segment(wflow, segDir,
-                                                               sciSegs)
+    onSrc, sciSegs, segs_plot = _workflow.get_triggered_single_ifo_segment(\
+            wflow, segDir, sciSegs)
 else:
-    onSrc, offSrc = _workflow.get_triggered_coherent_segment(wflow, segDir,
-            sciSegs, single_ifo)
-
-sciSegs = segmentlistdict(sciSegs)
-if onSrc is None:
-    plot_met = make_grb_segments_plot(wflow.ifos, sciSegs, triggertime,
-            triggername, segDir, fail_criterion=offSrc)
-    sys.exit()
-else:
-    plot_met = make_grb_segments_plot(wflow.ifos, sciSegs, triggertime,
-            triggername, segDir, coherent_seg=offSrc[offSrc.keys()[0]][0])
-    segs_plot = _workflow.File(plot_met[0], plot_met[1], plot_met[2],
-                               file_url=plot_met[3])
-    segs_plot.PFN(segs_plot.cache_entry.path, site="local")
-    sciSegs = offSrc
-    all_files.extend(_workflow.FileList([segs_plot]))
+    onSrc, sciSegs, segs_plot = _workflow.get_triggered_coherent_segment(wflow,
+            segDir, sciSegs, single_ifo)
+all_files.extend(_workflow.FileList([segs_plot]))
 
 # How many IFOs do we have in the search?
 if len(sciSegs.keys()) == 1:

--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -57,7 +57,7 @@ else:
     baseDir = os.getcwd()
 runDir = os.path.join(baseDir, "GRB%s" % str(wflow.cp.get("workflow",
                                                           "trigger-name")))
-logging.info("Workflow will be generated in %s" % runDir)
+logging.info("Workflow will be generated in %s" % baseDir)
 if not os.path.exists(runDir):
     os.makedirs(runDir)
 os.chdir(runDir)
@@ -84,12 +84,12 @@ if len(sciSegs.keys()) < 2 and not single_ifo:
     raise RuntimeError(msg)
 elif len(sciSegs.keys()) < 2:
     logging.info("Generating a single IFO search.")
-    onSrc, sciSegs, segs_plot = _workflow.get_triggered_single_ifo_segment(\
-            wflow, segDir, sciSegs)
+    onSrc, sciSegs = _workflow.get_triggered_single_ifo_segment(wflow, segDir,
+                                                                sciSegs)
 else:
-    onSrc, sciSegs, segs_plot = _workflow.get_triggered_coherent_segment(wflow,
-            segDir, sciSegs, single_ifo)
-all_files.extend(_workflow.FileList([segs_plot]))
+    onSrc, sciSegs = _workflow.get_triggered_coherent_segment(wflow, segDir,
+                                                              sciSegs,
+                                                              single_ifo)
 
 # How many IFOs do we have in the search?
 if len(sciSegs.keys()) == 1:
@@ -264,7 +264,7 @@ if post_proc_method == "COH_PTF_WORKFLOW":
             injection_trigger_files=inj_insp_files, injection_files=injs,
             injection_trigger_caches=inj_insp_caches,
             injection_caches=inj_caches, config_file=cp_file, web_dir=html_dir,
-            segments_plot=segs_plot, ifos=ifos, inj_tags=inj_tags)
+            ifos=ifos, inj_tags=inj_tags)
 
     # Retrieve style files for webpage
     summary_files = _workflow.get_coh_PTF_files(wflow.cp, ifos, ppDir,

--- a/pycbc/workflow/legacy_ihope.py
+++ b/pycbc/workflow/legacy_ihope.py
@@ -617,8 +617,8 @@ class PyGRBMakeSummaryPage(LegacyAnalysisExecutable):
         self.num_threads = 1
 
     def create_node(self, parent=None, c_file=None, open_box=False,
-                    seg_plot=None, tuning_tags=None, exclusion_tags=None,
-                    html_dir=None, tags=[]):
+                    tuning_tags=None, exclusion_tags=None, html_dir=None,
+                    tags=[]):
         node = Node(self)
 
         node.add_opt('--grb-name', self.cp.get('workflow', 'trigger-name'))
@@ -632,9 +632,6 @@ class PyGRBMakeSummaryPage(LegacyAnalysisExecutable):
 
         if exclusion_tags is not None:
             node.add_opt('--exclusion-injections', ','.join(exclusion_tags))
-
-        if seg_plot is not None:
-            node.add_opt('--seg-plot', seg_plot.storage_path)
 
         if open_box:
             node.add_opt('--open-box')

--- a/pycbc/workflow/postprocessing_cohptf.py
+++ b/pycbc/workflow/postprocessing_cohptf.py
@@ -43,7 +43,7 @@ def setup_coh_PTF_post_processing(workflow, trigger_files, trigger_cache,
         output_dir, segment_dir, injection_trigger_files=None,
         injection_files=None, injection_trigger_caches=None,
         injection_caches=None, config_file=None, run_dir=None, ifos=None,
-        web_dir=None, segments_plot=None, inj_tags=[], tags=[], **kwargs):
+        web_dir=None, inj_tags=[], tags=[], **kwargs):
     """
     This function aims to be the gateway for running postprocessing in CBC
     offline workflows. Post-processing generally consists of calculating the
@@ -87,8 +87,8 @@ def setup_coh_PTF_post_processing(workflow, trigger_files, trigger_cache,
         post_proc_files = setup_postproc_coh_PTF_workflow(workflow,
                 trigger_files, trigger_cache, injection_trigger_files,
                 injection_files, injection_trigger_caches, injection_caches,
-                config_file, output_dir, web_dir, segment_dir, segments_plot,
-                ifos=ifos, inj_tags=inj_tags, tags=tags, **kwargs)
+                config_file, output_dir, web_dir, segment_dir, ifos=ifos,
+                inj_tags=inj_tags, tags=tags, **kwargs)
     else:
         errMsg = "Post-processing method not recognized. Must be "
         errMsg += "COH_PTF_WORKFLOW."
@@ -102,8 +102,8 @@ def setup_coh_PTF_post_processing(workflow, trigger_files, trigger_cache,
 def setup_postproc_coh_PTF_workflow(workflow, trig_files, trig_cache,
                                     inj_trig_files, inj_files, inj_trig_caches,
                                     inj_caches, config_file, output_dir,
-                                    html_dir, segment_dir, segs_plot, ifos,
-                                    inj_tags=[], tags=[]):
+                                    html_dir, segment_dir, ifos, inj_tags=[],
+                                    tags=[]):
     """
     This module sets up the post-processing stage in the workflow, using a
     coh_PTF style set up. This consists of running trig_combiner to find
@@ -449,10 +449,10 @@ def setup_postproc_coh_PTF_workflow(workflow, trig_files, trig_cache,
                           if "DETECTION" not in inj_tag]
         html_summary_node = html_summary_jobs.create_node(c_file=config_file,
                 tuning_tags=tuning_tags, exclusion_tags=exclusion_tags,
-                seg_plot=segs_plot, html_dir=html_dir)
+                html_dir=html_dir)
     else:
         html_summary_node = html_summary_jobs.create_node(c_file=config_file,
-                seg_plot=segs_plot, html_dir=html_dir)
+                                                          html_dir=html_dir)
     workflow.add_node(html_summary_node)
     for pp_node in pp_nodes:
         dep = dax.Dependency(parent=pp_node._dax_node,

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -36,7 +36,6 @@ from glue.ligolw import utils, table, lsctables, ligolw
 from pycbc.workflow.core import Executable, FileList, Node, OutSegFile, make_analysis_dir, make_external_call, File
 from pycbc.workflow.core import resolve_url
 from pycbc.workflow.jobsetup import LigolwAddExecutable, LigoLWCombineSegsExecutable
-from pycbc.results.legacy_grb import make_grb_segments_plot
 
 class ContentHandler(ligolw.LIGOLWContentHandler):
     pass
@@ -842,7 +841,6 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
     # Load parsed workflow config options
     cp = workflow.cp
     triggertime = int(os.path.basename(cp.get('workflow', 'trigger-time')))
-    triggername = cp.get('workflow', 'trigger-name')
     minbefore = int(os.path.basename(cp.get('workflow-exttrig_segments',
                                             'min-before')))
     minafter = int(os.path.basename(cp.get('workflow-exttrig_segments',
@@ -876,20 +874,10 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
                     return get_triggered_single_ifo_segment(workflow, out_dir,
                                                             snglsegs)
             if len(snglsegs.keys()) == 0:
-                plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs,
-                        triggertime, triggername, out_dir)
-                seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
-                                file_url=plot_met[3])
-                seg_plot.PFN(seg_plot.cache_entry.path, site="local")
                 logging.error("Trigger is not contained within any available "
                               "science segment. Exiting.")
                 sys.exit()
         else:
-            plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs,
-                    triggertime, triggername, out_dir)
-            seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
-                            file_url=plot_met[3])
-            seg_plot.PFN(seg_plot.cache_entry.path, site="local")
             logging.error("Trigger is not contained within any available "
                           "coherent science segment. If you wish to enable "
                           "single IFO running add the option "
@@ -916,13 +904,6 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
             return get_triggered_single_ifo_segment(workflow, out_dir,
                                                     sciencesegs)
         else:
-            fail = segments.segment([triggertime - minbefore - padding,
-                                     triggertime + minbefore + padding])
-            plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs,
-                    triggertime, triggername, out_dir, fail_criterion=fail)
-            seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
-                            file_url=plot_met[3])
-            seg_plot.PFN(seg_plot.cache_entry.path, site="local")
             logging.error("Not enough data either side of trigger time. If "
                           "you wish to enable single IFO running add the "
                           "option 'allow-single-ifo-search' to the [workflow] "
@@ -937,13 +918,6 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
             return get_triggered_single_ifo_segment(workflow, out_dir,
                                                     sciencesegs)
         else:
-            fail = segments.segment([triggertime - minduration / 2. - padding,
-                                     triggertime + minduration / 2. + padding])
-            plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs,
-                    triggertime, triggername, out_dir, fail_criterion=fail)
-            seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
-                            file_url=plot_met[3])
-            seg_plot.PFN(seg_plot.cache_entry.path, site="local")
             logging.error("Available network segment shorter than minimum "
                           "allowed duration. If you wish to enable single IFO "
                           "running add the option 'allow-single-ifo-search' "
@@ -1016,11 +990,6 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
             offsrc = segments.segment(start, end)
             assert abs(offsrc) % quanta == 2 * padding
 
-    plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs, triggertime,
-            triggername, out_dir, coherent_seg=offsrc)
-    seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
-                    file_url=plot_met[3])
-    seg_plot.PFN(seg_plot.cache_entry.path, site="local")
     logging.info("Constructed OFF-SOURCE: duration %ds (%ds before to %ds "
                  "after trigger)."
                  % (abs(offsrc) - 2 * padding,
@@ -1060,7 +1029,7 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
     segmentsUtils.tosegwizard(file(bufferSegfile, "w"),
                               segments.segmentlist([bufferSegment]))
 
-    return onsource, offsource, seg_plot
+    return onsource, offsource
 
 def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
     """
@@ -1087,7 +1056,6 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
     # Load parsed workflow config options
     cp = workflow.cp
     triggertime = int(os.path.basename(cp.get('workflow', 'trigger-time')))
-    triggername = cp.get('workflow', 'trigger-name')
     minbefore = int(os.path.basename(cp.get('workflow-exttrig_segments',
                                             'min-before')))
     minafter = int(os.path.basename(cp.get('workflow-exttrig_segments',
@@ -1108,7 +1076,6 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
     bufferright = int(cp.get('workflow-exttrig_segments', 'num-buffer-after'))
 
     # Check available data segments meet criteria specified in arguments
-    sciencesegs = segments.segmentlistdict(sciencesegs)
     snglsegs = segments.segmentlistdict()
     for key in sciencesegs.keys():
         if triggertime in sciencesegs[key]:
@@ -1116,11 +1083,6 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
             logging.info("Trigger is within %s segments." % key)
     
     if len(snglsegs.keys()) == 0:
-        plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs,
-                triggertime, triggername, out_dir)
-        seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
-                        file_url=plot_met[3])
-        seg_plot.PFN(seg_plot.cache_entry.path, site="local")
         logging.error("Trigger is not contained within any available segment. "
                       "Exiting.")
         sys.exit()
@@ -1143,13 +1105,6 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
                          % key)
             offsrc.pop(key)
     if len(offsrc.keys()) == 0:
-        fail = segments.segment([triggertime - minbefore,
-                                 triggertime + minafter])
-        plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs,
-                triggertime, triggername, out_dir, fail_criterion=fail)
-        seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
-                        file_url=plot_met[3])
-        seg_plot.PFN(seg_plot.cache_entry.path, site="local")
         logging.error("Not enough data either side of trigger time in any "
                       "IFO. Exiting.")
         sys.exit()
@@ -1160,13 +1115,6 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
                          % key)
             offsrc.pop(key)
     if len(offsrc.keys()) == 0:
-        fail = segments.segment([triggertime - minduration / 2. - padding,
-                                 triggertime + minduration / 2. + padding])
-        plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs,
-                triggertime, triggername, out_dir, fail_criterion=fail)
-        seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
-                        file_url=plot_met[3])
-        seg_plot.PFN(seg_plot.cache_entry.path, site="local")
         logging.error("All available segments shorter than minimum allowed "
                       "duration. Exiting.")
         sys.exit()
@@ -1244,11 +1192,6 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
             offsrc = segments.segment(start, end)
             assert abs(offsrc) % quanta == 2 * padding
 
-    plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs, triggertime,
-            triggername, out_dir, coherent_seg=offsrc)
-    seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
-                    file_url=plot_met[3])
-    seg_plot.PFN(seg_plot.cache_entry.path, site="local")
     logging.info("Constructed OFF-SOURCE: duration %ds (%ds before to %ds "
                  "after trigger)."
                  % (abs(offsrc) - 2 * padding,
@@ -1285,7 +1228,7 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
     segmentsUtils.tosegwizard(file(bufferSegfile, "w"),
                               segments.segmentlist([bufferSegment]))
 
-    return onsource, offsource, seg_plot
+    return onsource, offsource
 
 def save_veto_definer(cp, out_dir, tags=[]):
     """ Retrieve the veto definer file and save it locally

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -36,6 +36,7 @@ from glue.ligolw import utils, table, lsctables, ligolw
 from pycbc.workflow.core import Executable, FileList, Node, OutSegFile, make_analysis_dir, make_external_call, File
 from pycbc.workflow.core import resolve_url
 from pycbc.workflow.jobsetup import LigolwAddExecutable, LigoLWCombineSegsExecutable
+from pycbc.results.legacy_grb import make_grb_segments_plot
 
 class ContentHandler(ligolw.LIGOLWContentHandler):
     pass
@@ -875,16 +876,26 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
                     return get_triggered_single_ifo_segment(workflow, out_dir,
                                                             snglsegs)
             if len(snglsegs.keys()) == 0:
+                plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs,
+                        triggertime, triggername, out_dir)
+                seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
+                                file_url=plot_met[3])
+                seg_plot.PFN(seg_plot.cache_entry.path, site="local")
                 logging.error("Trigger is not contained within any available "
                               "science segment. Exiting.")
-                return None, None
+                sys.exit()
         else:
+            plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs,
+                    triggertime, triggername, out_dir)
+            seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
+                            file_url=plot_met[3])
+            seg_plot.PFN(seg_plot.cache_entry.path, site="local")
             logging.error("Trigger is not contained within any available "
                           "coherent science segment. If you wish to enable "
                           "single IFO running add the option "
                           "'allow-single-ifo-search' to the [workflow] "
                           "section of your configuration file. Exiting.")
-            return None, None
+            sys.exit()
 
     offsrclist = commonsegs[commonsegs.keys()[0]]
     if len(offsrclist) > 1:
@@ -907,11 +918,16 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
         else:
             fail = segments.segment([triggertime - minbefore - padding,
                                      triggertime + minbefore + padding])
+            plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs,
+                    triggertime, triggername, out_dir, fail_criterion=fail)
+            seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
+                            file_url=plot_met[3])
+            seg_plot.PFN(seg_plot.cache_entry.path, site="local")
             logging.error("Not enough data either side of trigger time. If "
                           "you wish to enable single IFO running add the "
                           "option 'allow-single-ifo-search' to the [workflow] "
                           "section of your configuration file. Exiting.")
-            return None, fail
+            sys.exit()
 
     if abs(offsrc) < minduration + 2 * padding:
         if sngl_ifo:
@@ -923,12 +939,17 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
         else:
             fail = segments.segment([triggertime - minduration / 2. - padding,
                                      triggertime + minduration / 2. + padding])
+            plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs,
+                    triggertime, triggername, out_dir, fail_criterion=fail)
+            seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
+                            file_url=plot_met[3])
+            seg_plot.PFN(seg_plot.cache_entry.path, site="local")
             logging.error("Available network segment shorter than minimum "
                           "allowed duration. If you wish to enable single IFO "
                           "running add the option 'allow-single-ifo-search' "
                           "to the [workflow] section of your configuration "
                           "file. Exiting.")
-            return None, fail
+            sys.exit()
 
     # Will segment duration be the maximum desired length or not?
     if abs(offsrc) >= maxduration + 2 * padding:
@@ -995,6 +1016,11 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
             offsrc = segments.segment(start, end)
             assert abs(offsrc) % quanta == 2 * padding
 
+    plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs, triggertime,
+            triggername, out_dir, coherent_seg=offsrc)
+    seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
+                    file_url=plot_met[3])
+    seg_plot.PFN(seg_plot.cache_entry.path, site="local")
     logging.info("Constructed OFF-SOURCE: duration %ds (%ds before to %ds "
                  "after trigger)."
                  % (abs(offsrc) - 2 * padding,
@@ -1034,7 +1060,7 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
     segmentsUtils.tosegwizard(file(bufferSegfile, "w"),
                               segments.segmentlist([bufferSegment]))
 
-    return onsource, offsource
+    return onsource, offsource, seg_plot
 
 def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
     """
@@ -1057,6 +1083,7 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
     offsource : glue.segments.segmentlistdict
         A dictionary containing the off source segment for a single IFO
     """
+
     # Load parsed workflow config options
     cp = workflow.cp
     triggertime = int(os.path.basename(cp.get('workflow', 'trigger-time')))
@@ -1089,9 +1116,14 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
             logging.info("Trigger is within %s segments." % key)
     
     if len(snglsegs.keys()) == 0:
+        plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs,
+                triggertime, triggername, out_dir)
+        seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
+                        file_url=plot_met[3])
+        seg_plot.PFN(seg_plot.cache_entry.path, site="local")
         logging.error("Trigger is not contained within any available segment. "
                       "Exiting.")
-        return None, None
+        sys.exit()
 
     offsrc = segments.segmentlistdict()
     for key in snglsegs.keys():
@@ -1113,9 +1145,14 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
     if len(offsrc.keys()) == 0:
         fail = segments.segment([triggertime - minbefore,
                                  triggertime + minafter])
+        plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs,
+                triggertime, triggername, out_dir, fail_criterion=fail)
+        seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
+                        file_url=plot_met[3])
+        seg_plot.PFN(seg_plot.cache_entry.path, site="local")
         logging.error("Not enough data either side of trigger time in any "
                       "IFO. Exiting.")
-        return None, fail
+        sys.exit()
 
     for key in offsrc.keys():
         if abs(offsrc[key]) < minduration + 2 * padding:
@@ -1125,9 +1162,14 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
     if len(offsrc.keys()) == 0:
         fail = segments.segment([triggertime - minduration / 2. - padding,
                                  triggertime + minduration / 2. + padding])
+        plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs,
+                triggertime, triggername, out_dir, fail_criterion=fail)
+        seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
+                        file_url=plot_met[3])
+        seg_plot.PFN(seg_plot.cache_entry.path, site="local")
         logging.error("All available segments shorter than minimum allowed "
                       "duration. Exiting.")
-        return None, fail
+        sys.exit()
     elif len(offsrc.keys()) > 1:
         logging.error("Something is broken! At this point there should only "
                       "be 1 IFO in play, but there are %d."
@@ -1202,6 +1244,11 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
             offsrc = segments.segment(start, end)
             assert abs(offsrc) % quanta == 2 * padding
 
+    plot_met = make_grb_segments_plot(workflow.ifos, sciencesegs, triggertime,
+            triggername, out_dir, coherent_seg=offsrc)
+    seg_plot = File(plot_met[0], plot_met[1], plot_met[2],
+                    file_url=plot_met[3])
+    seg_plot.PFN(seg_plot.cache_entry.path, site="local")
     logging.info("Constructed OFF-SOURCE: duration %ds (%ds before to %ds "
                  "after trigger)."
                  % (abs(offsrc) - 2 * padding,
@@ -1238,7 +1285,7 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
     segmentsUtils.tosegwizard(file(bufferSegfile, "w"),
                               segments.segmentlist([bufferSegment]))
 
-    return onsource, offsource
+    return onsource, offsource, seg_plot
 
 def save_veto_definer(cp, out_dir, tags=[]):
     """ Retrieve the veto definer file and save it locally


### PR DESCRIPTION
The code changes to add the GRB segment plots have introduced a dependency on the ```Tkinter``` package, which is not installed on LDG clusters and the ```setup.py``` script is not installing it. When running the code with
```shell
(pycbc-dev)[dbrown@crush0211 main_ID0000001]$ pycbc_plot_bank_bins   --bank-file   H1L1-BANK2HDF-1128466607-20000.hdf   --background-bins   bns:chirp:1.74   edge:SEOBNRv2Peak:100   bulk:total:150   --output-file   H1L1-PLOT_BANK-1128466607-20000.png  
```
these patches on an _LDG_ node I get
```python
Traceback (most recent call last):
  File "/home/dbrown/src/pycbc-dev/bin/pycbc_plot_bank_bins", line 4, in <module>
    __import__('pkg_resources').run_script('PyCBC==888834', 'pycbc_plot_bank_bins')
  File "/home/dbrown/src/pycbc-dev/lib/python2.6/site-packages/pkg_resources/__init__.py", line 735, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/home/dbrown/src/pycbc-dev/lib/python2.6/site-packages/pkg_resources/__init__.py", line 1652, in run_script
    exec(code, namespace, namespace)
  File "/home/dbrown/src/pycbc-dev/lib/python2.6/site-packages/PyCBC-888834-py2.6.egg/EGG-INFO/scripts/pycbc_plot_bank_bins", line 4, in <module>
    import argparse, h5py, pycbc.events, pycbc.version, pycbc.results, sys
  File "/home/dbrown/src/pycbc-dev/lib/python2.6/site-packages/PyCBC-888834-py2.6.egg/pycbc/results/__init__.py", line 6, in <module>
    from pycbc.results.legacy_grb import *
  File "/home/dbrown/src/pycbc-dev/lib/python2.6/site-packages/PyCBC-888834-py2.6.egg/pycbc/results/legacy_grb.py", line 27, in <module>
    import matplotlib.pyplot as plt
  File "/home/dbrown/src/pycbc-dev/lib/python2.6/site-packages/matplotlib/pyplot.py", line 109, in <module>
    _backend_mod, new_figure_manager, draw_if_interactive, _show = pylab_setup()
  File "/home/dbrown/src/pycbc-dev/lib/python2.6/site-packages/matplotlib/backends/__init__.py", line 32, in pylab_setup
    globals(),locals(),[backend_name],0)
  File "/home/dbrown/src/pycbc-dev/lib/python2.6/site-packages/matplotlib/backends/backend_tkagg.py", line 6, in <module>
    from six.moves import tkinter as Tk
  File "/home/dbrown/src/pycbc-dev/lib/python2.6/site-packages/six.py", line 199, in load_module
    mod = mod._resolve()
  File "/home/dbrown/src/pycbc-dev/lib/python2.6/site-packages/six.py", line 113, in _resolve
    return _import_module(self.mod)
  File "/home/dbrown/src/pycbc-dev/lib/python2.6/site-packages/six.py", line 80, in _import_module
    __import__(name)
ImportError: No module named Tkinter
```
Reverting these patches and re-running the same command works:
```shell
(pycbc-dev)[dbrown@crush0211 main_ID0000001]$ pycbc_plot_bank_bins   --bank-file   H1L1-BANK2HDF-1128466607-20000.hdf   --background-bins   bns:chirp:1.74   edge:SEOBNRv2Peak:100   bulk:total:150   --output-file   H1L1-PLOT_BANK-1128466607-20000.png  
(pycbc-dev)[dbrown@crush0211 main_ID0000001]$ echo $?
0
```
Since these patches are not essential for the all-sky 1.2.6 release, I am reverting them and they can be re-applied (once the ```Tkinter``` dependence is fixed) afterwards.