### PR TITLE
Make nonsharedfs the default

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -21,6 +21,7 @@ LOCAL_PEGASUS_DIR=""
 ACCOUNTING_GROUP=""
 NO_ACCOUNTING_GROUP=0
 PEGASUS_PROPERTIES=""
+SHARED_FILESYSTEM=0
 SITE_LIST=""
 STAGING_SITES=""
 TRANSFORMATION_CATALOG=""
@@ -45,7 +46,7 @@ rm -f _reuse.cache
 touch _reuse.cache
 rm -f *-extra-site-properties.xml
 
-GETOPT_CMD=`getopt -o d:c:g:r:a:p:P:s:S:k:t:Fknl:h --long dax:,cache-file:,local-gsiftp-server:,remote-staging-server:,accounting-group:,pegasus-properties:,append-pegasus-property:,execution-sites:,staging-sites:,append-site-profile:,transformation-catalog:,force-no-accounting-group,no-create-proxy,no-submit,local-dir:,help -n 'pycbc_submit_dax' -- "$@"`
+GETOPT_CMD=`getopt -o d:c:g:r:a:p:P:es:S:k:t:Fknl:h --long dax:,cache-file:,local-gsiftp-server:,remote-staging-server:,accounting-group:,pegasus-properties:,append-pegasus-property:,enable-shared-filesystem,execution-sites:,staging-sites:,append-site-profile:,transformation-catalog:,force-no-accounting-group,no-create-proxy,no-submit,local-dir:,help -n 'pycbc_submit_dax' -- "$@"`
 eval set -- "$GETOPT_CMD"
 
 while true ; do
@@ -92,6 +93,7 @@ while true ; do
         "") shift 2 ;;
         *) echo $2 >> extra-properties.conf ; shift 2 ;;
       esac ;;
+    -e|--enable-shared-filesystem) SHARED_FILESYSTEM=1 ; shift ;;
     -s|--execution-sites)
       case "$2" in
         "") shift 2 ;;
@@ -323,6 +325,20 @@ fi
 
 echo >> pegasus-properties.conf
 cat extra-properties.conf >> pegasus-properties.conf
+
+# If user specified a value for pegasus.data.configuration
+# then don't add another one
+if ! grep -q pegasus.data.configuration= pegasus-properties.conf
+then
+  # No option specified, append nonshared unless user said 
+  # not to
+  if [ $SHARED_FILESYSTEM == 0 ]
+  then
+    echo 'pegasus.data.configuration=nonsharedfs' >> pegasus-properties.conf
+  fi
+fi
+
+
 
 if [ $CACHE_FILE == 0 ]; then
   pegasus-plan --conf ./pegasus-properties.conf -d $DAX_FILE --sites $SITE_LIST $STAGING_SITES -o local --dir $SUBMIT_DIR --cleanup inplace --relative-submit-dir work --cluster label $SUBMIT_DAX 


### PR DESCRIPTION
Addresses https://github.com/ligo-cbc/pycbc/issues/664

This makes
```
pegasus.data.configuration=nonsharedfs
```

the default, and allows the user to override this setting by either specifying the `pegasus.data.configuration` property directly or giving the `--enable-shared-filesystem` option.  I have tested the various combinations and verified that they work.  I have also verified that using this setting doesn't cause any problems

  * [shared filesystem with autogating, for reference](https://sugar-dev3.phy.syr.edu/pegasus/u/lppekows/r/54/w?wf_uuid=f960f184-7971-40dc-9080-a41a369f9f1b)
  * [nonshared filesystem with autogating](https://sugar-dev3.phy.syr.edu/pegasus/u/lppekows/r/55/w?wf_uuid=bfe92f2f-a17c-47f4-b6c2-fd5a3b21e25d)
  * [shared filesystem with omicron gates, for reference](https://sugar-dev3.phy.syr.edu/pegasus/u/lppekows/r/58/w?wf_uuid=d3fa1ce6-6040-400d-ae39-9e6a5b3ef681)
  * [nonshared filesystem with omicron gates](https://sugar-dev3.phy.syr.edu/pegasus/u/lppekows/r/57/w?wf_uuid=19823108-9142-42eb-b19b-175fbedc7fcb)

The latter two test the condition where the workflow uses a file that is not generated within the workflow.  In all cases moving to nonsharedfs caused no problems.
