### PR TITLE
Add --low-frequency-cutoff to pycbc_insert_frame_hwinj

### DIFF
--- a/bin/hwinj/pycbc_insert_frame_hwinj
+++ b/bin/hwinj/pycbc_insert_frame_hwinj
@@ -41,6 +41,10 @@ parser.add_argument('--ifo', type=str, required=True,
 parser.add_argument('--output-file', type=str, required=True,
              help='Path to output frame file.')
 
+# fake data options
+parser.add_argument('--low-frequency-cutoff', type=int, required=False,
+             help='Low-frequency cutoff for generating fake PSD.')
+
 # add option groups
 _strain.insert_strain_option_group(parser)
 


### PR DESCRIPTION
This PR adds the ``--low-frequency-cutoff`` so that the code works with fake strain options. Originally the code was only used for inserting the injection into frame data.