### PR TITLE
Use tinj naming convention and use SimInspiral instance for derivative calculations

### DIFF
--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -401,7 +401,7 @@ for ifo in opts.instruments:
 
     # populate IFO distance columns
     eff_distance = effective_distance(sim.distance, sim.inclination,
-                                      f_plus, f_cross**2)
+                                      f_plus, f_cross)
     setattr(sim, 'eff_dist_'+ifo[0].lower(), eff_distance)
 
     # populate IFO end time columns

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -320,7 +320,7 @@ for ifo in opts.instruments:
 
     # get antenna pattern
     f_plus, f_cross = det.antenna_pattern(sim.longitude, sim.latitude,
-                        sim.polarization, sim.geocentric_end_time)
+                        sim.polarization, sim.geocent_end_time)
 
     # calculate strain
     logging.info('Calculating strain for %s', ifo)

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -400,7 +400,7 @@ for ifo in opts.instruments:
     setattr(sim, ifo[0].lower()+'_end_time_ns', int(end_time % 1 * 1e9))
 
     # populate IFO distance columns
-    eff_distance = sim.distance / ( 1 + numpy.cos( opts.inclination )**2 )**2 / 4 * f_plus**2 + numpy.cos( opts.inclination )**2 * f_cross**2
+    eff_distance = sim.distance / np.sqrt( ( 1 + numpy.cos( opts.inclination )**2 )**2 / 4 * f_plus**2 + numpy.cos( opts.inclination )**2 * f_cross**2 )
     setattr(sim, 'eff_dist_'+ifo[0].lower(), eff_distance)
 
     # populate IFO end time columns

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -400,7 +400,7 @@ for ifo in opts.instruments:
     setattr(sim, ifo[0].lower()+'_end_time_ns', int(end_time % 1 * 1e9))
 
     # populate IFO distance columns
-    eff_distance = sim.distance / np.sqrt( ( 1 + numpy.cos( sim.inclination )**2 )**2 / 4 * f_plus**2 + numpy.cos( sim.inclination )**2 * f_cross**2 )
+    eff_distance = sim.distance / numpy.sqrt( ( 1 + numpy.cos( sim.inclination )**2 )**2 / 4 * f_plus**2 + numpy.cos( sim.inclination )**2 * f_cross**2 )
     setattr(sim, 'eff_dist_'+ifo[0].lower(), eff_distance)
 
     # populate IFO end time columns

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -319,8 +319,8 @@ for ifo in opts.instruments:
     det = Detector(ifo)
 
     # get antenna pattern
-    f_plus, f_cross = det.antenna_pattern(opts.ra, opts.dec,
-                        opts.polarization, opts.geocentric_end_time)
+    f_plus, f_cross = det.antenna_pattern(sim.longitude, sim.latitude,
+                        sim.polarization, sim.geocentric_end_time)
 
     # calculate strain
     logging.info('Calculating strain for %s', ifo)
@@ -328,7 +328,7 @@ for ifo in opts.instruments:
 
     # taper waveform
     logging.info('Tapering strain for %s', ifo)
-    strain = taper_timeseries(strain, tapermethod=opts.taper)
+    strain = taper_timeseries(strain, tapermethod=sim.taper)
 
     # FFT strain
     logging.info('FFT strain for %s', ifo)
@@ -368,13 +368,13 @@ for ifo in opts.instruments:
     det = Detector(ifo)
 
     # get time delay to detector from center of the Earth
-    time_delay = det.time_delay_from_earth_center(opts.ra, opts.dec,
-                        opts.geocentric_end_time)
-    end_time = opts.geocentric_end_time + time_delay
+    time_delay = det.time_delay_from_earth_center(sim.longitude, sim.latitude,
+                        sim.geocent_end_time)
+    end_time = sim.geocent_end_time + time_delay
 
     # get antenna pattern
-    f_plus, f_cross = det.antenna_pattern(opts.ra, opts.dec,
-                        opts.polarization, opts.geocentric_end_time)
+    f_plus, f_cross = det.antenna_pattern(sim.longitude, sim.latitude,
+                        sim.polarization, sim.geocent_end_time)
 
     # calculate strain
     logging.info('Calculating strain for %s', ifo)
@@ -382,7 +382,7 @@ for ifo in opts.instruments:
 
     # taper waveform
     logging.info('Tapering strain for %s', ifo)
-    strain = taper_timeseries(strain, tapermethod=opts.taper)
+    strain = taper_timeseries(strain, tapermethod=sim.taper)
 
     # FFT strain
     logging.info('FFT strain for '+ifo+'...')
@@ -400,7 +400,7 @@ for ifo in opts.instruments:
     setattr(sim, ifo[0].lower()+'_end_time_ns', int(end_time % 1 * 1e9))
 
     # populate IFO distance columns
-    eff_distance = sim.distance / np.sqrt( ( 1 + numpy.cos( opts.inclination )**2 )**2 / 4 * f_plus**2 + numpy.cos( opts.inclination )**2 * f_cross**2 )
+    eff_distance = sim.distance / np.sqrt( ( 1 + numpy.cos( sim.inclination )**2 )**2 / 4 * f_plus**2 + numpy.cos( sim.inclination )**2 * f_cross**2 )
     setattr(sim, 'eff_dist_'+ifo[0].lower(), eff_distance)
 
     # populate IFO end time columns
@@ -424,8 +424,8 @@ h_plus, _ = get_td_waveform(sim, approximant=name, phase_order=phase_order,
                       delta_t=1.0/sample_rate)
 pad_seconds = 5
 template_duration_seconds = int( len(h_plus) / sample_rate ) + 1
-start_time = int(opts.geocentric_end_time) - template_duration_seconds - pad_seconds
-end_time = int(opts.geocentric_end_time) + 1 + pad_seconds
+start_time = int(sim.geocent_end_time) - template_duration_seconds - pad_seconds
+end_time = int(sim.geocent_end_time) + 1 + pad_seconds
 num_samples = (end_time - start_time) * sample_rate
 
 # append rows to XML tables

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -398,8 +398,7 @@ for ifo in opts.instruments:
     setattr(sim, ifo[0].lower()+'_end_time_ns', int(end_time % 1 * 1e9))
 
     # populate IFO distance columns
-    eff_distance = 2 * distance 
-    eff_distance /= ( 1 + numpy.cos( opts.inclination )**2 )**2 / 4 * f_plus**2 + numpy.cos( opts.inclination )**2 * f_cross**2
+    eff_distance = sim.distance / ( 1 + numpy.cos( opts.inclination )**2 )**2 / 4 * f_plus**2 + numpy.cos( opts.inclination )**2 * f_cross**2
     setattr(sim, 'eff_dist_'+ifo[0].lower(), eff_distance)
 
     # populate IFO end time columns

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -174,6 +174,8 @@ parser.add_argument("--frame-type", type=str, nargs="+",
                        'to get the needed frame file(s) of this type.')
 
 # output options
+parser.add_argument("--tag", type=str, default='hwinjcbc',
+                    help="Prefix added to output filenames.")
 parser.add_argument("--instruments", nargs="+", type=str, required=True,
                     help="List of instruments to analyze.")
 
@@ -426,11 +428,16 @@ start_time = int(opts.geocentric_end_time) - template_duration_seconds - pad_sec
 end_time = int(opts.geocentric_end_time) + 1 + pad_seconds
 num_samples = (end_time - start_time) * sample_rate
 
-# save XML output file if it does not exist
-logging.info('Writing XML file')
+# append rows to XML tables
 sim_table.append(sim)
 sngl_table.append(sngl)
-xml_filename = ''.join(opts.instruments) + '-' + 'HWINJ_CBC' + '-' + str(start_time) + '-' + str(end_time-start_time) + '.xml.gz'
+
+# construct filenames prefix
+prefix = opts.tag + '_' + str(start_time)
+
+# save XML output file if it does not exist
+logging.info('Writing XML file')
+xml_filename = prefix + '.xml.gz'
 if os.path.exists(xml_filename):
     logging.warn('Filename %s already exists and will not be overwritten', xml_filename)
     sys.exit()
@@ -450,7 +457,7 @@ for ifo in opts.instruments:
     injections.apply(output, ifo)
 
     # set output filename
-    txt_filename = ifo + '-' + 'HWINJ_CBC' + '-' + str(start_time) + '-' + str(end_time-start_time) + '.txt'
+    txt_filename = prefix + '_' + ifo + '.txt'
 
     # check if filename exists
     if os.path.exists(txt_filename):

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -29,7 +29,7 @@ from pycbc import fft
 from pycbc import pnutils
 from pycbc import psd as _psd
 from pycbc import strain as _strain
-from pycbc.detector import Detector
+from pycbc.detector import Detector, effective_distance
 from pycbc.inject import InjectionSet, legacy_approximant_name
 from pycbc.filter import make_frequency_series
 from pycbc.filter import sigmasq
@@ -400,7 +400,8 @@ for ifo in opts.instruments:
     setattr(sim, ifo[0].lower()+'_end_time_ns', int(end_time % 1 * 1e9))
 
     # populate IFO distance columns
-    eff_distance = sim.distance / numpy.sqrt( ( 1 + numpy.cos( sim.inclination )**2 )**2 / 4 * f_plus**2 + numpy.cos( sim.inclination )**2 * f_cross**2 )
+    eff_distance = effective_distance(sim.distance, sim.inclination,
+                                      f_plus, f_cross**2)
     setattr(sim, 'eff_dist_'+ifo[0].lower(), eff_distance)
 
     # populate IFO end time columns

--- a/bin/hwinj/pycbc_generate_hwinj_from_xml
+++ b/bin/hwinj/pycbc_generate_hwinj_from_xml
@@ -52,6 +52,8 @@ parser.add_argument('--injection-file', type=str, required=True,
              help='Path to the LIGOLW XML file that contains a sim_inspiral table.')
 parser.add_argument('--sample-rate', type=int, required=True,
              help='Sample rate that waveforms will be generated.')
+parser.add_argument("--tag", type=str, default='hwinjcbcsimid',
+                    help="Prefix added to output filenames.")
 
 # parse command line
 opts = parser.parse_args()
@@ -102,7 +104,7 @@ for sim in injections.table:
         injections.apply(output, ifo, simulation_ids=[sim.simulation_id])
 
         # set output filename
-        txt_filename = ifo + '-' + 'HWINJ_CBC_FROM_SIMULATION_ID_' + str(sim_id) + '-' + str(start_time) + '-' + str(end_time-start_time) + '.txt'
+        txt_filename = opts.tag + str(sim_id) + '_' + str(start_time) + '_' + ifo + '.txt'
 
         # check if filename does not exist
         if os.path.exists(txt_filename):

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -94,3 +94,6 @@ def overhead_antenna_pattern(right_ascension, declination, polarization):
 
     return f_plus, f_cross
 
+def effective_distance(distance, inclination, f_plus, f_cross):
+    return distance / np.sqrt( ( 1 + np.cos( inclination )**2 )**2 / 4 * f_plus**2 + np.cos( inclination )**2 * f_cross**2 )
+


### PR DESCRIPTION
This PR does the following:
  * Changes the naming convention of the output files to match ``tinj`` (the hardware injection scheduling program). Right now the files have to be renamed and it would be best to eliminate this step. Once ``tinj`` has been deprecated we can revert back.

  * In the executable ``pycbc_generate_hwinj`` it changes from using the command line options to the lines in the ``SimInspiral`` row. Ie. in the diff you see ``opts.taper`` go to ``sim.taper``, ``opts.geocentric_end_time`` go to ``sim.geocent_end_time``, ``opts.ra`` go to ``sim.longitude``, etc. There is no problem here but its better practice.

  * Fixes the effective distance that is stored in the ``SimInspiral`` table, should've had a square root instead of a factor of 2. For those following this, this did not affect anything presented for the review. This is the fix that was used for the review.