### PR TITLE
Bug-fix pycbc_single_template --window option

### DIFF
--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -179,12 +179,16 @@ with ctx:
     snrs, chisqs = [], []  
     raw_bins = [[] for b in range(chisq_bins)]
     
+    start_time = opt.gps_start_time + opt.segment_start_pad
+    end_time = opt.gps_end_time - opt.segment_end_pad
+
     if opt.window:
-        start_time = opt.trigger_time - opt.window
-        end_time = opt.trigger_time + opt.window
-    else:
-        start_time = opt.gps_start_time + opt.segment_start_pad
-        end_time = opt.gps_end_time - opt.segment_end_pad
+        start_time_wind = opt.trigger_time - opt.window
+        if start_time_wind > start_time:
+            start_time = start_time_wind
+        end_time_wind = opt.trigger_time + opt.window
+        if end_time_wind < end_time:
+            end_time = end_time_wind
                         
     for s_num, stilde in enumerate(segments):    
         start = stilde.epoch + stilde.analyze.start / float(opt.sample_rate)


### PR DESCRIPTION
There is an edge-case bug in pycbc_single_template when using the window option and within window of the start/end of the analysable segment. Basically the code needs to check if it is at the start or end and then shrink the window as necessary. Otherwise start and end idx can become invalid and this can cause a failure either in this exe *or* in the plot exe.

I would like to get this into a production release as I want to use this in production runs.

Using the window option prevents these jobs having any memory-related problems. This is tested in ongoing chunk5 runs.