### PR TITLE
Chunkread

### DIFF
--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -197,7 +197,7 @@ class StatmapData(DictArray):
 class FileData(object):
 
     def __init__(self, fname, group=None, columnlist=None, filter_func=None):
-        '''
+        """
         Parameters
         ----------
         group : string
@@ -207,7 +207,7 @@ class FileData(object):
         filter_func : string 
             String should evaluate to a Boolean expression using attributes
             of the class instance derived from columns: ex. 'self.snr < 6.5'
-        '''
+        """
         if not fname: raise RuntimeError("Didn't get a file!")
         self.fname = fname
         self.h5file = HFile(fname, "r")
@@ -228,14 +228,14 @@ class FileData(object):
 
     @property
     def mask(self):
-        '''
+        """
         Create a mask implementing the requested filter on the datasets
 
         Returns
         -------
         array of Boolean
             True for dataset indices to be returned by the get_column method
-        '''
+        """
         if self.filter_func is None:
             raise RuntimeError("Can't get a mask without a filter function!")
         else:
@@ -249,7 +249,7 @@ class FileData(object):
             return self._mask
 
     def get_column(self, col):
-        '''
+        """
         Parameters
         ----------
         col : string
@@ -259,7 +259,7 @@ class FileData(object):
         -------
         numpy array
             Values from the dataset, filtered if requested
-        '''
+        """
         # catch corner case with an empty file (group with no datasets)
         if not len(self.group.keys()):
             return np.array([])
@@ -279,7 +279,7 @@ class DataFromFiles(object):
         self.filter_func = filter_func
 
     def get_column(self, col):
-        '''
+        """
         Loop over files getting the requested dataset values from each
 
         Parameters
@@ -292,7 +292,7 @@ class DataFromFiles(object):
         numpy array
             Values from the dataset, filtered if requested and
             concatenated in order of file list
-        '''
+        """
         logging.info('getting %s' % col)
         vals = []
         for f in self.files:

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -45,7 +45,7 @@ class HFile(HFile):
         hdf5 file that are given.
 
         >>> f = HFile(filename)
-        >>> snr, chisq = f.select(lambda snr: snr > 6, 'H1/snr')
+        >>> snr = f.select(lambda snr: snr > 6, 'H1/snr')
         """
 
         # get references to each array

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -6,6 +6,7 @@ import h5py
 import numpy as np
 import logging
 import inspect
+import numpy
 
 from lal import LIGOTimeGPS, YRJUL_SI
 
@@ -21,11 +22,11 @@ from pycbc.tmpltbank import return_search_summary
 from pycbc.tmpltbank import return_empty_sngl
 from pycbc import events, pnutils
 
-class HFile(HFile):   
+class HFile(h5py.File):   
     """ Low level extensions to the capabilities of reading an hdf5 File
     """
 
-    def select(self, fcn, *args):
+    def select(self, fcn, *args, **kwds):
         """ Return arrays from an hdf5 file that satisfy the given function
 
         Parameters
@@ -37,6 +38,9 @@ class HFile(HFile):
         args: strings
             A variable number of strings that are keys into the hdf5. These must
         refer to arrays of equal length.
+
+        chunksize: {1e6, int}, optional
+            Number of elements to read and process at a time.
 
         Returns
         -------
@@ -56,7 +60,7 @@ class HFile(HFile):
             data[arg] = []
         
         # To conserve memory read the array in chunks
-        chunksize = int(1e6)
+        chunksize = kwds.get('chunksize', int(1e6))
         size = len(refs[arg])
 
         i = 0

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -43,6 +43,9 @@ class HFile(HFile):
         values : numpy.ndarrays
             A variable number of arrays depending on the number of keys into the
         hdf5 file that are given.
+
+        >>> f = HFile(filename)
+        >>> snr, chisq = f.select(lambda snr: snr > 6, 'H1/snr')
         """
 
         # get references to each array

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -25,7 +25,7 @@
 """
 This module provides classes that describe banks of waveforms
 """
-import types
+import types, logging
 import pycbc.waveform
 from pycbc.types import zeros
 from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
@@ -94,6 +94,8 @@ class FilterBank(object):
         return len(self.table)
 
     def __getitem__(self, index):
+        logging.info('generating waveform at position: %s' % index)
+    
         # Make new memory for templates if we aren't given output memory
         if self.out is None:
             tempout = zeros(self.filter_length, dtype=self.dtype)


### PR DESCRIPTION
Start a superclass of the h5py.File object to we can add low level query type functionality. I also add a "select" function that allows one to get columns from and hdf5 file that satisfy some sort of function that returns a boolean. 

Here is an example, 
f = HFile(filename)
snr = f.select(lambda snr: snr > 6, 'H1/snr')

Read in an get only the SNR values above 6. Does not read in all the values at once, which should allow people to write code that uses a lot less memory when making plots, etc. Any function may be given as long as it returns a boolean array the same length as your vector(s).  The following also works.

snr, time = f.select(labmda snr, time: time > 1000000, 'H1/snr', 'H1/end_time')

This should be integrated into the SingleDetTriggers class in the future and others. I'll let the authors of those classes decide how best to do that.