### PR TITLE
Adding missing import of sys to PyGRB

### DIFF
--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -28,6 +28,7 @@ __date__ = pycbc.version.date
 __program__ = "pycbc_make_offline_grb_workflow"
 
 import shutil
+import sys
 import os
 import argparse
 import logging


### PR DESCRIPTION
Hi Steve,

pycbc_make_offline_grb_workflow has a missing import of sys. When the GRB doesn't fall within any science segments the code should produce the segments plot then exit gracefully via sys.exit().

Cheers,
Andrew