### PR TITLE
Fix so that pycbc_make_html_page will not fail if there are non-LIGOLW XML files

### DIFF
--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -126,8 +126,8 @@ def render_default(path, cp):
         with open(path, 'r') as xmlfile:
             try:
                 content = fromsegmentxml(xmlfile, return_dict=True)
-            except ValueError:
-                pass
+            except Exception as e:
+                print 'No segment table found in', path, ':', e
 
     # render template
     template_dir = pycbc.results.__path__[0] + '/templates/files'


### PR DESCRIPTION
Currently ``pycbc_make_html_page`` will fail if there is a non-LIGOLW XML file in the results dir.

This patch makes the try-except statement more general to allow this case to be ignored.