### PR TITLE
Make pycbc_single_template be able to use the closest injection as filter

### DIFF
--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -158,7 +158,7 @@ for num_event in range(num_events):
 
     files += mini.make_single_template_plots(workflow, insp_segs,
                             args.inspiral_segment_name, inj_params,
-                            args.output_dir,
+                            args.output_dir, inj_file=injection_xml_file,
                             tags=args.tags+['INJ_PARAMS_NOINJ',
                                             str(num_event)],
                             params_str='injection parameters, no injection.')

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -147,21 +147,27 @@ for num_event in range(num_events):
                             args.inspiral_segment_name, inj_params,
                             args.output_dir, inj_file=injection_xml_file,
                             tags=args.tags+['INJ_PARAMS',str(num_event)],
-                            params_str='injection parameters.')
+                            params_str='injection parameters as template, ' +\
+                                       'here the injection is made as normal',
+                            use_exact_inj_params=True)
 
     files += mini.make_single_template_plots(workflow, insp_segs,
                             args.inspiral_segment_name, inj_params,
                             args.output_dir, inj_file=injection_xml_file,
                             tags=args.tags+['INJ_PARAMS_INVERTED',
                                             str(num_event)],
-                            params_str='injection parameters inverted.')
+                            params_str='injection parameters as template, ' +\
+                                       'here the injection is made inverted',
+                            use_exact_inj_params=True)
 
     files += mini.make_single_template_plots(workflow, insp_segs,
                             args.inspiral_segment_name, inj_params,
                             args.output_dir, inj_file=injection_xml_file,
                             tags=args.tags+['INJ_PARAMS_NOINJ',
                                             str(num_event)],
-                            params_str='injection parameters, no injection.')
+                            params_str='injection parameters, here no ' +\
+                                       'injection was actually performed',
+                            use_exact_inj_params=True)
 
     for curr_ifo in args.single_detector_triggers:
         single_fname = args.single_detector_triggers[curr_ifo]

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -22,7 +22,7 @@ from pycbc import vetoes, psd, waveform, version, strain, scheme, fft, filter
 from pycbc import events
 from pycbc.filter import resample_to_delta_t
 from pycbc.types import zeros, float32, complex64, TimeSeries, FrequencySeries
-from pycbc.types import real_same_precision_as
+from pycbc.types import complex_same_precision_as
 
 def select_segment(fname, segment, ifo, time, start_pad, end_pad):
     segs = events.select_segments_by_definer(fname, segment, ifo)
@@ -160,11 +160,6 @@ row.params.mass2 = opt.mass2
 row.params.spin1z = opt.spin1z
 row.params.spin2z = opt.spin2z
 
-chisq_bins = int(vetoes.SingleDetPowerChisq.parse_option(row, opt.chisq_bins))
-# FIXME: This check is hacky!
-if opt.approximant and 'params' in opt.approximant:
-    opt.approximant = waveform.FilterBank.parse_option(row, opt.approximant)
-
 with ctx:
     fft.from_cli(opt)
     flow = opt.low_frequency_cutoff
@@ -186,10 +181,16 @@ with ctx:
             err_msg += "be making injections with an injection file and using "
             err_msg += "the --trigger-time option."
             raise ValueError(err_msg)
+        logging.info("Making template directly from injection.")
         inj_set = gwstrain.injections
         end_times = numpy.array(inj_set.end_times())
         inj_idx = abs(end_times - opt.trigger_time).argmin()
         inj = inj_set.table[inj_idx]
+        # Use injection values for things like choosing number of chisq bins
+        row.params.mass1 = opt.mass1 = inj.mass1
+        row.params.mass2 = opt.mass2 = inj.mass2
+        row.params.spin1z = opt.spin1z = inj.spin1z
+        row.params.spin2z = opt.spin2z = inj.spin2z
         # FIXME: Don't like hardcoded 16384 here
         # NOTE: f_lower is set in strain.py as inj.f_lower, but this is a
         #       little unclear to see and caused me some problems! Stating
@@ -199,27 +200,17 @@ with ctx:
                                     distance_scale=opt.injection_scale_factor)
         td_template = resample_to_delta_t(td_template, gwstrain.delta_t,
                                           method='ldas')
-        td_template._epoch -= inj.get_end(site=opt.channel_name[0])
-        # total duration of the waveform
-        tmplt_length = len(td_template) * td_template.delta_t
-        # for IMR templates the zero of time is at max amplitude (merger)
-        # thus the start time is minus the duration of the template from
-        # lower frequency cutoff to merger, i.e. minus the 'chirp time'
-        tChirp = - float(td_template.start_time )  # conversion from LIGOTimeGPS
-        td_template.resize((flen-1)*2)
-        k_zero = int(td_template.start_time / td_template.delta_t)
-        td_template.roll(k_zero)
         td_template = td_template * pycbc.DYN_RANGE_FAC
-        # Create output memory
-        out = zeros(flen, dtype=complex64)
-        template = FrequencySeries(out, delta_f=delta_f, copy=False) 
-        # And FFT
-        fft.fft(td_template.astype(real_same_precision_as(template)), template)
-
-        template.length_in_time = tmplt_length
-        template.chirp_length = tChirp
+        td_template._epoch -= inj.get_end(site=opt.channel_name[0])
         opt.approximant = inj.waveform
+        template = waveform.td_waveform_to_fd_waveform(td_template, length=flen)
+        template = template.astype(complex_same_precision_as(segments[0]))
     else:
+        # FIXME: This check is hacky!
+        if opt.approximant and 'params' in opt.approximant:
+            opt.approximant = waveform.FilterBank.parse_option(row,
+                                                               opt.approximant)
+        logging.info("Making template: %s" % opt.approximant)
         template = waveform.get_waveform_filter(zeros(flen, dtype=complex64), 
                                     approximant=opt.approximant,
                                     mass1=opt.mass1, mass2=opt.mass2,
@@ -227,6 +218,9 @@ with ctx:
                                     taper=opt.taper_template, 
                                     f_lower=flow, delta_f=delta_f,
                                     delta_t=gwstrain.delta_t)
+    chisq_bins = int(vetoes.SingleDetPowerChisq.parse_option(row,
+                                                               opt.chisq_bins))
+
     f['template'] = template.numpy()                  
     snrs, chisqs = [], []  
     raw_bins = [[] for b in range(chisq_bins)]

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -18,8 +18,11 @@
 a specific Nth loudest coincident event.
 """
 import sys, logging, argparse, numpy, itertools, pycbc, h5py
-from pycbc import vetoes, psd, waveform, version, strain, scheme, fft, filter, events
-from pycbc.types import zeros, float32, complex64, TimeSeries
+from pycbc import vetoes, psd, waveform, version, strain, scheme, fft, filter
+from pycbc import events
+from pycbc.filter import resample_to_delta_t
+from pycbc.types import zeros, float32, complex64, TimeSeries, FrequencySeries
+from pycbc.types import real_same_precision_as
 
 def select_segment(fname, segment, ifo, time, start_pad, end_pad):
     segs = events.select_segments_by_definer(fname, segment, ifo)
@@ -48,22 +51,30 @@ parser.add_argument("--chisq-bins", default="0", type=str, help=
                     "Number of frequency bins to use for power chisq.")
 parser.add_argument("--psd-recalculate-segments", type=int, 
                     help="Number of segments to use before recalculating the PSD", default=0)
-parser.add_argument("--approximant", type=str,
-                  help="The name of the approximant to use for filtering. ")
-parser.add_argument("--mass1", type=float, 
-                  help="The mass of the first component object. "
-                       "Do not use if giving a statmap file")
-parser.add_argument("--mass2", type=float,
-                  help="The mass of the second component object. "
-                    "Do not use if giving a statmap file.")
-parser.add_argument("--spin1z", type=float, default=0,
-                  help="The aligned spin of the first component object. "
-                    "Do not use if giving a statmap file.")
-parser.add_argument("--spin2z", type=float, default=0,
-                  help="The aligned pin of the second component object. "
-                    "Do not use if giving a statmap file.")
 parser.add_argument("--trigger-time", type=float, default=0,
                   help="The central time of the trigger to use.")
+parser.add_argument("--use-params-of-closest-injection", action="store_true",
+                  default=False,
+                  help="If given, use the injection with end_time closest to "
+                       "--trigger-time as the waveform for filtering. If "
+                       "using this do not supply mass and spin options. "
+                       "Using this requires trigger-time and injection-file "
+                       "to be given.")
+parser.add_argument("--approximant", type=str,
+                  help="The name of the approximant to use for filtering. "
+                      "Do not use if using --use-params-of-closest-injection.")
+parser.add_argument("--mass1", type=float, 
+                  help="The mass of the first component object. "
+                      "Do not use if using --use-params-of-closest-injection.")
+parser.add_argument("--mass2", type=float,
+                  help="The mass of the second component object. "
+                      "Do not use if using --use-params-of-closest-injection.")
+parser.add_argument("--spin1z", type=float, default=0,
+                  help="The aligned spin of the first component object. "
+                      "Do not use if using --use-params-of-closest-injection.")
+parser.add_argument("--spin2z", type=float, default=0,
+                  help="The aligned pin of the second component object. "
+                      "Do not use if using --use-params-of-closest-injection.")
 parser.add_argument("--window", type=float, 
                   help="Time to save around the trigger time (if given)")
 parser.add_argument("--order", type=int,
@@ -150,7 +161,8 @@ row.params.spin1z = opt.spin1z
 row.params.spin2z = opt.spin2z
 
 chisq_bins = int(vetoes.SingleDetPowerChisq.parse_option(row, opt.chisq_bins))
-if 'params' in opt.approximant:
+# FIXME: This check is hacky!
+if opt.approximant and 'params' in opt.approximant:
     opt.approximant = waveform.FilterBank.parse_option(row, opt.approximant)
 
 with ctx:
@@ -168,7 +180,47 @@ with ctx:
                          flen, delta_f, flow)
 
     logging.info("Making template: %s" % opt.approximant)
-    template = waveform.get_waveform_filter(zeros(flen, dtype=complex64), 
+    if opt.use_params_of_closest_injection:
+        if gwstrain.injections is None or not opt.trigger_time:
+            err_msg = "To use --use-params-of-closest-injection you must "
+            err_msg += "be making injections with an injection file and using "
+            err_msg += "the --trigger-time option."
+            raise ValueError(err_msg)
+        inj_set = gwstrain.injections
+        end_times = numpy.array(inj_set.end_times())
+        inj_idx = abs(end_times - opt.trigger_time).argmin()
+        inj = inj_set.table[inj_idx]
+        # FIXME: Don't like hardcoded 16384 here
+        # NOTE: f_lower is set in strain.py as inj.f_lower, but this is a
+        #       little unclear to see and caused me some problems! Stating
+        #       this clearly here so no-one makes the same mistake as me.
+        td_template = inj_set.make_strain_from_inj_object(inj, 1./16384.,
+                                    opt.channel_name[0:2], f_lower=inj.f_lower,
+                                    distance_scale=opt.injection_scale_factor)
+        td_template = resample_to_delta_t(td_template, gwstrain.delta_t,
+                                          method='ldas')
+        td_template._epoch -= inj.get_end(site=opt.channel_name[0])
+        # total duration of the waveform
+        tmplt_length = len(td_template) * td_template.delta_t
+        # for IMR templates the zero of time is at max amplitude (merger)
+        # thus the start time is minus the duration of the template from
+        # lower frequency cutoff to merger, i.e. minus the 'chirp time'
+        tChirp = - float(td_template.start_time )  # conversion from LIGOTimeGPS
+        td_template.resize((flen-1)*2)
+        k_zero = int(td_template.start_time / td_template.delta_t)
+        td_template.roll(k_zero)
+        td_template = td_template * pycbc.DYN_RANGE_FAC
+        # Create output memory
+        out = zeros(flen, dtype=complex64)
+        template = FrequencySeries(out, delta_f=delta_f, copy=False) 
+        # And FFT
+        fft.fft(td_template.astype(real_same_precision_as(template)), template)
+
+        template.length_in_time = tmplt_length
+        template.chirp_length = tChirp
+        opt.approximant = inj.waveform
+    else:
+        template = waveform.get_waveform_filter(zeros(flen, dtype=complex64), 
                                     approximant=opt.approximant,
                                     mass1=opt.mass1, mass2=opt.mass2,
                                     spin1z=opt.spin1z, spin2z=opt.spin2z,

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -176,7 +176,7 @@ with ctx:
 
     logging.info("Making template: %s" % opt.approximant)
     if opt.use_params_of_closest_injection:
-        if gwstrain.injections is None or not opt.trigger_time:
+        if not hasattr(gwstrain, 'injections') or not opt.trigger_time:
             err_msg = "To use --use-params-of-closest-injection you must "
             err_msg += "be making injections with an injection file and using "
             err_msg += "the --trigger-time option."

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -32,6 +32,11 @@ from numpy import log
 import numpy
 from scipy.optimize import bisect
 
+def nearest_larger_binary_number(input_len):
+    """ Return the nearest binary number larger than input_len.
+    """
+    return 2**numpy.ceil(numpy.log2(input_len))
+
 def chirp_distance(dist, mchirp, ref_mass=1.4):
     return dist * (2.**(-1./5) * ref_mass / mchirp)**(5./6)
 

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -260,8 +260,6 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
 
     if opt.injection_file or opt.sgburst_injection_file:
         strain.injections = injections
-    else:
-        strain.injections = None
 
     strain.gating_info = gating_info
 

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -258,8 +258,10 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
             logging.info("Converting to float32")
             strain = (dyn_range_fac * strain).astype(float32)
 
-    if opt.injection_file:
+    if opt.injection_file or opt.sgburst_injection_file:
         strain.injections = injections
+    else:
+        strain.injections = None
 
     strain.gating_info = gating_info
 

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -275,7 +275,8 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
 
 def make_single_template_plots(workflow, segs, seg_name, params,
                                    out_dir, inj_file=None, exclude=None,
-                                   require=None, tags=None, params_str=None):
+                                   require=None, tags=None, params_str=None,
+                                   use_exact_inj_params=False):
     tags = [] if tags is None else tags
     makedir(out_dir)
     name = 'single_template_plot'
@@ -287,10 +288,13 @@ def make_single_template_plots(workflow, segs, seg_name, params,
             # Reanalyze the time around the trigger in each detector
             node = PlotExecutable(workflow.cp, 'single_template', ifos=[ifo],
                               out_dir=out_dir, tags=[tag] + tags).create_node()
-            node.add_opt('--mass1', "%.6f" % params['mass1'])
-            node.add_opt('--mass2', "%.6f" % params['mass2'])
-            node.add_opt('--spin1z',"%.6f" % params['spin1z'])
-            node.add_opt('--spin2z',"%.6f" % params['spin2z'])
+            if use_exact_inj_params:
+                node.add_opt('--use-params-of-closest-injection')
+            else:
+                node.add_opt('--mass1', "%.6f" % params['mass1'])
+                node.add_opt('--mass2', "%.6f" % params['mass2'])
+                node.add_opt('--spin1z',"%.6f" % params['spin1z'])
+                node.add_opt('--spin2z',"%.6f" % params['spin2z'])
             # str(numpy.float64) restricts to 2d.p. BE CAREFUL WITH THIS!!!
             str_trig_time = '%.6f' %(params[ifo + '_end_time'])
             node.add_opt('--trigger-time', str_trig_time)
@@ -316,8 +320,11 @@ def make_single_template_plots(workflow, segs, seg_name, params,
             caption = "'The SNR and chi^2 timeseries around the injection"
             if params_str is not None:
                 caption += " using %s" %(params_str)
-            caption += ". The template used has the following parameters: "
-            caption += "mass1=%s, mass2=%s, spin1z=%s, spin2z=%s'"\
+            if use_exact_inj_params:
+                caption += ". The injection itself was used as the template.'"
+            else:
+                caption += ". The template used has the following parameters: "
+                caption += "mass1=%s, mass2=%s, spin1z=%s, spin2z=%s'"\
                        %(params['mass1'], params['mass2'], params['spin1z'],
                          params['spin2z'])
             node.add_opt('--plot-caption', caption)


### PR DESCRIPTION
Our minifollowup plots of precessing injections are currently broken when using the injection parameters because the precessing injection is filtered against an aligned-spin template with similar parameters to the injection. (They are also broken to a smaller degree in the case of an aligned-spin injection with a different approximant to the template bank).

This fixes this by allowing the pycbc_single_template code to take a use-params-of-closest-injection option, which filters against the actual injection that went into the data. This requires some restructuring of the injection module, but no changes to functionality other than being able to regenerate injection waveforms .... There is also the possibility to extend this to store the injected waveforms to avoid regeneration, but I don't add this at this time.

This can create a meaningful precessing injection followup:

https://galahad.aei.mpg.de/~spxiwh/LVC/aLIGO/O1/analyses/o1-analysis5_pt10_invinjs_mk2/5._injections/5.10_followup_of_missed_NSBHPRECT2_INJ/

Some further cosmetic changes to the caption when running this will be added soon, but I wanted to see if you are happy with the idea behind this first.

There are some associated ini file changes, which are reasonably straightforward. Maybe the only hacky bit is that I still want to do the plots with injection parameters but no injections. To avoid issues here I now make the injection, but set the scale factor really high so the injection is made at such a large distance it has an SNR of essentially 0. I didn't like the idea of sending an injection file and not actually making an injection.