### PR TITLE
Stampede site catalog set up for glidein

### DIFF
--- a/pycbc/workflow/pegasus_files/stampede-site-template.xml
+++ b/pycbc/workflow/pegasus_files/stampede-site-template.xml
@@ -6,4 +6,7 @@
     <profile namespace="condor" key="should_transfer_files">YES</profile>
     <profile namespace="condor" key="when_to_transfer_output">ON_EXIT_OR_EVICT</profile>
     <profile namespace="condor" key="Requirements">GLIDEIN_Site=?="Stampede"</profile>
+    <profile namespace="env" key="PATH">/scratch/projects/xsede/globus-6.0/sbin:/scratch/projects/xsede/globus-6.0/bin</profile>
+    <profile namespace="env" key="LD_LIBRARY_PATH">/scratch/projects/xsede/globus-6.0/lib:/scratch/projects/xsede/globus-6.0/lib64</profile>
+    <profile namespace="env" key="X509_CERT_DIR">/home1/02597/bbockelm/certificates</profile>
     <profile namespace="env" key="LAL_DATA_PATH">/scratch/01858/larne/lal-data/lalsimulation</profile>

--- a/pycbc/workflow/pegasus_files/stampede-site-template.xml
+++ b/pycbc/workflow/pegasus_files/stampede-site-template.xml
@@ -6,7 +6,7 @@
     <profile namespace="condor" key="should_transfer_files">YES</profile>
     <profile namespace="condor" key="when_to_transfer_output">ON_EXIT_OR_EVICT</profile>
     <profile namespace="condor" key="Requirements">GLIDEIN_Site=?="Stampede"</profile>
-    <profile namespace="env" key="PATH">/scratch/projects/xsede/globus-6.0/sbin:/scratch/projects/xsede/globus-6.0/bin</profile>
+    <profile namespace="env" key="PATH">/scratch/projects/xsede/globus-6.0/sbin:/scratch/projects/xsede/globus-6.0/bin:/opt/apps/xalt/0.6/bin:/opt/apps/intel15/mvapich2/2.1/bin:/opt/apps/intel/15/composer_xe_2015.2.164/bin/intel64:/usr/lib64/qt-3.3/bin:/usr/local/bin:/bin:/usr/bin:/opt/apps/xsede/gsi-openssh-5.7/bin:/usr/X11R6/bin:/opt/ofed/bin:/opt/ofed/sbin:/opt/dell/srvadmin/bin</profile>
     <profile namespace="env" key="LD_LIBRARY_PATH">/scratch/projects/xsede/globus-6.0/lib:/scratch/projects/xsede/globus-6.0/lib64</profile>
     <profile namespace="env" key="X509_CERT_DIR">/home1/02597/bbockelm/certificates</profile>
     <profile namespace="env" key="LAL_DATA_PATH">/scratch/01858/larne/lal-data/lalsimulation</profile>

--- a/pycbc/workflow/pegasus_files/stampede-site-template.xml
+++ b/pycbc/workflow/pegasus_files/stampede-site-template.xml
@@ -1,13 +1,9 @@
   <site handle="stampede" arch="x86_64" os="LINUX">
-      <grid type="gt5" contact="login5.stampede.tacc.utexas.edu:2119/jobmanager-fork" scheduler="Fork" jobtype="auxillary"/>
-      <grid type="gt5" contact="login5.stampede.tacc.utexas.edu:2119/jobmanager-slurm" scheduler="unknown" jobtype="compute"/>
-      <directory type="shared-scratch" path="$STAMPEDE_SCRATCH">
-          <file-server operation="all" url="gsiftp://gridftp.stampede.tacc.xsede.org/$STAMPEDE_SCRATCH"/>
-      </directory>
-      <profile namespace="env" key="PEGASUS_HOME">$STAMPEDE_PEGASUS_HOME</profile>
-      <profile namespace="pegasus" key="job.aggregator" >mpiexec</profile>
-      <profile namespace="pegasus" key="cluster.arguments" >--tries 3</profile>
-      <profile namespace="globus" key="queue">normal</profile>
-      <profile namespace="globus" key="maxwalltime">30</profile>
-      <profile namespace="condor" key="accounting_group">$ACCOUNTING_GROUP</profile>
-      <profile namespace="globus" key="jobtype">single</profile>
+    <profile namespace="env" key="GLOBUS_LOCATION">/opt/apps/xsede/gram5-5.2.3</profile>
+    <profile namespace="pegasus" key="style">condor</profile>
+    <profile namespace="condor" key="getenv">True</profile>
+    <profile namespace="condor" key="accounting_group">$ACCOUNTING_GROUP</profile>
+    <profile namespace="condor" key="should_transfer_files">YES</profile>
+    <profile namespace="condor" key="when_to_transfer_output">ON_EXIT_OR_EVICT</profile>
+    <profile namespace="condor" key="Requirements">GLIDEIN_Site=?="Stampede"</profile>
+    <profile namespace="env" key="LAL_DATA_PATH">/scratch/01858/larne/lal-data/lalsimulation</profile>


### PR DESCRIPTION
Addresses https://github.com/ligo-cbc/pycbc/issues/634 .

This does not set PATH or LD_LIBRARY_PATH for gcc.  In previous tests on Stampede the default installation of gcc worked, but should that no longer be the case other versions are available.