### PR TITLE
Use correct LAL_DATA_PATH if you choose to install it.

### DIFF
--- a/install_pycbc.sh
+++ b/install_pycbc.sh
@@ -518,7 +518,7 @@ for j in "${rom_hash[@]}" ; do
     if [[ ${install_rom} == "yes" ]] ; then
         echo "export LAL_DATA_PATH=${LAL_DATA_PATH}" >>  ${VIRTUAL_ENV}/bin/activate
     elif [[ ${install_rom} == "no" ]] ; then
-        echo "export LAL_DATA_PATH=${LAL_DATA_PATH}"/share/lalsimulation >>  ${VIRTUAL_ENV}/bin/activate
+        echo "export LAL_DATA_PATH=${LAL_DATA_PATH}/share/lalsimulation" >>  ${VIRTUAL_ENV}/bin/activate
     fi
     break
   fi

--- a/install_pycbc.sh
+++ b/install_pycbc.sh
@@ -515,7 +515,11 @@ fi
 for j in "${rom_hash[@]}" ; do
   if [[ ${rom_hash[*]} == ${md5sum_hash[*]} ]] ; then
     echo "All files are in ${LAL_DATA_PATH}." 
-    echo "export LAL_DATA_PATH=${LAL_DATA_PATH}" >>  ${VIRTUAL_ENV}/bin/activate
+    if [[ ${install_rom} == "yes" ]] ; then
+        echo "export LAL_DATA_PATH=${LAL_DATA_PATH}" >>  ${VIRTUAL_ENV}/bin/activate
+    elif [[ ${install_rom} == "no" ]] ; then
+        echo "export LAL_DATA_PATH=${LAL_DATA_PATH}"/share/lalsimulation >>  ${VIRTUAL_ENV}/bin/activate
+    fi
     break
   fi
 


### PR DESCRIPTION
I tested out this ``install_pycbc.sh`` script.

It will SVN co the LAL data repo but it doesn't assign the correct path in the ``activate`` executable. So if you run a workflow and use ROMs, the workflow fails.

I had to manually append ``share/lalsimulation`` to the end of ``LAL_DATA_PATH`` in ``activate``.

This PR should fix that.