### PR TITLE
Create a generic OSG site template.

### DIFF
--- a/pycbc/workflow/pegasus_files/osg-site-template.xml
+++ b/pycbc/workflow/pegasus_files/osg-site-template.xml
@@ -1,0 +1,13 @@
+  <site handle="osg" arch="x86_64" os="LINUX">
+    <profile namespace="env" key="GLOBUS_LOCATION">/usr</profile>
+    <profile namespace="pegasus" key="style">condor</profile>
+    <profile namespace="condor" key="getenv">True</profile>
+    <profile namespace="condor" key="accounting_group">$ACCOUNTING_GROUP</profile>
+    <profile namespace="condor" key="should_transfer_files">YES</profile>
+    <profile namespace="condor" key="when_to_transfer_output">ON_EXIT_OR_EVICT</profile>
+    <profile namespace="condor" key="Requirements">(GLIDEIN_Site isnt undefined)</profile>
+    <profile namespace="env" key="PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/gcc/4.9.2/bin:/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/bin:/cvmfs/oasis.opensciencegrid.org/osg/modules/lua/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin</profile>
+    <profile namespace="env" key="LD_LIBRARY_PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/gmp/6.0.0/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/mpfr/3.1.3/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/mpc/1.0.3/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/gcc/4.9.2/lib64:/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/lib</profile>
+    <profile namespace="env" key="LIBRARY_PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/lib</profile>
+    <profile namespace="env" key="CPATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/include</profile>
+    <profile namespace="env" key="LAL_DATA_PATH">/cvmfs/oasis.opensciencegrid.org/ligo/pycbc/ROM/lal-data/lalsimulation</profile>


### PR DESCRIPTION
This site template is for workflows that can run at any OSG site (i.e.,
the input files are read from gsiftp://red-gridftp.unl.edu).  Note the
requirements are set to prevent these jobs from running on Sugar.

Jobs submitted to this Pegasus 'site' will actually run on any site
where LIGO is enabled.  So, if this is used right now, the jobs will
run on a combination of OrangeGrid, Comet, and Nebraska (hoping
to add GLOW soon).

If desired, we could add:

```
    <profile namespace="condor" key="+DESIRED_Sites">&quot;UCSD,Nebraska,GLOW&quot;</profile>
```

to whitelist specific sites.  This may be desirable to avoid sites like OrangeGrid where the data has already been prestaged.

@lppekows @duncan-brown 