### PR TITLE
Fix pycbc_page_segtable for when there is no & in the segment name

### DIFF
--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -122,8 +122,12 @@ for segment_name in opts.segment_names:
         caption += " ("+comment_dict[key]+")"
 
     # get length of time of single-IFO segments in seconds
-    h1_len = abs( ( base_segs['H1'].coalesce() & comp_segs["H1"].coalesce() ).coalesce() )
-    l1_len = abs( ( base_segs['L1'].coalesce() & comp_segs["L1"].coalesce() ).coalesce() )
+    if len(names) > 1:
+        h1_len = abs( ( base_segs['H1'].coalesce() & comp_segs["H1"].coalesce() ).coalesce() )
+        l1_len = abs( ( base_segs['L1'].coalesce() & comp_segs["L1"].coalesce() ).coalesce() )
+    else:
+        h1_len = abs( base_segs['H1'].coalesce() )
+        l1_len = abs( base_segs['L1'].coalesce() )
 
     # find the AND of H1 and L1 time
     h1l1_base_segs = base_segs["H1"].coalesce() & base_segs["L1"].coalesce()
@@ -134,7 +138,10 @@ for segment_name in opts.segment_names:
     h1l1_comp_segs.coalesce()
 
     # get length of time in coincident H1L1 segments in seconds
-    h1l1_len = abs( (h1l1_base_segs & h1l1_comp_segs).coalesce() )
+    if len(names) > 1:
+        h1l1_len = abs( (h1l1_base_segs & h1l1_comp_segs).coalesce() )
+    else:
+        h1l1_len = abs( h1l1_base_segs.coalesce() )
 
     # put values into columns
     columns[0][1].append(segment_name)


### PR DESCRIPTION
In #687 I accidentally removed the logic for checking if you should not take the AND of two ``segmentlist``.

So what happens right now is that if ``pycbc_page_segtable`` does not have an & in the ``--segment-name`` option then it takes the AND of the segment with an empty ``segmentlist``. That result is 0. This PR fixes that.

Here's a test of the veto table (A4): https://sugar-jobs.phy.syr.edu/~cbiwer/segtable_2.html

Here's a test of the segment table (A3): https://sugar-jobs.phy.syr.edu/~cbiwer/segtable_3.html