### PR TITLE
Allow daily scripts to get date from command line for easy reruns

### DIFF
--- a/bin/sngl/run_daily_pycbc_export_censored_trigs
+++ b/bin/sngl/run_daily_pycbc_export_censored_trigs
@@ -17,13 +17,14 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # sanity check command line
-if [$# -gt 1]; then
+if [ $# -gt 1 ]; then
     echo "illegal number of command line options"
+    exit
 fi
 
 # parse command line
 # get midnight from yesterday in form of MM/DD/YYYY
-if [$# -eq 1]; then
+if [ $# -eq 1 ]; then
     YESTERDAY=$1
 else
     YESTERDAY=`date -u --date="yesterday" +"%x"`

--- a/bin/sngl/run_daily_pycbc_export_censored_trigs
+++ b/bin/sngl/run_daily_pycbc_export_censored_trigs
@@ -16,8 +16,18 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+# sanity check command line
+if [$# -gt 1]; then
+    echo "illegal number of command line options"
+fi
+
+# parse command line
 # get midnight from yesterday in form of MM/DD/YYYY
-YESTERDAY=`date -u --date="yesterday" +"%x"`
+if [$# -eq 1]; then
+    YESTERDAY=$1
+else
+    YESTERDAY=`date -u --date="yesterday" +"%x"`
+fi
 
 # convert midnight to GPS time and analyze a day of data
 GPS_START_TIME=`lalapps_tconvert ${YESTERDAY}`

--- a/bin/sngl/run_daily_pycbc_make_coinc_search_workflow
+++ b/bin/sngl/run_daily_pycbc_make_coinc_search_workflow
@@ -17,13 +17,14 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # sanity check command line
-if [$# -gt 1]; then
+if [ $# -gt 1 ]; then
     echo "illegal number of command line options"
+    exit
 fi
 
 # parse command line
 # get midnight from yesterday in form of MM/DD/YYYY
-if [$# -eq 1]; then
+if [ $# -eq 1 ]; then
     YESTERDAY=$1
 else
     YESTERDAY=`date -u --date="yesterday" +"%x"`

--- a/bin/sngl/run_daily_pycbc_make_coinc_search_workflow
+++ b/bin/sngl/run_daily_pycbc_make_coinc_search_workflow
@@ -16,8 +16,18 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+# sanity check command line
+if [$# -gt 1]; then
+    echo "illegal number of command line options"
+fi
+
+# parse command line
 # get midnight from yesterday in form of MM/DD/YYYY
-YESTERDAY=`date -u --date="yesterday" +"%x"`
+if [$# -eq 1]; then
+    YESTERDAY=$1
+else
+    YESTERDAY=`date -u --date="yesterday" +"%x"`
+fi
 
 # convert midnight to GPS time and analyze a day of data
 GPS_START_TIME=`lalapps_tconvert ${YESTERDAY}`


### PR DESCRIPTION
This PR allows the user to put the date on the command line to easily rerun the daily search. If no date is on the command line, then it will get the current date.

The date on the command line should be in the form ``MM/DD/YYYY`` where ``M`` is month, ``D`` is day, and ``Y`` is year.