### PR TITLE
Add single-detector histograms to workflow for background bins

### DIFF
--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -243,7 +243,7 @@ for insp in full_insps:
            'closed_box', rdir['single_triggers/%s_binned_triggers' % insp.ifo], tags=[tag])
     wf.make_single_hist(workflow, insp, censored_veto, 'closed_box', 
            rdir['single_triggers/%s_trigger_histograms' % insp.ifo], 
-           exclude='summ', tags=[tag])
+           bank_file=hdfbank[0], exclude='summ', tags=[tag])
     hists = wf.make_single_hist(workflow, insp, censored_veto, 'closed_box', 
            rdir['single_triggers/%s_trigger_histograms' % insp.ifo], 
            require='summ', tags=[tag])

--- a/bin/hdfcoinc/pycbc_plot_hist
+++ b/bin/hdfcoinc/pycbc_plot_hist
@@ -1,8 +1,10 @@
 #!/bin/env python
 """ Make histograms of single detector triggers
 """
+
 import numpy, argparse, h5py, logging, sys
 import pycbc.version, pycbc.results, pycbc.io
+from itertools import cycle
 from matplotlib import use; use('Agg')
 from matplotlib import pyplot
 from pycbc.events import background_bin_from_string, veto
@@ -78,16 +80,34 @@ elif args.background_bins:
                  'spin2z' : trigs.spin2z,
     }
     locs_dict = background_bin_from_string(args.background_bins, bank_data)
-
+ 
     # get a list of bin names and a corresponding list for x values
     loc_bin_keys = [key for key in locs_dict.keys()]
     loc_bin_vals = [val[locs_dict[key]] for key in loc_bin_keys]
 
-    # plot
+    # assign a color for each bin
+    color_cycle = cycle(['red', 'green', 'blue', 'black', 'magenta', 'cyan'])
+    loc_bin_colors = [color_cycle.next() for key in loc_bin_keys]
+
+    # get number of overflows for each background bin
+    loc_bin_overflows = [len(vals[vals>=x_max]) for vals in loc_bin_vals]
+    num_bins = len(loc_bin_overflows)
+
+    # plot histograms
     binvals = numpy.linspace(args.x_min, x_max, args.bins, endpoint=True)
     pyplot.hist(loc_bin_vals, bins=binvals, histtype='step',
-                stacked=False, label=loc_bin_keys)
+                stacked=False, label=loc_bin_keys, color=loc_bin_colors)
     pyplot.legend(loc='upper right')
+
+    # plot overflow bin
+    rects = pyplot.bar(num_bins*[x_max+0.05],
+                      loc_bin_overflows, .5,
+                      facecolor='None', edgecolor=loc_bin_colors)
+
+    # write text for overflow bin
+    text_left = rects[0].get_x()
+    text_height = 1.10 * max([rect.get_height() for rect in rects])
+    pyplot.text(text_left, text_height, '%s+'%x_max)
 
 # plot all triggers in a single label
 else:

--- a/bin/hdfcoinc/pycbc_plot_hist
+++ b/bin/hdfcoinc/pycbc_plot_hist
@@ -93,6 +93,9 @@ elif args.background_bins:
     loc_bin_overflows = [len(vals[vals>=x_max]) for vals in loc_bin_vals]
     num_bins = len(loc_bin_overflows)
 
+    # remove overflow triggers from plotting
+    loc_bin_vals = [vals[vals<x_max] for vals in loc_bin_vals]
+
     # plot histograms
     pyplot.hist(loc_bin_vals, bins=args.bins, histtype='step',
                 stacked=False, label=loc_bin_keys, color=loc_bin_colors)

--- a/bin/hdfcoinc/pycbc_plot_hist
+++ b/bin/hdfcoinc/pycbc_plot_hist
@@ -34,7 +34,7 @@ parser.add_argument('--verbose')
 args = parser.parse_args()
 
 # sanity check command line options
-if args.sepcial_time and args.background_bins:
+if args.special_time and args.background_bins:
     raise ValueError("Cannot use both --special-time and --background-bins")
 
 # setup logging

--- a/bin/hdfcoinc/pycbc_plot_hist
+++ b/bin/hdfcoinc/pycbc_plot_hist
@@ -94,8 +94,7 @@ elif args.background_bins:
     num_bins = len(loc_bin_overflows)
 
     # plot histograms
-    binvals = numpy.linspace(args.x_min, x_max, args.bins, endpoint=True)
-    pyplot.hist(loc_bin_vals, bins=binvals, histtype='step',
+    pyplot.hist(loc_bin_vals, bins=args.bins, histtype='step',
                 stacked=False, label=loc_bin_keys, color=loc_bin_colors)
     pyplot.legend(loc='upper right')
 

--- a/pycbc/results/plot.py
+++ b/pycbc/results/plot.py
@@ -1,4 +1,4 @@
-""" Plotting utililities and premade plot configurations
+""" Plotting utilities and premade plot configurations
 """
 
 def hist_overflow(val, val_max, **kwds):

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -338,7 +338,8 @@ def make_results_web_page(workflow, results_dir):
     workflow += node
 
 def make_single_hist(workflow, trig_file, veto_file, veto_name, 
-                     out_dir, exclude=None, require=None, tags=[]):
+                     out_dir, bank_file=None, exclude=None,
+                     require=None, tags=[]):
     makedir(out_dir)
     secs = requirestr(workflow.cp.get_subsections('plot_hist'), require)  
     secs = excludestr(secs, exclude)
@@ -352,6 +353,8 @@ def make_single_hist(workflow, trig_file, veto_file, veto_name,
         node.add_opt('--segment-name', veto_name)
         node.add_input_opt('--veto-file', veto_file)
         node.add_input_opt('--trigger-file', trig_file)
+        if bank_file:
+            node.add_input_opt('--bank-file', bank_file)
         node.new_output_file_opt(trig_file.segment, '.png', '--output-file')
         workflow += node
         files += node.output_files


### PR DESCRIPTION
This PR adds single-detector histograms for each background bin to the summary pages, an example is here: https://sugar-jobs.phy.syr.edu/~cbiwer/hwinj_run_workflow/test_pr/3._single_triggers/3.02_H1_trigger_histograms/

Example of config file to get those plots is:
```
[plot_hist-bkg_newsnr]
x-max = ${plot_hist-summ_newsnr|x-max}
x-min = ${plot_hist-summ_newsnr|x-min}
x-var = ${plot_hist-summ_newsnr|x-var}
background-bins = ${workflow-coincidence|background-bins}

[plot_hist-bkg_snr]
x-max = ${plot_hist-summ_snr|x-max}
x-min = ${plot_hist-summ_snr|x-min}
x-var = ${plot_hist-summ_snr|x-var}
background-bins = ${workflow-coincidence|background-bins}
```

Things in this PR:
   * Adds ``bank_file`` as an option to ``make_single_hist``.
   * Add overflow bins to ``pycbc_plot_hist`` background bins plotting.