### PR TITLE
Make group an option for ForegroundTriggers

### DIFF
--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -437,8 +437,9 @@ class SingleDetTriggers(object):
 
 class ForegroundTriggers(object):
     # FIXME: A lot of this is hardcoded to expect two ifos
-    def __init__(self, coinc_file, bank_file, sngl_files=None, n_loudest=None):
-        self.coinc_file = FileData(coinc_file, group='foreground')
+    def __init__(self, coinc_file, bank_file, sngl_files=None, n_loudest=None,
+                     group='foreground'):
+        self.coinc_file = FileData(coinc_file, group=group)
         self.sngl_files = {}
         if sngl_files is not None:
             for file in sngl_files:


### PR DESCRIPTION
This PR makes group an option for the ``ForegroundTriggers`` class in the ``pycbc.io.hdf`` module.

The reason is that this class has a nice LIGOLW XML file writing function that I'd like to use to write the ``background_exc`` triggers in the HDF files to LIGOLW XML files.