### PR TITLE
Take globus-url-copy from CVMFS.

### DIFF
--- a/pycbc/workflow/pegasus_files/osg-site-template.xml
+++ b/pycbc/workflow/pegasus_files/osg-site-template.xml
@@ -6,8 +6,8 @@
     <profile namespace="condor" key="should_transfer_files">YES</profile>
     <profile namespace="condor" key="when_to_transfer_output">ON_EXIT_OR_EVICT</profile>
     <profile namespace="condor" key="Requirements">(GLIDEIN_Site isnt undefined)</profile>
-    <profile namespace="env" key="PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/gcc/4.9.2/bin:/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/bin:/cvmfs/oasis.opensciencegrid.org/osg/modules/lua/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin</profile>
-    <profile namespace="env" key="LD_LIBRARY_PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/gmp/6.0.0/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/mpfr/3.1.3/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/mpc/1.0.3/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/gcc/4.9.2/lib64:/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/lib</profile>
+    <profile namespace="env" key="PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/gcc/4.9.2/bin:/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/bin:/cvmfs/oasis.opensciencegrid.org/osg/modules/lua/bin:/cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/3.2/current/el6-x86_64/usr/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin</profile>
+    <profile namespace="env" key="LD_LIBRARY_PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/gmp/6.0.0/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/mpfr/3.1.3/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/mpc/1.0.3/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/gcc/4.9.2/lib64:/cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/3.2/current/el6-x86_64/usr/lib64:/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/lib</profile>
     <profile namespace="env" key="LIBRARY_PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/lib</profile>
     <profile namespace="env" key="CPATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/include</profile>
     <profile namespace="env" key="LAL_DATA_PATH">/cvmfs/oasis.opensciencegrid.org/ligo/pycbc/ROM/lal-data/lalsimulation</profile>


### PR DESCRIPTION
This allows PyCBC to work at OSG sites with a fixed PATH variable.

@lppekows @duncan-brown 