### PR TITLE
Match coinc definer descriptions to thinca strings

### DIFF
--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -1022,7 +1022,7 @@ class EventManagerMultiDet(EventManager):
         # Create coinc_definer table
         coinc_def_row = glue.ligolw.lsctables.CoincDef()
         coinc_def_row.search = "inspiral"
-        coinc_def_row.description = "sngl_inspiral-sngl_inspiral coincidences"
+        coinc_def_row.description = "sngl_inspiral<-->sngl_inspiral coincidences"
         coinc_def_row.coinc_def_id = coinc_def_id
         coinc_def_row.search_coinc_type = 0
         coinc_def_table.append(coinc_def_row)

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -538,7 +538,7 @@ class ForegroundTriggers(object):
         coinc_def_id = lsctables.CoincDefID(0)
         coinc_def_row = lsctables.CoincDef()
         coinc_def_row.search = "inspiral"
-        coinc_def_row.description = "sngl_inspiral-sngl_inspiral coincidences"
+        coinc_def_row.description = "sngl_inspiral<-->sngl_inspiral coincidences"
         coinc_def_row.coinc_def_id = coinc_def_id
         coinc_def_row.search_coinc_type = 0
         coinc_def_table.append(coinc_def_row)


### PR DESCRIPTION
thinca uses the string `sngl_inspiral<-->sngl_inspiral coincidences`. Deviating from this convention causes issues with some tools.