### PR TITLE
Remove hardcoded parsing of filename when rendering an segment XML file

### DIFF
--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -123,9 +123,11 @@ def render_default(path, cp):
 
     if path.endswith('.xml') or path.endswith('.xml.gz'):
         # segment or veto file return a segmentslistdict instance
-        if 'SEG' in path or 'VETO' in path:
-            with open(path, 'r') as xmlfile:
+        with open(path, 'r') as xmlfile:
+            try:
                 content = fromsegmentxml(xmlfile, return_dict=True)
+            except ValueError:
+                pass
 
     # render template
     template_dir = pycbc.results.__path__[0] + '/templates/files'


### PR DESCRIPTION
Workflow failed on veto-definer file because it had ``VETO`` in the name but does not contain a ``segment`` table.

This PR removes the hardcoding check of the filename and uses a try-except statement to see if the XML file has a segment table.