### PR TITLE
Add --acounting-group-user to pycbc_submit_dax for daily runs

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -19,6 +19,7 @@ DAX_FILE=""
 CACHE_FILE=0
 LOCAL_PEGASUS_DIR=""
 ACCOUNTING_GROUP=""
+ACCOUNTING_GROUP_USER=""
 NO_ACCOUNTING_GROUP=0
 PEGASUS_PROPERTIES=""
 SHARED_FILESYSTEM=0
@@ -46,7 +47,7 @@ rm -f _reuse.cache
 touch _reuse.cache
 rm -f *-extra-site-properties.xml
 
-GETOPT_CMD=`getopt -o d:c:g:r:a:p:P:es:S:k:t:Fknl:h --long dax:,cache-file:,local-gsiftp-server:,remote-staging-server:,accounting-group:,pegasus-properties:,append-pegasus-property:,enable-shared-filesystem,execution-sites:,staging-sites:,append-site-profile:,transformation-catalog:,force-no-accounting-group,no-create-proxy,no-submit,local-dir:,help -n 'pycbc_submit_dax' -- "$@"`
+GETOPT_CMD=`getopt -o d:c:g:r:a:u:p:P:es:S:k:t:Fknl:h --long dax:,cache-file:,local-gsiftp-server:,remote-staging-server:,accounting-group:,accounting-group-user:,pegasus-properties:,append-pegasus-property:,enable-shared-filesystem,execution-sites:,staging-sites:,append-site-profile:,transformation-catalog:,force-no-accounting-group,no-create-proxy,no-submit,local-dir:,help -n 'pycbc_submit_dax' -- "$@"`
 eval set -- "$GETOPT_CMD"
 
 while true ; do
@@ -82,6 +83,11 @@ while true ; do
       case "$2" in
         "") shift 2 ;;
         *) export ACCOUNTING_GROUP=$2 ; shift 2 ;;
+      esac ;;
+    -u|--accounting-group-user)
+      case "$2" in
+        "") shift 2 ;;
+        *) export ACCOUNTING_GROUP_USER=$2 ; shift 2 ;;
       esac ;;
     -p|--pegasus-properties)
       case "$2" in
@@ -197,7 +203,7 @@ if [ "x$DAX_FILE" == "x" ]; then
 fi
 
 if [ "x$ACCOUNTING_GROUP" == "x" ] && [ $NO_ACCOUNTING_GROUP == 0 ]; then
-  echo "Error: You must specify and accounting group with --accounting-group or"
+  echo "Error: You must specify an accounting group with --accounting-group or"
   echo "override this check with --force-no-accounting-group. If you do not specify"
   echo "an accounting group, job submission will fail on the LIGO Data Grid."
   echo

--- a/bin/sngl/run_daily_pycbc_export_censored_trigs
+++ b/bin/sngl/run_daily_pycbc_export_censored_trigs
@@ -17,13 +17,14 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # sanity check command line
-if [$# -gt 1]; then
+if [ $# -gt 1 ]; then
     echo "illegal number of command line options"
+    exit
 fi
 
 # parse command line
 # get midnight from yesterday in form of MM/DD/YYYY
-if [$# -eq 1]; then
+if [ $# -eq 1 ]; then
     YESTERDAY=$1
 else
     YESTERDAY=`date -u --date="yesterday" +"%x"`

--- a/bin/sngl/run_daily_pycbc_export_censored_trigs
+++ b/bin/sngl/run_daily_pycbc_export_censored_trigs
@@ -16,8 +16,18 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+# sanity check command line
+if [$# -gt 1]; then
+    echo "illegal number of command line options"
+fi
+
+# parse command line
 # get midnight from yesterday in form of MM/DD/YYYY
-YESTERDAY=`date -u --date="yesterday" +"%x"`
+if [$# -eq 1]; then
+    YESTERDAY=$1
+else
+    YESTERDAY=`date -u --date="yesterday" +"%x"`
+fi
 
 # convert midnight to GPS time and analyze a day of data
 GPS_START_TIME=`lalapps_tconvert ${YESTERDAY}`

--- a/bin/sngl/run_daily_pycbc_make_coinc_search_workflow
+++ b/bin/sngl/run_daily_pycbc_make_coinc_search_workflow
@@ -81,9 +81,16 @@ ${RUN_DIR}/pycbc_make_coinc_search_workflow --workflow-name ${WORKFLOW_NAME} --o
       "inspiral:chisq-bins:\"0.4*get_freq('fSEOBNRv2Peak',params.mass1,params.mass2,params.spin1z,params.spin2z)**(2./3.)\"" \
       "results_page:analysis-subtitle:'Daily CBC Offline ${DAY}'"
 
+#!FIXME: previous releases do not support ACCOUNTING_GROUP_USER so use the installed version
 # plan and submit the workflow
+LOCAL_DIR=${RUN_DIR}/condor
+mkdir -p ${LOCAL_DIR}
 cd ${OUTPUT_DIR}
-${RUN_DIR}/pycbc_submit_dax --accounting-group ligo.dev.o1.detchar.singleifo.dailyahope --dax ${WORKFLOW_NAME}.dax --no-create-proxy
+pycbc_submit_dax --accounting-group ligo.dev.o1.detchar.singleifo.dailyahope \
+    --accounting-group-user christopher.biwer \
+    --dax ${WORKFLOW_NAME}.dax \
+    --local-dir ${LOCAL_DIR} \
+    --no-create-proxy
 
 # name of the nagios monitor file
 NAGIOS_GPS_TIME=`lalapps_tconvert`

--- a/bin/sngl/run_daily_pycbc_make_coinc_search_workflow
+++ b/bin/sngl/run_daily_pycbc_make_coinc_search_workflow
@@ -17,13 +17,14 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # sanity check command line
-if [$# -gt 1]; then
+if [ $# -gt 1 ]; then
     echo "illegal number of command line options"
+    exit
 fi
 
 # parse command line
 # get midnight from yesterday in form of MM/DD/YYYY
-if [$# -eq 1]; then
+if [ $# -eq 1 ]; then
     YESTERDAY=$1
 else
     YESTERDAY=`date -u --date="yesterday" +"%x"`

--- a/bin/sngl/run_daily_pycbc_make_coinc_search_workflow
+++ b/bin/sngl/run_daily_pycbc_make_coinc_search_workflow
@@ -16,8 +16,18 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+# sanity check command line
+if [$# -gt 1]; then
+    echo "illegal number of command line options"
+fi
+
+# parse command line
 # get midnight from yesterday in form of MM/DD/YYYY
-YESTERDAY=`date -u --date="yesterday" +"%x"`
+if [$# -eq 1]; then
+    YESTERDAY=$1
+else
+    YESTERDAY=`date -u --date="yesterday" +"%x"`
+fi
 
 # convert midnight to GPS time and analyze a day of data
 GPS_START_TIME=`lalapps_tconvert ${YESTERDAY}`

--- a/pycbc/workflow/pegasus_files/local-site-template.xml
+++ b/pycbc/workflow/pegasus_files/local-site-template.xml
@@ -11,6 +11,7 @@
     <profile namespace="pegasus" key="style">condor</profile>
     <profile namespace="condor" key="getenv">True</profile>
     <profile namespace="condor" key="accounting_group">$ACCOUNTING_GROUP</profile>
+    <profile namespace="condor" key="accounting_group_user">$ACCOUNTING_GROUP_USER</profile>
     <profile namespace="condor" key="should_transfer_files">YES</profile>
     <profile namespace="condor" key="when_to_transfer_output">ON_EXIT_OR_EVICT</profile>
     <profile namespace="condor" key="+DESIRED_Sites">&quot;nogrid&quot;</profile>


### PR DESCRIPTION
This PR is dependent on #698.

This PR:
   * Adds ``acounting_group_user`` to the local site map for pegasus.
   * Adds ``--accounting-group-user`` to ``pycbc_submit_dax``.
   * Sets the account group user in the daily script, this requires a LIGO.ORG name (no password needed). I've left my LIGO.ORG in, this could just be a command line option to the run script in a future PR.