### PR TITLE
FIx potential underflow in estimate.py

### DIFF
--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -238,8 +238,8 @@ def interpolate(series, delta_f):
     interpolated series : FrequencySeries
         A new FrequencySeries that has been interpolated.
     """
-    new_n = (len(series)-1) * series.delta_f / delta_f + 1.000001
-    samples = numpy.arange(0, int(new_n)) * delta_f
+    new_n = (len(series)-1) * series.delta_f / delta_f
+    samples = numpy.arange(0, numpy.rint(new_n)) * delta_f
     interpolated_series = numpy.interp(samples, series.sample_frequencies.numpy(), series.numpy())
     return FrequencySeries(interpolated_series, epoch=series.epoch, 
                            delta_f=delta_f, dtype=series.dtype)

--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -238,7 +238,7 @@ def interpolate(series, delta_f):
     interpolated series : FrequencySeries
         A new FrequencySeries that has been interpolated.
     """
-    new_n = (len(series)-1) * series.delta_f / delta_f
+    new_n = (len(series)-1) * series.delta_f / delta_f + 1
     samples = numpy.arange(0, numpy.rint(new_n)) * delta_f
     interpolated_series = numpy.interp(samples, series.sample_frequencies.numpy(), series.numpy())
     return FrequencySeries(interpolated_series, epoch=series.epoch, 

--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -238,8 +238,8 @@ def interpolate(series, delta_f):
     interpolated series : FrequencySeries
         A new FrequencySeries that has been interpolated.
     """
-    new_n = (len(series)-1) * series.delta_f / delta_f + 1
-    samples = numpy.arange(0, new_n) * delta_f
+    new_n = (len(series)-1) * series.delta_f / delta_f + 1.000001
+    samples = numpy.arange(0, int(new_n)) * delta_f
     interpolated_series = numpy.interp(samples, series.sample_frequencies.numpy(), series.numpy())
     return FrequencySeries(interpolated_series, epoch=series.epoch, 
                            delta_f=delta_f, dtype=series.dtype)


### PR DESCRIPTION
Estimate.py can suffer from float underflow in some edge cases. Basically new_n is a float that is almost an int. However

```
numpy.arange(0,10.0000001)
```

and

```
numpy.arange(0,9.99999999)
```

do not give the same thing. By adding 1.000001 and then casting back to int we ensure

```
numpy.arange(0,10)
```

which gives the correct behaviour (include the Nyquist point, but *not* an extra point).

This has been tested in inspiral jobs from the test workflow.