### PR TITLE
Save dynamic range factor in HDF5 PSD files

### DIFF
--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -122,6 +122,7 @@ for gpsd in psds:
 f[ifo + '/start_time'] = numpy.array(start, dtype=numpy.uint32)
 f[ifo + '/end_time'] = numpy.array(end, dtype=numpy.uint32)
 f.attrs['low_frequency_cutoff'] = args.low_frequency_cutoff
+f.attrs['dynamic_range_factor'] = pycbc.DYN_RANGE_FAC
 
 logging.info('Done!')
 

--- a/bin/hdfcoinc/pycbc_merge_psds
+++ b/bin/hdfcoinc/pycbc_merge_psds
@@ -63,4 +63,5 @@ for ifo in start:
     outf[ifo + '/end_time'] = numpy.array(end[ifo], dtype=numpy.uint32)
 
 outf.attrs['low_frequency_cutoff'] = f.attrs['low_frequency_cutoff']
+outf.attrs['dynamic_range_factor'] = pycbc.DYN_RANGE_FAC
 logging.info('Done!')


### PR DESCRIPTION
Some codes in LALSuite (e.g., BAYESTAR) need this constant, but do not depend on LALInference.

Note that this will cause problems if `pycbc.DYN_RANGE_FACTOR` is ever changed.

This patch is untested. A pycbc expert will need to run it.