### PR TITLE
Make an analysis time summary page

### DIFF
--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -405,6 +405,9 @@ if len(files_for_combined_injfind) > 0:
     inj = wf.make_foundmissed_plot(workflow, found_inj, 
                 rdir['injections'], require='summ', tags=['ALLINJ'])
     inj_summ = list(layout.grouper(inj + sen, 2))
+
+# make analysis time summary
+layout.single_layout(rdir['analysis_time'], ([time_file,seg_summ_plot]))
                             
 # make full summary
 summ = ([(time_file,)] + [(seg_summ_plot,)] + [(seg_summ_table, veto_summ_table)] + 

--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -407,8 +407,16 @@ if len(files_for_combined_injfind) > 0:
     inj_summ = list(layout.grouper(inj + sen, 2))
 
 # make analysis time summary
-layout.single_layout(rdir['analysis_time'], ([time_file, seg_summ_plot]))
-                            
+analysis_time_summ = [time_file, seg_summ_plot]
+for f in analysis_time_summ:
+    if f is None:
+        continue
+    try:
+        os.symlink(f.storage_path, os.path.join(rdir['analysis_time'], f.name))
+    except OSError:
+        pass
+layout.single_layout(rdir['analysis_time'], (analysis_time_summ))
+
 # make full summary
 summ = ([(time_file,)] + [(seg_summ_plot,)] + [(seg_summ_table, veto_summ_table)] + 
        det_summ + hist_summ + bank_plot + list(layout.grouper(closed_snrifar, 2)) + inj_summ)

--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -407,7 +407,7 @@ if len(files_for_combined_injfind) > 0:
     inj_summ = list(layout.grouper(inj + sen, 2))
 
 # make analysis time summary
-layout.single_layout(rdir['analysis_time'], ([time_file,seg_summ_plot]))
+layout.single_layout(rdir['analysis_time'], ([time_file, seg_summ_plot]))
                             
 # make full summary
 summ = ([(time_file,)] + [(seg_summ_plot,)] + [(seg_summ_table, veto_summ_table)] + 


### PR DESCRIPTION
The recent changes re-organization of the results pages in https://github.com/ligo-cbc/pycbc/pull/575 has left the Analysis Time summary page without a plot, since all the files are in sub-sections. This isn't wrong, but the blank page may make people think that something is up. This adds a couple of sections to the summary page.