### PR TITLE
handle corner case where foreground is quieter than background

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -119,8 +119,12 @@ back_cnum, fnlouder = coinc.calculate_n_louder(back_stat, fore_stat,
 back_cnum_exc, fnlouder_exc = coinc.calculate_n_louder(e.stat, fore_stat, 
                                                e.decimation_factor)         
 
+
 f['background/ifar'] = sec_to_year(background_time / (back_cnum + 1))  
 f['background_exc/ifar'] = sec_to_year(background_time_exc / (back_cnum_exc + 1))
+
+print fnlouder, fore_stat
+
 
 f.attrs['background_time'] = background_time
 f.attrs['foreground_time'] = coinc_time

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -123,9 +123,6 @@ back_cnum_exc, fnlouder_exc = coinc.calculate_n_louder(e.stat, fore_stat,
 f['background/ifar'] = sec_to_year(background_time / (back_cnum + 1))  
 f['background_exc/ifar'] = sec_to_year(background_time_exc / (back_cnum_exc + 1))
 
-print fnlouder, fore_stat
-
-
 f.attrs['background_time'] = background_time
 f.attrs['foreground_time'] = coinc_time
 f.attrs['background_time_exc'] = background_time_exc

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -108,6 +108,9 @@ def calculate_n_louder(bstat, fstat, dec, skip_background=False):
     # found index
     idx = numpy.searchsorted(bstat, fstat, side='left') - 1
 
+    # If the foreground are *quieter* than the background or at the same value
+    # then the search sorted alorithm will choose position -1, which does not exist
+    # We force it back to zero. 
     if isinstance(idx, numpy.ndarray):
         idx[idx < 0] = 0
     else:

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -111,9 +111,9 @@ def calculate_n_louder(bstat, fstat, dec, skip_background=False):
     # If the foreground are *quieter* than the background or at the same value
     # then the search sorted alorithm will choose position -1, which does not exist
     # We force it back to zero. 
-    if isinstance(idx, numpy.ndarray):
+    if isinstance(idx, numpy.ndarray): # Handle the case where our input is an array
         idx[idx < 0] = 0
-    else:
+    else: # Handle the case where we are simply given a scalar value
         if idx < 0:
             idx = 0
 

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -106,7 +106,15 @@ def calculate_n_louder(bstat, fstat, dec, skip_background=False):
     # We need to subtract one from the index, to be consistent with the definition
     # of n_louder, as here we do want to include the background value at the
     # found index
-    fore_n_louder = n_louder[numpy.searchsorted(bstat, fstat, side='left') - 1]
+    idx = numpy.searchsorted(bstat, fstat, side='left') - 1
+
+    if isinstance(idx, numpy.ndarray):
+        idx[idx < 0] = 0
+    else:
+        if idx < 0:
+            idx = 0
+
+    fore_n_louder = n_louder[idx]
 
     if not skip_background:
         unsort = sort.argsort()


### PR DESCRIPTION
Handle the corner case in the function which determines how many triggers are louder than the current value. Currently it would try to access the [-1]  position if the zerolag trigger is quieter than all the background. This isn't likely, but I've been able to force it to happen. 