### PR TITLE
convert argument input to absolute path in minifollowups

### DIFF
--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -26,6 +26,7 @@ import pycbc.version
 def to_file(path, ifo=None):
     fil = wdax.File(os.path.basename(path))
     fil.ifo = ifo
+    path = os.path.abspath(path)
     fil.PFN(path, 'local')
     return fil
 

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -29,6 +29,7 @@ from pycbc.io.hdf import SingleDetTriggers
 def to_file(path, ifo=None):
     fil = wdax.File(os.path.basename(path))
     fil.ifo = ifo
+    path = os.path.abspath(path)
     fil.PFN(path, 'local')
     return fil
 


### PR DESCRIPTION
Make sure the paths are converted to absolute paths. This appears to have already been done in the sngls_minifollowup, but was not in place for the injections or foreground. 