### PR TITLE
Setting matplotlib backend

### DIFF
--- a/pycbc/results/legacy_grb.py
+++ b/pycbc/results/legacy_grb.py
@@ -25,6 +25,7 @@ from __future__ import division
 import re
 import os
 from argparse import ArgumentParser
+import matplotlib; matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from glue import markup, segments
 from pylal import antenna, git_version


### PR DESCRIPTION
Hi Duncan,

In the hope of rendering #576 unnecessary, can you check if this fixes the issue? We have tried in python by hand on CIT and this allows the import without error. It also follows the import of matplotlib you do within your bank bin plotting code.

Cheers,
Andrew