### PR TITLE
Reduce inspiral memory requirements to 1920MB.

### DIFF
--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -709,7 +709,7 @@ class PyCBCInspiralExecutable(Executable):
                  gate_files=None, tags=[]):
         super(PyCBCInspiralExecutable, self).__init__(cp, exe_name, None, ifo, out_dir, tags=tags)
         self.cp = cp
-        self.set_memory(2000)
+        self.set_memory(1920)
         self.injection_file = injection_file
         self.gate_files = gate_files
         


### PR DESCRIPTION
Some OSG sites set aside a bit of memory for the system, resulting in
1920MB / core available to HTCondor.  This will allow us to run there.

Looking at previous runs, it appears that inspiral stays comfortably
within the new 1920MB limit.