### PR TITLE
Add UNIT4 time series to frame reading.

### DIFF
--- a/pycbc/frame.py
+++ b/pycbc/frame.py
@@ -54,7 +54,7 @@ _fr_type_map = {
         lalframe.FrameAddCOMPLEX16TimeSeriesProcData
     ],
     lal.U4_TYPE_CODE: [
-        lalframe.FrStreamReadUINT4TimeSeries, numpy.float64,
+        lalframe.FrStreamReadUINT4TimeSeries, numpy.uint64,
         lal.CreateUINT4TimeSeries,
         lalframe.FrStreamGetUINT4TimeSeriesMetadata,
         lal.CreateUINT4Sequence,

--- a/pycbc/frame.py
+++ b/pycbc/frame.py
@@ -54,7 +54,7 @@ _fr_type_map = {
         lalframe.FrameAddCOMPLEX16TimeSeriesProcData
     ],
     lal.U4_TYPE_CODE: [
-        lalframe.FrStreamReadUINT4TimeSeries, numpy.uint64,
+        lalframe.FrStreamReadUINT4TimeSeries, numpy.uint32,
         lal.CreateUINT4TimeSeries,
         lalframe.FrStreamGetUINT4TimeSeriesMetadata,
         lal.CreateUINT4Sequence,

--- a/pycbc/frame.py
+++ b/pycbc/frame.py
@@ -53,6 +53,13 @@ _fr_type_map = {
         lal.CreateCOMPLEX16Sequence,
         lalframe.FrameAddCOMPLEX16TimeSeriesProcData
     ],
+    lal.U4_TYPE_CODE: [
+        lalframe.FrStreamReadUINT4TimeSeries, numpy.float64,
+        lal.CreateUINT4TimeSeries,
+        lalframe.FrStreamGetUINT4TimeSeriesMetadata,
+        lal.CreateUINT4Sequence,
+        lalframe.FrameAddUINT4TimeSeriesProcData
+    ],
 }
 
 def _read_channel(channel, stream, start, duration):

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -44,7 +44,7 @@ from pycbc.types.aligned import ArrayWithAligned
 
 
 _ALLOWED_DTYPES = [_numpy.float32, _numpy.float64, _numpy.complex64,
-                   _numpy.complex128, _numpy.uint64]
+                   _numpy.complex128, _numpy.uint32]
 _ALLOWED_SCALARS = [int, long, float, complex] + _ALLOWED_DTYPES
 
 def _convert_to_scheme(ary):

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -44,7 +44,7 @@ from pycbc.types.aligned import ArrayWithAligned
 
 
 _ALLOWED_DTYPES = [_numpy.float32, _numpy.float64, _numpy.complex64,
-                   _numpy.complex128]
+                   _numpy.complex128, _numpy.uint64]
 _ALLOWED_SCALARS = [int, long, float, complex] + _ALLOWED_DTYPES
 
 def _convert_to_scheme(ary):

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -42,7 +42,9 @@ import pycbc.scheme as _scheme
 from pycbc.scheme import schemed, cpuonly
 from pycbc.types.aligned import ArrayWithAligned
 
-
+#! FIXME: the uint32 datatype has not been fully tested,
+# we should restrict any functions that do not allow an
+# array of uint32 integers
 _ALLOWED_DTYPES = [_numpy.float32, _numpy.float64, _numpy.complex64,
                    _numpy.complex128, _numpy.uint32]
 _ALLOWED_SCALARS = [int, long, float, complex] + _ALLOWED_DTYPES


### PR DESCRIPTION
Allows ``frame.py`` to read channels that are ``UNIT4``.

This is needed to read ODC channels.