### PR TITLE
Add PCAL saturation example

### DIFF
--- a/examples/cal/foton_filter_esd_saturation/README.rst
+++ b/examples/cal/foton_filter_esd_saturation/README.rst
@@ -1,5 +1,5 @@
 #################################################
-ESD Saturation Example
+ESD/PCAL Saturation Example
 #################################################
 
 .. contents::
@@ -12,9 +12,9 @@ Here we walkthrough an example of using the foton filtering module in pycbc. Thi
 
   examples/cal/foton_filter_esd_saturation
 
-We will generate h(t) for a CBC waveform and filter it will several filterbanks to get ETMY DAC counts.
+We will generate h(t) for a CBC waveform and filter it will several filterbanks to get ETMY DAC counts or PCAL counts.
 
-This example should be run at either the LLO or LHO cluster.
+This example should be run at either the CIT, LLO, or LHO cluster.
 
 =================================================
 Add ROOT and foton to pycbc installation
@@ -110,7 +110,7 @@ An example command is ::
 The output files will be written to ``${PWD}/esd_output/``. It will contain a single-column ASCII file after each stage of filtering. The final time series will contain ``*ETMY_L3_ESDOUTF_LL*``.
 
 =================================================
-Plotting the output
+Plotting the ESD saturation output
 =================================================
 
 In the example directory (``examples/cal/foton_filter_esd_saturation``) there is a script to use gwpy to make some plots of the output; the script is called ``gwpy_plot_hwinj``. The script ``gwpy_plot_hwinj`` will plot a timeseries and a spectrogram.
@@ -151,3 +151,9 @@ If you have an X11 session open then you can use the interactive hardware inject
 
   INPUT_FILE=`ls esd_output/${IFO}-FILTER_ETMY_L3_ESDOUTF_LL-*.txt`
   pycbc_plot_hwinj ${INPUT_FILE}
+
+=================================================
+Run the PCAL saturation script
+=================================================
+
+In the example directory (``examples/cal/foton_filter_esd_saturation``) there is a bash script called ``pycbc_check_pcal_saturation.sh``. This script will filter the waveform will the PCAL inverse actuation filter. There is a script called ``run_pcal_saturation_example.sh`` that shows how to use the ``pycbc_check_pcal_saturation.sh`` executable.

--- a/examples/cal/foton_filter_esd_saturation/pycbc_check_esd_saturation.sh
+++ b/examples/cal/foton_filter_esd_saturation/pycbc_check_esd_saturation.sh
@@ -1,5 +1,21 @@
 #! /bin/bash -e
 
+# Copyright (C) 2015  Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 # where to run the executables
 RUN_DIR=./esd_output
 

--- a/examples/cal/foton_filter_esd_saturation/pycbc_check_pcal_saturation.sh
+++ b/examples/cal/foton_filter_esd_saturation/pycbc_check_pcal_saturation.sh
@@ -1,0 +1,98 @@
+#! /bin/bash -e
+
+# where to run the executables
+RUN_DIR=./pcal_output
+
+# default option values
+DATA_FILE=""
+GPS_START_TIME=""
+GPS_END_TIME=""
+IFO=""
+FRAME_TYPE=""
+SAMPLE_RATE=16384
+CALEX_FILTER_FILE=""
+
+# parse command line
+GETOPT_CMD=`getopt -o d:c:a:F:h:l --long data-file:,gps-start-time:,gps-end-time:,ifo:,frame-type:,sample-rate:,calcs-filter-file:,sus-filter-file:,help -n 'pycbc_check_esd_saturation.sh' -- "$@"`
+eval set -- "$GETOPT_CMD"
+while true ; do
+  case "$1" in
+    -d|--data-file)
+      case "$2" in
+        "") shift 2 ;;
+        *) DATA_FILE=$2 ; shift 2 ;;
+      esac ;;
+    -s|--gps-start-time)
+      case "$2" in
+        "") shift 2 ;;
+        *) GPS_START_TIME=$2 ; shift 2 ;;
+      esac ;;
+    -e|--gps-end-time)
+      case "$2" in
+        "") shift 2 ;;
+        *) GPS_END_TIME=$2 ; shift 2 ;;
+      esac ;;
+    -i|--ifo)
+      case "$2" in
+        "") shift 2 ;;
+        *) IFO=$2 ; shift 2 ;;
+      esac ;;
+    -f|--frame-type)
+      case "$2" in
+        "") shift 2 ;;
+        *) FRAME_TYPE=$2 ; shift 2 ;;
+      esac ;;
+    -r|--sample-rate)
+      case "$2" in
+        "") shift 2 ;;
+        *) SAMPLE_RATE=$2 ; shift 2 ;;
+      esac ;;
+    -c|--calcs-filter-file)
+      case "$2" in
+        "") shift 2 ;;
+        *) CALEX_FILTER_FILE=$2 ; shift 2 ;;
+      esac ;;
+    -h|--help)
+      echo "usage: pycbc_check_esd_saturation.sh [-h] [--options]"
+      echo
+      echo "required arguments:"
+      echo "  -d, --data-file DATA_FILE                       single-column ASCII file"
+      echo "  -s, --gps-start-time GPS_START_TIME             time to start reading data for filterbank values"
+      echo "  -e, --gps-end-time GPS_END_TIME                 time to stop reading data for filterbank values"
+      echo "  -i, --ifo IFO                                   IFO, eg. H1 or L1"
+      echo "  -f, --frame-type FRAME_TYPE                     frame type that has SWSTAT and GAIN channels"
+      echo "  -r, --sample-rate SAMPLE_RATE                   sample rate of the input file"
+      echo "  -c, --calcs-filter-file CALEX_FILTER_FILE       path to CALEX.txt"
+      echo
+      echo "Filter a single-column ASCII file to see if it saturates the ETMY DAC."
+      echo
+      echo "You need to have ROOT and foton python packages in your environment."
+      echo "To do this on the LLO or LHO clusters do:"
+      echo 
+      echo "NAME=/path/to/virtualenv"
+      echo "cd ${NAME}/lib64/python2.6/site-packages"
+      echo "ln -s /usr/lib64/python2.6/site-packages/libPyROOT.so"
+      echo "ln -s /usr/lib64/python2.6/site-packages/ROOT.py"
+      echo "ln -s /usr/lib64/python2.6/site-packages/ROOTwriter.py"
+      echo "cd ${NAME}/lib/python2.6/site-packages"
+      echo "ln -s /usr/lib/python2.6/site-packages/foton.py"
+      echo
+      exit 0 ;;
+    --) shift ; break ;;
+    *) echo "Internal error!" ; exit 1 ;;
+  esac
+done
+
+# save current directory to get path to executables
+EXE_DIR=${PWD}
+
+# change into directory where executables will be run
+mkdir -p ${RUN_DIR}
+cd ${RUN_DIR}
+
+# filter with CAL-INJ_HARDWARE
+MODEL_NAME=CAL
+FILTERBANK_NAME=PINJX_HARDWARE
+#DATA_FILE=`ls /home/cbiwer/src/pycbc_foton_dev/examples/cal/foton_filter_INJ_BLIND/hwinj/${IFO}-HWINJ_CBC-*-*.txt`
+OUTPUT_FILE=${IFO}-FILTER_${FILTERBANK_NAME}-${GPS_START_TIME}.txt
+python ${EXE_DIR}/pycbc_foton_filter --filterbank-ignore-off --model-name ${MODEL_NAME} --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --filterbank-name ${FILTERBANK_NAME} --data-file ${DATA_FILE} --filter-file ${CALEX_FILTER_FILE} --output-file ${OUTPUT_FILE} --sample-rate ${SAMPLE_RATE} --frame-type ${FRAME_TYPE} --ifo ${IFO}

--- a/examples/cal/foton_filter_esd_saturation/pycbc_check_pcal_saturation.sh
+++ b/examples/cal/foton_filter_esd_saturation/pycbc_check_pcal_saturation.sh
@@ -1,5 +1,21 @@
 #! /bin/bash -e
 
+# Copyright (C) 2015  Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 # where to run the executables
 RUN_DIR=./pcal_output
 

--- a/examples/cal/foton_filter_esd_saturation/run_pcal_saturation_example.sh
+++ b/examples/cal/foton_filter_esd_saturation/run_pcal_saturation_example.sh
@@ -20,8 +20,8 @@
 IFO=H1
 FRAME_TYPE=H1_R
 
-# get data file
-DATA_FILE=${PWD}/H1-HWINJ_CBC-1131174986-20.txt
+# get single-column ASCII file that contains h(t) time series
+DATA_FILE=`ls ${PWD}/H1-HWINJ_CBC-*-*.txt`
 
 # injection options
 SAMPLE_RATE=16384

--- a/examples/cal/foton_filter_esd_saturation/run_pcal_saturation_example.sh
+++ b/examples/cal/foton_filter_esd_saturation/run_pcal_saturation_example.sh
@@ -1,0 +1,65 @@
+#! /bin/bash -e
+
+# Copyright (C) 2015  Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+# frame options note these options are for reading SWSTAT and GAIN channels
+IFO=H1
+FRAME_TYPE=H1_R
+
+# get data file
+DATA_FILE=${PWD}/H1-HWINJ_CBC-1131174986-20.txt
+
+# injection options
+SAMPLE_RATE=16384
+
+# output options
+HTMLDIR=/home/${USER}/public_html/hwinj_check/doc/
+mkdir -p ${HTMLDIR}
+
+# checkout the calibration SVN to get foton filter files
+svn co --username=christopher.biwer https://daqsvn.ligo-la.caltech.edu/svn/h1_filter_files/h1_archive
+svn co --username=christopher.biwer https://daqsvn.ligo-la.caltech.edu/svn/l1_filter_files/l1_archive
+
+# foton filter files
+CALEX_FILTER_FILE=h1_archive/H1CALEX.txt
+
+# time options
+GPS_START_TIME=$((`lalapps_tconvert` - 30000))
+GPS_END_TIME=$((${GPS_START_TIME}+1))
+
+# filter injection
+sh pycbc_check_pcal_saturation.sh --data-file ${DATA_FILE} --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --ifo ${IFO} --frame-type ${FRAME_TYPE} --calex-filter-file ${PWD}/${CALEX_FILTER_FILE}
+
+# source detchar env
+# note that this path is specific to the CIT, LHO, and LLO clusters
+source /home/detchar/opt/gwpysoft/etc/gwpy-user-env.sh
+
+# output options
+INPUT_FILE=${DATA_FILE}
+TIMESERIES_FILE=${HTMLDIR}/${IFO}-TIMESERIES_HOFT.png
+SPECTROGRAM_FILE=${HTMLDIR}/${IFO}-SPECTROGRAM_HOFT.png
+
+# run plotting script
+python gwpy_plot_hwinj ${INPUT_FILE} ${TIMESERIES_FILE} ${SPECTROGRAM_FILE} 0 1027 -1e-22 1e-22 1e-21 1e-27
+
+# output options
+INPUT_FILE=`ls pcal_output/${IFO}-FILTER_PINJX_HARDWARE-*.txt`
+TIMESERIES_FILE=${HTMLDIR}/${IFO}-TIMESERIES_PINJX_HARDWARE.png
+SPECTROGRAM_FILE=${HTMLDIR}/${IFO}-SPECTROGRAM_PINJX_HARDWARE.png
+
+# run plotting script
+python gwpy_plot_hwinj ${INPUT_FILE} ${TIMESERIES_FILE} ${SPECTROGRAM_FILE} 0 21 -30000 30000 1e1 1e-7


### PR DESCRIPTION
There is already an example for calculating the number of counts a hardware injection will create at the ESD so that we can check for ESD saturations.

Now we have moved the hardware injection infrastructure over to PCALX. So this PR adds another example for checking the number of counts from the PCAL inverse actuation filter.

There is a script ``run_pcal_saturation_example.sh`` that shows how to do the example.