### PR TITLE
Page ifar changes

### DIFF
--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -172,16 +172,19 @@ censored_veto = wf.make_foreground_censored_veto(workflow,
                        'closed_box', 'segments')      
               
 closed_snrifar = []
+all_snrifar = []
 for bg_file, bg_bins in (bg_files + final_bg_files):
     for bg_bin in bg_bins:
         snrifar = wf.make_snrifar_plot(workflow, bg_bin,
                         rdir['coincident_triggers'], 
                          closed_box=True, tags=bg_bin.tags + ['closed'])
+        all_snrifar.append(snrifar)
         if bg_file == final_bg_file:
             closed_snrifar.append(snrifar)
     
 results_page = []        
 results_aux_page = []
+closed_box_ifars = []
 for bin_file in bin_files:
     snrifar = wf.make_snrifar_plot(workflow, bin_file,
                     rdir['open_box_result'], tags=bin_file.tags)
@@ -196,10 +199,18 @@ for bin_file in bin_files:
                     cumulative=False, tags=bin_file.tags + ['ifar'])
     ifar = wf.make_ifar_plot(workflow, bin_file, 
                     rdir['open_box_result/significance'], tags=bin_file.tags)
+    # Closed box
+    ifar = wf.make_ifar_plot(workflow, bin_file,
+                    rdir['coincident_triggers'],
+                    tags=bin_file.tags + ['closed_box'])
+    closed_box_ifars.append(ifar)
                     
     symlink_result(snrifar, 'open_box_result/significance')
     symlink_result(ratehist, 'open_box_result/significance')
     results_aux_page += [(snrifar, ratehist), (snrifar_ifar, ifar)]
+
+layout.group_layout(rdir['coincident_triggers'],
+                    closed_box_ifars + all_snrifar + [bank_plot[0][0]])
 
 wf.make_ifar_plot(workflow, final_bg_file, rdir['open_box_result'])
 

--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -198,7 +198,8 @@ for bin_file in bin_files:
                     rdir['open_box_result/significance'], 
                     cumulative=False, tags=bin_file.tags + ['ifar'])
     ifar = wf.make_ifar_plot(workflow, bin_file, 
-                    rdir['open_box_result/significance'], tags=bin_file.tags)
+                    rdir['open_box_result/significance'],
+                    tags=bin_file.tags + ['open_box')
     # Closed box
     ifar = wf.make_ifar_plot(workflow, bin_file,
                     rdir['coincident_triggers'],
@@ -212,7 +213,8 @@ for bin_file in bin_files:
 layout.group_layout(rdir['coincident_triggers'],
                     closed_box_ifars + all_snrifar + [bank_plot[0][0]])
 
-wf.make_ifar_plot(workflow, final_bg_file, rdir['open_box_result'])
+wf.make_ifar_plot(workflow, final_bg_file, rdir['open_box_result'],
+                  tags=['open_box'])
 
 table = wf.make_foreground_table(workflow, final_bg_file, 
                     hdfbank[0], tag, rdir['open_box_result'], singles=insps,

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -104,9 +104,6 @@ max_tsid = (fp['segments'][ifo1]['end'][:].max() - fp['segments'][ifo2]['start']
 max_tsid = numpy.rint(max_tsid) // opts.decimation_factor
 
 tsids = numpy.arange(min_tsid, max_tsid, 1).astype(numpy.int64) * opts.decimation_factor
-old_mintsid = numpy.ceil(back_tsid.min() / float(opts.decimation_factor))
-old_maxtsid = int(back_tsid.max() / opts.decimation_factor)
-old_tsids = numpy.arange(old_mintsid, old_maxtsid, 1).astype(numpy.int64) * opts.decimation_factor
 
 allbkg_dur = 0
 allbkg_ifars = []

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -54,16 +54,15 @@ parser.add_argument('--decimation-factor', type=int, required=True,
                           'Decimation factor means that every nth time' 
                           'slide kept all of its coincident triggers in' 
                           'the HDF file.')
-parser.add_argument('--closed-box', action='store_true', default=False,
-                    help='Do not show any foreground triggers. '
-                          'Background only.')
+parser.add_argument('--open-box', action='store_true', default=False,
+                    help='Show the foreground triggers on the output plot. ')
 opts = parser.parse_args()
 
 # read file
 fp = h5py.File(opts.trigger_file, 'r')
 
 # get foreground IFAR values and cumulative number for each IFAR value
-if not opts.closed_box:
+if opts.open_box:
     fore_ifar = fp['foreground/ifar'][:]
     fore_ifar.sort()
     fore_cumnum = numpy.arange(len(fore_ifar), 0, -1)
@@ -153,11 +152,11 @@ xs, ys = pylab.poly_between(expected_ifar, error_minus, error_plus)
 pylab.fill(xs, ys, facecolor='y', alpha=0.2, label='$2N^{1/2}$ Errors')
 
 # plot the foreground triggers
-if not opts.closed_box:
+if not opts.open_box:
     pylab.loglog(fore_ifar, fore_cumnum, linestyle='None', color='blue', marker='^', label='Foreground')
 
 # format plot
-if not opts.closed_box and len(fore_cumnum) > 100:
+if not opts.open_box and len(fore_cumnum) > 100:
     pylab.ylim(0.8, 1.1 * len(fore_cumnum))
     pylab.xlim(0.9 * min(fore_ifar))
 else:

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -98,9 +98,21 @@ l1_segments = segments.segmentlist([segments.segment(s,e) for s,e in zip(fp['seg
 fig = pylab.figure(1)
 
 # get a unique list of timeslide_ids and loop over them
-min_tsid = numpy.ceil(back_tsid.min() / float(opts.decimation_factor))
-max_tsid = int(back_tsid.max() / opts.decimation_factor)
+interval = fp.attrs['timeslide_interval']
+ifo1, ifo2 = fp.attrs['detector_1'], fp.attrs['detector_2']
+min_tsid = (fp['segments'][ifo1]['start'][:].min() - \
+            fp['segments'][ifo2]['end'][:].max()) / interval
+min_tsid = numpy.rint(min_tsid) // opts.decimation_factor
+max_tsid = (fp['segments'][ifo1]['end'][:].max() - fp['segments'][ifo2]['start'][:].min()) / interval
+max_tsid = numpy.rint(max_tsid) // opts.decimation_factor
+
 tsids = numpy.arange(min_tsid, max_tsid, 1).astype(numpy.int64) * opts.decimation_factor
+old_mintsid = numpy.ceil(back_tsid.min() / float(opts.decimation_factor))
+old_maxtsid = int(back_tsid.max() / opts.decimation_factor)
+old_tsids = numpy.arange(old_mintsid, old_maxtsid, 1).astype(numpy.int64) * opts.decimation_factor
+
+print min_tsid, max_tsid
+print old_mintsid, old_maxtsid - 1
 
 allbkg_dur = 0
 allbkg_ifars = []

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -54,21 +54,18 @@ parser.add_argument('--decimation-factor', type=int, required=True,
                           'Decimation factor means that every nth time' 
                           'slide kept all of its coincident triggers in' 
                           'the HDF file.')
-parser.add_argument('--all-decimated-background-min-far', type=float,
+parser.add_argument('--all-decimated-background-min-ifar', type=float,
                     default=0.01, metavar='VAL',
-                    help='When plotting the green line representing all the '
-                          'decimated background, if it is plotted using all '
-                          'triggers it can be memory intensive and it is '
-                          'not normally informative to show the green line '
-                          'up to very small FARs. This value means that '
-                          'triggers with a FARs less than VAL (normalized '
-                          'to total foreground time, not total decimated '
-                          'background time) are not included. This does not '
-                          'in any way invalidate the result, the green line '
-                          'will simply cutoff at some point. The default '
-                          'value should be fine, so it is recommended not to '
-                          'supply this option, which will use the default '
-                          'value of 0.01 (per year).')
+                    help='Threshold the IFARs of decimated background events '
+                          'before combining them and rescaling to zerolag '
+                          '(green line). Plotting all decimated background '
+                          'can be memory intensive and is not necessary for '
+                          'checking the background estimate at interesting '
+                          'IFAR levels. Slide coincs with IFARs below VAL '
+                          'will be cut, the green line will then be valid for '
+                          'zerolag down to VAL*(zerolag coinc time/total '
+                          'decimated slide time). Recommended value equal '
+                          'to default value 0.01yr.')
 parser.add_argument('--open-box', action='store_true', default=False,
                     help='Show the foreground triggers on the output plot. ')
 opts = parser.parse_args()
@@ -135,7 +132,7 @@ for tsid in tsids:
     allbkg_dur = allbkg_dur + back_dur
     # Limit how far back the decimated background gets plotted
     red_trigs = back_ifar[ts_indx][back_ifar[ts_indx] > \
-                                          opt.all_decimated_background_min_far]
+                                        opts.all_decimated_background_min_ifar]
     allbkg_ifars.extend(red_trigs)
 
     # apply the correction factor for this time slide to its IFAR
@@ -199,7 +196,7 @@ pylab.ylabel('Cumulative Number')
 pylab.xlabel('Inverse False Alarm Rate (yr)')
 
 # save
-caption = 'This is a cumulative historgram of triggers. The blue triangles represent ' \
+caption = 'This is a cumulative histogram of triggers. The blue triangles represent ' \
           + 'coincident foreground triggers. The dashed line represents the expected background ' \
           + 'given the analysis time. The shaded regions represent ' \
           + 'counting errors. The gray lines are time slides treated as zero lag, here there are %d time ' %(plotted_slide_count) \

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -83,23 +83,6 @@ l1_segments = segments.segmentlist([segments.segment(s,e) for s,e in zip(fp['seg
 # make figure
 fig = pylab.figure(1)
 
-# plot the expected background
-pylab.loglog(expected_ifar, expected_cumnum, linestyle='--', linewidth=2, color='black', label='Expected Background')
-
-# plot the counting error
-error_plus = expected_cumnum + numpy.sqrt(expected_cumnum)
-error_minus = expected_cumnum - numpy.sqrt(expected_cumnum)
-error_minus = numpy.where(error_minus<=0, 1e-5, error_minus)
-xs, ys = pylab.poly_between(expected_ifar, error_minus, error_plus)
-pylab.fill(xs, ys, facecolor='y', alpha=0.4, label='$N^{1/2}$ Errors')
-
-# plot the counting error
-error_plus = expected_cumnum + 2 * numpy.sqrt(expected_cumnum)
-error_minus = expected_cumnum - 2*numpy.sqrt(expected_cumnum)
-error_minus = numpy.where(error_minus<=0, 1e-5, error_minus)
-xs, ys = pylab.poly_between(expected_ifar, error_minus, error_plus)
-pylab.fill(xs, ys, facecolor='y', alpha=0.2, label='$2N^{1/2}$ Errors')
-
 # get a unique list of timeslide_ids and loop over them
 min_tsid = numpy.ceil(back_tsid.min() / float(opts.decimation_factor))
 max_tsid = int(back_tsid.max() / opts.decimation_factor)
@@ -151,6 +134,23 @@ allbkg_ifars.sort()
 allbkg_cumnum = numpy.arange(len(allbkg_ifars), 0, -1)
 pylab.loglog(allbkg_ifars, allbkg_cumnum, color='green', linewidth=1.5,
              label="All decimated background")
+
+# plot the expected background
+pylab.loglog(expected_ifar, expected_cumnum, linestyle='--', linewidth=2, color='black', label='Expected Background')
+
+# plot the counting error
+error_plus = expected_cumnum + numpy.sqrt(expected_cumnum)
+error_minus = expected_cumnum - numpy.sqrt(expected_cumnum)
+error_minus = numpy.where(error_minus<=0, 1e-5, error_minus)
+xs, ys = pylab.poly_between(expected_ifar, error_minus, error_plus)
+pylab.fill(xs, ys, facecolor='y', alpha=0.4, label='$N^{1/2}$ Errors')
+
+# plot the counting error
+error_plus = expected_cumnum + 2 * numpy.sqrt(expected_cumnum)
+error_minus = expected_cumnum - 2*numpy.sqrt(expected_cumnum)
+error_minus = numpy.where(error_minus<=0, 1e-5, error_minus)
+xs, ys = pylab.poly_between(expected_ifar, error_minus, error_plus)
+pylab.fill(xs, ys, facecolor='y', alpha=0.2, label='$2N^{1/2}$ Errors')
 
 # plot the foreground triggers
 if not opts.closed_box:

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -54,6 +54,21 @@ parser.add_argument('--decimation-factor', type=int, required=True,
                           'Decimation factor means that every nth time' 
                           'slide kept all of its coincident triggers in' 
                           'the HDF file.')
+parser.add_argument('--all-decimated-background-min-far', type=float,
+                    default=0.01, metavar='VAL',
+                    help='When plotting the green line representing all the '
+                          'decimated background, if it is plotted using all '
+                          'triggers it can be memory intensive and it is '
+                          'not normally informative to show the green line '
+                          'up to very small FARs. This value means that '
+                          'triggers with a FARs less than VAL (normalized '
+                          'to total foreground time, not total decimated '
+                          'background time) are not included. This does not '
+                          'in any way invalidate the result, the green line '
+                          'will simply cutoff at some point. The default '
+                          'value should be fine, so it is recommended not to '
+                          'supply this option, which will use the default '
+                          'value of 0.01 (per year).')
 parser.add_argument('--open-box', action='store_true', default=False,
                     help='Show the foreground triggers on the output plot. ')
 opts = parser.parse_args()
@@ -106,8 +121,9 @@ for tsid in tsids:
         continue
     plotted_slide_count += 1
     allbkg_dur = allbkg_dur + back_dur
-    # Don't plot all triggers!!!
-    red_trigs = back_ifar[ts_indx][back_ifar[ts_indx] > 0.01]
+    # Limit how far back the decimated background gets plotted
+    red_trigs = back_ifar[ts_indx][back_ifar[ts_indx] > \
+                                          opt.all_decimated_background_min_far]
     allbkg_ifars.extend(red_trigs)
 
     # apply the correction factor for this time slide to its IFAR
@@ -157,9 +173,12 @@ if not opts.open_box:
 
 # format plot
 if not opts.open_box and len(fore_cumnum) > 100:
+    # If we have > 100 foreground triggers, scale the plot around the foreground
     pylab.ylim(0.8, 1.1 * len(fore_cumnum))
     pylab.xlim(0.9 * min(fore_ifar))
 else:
+    # If we have < 100 foreground triggers (or this is closed box), scale the
+    # plot around the cumulative background (the green line).
     pylab.ylim(0.8, 1.1 * len(allbkg_cumnum))
     pylab.xlim(0.9 * min(allbkg_ifars))
 pylab.grid()
@@ -169,11 +188,12 @@ pylab.xlabel('Inverse False Alarm Rate (yr)')
 
 # save
 caption = 'This is a cumulative historgram of triggers. The blue triangles represent ' \
-          + 'coincident foreground triggers. The dashed line represents the expected background, ' \
-          + 'the expected background is determined by the foreground time. The shaded regions represent ' \
+          + 'coincident foreground triggers. The dashed line represents the expected background ' \
+          + 'given the analysis time. The shaded regions represent ' \
           + 'counting errors. The gray lines are time slides treated as zero lag, here there are %d time ' %(plotted_slide_count) \
           + 'slides plotted. Gray dots are time slides with only one event. ' \
-          + '%d of the plotted slides have no events at all.' %(empty_slide_count)
+          + '%d of the plotted slides have zero events. ' %(empty_slide_count) \
+          + 'The green line represents all decimated time slides rescaled to the analysis time.'
 pycbc.results.save_fig_with_metadata(fig, opts.output_file,
      title='Cumulative Number vs. IFAR',
      caption=caption,

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -108,9 +108,6 @@ old_mintsid = numpy.ceil(back_tsid.min() / float(opts.decimation_factor))
 old_maxtsid = int(back_tsid.max() / opts.decimation_factor)
 old_tsids = numpy.arange(old_mintsid, old_maxtsid, 1).astype(numpy.int64) * opts.decimation_factor
 
-print min_tsid, max_tsid
-print old_mintsid, old_maxtsid - 1
-
 allbkg_dur = 0
 allbkg_ifars = []
 empty_slide_count = 0
@@ -177,11 +174,11 @@ xs, ys = pylab.poly_between(expected_ifar, error_minus, error_plus)
 pylab.fill(xs, ys, facecolor='y', alpha=0.2, label='$2N^{1/2}$ Errors')
 
 # plot the foreground triggers
-if not opts.open_box:
+if opts.open_box:
     pylab.loglog(fore_ifar, fore_cumnum, linestyle='None', color='blue', marker='^', label='Foreground')
 
 # format plot
-if not opts.open_box and len(fore_cumnum) > 100:
+if opts.open_box and len(fore_cumnum) > 100:
     # If we have > 100 foreground triggers, scale the plot around the foreground
     pylab.ylim(0.8, 1.1 * len(fore_cumnum))
     pylab.xlim(0.9 * min(fore_ifar))

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -54,15 +54,19 @@ parser.add_argument('--decimation-factor', type=int, required=True,
                           'Decimation factor means that every nth time' 
                           'slide kept all of its coincident triggers in' 
                           'the HDF file.')
+parser.add_argument('--closed-box', action='store_true', default=False,
+                    help='Do not show any foreground triggers. '
+                          'Background only.')
 opts = parser.parse_args()
 
 # read file
 fp = h5py.File(opts.trigger_file, 'r')
 
 # get foreground IFAR values and cumulative number for each IFAR value
-fore_ifar = fp['foreground/ifar'][:]
-fore_ifar.sort()
-fore_cumnum = numpy.arange(len(fore_ifar), 0, -1)
+if not opts.closed_box:
+    fore_ifar = fp['foreground/ifar'][:]
+    fore_ifar.sort()
+    fore_cumnum = numpy.arange(len(fore_ifar), 0, -1)
 
 # get expected foreground IFAR values and cumulative number for each IFAR value
 expected_ifar = numpy.logspace(-8, 2, num=100, endpoint=True, base=10.0)
@@ -100,6 +104,12 @@ pylab.fill(xs, ys, facecolor='y', alpha=0.2, label='$2N^{1/2}$ Errors')
 min_tsid = numpy.ceil(back_tsid.min() / float(opts.decimation_factor))
 max_tsid = int(back_tsid.max() / opts.decimation_factor)
 tsids = numpy.arange(min_tsid, max_tsid, 1).astype(numpy.int64) * opts.decimation_factor
+
+allbkg_dur = 0
+allbkg_ifars = []
+empty_slide_count = 0
+plotted_slide_count = 0
+
 for tsid in tsids:
     if tsid == 0:
         continue
@@ -110,6 +120,13 @@ for tsid in tsids:
     # calculate the amount of coincident time in this time slide
     offset = tsid*fp.attrs['timeslide_interval']
     back_dur = calculate_time_slide_duration(h1_segments, l1_segments, offset=offset)
+    if back_dur == 0:
+        continue
+    plotted_slide_count += 1
+    allbkg_dur = allbkg_dur + back_dur
+    # Don't plot all triggers!!!
+    red_trigs = back_ifar[ts_indx][back_ifar[ts_indx] > 0.01]
+    allbkg_ifars.extend(red_trigs)
 
     # apply the correction factor for this time slide to its IFAR
     # you need a correction factor because the analyzed time of the time slide
@@ -121,26 +138,43 @@ for tsid in tsids:
     ts_cumnum = numpy.arange(len(ts_ifar), 0, -1)
 
     # plot the time slide triggers
-    pylab.loglog(ts_ifar, ts_cumnum, color='gray', alpha=0.4)
+    if len(ts_ifar) > 1:
+        pylab.loglog(ts_ifar, ts_cumnum, color='gray', alpha=0.4)
+    elif len(ts_ifar) == 1:
+        pylab.plot(ts_ifar, ts_cumnum, color='gray', marker='.', alpha=0.4)
+    else:
+        empty_slide_count += 1
+
+allbkg_ifars = numpy.array(allbkg_ifars)
+allbkg_ifars = allbkg_ifars * (fp.attrs['foreground_time'] / allbkg_dur )
+allbkg_ifars.sort()
+allbkg_cumnum = numpy.arange(len(allbkg_ifars), 0, -1)
+pylab.loglog(allbkg_ifars, allbkg_cumnum, color='green', linewidth=1.5,
+             label="All decimated background")
 
 # plot the foreground triggers
-pylab.loglog(fore_ifar, fore_cumnum, linestyle='None', color='blue', marker='^', label='Foreground')
+if not opts.closed_box:
+    pylab.loglog(fore_ifar, fore_cumnum, linestyle='None', color='blue', marker='^', label='Foreground')
 
 # format plot
-if len(fore_cumnum) > 0:
+if not opts.closed_box and len(fore_cumnum) > 100:
     pylab.ylim(0.8, 1.1 * len(fore_cumnum))
     pylab.xlim(0.9 * min(fore_ifar))
+else:
+    pylab.ylim(0.8, 1.1 * len(allbkg_cumnum))
+    pylab.xlim(0.9 * min(allbkg_ifars))
 pylab.grid()
 pylab.legend()
 pylab.ylabel('Cumulative Number')
 pylab.xlabel('Inverse False Alarm Rate (yr)')
 
 # save
-caption = 'This is a cumulative historgram of triggers. The blue triangles represent' \
-          + 'coincident foreground triggers. The dashed line represents the expected background,' \
-          + 'the expected background is determined by the foreground time. The shaded regions represent' \
-          + 'counting errors. The gray lines are time slides treated as zero lag, here there are %d time'%(len(tsids)) \
-          + 'slides plotted.'
+caption = 'This is a cumulative historgram of triggers. The blue triangles represent ' \
+          + 'coincident foreground triggers. The dashed line represents the expected background, ' \
+          + 'the expected background is determined by the foreground time. The shaded regions represent ' \
+          + 'counting errors. The gray lines are time slides treated as zero lag, here there are %d time ' %(plotted_slide_count) \
+          + 'slides plotted. Gray dots are time slides with only one event. ' \
+          + '%d of the plotted slides have no events at all.' %(empty_slide_count)
 pycbc.results.save_fig_with_metadata(fig, opts.output_file,
      title='Cumulative Number vs. IFAR',
      caption=caption,


### PR DESCRIPTION
Here are the code changes that were needed to make the changes to section IV (ie. page ifar) here:

https://atlas1.atlas.aei.uni-hannover.de/~spxiwh/LSC/aLIGO/O1/analyses/chunk5/o1-analysis5_pt8_invinjs/

as I showed on the call yesterday.

@tdent wanted to look at the changes to pycbc_page_ifar and suggest improvements to the comment.

There is also a potential issue that without the config file changes that I have, open box plots will appear in section 4. Should we change the behaviour so that pycbc_page_ifar requires a --open-box argument to show open-box results instead of doing this by default?