### PR TITLE
Use CVMFS version of CA certs on generic sites.

### DIFF
--- a/pycbc/workflow/pegasus_files/osg-site-template.xml
+++ b/pycbc/workflow/pegasus_files/osg-site-template.xml
@@ -9,5 +9,6 @@
     <profile namespace="env" key="PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/gcc/4.9.2/bin:/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/bin:/cvmfs/oasis.opensciencegrid.org/osg/modules/lua/bin:/cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/3.2/current/el6-x86_64/usr/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin</profile>
     <profile namespace="env" key="LD_LIBRARY_PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/gmp/6.0.0/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/mpfr/3.1.3/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/mpc/1.0.3/lib:/cvmfs/oasis.opensciencegrid.org/osg/modules/gcc/4.9.2/lib64:/cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/3.2/current/el6-x86_64/usr/lib64:/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/lib</profile>
     <profile namespace="env" key="LIBRARY_PATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/lib</profile>
+    <profile namespace="env" key="X509_CERT_DIR">/cvmfs/oasis.opensciencegrid.org/mis/certificates/</profile>
     <profile namespace="env" key="CPATH">/cvmfs/oasis.opensciencegrid.org/osg/modules/python-2.7.7/include</profile>
     <profile namespace="env" key="LAL_DATA_PATH">/cvmfs/oasis.opensciencegrid.org/ligo/pycbc/ROM/lal-data/lalsimulation</profile>


### PR DESCRIPTION
Take CA certs from the central location to prevent site-level differences.

@lppekows @duncan-brown 