### PR TITLE
changes for binning by template duration (also whitespace, sorry)

### DIFF
--- a/bin/hdfcoinc/pycbc_distribute_background_bins
+++ b/bin/hdfcoinc/pycbc_distribute_background_bins
@@ -11,23 +11,32 @@ parser.add_argument('--coinc-files', nargs='+',
 parser.add_argument('--background-bins', nargs='+',
                     help="Ordered list of mass bin upper boundaries. "
                          "An ordered list of type-boundary pairs, applied sequentially."
-                         "Must provide a name (can be anything, this is just for tagging "
-                         "puproses), the parameter to bin on, and the upper-boundary. "
-                         "Ex. name1:component:2 name2:total:15 name3:SEOBNRv2Peak:1000")
+                         "Must provide a name (can be any unique string for tagging "
+                         "purposes), the parameter to bin on, and the membership "
+                         "condition via 'lt' / 'gt' operators. "
+                         "Ex. name1:component:lt2 name2:total:lt15 name3:SEOBNRv2Peak:gt1000")
+parser.add_argument('--f-lower',
+                    help="Lower frequency cutoff for evaluating template duration. Should"
+                         " be equal to the lower cutoff used in inspiral jobs")
 parser.add_argument('--bank-file',
                     help="hdf format template bank file")
 parser.add_argument('--output-files', nargs='+',
                     help="list of output file names, one for each mass bin")
 args = parser.parse_args()
 
+if 'duration' in args.background_bins and not args.f_lower:
+    raise RuntimeError("Can't bin on template duration without f-lower!")
+
 pycbc.init_logging(args.verbose)
 
 if len(args.output_files) != len(args.background_bins):
-    raise ValueError('Number of mass bins and output files does not match') 
+    raise ValueError("Number of mass bins and output files does not match")
 
 f = h5py.File(args.bank_file)
 data = {'mass1':f['mass1'][:], 'mass2':f['mass2'][:],
         'spin1z':f['spin1z'][:], 'spin2z':f['spin2z'][:]}
+if args.f_lower:
+    data['f_lower'] = float(args.f_lower)
 
 locs_dict = pycbc.events.background_bin_from_string(args.background_bins, data)
 names = [b.split(':')[0] for b in args.background_bins]

--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -218,7 +218,6 @@ for bin_file in bin_files:
     ratehist = wf.make_snrratehist_plot(workflow, bin_file, 
                     rdir['open_box_result'], tags=bin_file.tags)
 
-                    
     results_page += [(snrifar, ratehist)]
     
     snrifar_ifar = wf.make_snrifar_plot(workflow, bin_file,

--- a/bin/hdfcoinc/pycbc_plot_bank_bins
+++ b/bin/hdfcoinc/pycbc_plot_bank_bins
@@ -11,6 +11,9 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--bank-file', help='hdf format template bank file')
 parser.add_argument('--background-bins', nargs='+', help='list of background bin format strings')
+parser.add_argument('--f-lower',
+                    help="Lower frequency cutoff for evaluating template duration. Should"
+                         " be equal to the lower cutoff used in inspiral jobs")
 parser.add_argument('--output-file', help='output file')
 args = parser.parse_args()
 
@@ -18,6 +21,8 @@ fig = pylab.figure()
 f = h5py.File(args.bank_file)
 data = {'mass1':f['mass1'][:], 'mass2':f['mass2'][:],
         'spin1z':f['spin1z'][:], 'spin2z':f['spin2z'][:]}
+if args.f_lower:
+    data['f_lower'] = float(args.f_lower)
 
 if args.background_bins:
     locs_dict = pycbc.events.background_bin_from_string(args.background_bins, data)

--- a/pycbc/events/coinc.py
+++ b/pycbc/events/coinc.py
@@ -26,11 +26,11 @@ coincident triggers.
 """
 import numpy, logging, h5py, pycbc.pnutils
 from itertools import izip
-from scipy.interpolate import interp1d  
+from scipy.interpolate import interp1d
 
 def background_bin_from_string(background_bins, data):
     """ Return template ids for each bin as defined by the format string
-    
+
     Parameters
     ----------
     bins: list of strings
@@ -39,36 +39,57 @@ def background_bin_from_string(background_bins, data):
     data: dict of numpy.ndarrays
         Dict with parameter key values and numpy.ndarray values which define
         the parameters of the template bank to bin up.
-    
+
     Returns
     -------
     bins: dict
         Dictionary of location indices indexed by a bin name
-    
     """
     used = numpy.array([], dtype=numpy.uint32)
     bins = {}
     for mbin in background_bins:
         name, bin_type, boundary = tuple(mbin.split(':'))
-        if bin_type == 'component':
-            locs = numpy.maximum(data['mass1'], data['mass2']) < float(boundary)
-        elif bin_type == 'total':
-            locs = data['mass1'] + data['mass2'] < float(boundary)
-        elif bin_type == 'chirp':
-            locs = pycbc.pnutils.mass1_mass2_to_mchirp_eta(data['mass1'], data['mass2'])[0] < float(boundary)
-        elif bin_type == 'SEOBNRv2Peak':
-            locs = pycbc.pnutils.get_freq('fSEOBNRv2Peak', data['mass1'],
-                data['mass2'], data['spin1z'], data['spin2z']) < float(boundary)
+
+        if boundary[0:2] == 'lt':
+            member_func = lambda vals: vals < float(boundary[2:])
+        elif boundary[0:2] == 'gt':
+            member_func = lambda vals: vals > float(boundary[2:])
         else:
-            raise ValueError('Invalid bin type %s' % bin_type)    
-        
-        # make sure we don't reuse anythign from an earlier bin
+            raise RuntimeError("Can't parse boundary condition! Must begin "
+                               "with 'lt' or 'gt'")
+
+        if bin_type == 'component' and boundary[0:2] == 'lt':
+            # maximum component mass is less than boundary value
+            vals = numpy.maximum(data['mass1'], data['mass2'])
+        if bin_type == 'component' and boundary[0:2] == 'gt':
+            # minimum component mass is greater than bdary
+            vals = numpy.minimum(data['mass1'], data['mass2'])
+        elif bin_type == 'total':
+            vals = data['mass1'] + data['mass2']
+        elif bin_type == 'chirp':
+            vals = pycbc.pnutils.mass1_mass2_to_mchirp_eta(
+                                               data['mass1'], data['mass2'])[0]
+        elif bin_type == 'SEOBNRv2Peak':
+            vals = pycbc.pnutils.get_freq('fSEOBNRv2Peak',
+                  data['mass1'], data['mass2'], data['spin1z'], data['spin2z'])
+        elif bin_type == 'duration':
+            # pnutils vectorized function shadowing pycbc.waveform
+            vals = pycbc.pnutils.get_seobnrrom_duration(data['mass1'],
+                data['mass2'], data['spin1z'], data['spin2z'], data['f_lower'])
+        else:
+            raise ValueError('Invalid bin type %s' % bin_type)
+
+        locs = member_func(vals)
+        del vals
+
+        # make sure we don't reuse anything from an earlier bin
         locs = numpy.where(locs)[0]
         locs = numpy.delete(locs, numpy.where(numpy.in1d(locs, used))[0])
-        used = numpy.concatenate([used, locs])   
+        used = numpy.concatenate([used, locs])
         bins[name] = locs
+
     return bins
-           
+
 
 def calculate_n_louder(bstat, fstat, dec, skip_background=False):
     """ Calculate for each foreground event the number of background events
@@ -84,24 +105,24 @@ def calculate_n_louder(bstat, fstat, dec, skip_background=False):
         Array of the decimation factors for the background statistics
     skip_background: optional, {boolean, False}
         Skip calculating cumulative numbers for background triggers
-    
+
     Returns
-    ------- 
+    -------
     cum_back_num: numpy.ndarray
         The cumulative array of background triggers. Does not return this
-        argument if skip_background == True 
+        argument if skip_background == True
     fore_n_louder: numpy.ndarray
         The number of background triggers above each foreground trigger
     """
     sort = bstat.argsort()
     bstat = bstat[sort]
     dec = dec[sort]
-    
-    # calculate cumulative number of triggers louder than the trigger in 
+
+    # calculate cumulative number of triggers louder than the trigger in
     # a given index. We need to subtract the decimation factor, as the cumsum
     # includes itself in the first sum (it is inclusive of the first value)
     n_louder = dec[::-1].cumsum()[::-1] - dec
-    
+
     # Determine how many values are louder than the foreground ones
     # We need to subtract one from the index, to be consistent with the definition
     # of n_louder, as here we do want to include the background value at the
@@ -110,7 +131,7 @@ def calculate_n_louder(bstat, fstat, dec, skip_background=False):
 
     # If the foreground are *quieter* than the background or at the same value
     # then the search sorted alorithm will choose position -1, which does not exist
-    # We force it back to zero. 
+    # We force it back to zero.
     if isinstance(idx, numpy.ndarray): # Handle the case where our input is an array
         idx[idx < 0] = 0
     else: # Handle the case where we are simply given a scalar value
@@ -128,11 +149,10 @@ def calculate_n_louder(bstat, fstat, dec, skip_background=False):
 
 def timeslide_durations(start1, start2, end1, end2, timeslide_offsets):
     """ Find the coincident time for each timeslide.
-    
+
     Find the coincident time for each timeslide, where the first time vector
-    is slid to the right by the offset in the given timeslide_offsets 
-    vector.
-    
+    is slid to the right by the offset in the given timeslide_offsets vector.
+
     Parameters
     ----------
     start1: numpy.ndarray
@@ -145,7 +165,7 @@ def timeslide_durations(start1, start2, end1, end2, timeslide_offsets):
         Array of the end of valid analyzed times for detector 2
     timseslide_offset: numpy.ndarray
         Array of offsets (in seconds) for each timeslide
-        
+
     Returns
     --------
     durations: numpy.ndarray
@@ -157,11 +177,11 @@ def timeslide_durations(start1, start2, end1, end2, timeslide_offsets):
     for offset in timeslide_offsets:
         seg1 = veto.start_end_to_segments(start1 + offset, end1 + offset)
         durations.append(abs((seg1 & seg2).coalesce()))
-    return numpy.array(durations)   
-    
+    return numpy.array(durations)
+
 def time_coincidence(t1, t2, window, slide_step=0):
     """ Find coincidences by time window
-    
+
     Parameters
     ----------
     t1 : numpy.ndarray
@@ -173,15 +193,15 @@ def time_coincidence(t1, t2, window, slide_step=0):
     slide_step : optional, {None, float}
         If calculating background coincidences, the interval between background
         slides in seconds.
-        
+
     Returns
     -------
     idx1 : numpy.ndarray
         Array of indices into the t1 array.
-    idx2 : numpy.ndarray 
+    idx2 : numpy.ndarray
         Array of indices into the t2 array.
     slide : numpy.ndarray
-        Array of slide ids 
+        Array of slide ids
     """
     if slide_step:
         fold1 = t1 % slide_step
@@ -189,12 +209,12 @@ def time_coincidence(t1, t2, window, slide_step=0):
     else:
         fold1 = t1
         fold2 = t2
-        
+
     sort1 = fold1.argsort()
-    sort2 = fold2.argsort()    
+    sort2 = fold2.argsort()
     fold1 = fold1[sort1]
     fold2 = fold2[sort2]
-    
+
     if slide_step:
         fold2 = numpy.concatenate([fold2 - slide_step, fold2, fold2 + slide_step])
         sort2 = numpy.concatenate([sort2, sort2, sort2])
@@ -209,19 +229,19 @@ def time_coincidence(t1, t2, window, slide_step=0):
         idx2 = numpy.concatenate(idx2)
     else:
         idx2 = numpy.array([])
-    
+
     if slide_step:
         diff = ((t1 / slide_step)[idx1] - (t2 / slide_step)[idx2])
         slide = numpy.rint(diff)
     else:
         slide = numpy.zeros(len(idx1))
-        
+
     return idx1.astype(numpy.uint32), idx2.astype(numpy.uint32), slide.astype(numpy.int32)
 
 
 def cluster_coincs(stat, time1, time2, timeslide_id, slide, window, argmax=numpy.argmax):
-    """Cluster coincident events for each timeslide separately, across 
-    templates, based on the ranking statistic 
+    """Cluster coincident events for each timeslide separately, across
+    templates, based on the ranking statistic
 
     Parameters
     ----------
@@ -240,7 +260,7 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window, argmax=numpy
 
     Returns
     -------
-    cindex: numpy.ndarray 
+    cindex: numpy.ndarray
         The set of indices corresponding to the surviving coincidences.
     """
     logging.info('clustering coinc triggers over %ss window' % window)
@@ -248,61 +268,61 @@ def cluster_coincs(stat, time1, time2, timeslide_id, slide, window, argmax=numpy
     if len(time1) == 0 or len(time2) == 0:
         logging.info('No coinc triggers in one, or both, ifos.')
         return numpy.array([])
-    
+
     indices = []
     if numpy.isfinite(slide):
         time = (time2 + (time1 + timeslide_id * slide)) / 2
     else:
         time = 0.5 * (time2 + time1)
-        
+
     tslide = timeslide_id.astype(numpy.float128)
     time = time.astype(numpy.float128)
-    
+
     span = (time.max() - time.min()) + window * 10
     time = time + span * tslide
-    
+
     time_sorting = time.argsort()
     stat = stat[time_sorting]
     time = time[time_sorting]
-    
+
     logging.info('sorting...')
     left = numpy.searchsorted(time, time - window)
     right = numpy.searchsorted(time, time + window)
     logging.info('done sorting')
     indices = numpy.zeros(len(left), dtype=numpy.uint32)
-    
+
     # i is the index we are inspecting, j is the next one to save
     i = 0
     j = 0
     while i < len(left):
         l = left[i]
         r = right[i]
-       
-        # If there are no other points to compare it is obviosly the max
+
+        # If there are no other points to compare it is obviously the max
         if (r - l) == 1:
             indices[j] = i
             j += 1
-            i += 1            
-            continue            
-        
+            i += 1
+            continue
+
         # Find the location of the maximum within the time interval around i
-        max_loc = argmax(stat[l:r]) + l 
-        
+        max_loc = argmax(stat[l:r]) + l
+
         # If this point is the max, we can skip to the right boundary
         if max_loc == i:
             indices[j] = i
             i = r
             j += 1
-        
+
         # If the max is later than i, we can skip to it
         elif max_loc > i:
-            i = max_loc 
-            
+            i = max_loc
+
         elif max_loc < i:
             i += 1
 
     indices = indices[:j]
-            
+
     logging.info('done clustering coinc triggers: %s triggers remaining' % len(indices))
     return time_sorting[indices]
 

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -378,7 +378,6 @@ def get_freq(freqfunc, m1, m2, s1z, s2z):
     lalsim_ffunc = getattr(lalsimulation, freqfunc)
     return _vec_get_freq(lalsim_ffunc, m1, m2, s1z, s2z)
 
-
 def _get_final_freq(approx, m1, m2, s1z, s2z):
     """
     Wrapper of the LALSimulation function returning the final (highest)
@@ -501,6 +500,20 @@ def frequency_cutoff_from_name(name, m1, m2, s1z, s2z):
     """
     params = {"m1":m1, "m2":m2, "s1z":s1z, "s2z":s2z}
     return named_frequency_cutoffs[name](params)
+
+def _get_seobnrrom_duration(m1, m2, s1z, s2z, f_low):
+    """Wrapper of lalsimulation template duration approximate formula"""
+    m1, m2, s1z, s2z, f_low = float(m1), float(m2), float(s1z), float(s2z),\
+                              float(f_low)
+    chi = lalsimulation.SimIMRPhenomBComputeChi(m1, m2, s1z, s2z)
+    time_length = lalsimulation.SimIMRSEOBNRv2ChirpTimeSingleSpin(
+                                m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, chi, f_low)
+    # FIXME The function seobnrrom_length_in_time() in waveform.py adds an
+    # extra factor of 1.1 for 'safety'.  For consistency with that code we do
+    # that here.  THIS IS FRAGILE AND HACKY
+    return time_length * 1.1
+
+get_seobnrrom_duration = numpy.vectorize(_get_seobnrrom_duration)
 
 def get_inspiral_tf(tc, mass1, mass2, f_low, f_high, n_points=50, pn_2order=7):
     """Compute the time-frequency evolution of an inspiral signal.

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -529,7 +529,7 @@ class PyCBCHDFInjFindExecutable(Executable):
 class PyCBCDistributeBackgroundBins(Executable):
     """ Distribute coinc files amoung different background bins """
     current_retention_level = Executable.CRITICAL
-    def create_node(self, coinc_files, bank_file,  background_bins, tags=[]):
+    def create_node(self, coinc_files, bank_file, background_bins, tags=[]):
         node = Node(self)
         node.add_input_list_opt('--coinc-files', coinc_files)
         node.add_input_opt('--bank-file', bank_file)
@@ -814,7 +814,7 @@ def setup_interval_coinc(workflow, hdfbank, trig_files,
             coinc_node = findcoinc_exe.create_node(trig_files, hdfbank, 
                                                    veto_file, veto_name,
                                                    group_str,
-                                                   tags= [veto_name, str(i)])
+                                                   tags=[veto_name, str(i)])
             bg_files += coinc_node.output_files
             workflow.add_node(coinc_node)
              


### PR DESCRIPTION
Allow template duration as a parameter, which also requires that various jobs get an argument for the low frequency cutoff to calculate the duration. 
Also generalize the background bins syntax to allow less-than and greater-than bin conditions.