### PR TITLE
For some upstream reason, the GLIDEIN_Site for Comet is UCSD but the

### DIFF
--- a/pycbc/workflow/pegasus_files/comet-site-template.xml
+++ b/pycbc/workflow/pegasus_files/comet-site-template.xml
@@ -5,7 +5,7 @@
     <profile namespace="condor" key="accounting_group">$ACCOUNTING_GROUP</profile>
     <profile namespace="condor" key="should_transfer_files">YES</profile>
     <profile namespace="condor" key="when_to_transfer_output">ON_EXIT_OR_EVICT</profile>
-    <profile namespace="condor" key="Requirements">GLIDEIN_ResourceName == &quot;UCSD&quot;</profile>
+    <profile namespace="condor" key="Requirements">GLIDEIN_Site == &quot;UCSD&quot;</profile>
     <profile namespace="condor" key="+DESIRED_Sites">&quot;UCSD&quot;</profile>
     <profile namespace="env" key="PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/gcc/4.9.2/bin:/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/bin:/cvmfs/oasis.opensciencegrid.org/osg/modules/lua/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin</profile>
     <profile namespace="env" key="LD_LIBRARY_PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/gmp/6.0.0/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/mpfr/3.1.3/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/mpc/1.0.3/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/gcc/4.9.2/lib64:/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/lib</profile>


### PR DESCRIPTION
GLIDEIN_ResourceName is UCSDT2.  This causes the Requirements expression
in the site template to fail.

Switching to GLIDEIN_Site.  We probably ought to do this for Nebraska
and OrangeGrid too, but we'll get those when we add more sites.

@lppekows @duncan-brown 