### PR TITLE
Adding short slide info to GRB post processing

### DIFF
--- a/pycbc/workflow/legacy_ihope.py
+++ b/pycbc/workflow/legacy_ihope.py
@@ -354,6 +354,11 @@ class LegacyCohPTFTrigCombiner(LegacyAnalysisExecutable):
 
         num_trials = int(self.cp.get("trig_combiner", "num-trials"))
         trig_name = self.cp.get('workflow', 'trigger-name')
+        if all("COHERENT_NO_INJECTIONS" in t.name for t in trig_files) and \
+                self.cp.has_option_tag('inspiral', 'do-short-slides',
+                                       'coherent_no_injections'):
+            node.add_opt('--short-slides')
+        
         node.add_opt('--grb-name', trig_name)
         
         node.add_opt('--pad-data', pad_data)
@@ -374,7 +379,6 @@ class LegacyCohPTFTrigCombiner(LegacyAnalysisExecutable):
                             directory=self.out_dir, extension='xml.gz',
                             tags=["GRB%s" % trig_name, out_tag],
                             store_file=self.retain_files)
-            #out_file.PFN(out_file.cache_entry.path, site="local")
             out_files.append(out_file)
 
         for trial in range(1, num_trials + 1):
@@ -382,7 +386,6 @@ class LegacyCohPTFTrigCombiner(LegacyAnalysisExecutable):
                             directory=self.out_dir, extension='xml.gz',
                             tags=["GRB%s" % trig_name, "OFFTRIAL_%d" % trial],
                             store_file=self.retain_files)
-            #out_file.PFN(out_file.cache_entry.path, site="local")
             out_files.append(out_file)
 
         node.add_profile('condor', 'request_cpus', self.num_threads)

--- a/pycbc/workflow/postprocessing_cohptf.py
+++ b/pycbc/workflow/postprocessing_cohptf.py
@@ -155,6 +155,11 @@ def setup_postproc_coh_PTF_workflow(workflow, trig_files, trig_cache,
 
     # Set up trig_combiner job
     trig_combiner_out_tags = ["OFFSOURCE", "ONSOURCE", "ALL_TIMES"]
+    if all("COHERENT_NO_INJECTIONS" in t.name for t in trig_files) and \
+            cp.has_option_tag("inspiral", "do-short-slides",
+                              "coherent_no_injections"):
+        trig_combiner_out_tags.extend(["ZEROLAG_OFF", "ZEROLAG_ALL"])
+    
     trig_combiner_jobs = trig_combiner_class(cp, "trig_combiner", ifo=ifos, 
                                              out_dir=output_dir, tags=tags)
     trig_combiner_node, trig_combiner_outs = trig_combiner_jobs.create_node(\
@@ -261,8 +266,8 @@ def setup_postproc_coh_PTF_workflow(workflow, trig_files, trig_cache,
 
     # Add trig_cluster jobs and their corresponding plotting jobs
     for out_tag in trig_combiner_out_tags:
-        unclust_file = [file for file in trig_combiner_outs \
-                        if out_tag in file.tag_str][0]
+        unclust_file = [f for f in trig_combiner_outs \
+                        if out_tag in f.tag_str][0]
         trig_cluster_node, curr_outs = trig_cluster_jobs.create_node(\
                 unclust_file)
         trig_cluster_outs.extend(curr_outs)
@@ -379,8 +384,8 @@ def setup_postproc_coh_PTF_workflow(workflow, trig_files, trig_cache,
 
     while trial <= num_trials:
         trial_tag = "OFFTRIAL_%d" % trial
-        unclust_file = [file for file in trig_combiner_outs \
-                        if trial_tag in file.tag_str][0]
+        unclust_file = [f for f in trig_combiner_outs \
+                        if trial_tag in f.tag_str][0]
         trig_cluster_node, clust_outs = trig_cluster_jobs.create_node(\
                 unclust_file)
         clust_file = clust_outs[0]


### PR DESCRIPTION
Hi Steve,

This change allows for the --short-slide option to be given to the trig_combiner code in GRB workflows. I have tested on single and 2 IFO data and it works correctly in both instances.

Cheers,
Andrew