### PR TITLE
Allow pycbc_submit_dax to be bundled into a self-contained executable

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -216,13 +216,11 @@ SUBMIT_DIR=`mktemp --tmpdir=${LOCAL_PEGASUS_DIR} -d pycbc-tmp.XXXXXXXXXX`
 chmod 755 $SUBMIT_DIR
 
 # find the site-local template directory
-if [ -z $PEGASUS_FILE_DIRECTORY ] ; then
-  if [ $DATA_INLINE == "True" ] ; then
-    expand_pegasus_files
-    PEGASUS_FILE_DIRECTORY=${PWD}/pegasus_files
-  else
-    PEGASUS_FILE_DIRECTORY=`python -c 'from pycbc.workflow import PEGASUS_FILE_DIRECTORY;print PEGASUS_FILE_DIRECTORY'`
-  fi
+if [ $DATA_INLINE == "True" ] ; then
+  expand_pegasus_files
+  PEGASUS_FILE_DIRECTORY=${PWD}/pegasus_files
+elif [ -z $PEGASUS_FILE_DIRECTORY ] ; then
+  PEGASUS_FILE_DIRECTORY=`python -c 'from pycbc.workflow import PEGASUS_FILE_DIRECTORY;print PEGASUS_FILE_DIRECTORY'`
 fi
 
 # Create the site catalog

--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -340,7 +340,7 @@ if [ -e output.map ] ; then
 fi
 
 # ugly shell to extract the sub-dax names from the uberdax xml
-for dax in `egrep '<[:blank:]*dax' ${DAX_FILE} | tr ' ' \\\n | grep file | awk -F= '{print $2}' | tr -d '">'` ; do 
+for dax in `egrep '<[[:blank:]]*dax' ${DAX_FILE} | tr ' ' \\\n | grep file | awk -F= '{print $2}' | tr -d '">'` ; do 
   cp ${dax} workflow/dax
   map=`basename ${dax} .dax`.map
   if [ -e ${map} ] ; then

--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -28,6 +28,17 @@ LOCAL_GSIFTP_SERVER=""
 NO_CREATE_PROXY=0
 SUBMIT_DAX="--submit"
 
+# These will be changed by the bundle builder
+DATA_INLINE=False
+
+function expand_pegasus_files() {
+(
+base64 -d <<DATA_END
+PEGASUS_FILE_DATA
+DATA_END
+) | tar -zx
+}
+
 echo "# Properties set on command line" > extra-properties.conf
 rm -f _reuse.cache
 touch _reuse.cache
@@ -206,7 +217,12 @@ chmod 755 $SUBMIT_DIR
 
 # find the site-local template directory
 if [ -z $PEGASUS_FILE_DIRECTORY ] ; then
-  PEGASUS_FILE_DIRECTORY=`python -c 'from pycbc.workflow import PEGASUS_FILE_DIRECTORY;print PEGASUS_FILE_DIRECTORY'`
+  if [ $DATA_INLINE == "True" ] ; then
+    expand_pegasus_files
+    PEGASUS_FILE_DIRECTORY=${PWD}/pegasus_files
+  else
+    PEGASUS_FILE_DIRECTORY=`python -c 'from pycbc.workflow import PEGASUS_FILE_DIRECTORY;print PEGASUS_FILE_DIRECTORY'`
+  fi
 fi
 
 # Create the site catalog

--- a/tools/static/bundle_pycbc_submit_dax.sh
+++ b/tools/static/bundle_pycbc_submit_dax.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+pushd ../../pycbc/workflow 
+
+PEGASUS_FILE_DATA=`tar -zc pegasus_files | base64 | xargs echo | sed 's+ +ZZZZ+g'`
+
+popd 
+
+echo ${PEGASUS_FILE_DATA}
+
+sed -e 's+DATA_INLINE=False+DATA_INLINE=True+' \
+    -e "s^PEGASUS_FILE_DATA^${PEGASUS_FILE_DATA}^" \
+    -e "s+ZZZZ+\n+g" pycbc_submit_dax > dist/pycbc_submit_dax
+
+

--- a/tools/static/bundle_pycbc_submit_dax.sh
+++ b/tools/static/bundle_pycbc_submit_dax.sh
@@ -6,10 +6,10 @@ PEGASUS_FILE_DATA=`tar -zc pegasus_files | base64 | xargs echo | sed 's+ +ZZZZ+g
 
 popd 
 
-echo ${PEGASUS_FILE_DATA}
+mkdir -p dist
 
 sed -e 's+DATA_INLINE=False+DATA_INLINE=True+' \
     -e "s^PEGASUS_FILE_DATA^${PEGASUS_FILE_DATA}^" \
-    -e "s+ZZZZ+\n+g" pycbc_submit_dax > dist/pycbc_submit_dax
+    -e "s+ZZZZ+\n+g" ../../bin/pycbc_submit_dax > dist/pycbc_submit_dax
 
 


### PR DESCRIPTION
Addresses https://github.com/ligo-cbc/pycbc/issues/589

This patch modifies pycbc_submit_dax in a way that has no effect when run from a local installation.  It also adds a program that uses these hooks to create a self-contained executable by embedding a base64-encoded tar file of the necessary runtime files.

I have tested 
  * from within a virtual environment using the version installed with a standard "python setup install"
  * outside a virtual environment using the bundled version

and both worked.