### PR TITLE
Fix typo

### DIFF
--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -199,7 +199,7 @@ for bin_file in bin_files:
                     cumulative=False, tags=bin_file.tags + ['ifar'])
     ifar = wf.make_ifar_plot(workflow, bin_file, 
                     rdir['open_box_result/significance'],
-                    tags=bin_file.tags + ['open_box')
+                    tags=bin_file.tags + ['open_box'])
     # Closed box
     ifar = wf.make_ifar_plot(workflow, bin_file,
                     rdir['coincident_triggers'],


### PR DESCRIPTION
As Steve noticed, a typo was introduced in the last commit. I'm not really sure how I missed this, as I ran an end-to-end test with the workflow and did not hit this. Therefore I am running the test again after having removed my PyCBC install directory. I'll put this here so that the Travis tests can run while this is happening.

Because the workflow generator is broken right now I will push myself once sanity checks complete.