### PR TITLE
add seed value option

### DIFF
--- a/bin/hdfcoinc/pycbc_stat_dtphase
+++ b/bin/hdfcoinc/pycbc_stat_dtphase
@@ -24,11 +24,12 @@ parser.add_argument('--amplitude-magnitude-bins', type=int, default=50,
                     help="Number of bins to use for storing the combined SNR magnitudes")
 parser.add_argument('--fixed-timing-error', default=1.0/4096, type=float,
                     help="Fixed value for a timing error")
+parser.add_argument('--seed', type=int, default=124)
 parser.add_argument('--output-file')
 parser.add_argument('--cores', default=1, type=int)
 parser.add_argument('--verbose', action='store_true')
 args = parser.parse_args()
-numpy.random.seed(seed=124)
+numpy.random.seed(args.seed)
 
 d1 = pycbc.detector.Detector(str(args.ifos[0]))
 d2 = pycbc.detector.Detector(str(args.ifos[1]))


### PR DESCRIPTION
Sorry, forgot to include this elsewhere. Small change to allow setting a seed value in pycbc_stat_dtphase. 