### PR TITLE
Stop conflation of inj sets with similar tags in GRB workflow

### DIFF
--- a/pycbc/workflow/legacy_ihope.py
+++ b/pycbc/workflow/legacy_ihope.py
@@ -489,7 +489,8 @@ class LegacyCohPTFInjcombiner(LegacyAnalysisExecutable):
 
         out_files = FileList([])
         for inj_trig in inj_trigs:
-            out_file_tag = [inj_string, "FILTERED", max_inc,
+            out_string = inj_string.split(max_inc)[0]
+            out_file_tag = [out_string, "FILTERED", max_inc,
                             inj_trig.tag_str.rsplit('_', 1)[-1]]
             out_file = File(self.ifos, inj_trig.description,
                             inj_trig.segment, extension="xml",

--- a/pycbc/workflow/postprocessing_cohptf.py
+++ b/pycbc/workflow/postprocessing_cohptf.py
@@ -223,8 +223,8 @@ def setup_postproc_coh_PTF_workflow(workflow, trig_files, trig_cache,
         pp_outs.extend(FileList([fm_cache]))
 
         # Set up injcombiner jobs
-        injcombiner_outs = FileList([file for file in injfinder_outs \
-                                     if "DETECTION" in file.tag_str])
+        injcombiner_outs = FileList([f for f in injfinder_outs \
+                                     if "DETECTION" in f.tag_str])
         injcombiner_tags = [inj_tag for inj_tag in inj_tags \
                             if "DETECTION" not in inj_tag]
         injcombiner_out_tags = [i.tag_str.rsplit('_', 1)[0] for i in \
@@ -234,13 +234,14 @@ def setup_postproc_coh_PTF_workflow(workflow, trig_files, trig_cache,
         for injcombiner_tag in injcombiner_tags:
             max_inc = cp.get_opt_tags("injections", "max-inc",
                                       [injcombiner_tag])
-            inj_str = injcombiner_tag.replace("INJ", "").split(max_inc)[0]
+            inj_str = injcombiner_tag.replace("INJ", "")
             inputs = FileList([f for f in injfinder_outs \
                                if injcombiner_tag in f.tagged_description])
             injcombiner_node, curr_outs = injcombiner_jobs.create_node(\
                     fm_cache, inputs, inj_str, max_inc, workflow.analysis_time)
             injcombiner_nodes.append(injcombiner_node)
-            injcombiner_out_tags.append("%s_FILTERED_%s" % (inj_str, max_inc))
+            injcombiner_out_tags.append("%s_FILTERED_%s"
+                                        % (inj_str.split(max_inc)[0], max_inc))
             injcombiner_outs.extend(curr_outs)
             pp_outs.extend(curr_outs)
             pp_nodes.append(injcombiner_node)


### PR DESCRIPTION
This change stops injection sets with similar tags being combined by pylal_cbc_cohptf_injcombiner. Before this change, if we had 3 injection sets with tags 'nsns30inj', 'nsnsnospins30inj', and 'nsns100mpc30inj', injections from all of these would be included in the found/missed files that should only include 'nsns30inj' injections.

Now we pass the full tag (less the compulsory 'inj' suffix) and this fixes the issue when combined with ligo-cbc/pycbc-pylal#20