### PR TITLE
Psd structure work

### DIFF
--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -17,7 +17,6 @@ parser.add_argument("--analysis-segment-file",  required=True,
                     help="File defining the segments to estimate PSDs over")
 parser.add_argument("--segment-name", help="Name of segment list to use")
 parser.add_argument("--cores", default=1, type=int)
-parser.add_argument("--psd-recalculate-segments", type=int, default=0)
 parser.add_argument("--output-file", required=True)
 
 pycbc.psd.insert_psd_option_group(parser, output=False)

--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -60,14 +60,14 @@ def get_psd((seg, i)):
     tlen = strain_segments.time_len
     delta_f = strain_segments.delta_f
 
-    logging.nfo('%d: calculating psd', i)
-    psds_and_times = generate_overlapping_psds(args, flen, delta_f, flow,
-                      dyn_range_factor=pycbc.DYN_RANGE_FAC)
+    logging.info('%d: calculating psd', i)
+    psds_and_times = pycbc.psd.generate_overlapping_psds(args, gwstrain,
+                      flen, delta_f, flow, dyn_range_factor=pycbc.DYN_RANGE_FAC)
 
     lpsd = []
     for start_idx, end_idx, psd in psds_and_times:
-        start_time = gwstrain.start_time + start_idx*gwstrain.sample_rate
-        end_time = gwstrain.start_time + end_idx*gwstrain.sample_rate
+        start_time = gwstrain.start_time + start_idx/gwstrain.sample_rate
+        end_time = gwstrain.start_time + end_idx/gwstrain.sample_rate
         lpsd.append((psd.numpy(), psd.delta_f, int(start_time), int(end_time)))
 
     return lpsd

--- a/bin/hdfcoinc/pycbc_calculate_psd
+++ b/bin/hdfcoinc/pycbc_calculate_psd
@@ -61,16 +61,15 @@ def get_psd((seg, i)):
     tlen = strain_segments.time_len
     delta_f = strain_segments.delta_f
 
-    logging.info('%d: calculating psd', i)
+    logging.nfo('%d: calculating psd', i)
+    psds_and_times = generate_overlapping_psds(args, flen, delta_f, flow,
+                      dyn_range_factor=pycbc.DYN_RANGE_FAC)
+
     lpsd = []
-    nsegs = args.psd_recalculate_segments
-    nsegs = nsegs if nsegs != 0 else len(strain_segments.full_segment_slices)
-    groups = grouper(nsegs, strain_segments.full_segment_slices)
-    
-    for psegs in groups:
-        strain_part = gwstrain[psegs[0].start:psegs[-1].stop]
-        psd = pycbc.psd.from_cli(args, flen, delta_f, flow, strain_part, pycbc.DYN_RANGE_FAC)        
-        lpsd.append((psd.numpy(), psd.delta_f, int(strain_part.start_time), int(strain_part.end_time)))
+    for start_idx, end_idx, psd in psds_and_times:
+        start_time = gwstrain.start_time + start_idx*gwstrain.sample_rate
+        end_time = gwstrain.start_time + end_idx*gwstrain.sample_rate
+        lpsd.append((psd.numpy(), psd.delta_f, int(start_time), int(end_time)))
 
     return lpsd
 

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -134,8 +134,6 @@ parser.add_argument("--user-tag", type=str, metavar="TAG", help="""
                     This is used to identify FULL_DATA jobs for
                     compatibility with pipedown post-processing.
                     Option will be removed when no longer needed.""")
-parser.add_argument("--psd-recalculate-segments", type=int,
-                    help="Number of segments to use before recalculating the PSD", default=0)
 parser.add_argument("--keep-loudest-interval", type=float,
                     help="Window in seconds to maximize triggers over bank")
 parser.add_argument("--keep-loudest-num", type=int,
@@ -162,30 +160,6 @@ fft.verify_fft_options(opt,parser)
 pycbc.opt.verify_optimization_options(opt, parser)
 pycbc.weave.verify_weave_options(opt, parser)
 
-def associate_psd(strain_segments, gwstrain, segments, nsegs, flen, delta_f, flow):
-    logging.info("Computing noise PSD")
-    def grouper(n, iterable):
-        args = [iter(iterable)] * n
-        return list([e for e in t if e != None] for t in itertools.izip_longest(*args))
-
-    nsegs = nsegs if nsegs != 0 else len(strain_segments.full_segment_slices)
-    groups = grouper(nsegs, strain_segments.full_segment_slices)
-    if len(groups[-1]) != len(groups[0]):
-        logging.warn('PSD recalculation does not divide equally among analysis'
-                     'segments. Make sure that this is what you want')
-
-    psds = []
-    for psegs in groups:
-        strain_part = gwstrain[psegs[0].start:psegs[-1].stop]
-        ppsd = psd.from_cli(opt, flen, delta_f, flow, 
-                            strain_part, DYN_RANGE_FAC).astype(float32)
-        psds.append(ppsd)
-        for seg in segments:
-            if seg.seg_slice in psegs:
-                seg.psd = ppsd
-    return psds
-
-
 pycbc.init_logging(opt.verbose)
 
 ctx = scheme.from_cli(opt)
@@ -202,8 +176,8 @@ with ctx:
 
     logging.info("Making frequency-domain data segments")
     segments = strain_segments.fourier_segments()
-    psds = associate_psd(strain_segments, gwstrain, segments,
-                  opt.psd_recalculate_segments, flen, delta_f, flow)
+    psd.associate_psds_to_segments(opt, segments, gwstrain, flen, delta_f,
+                  flow, dyn_range_factor=DYN_RANGE_FAC, precision='single')
 
     # storage for values and types to be passed to event manager
     out_types = {
@@ -227,7 +201,7 @@ with ctx:
     names = sorted(out_vals.keys())
 
     event_mgr = events.EventManager(
-            opt, names, [out_types[n] for n in names], psd=psds[0],
+            opt, names, [out_types[n] for n in names], psd=segments[0].psd,
             gating_info=gwstrain.gating_info)
 
     if len(strain_segments.segment_slices) == 0:

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -124,28 +124,6 @@ scheme.verify_processing_options(opt, parser)
 fft.verify_fft_options(opt,parser)
 pycbc.init_logging(opt.verbose)
 
-def associate_psd(strain_segments, gwstrain, segments, nsegs, flen, delta_f, flow):
-    logging.info("Computing noise PSD")
-    def grouper(n, iterable):
-        args = [iter(iterable)] * n
-        return list([e for e in t if e != None] for t in itertools.izip_longest(*args))
-
-    nsegs = nsegs if nsegs != 0 else len(strain_segments.full_segment_slices)
-    groups = grouper(nsegs, strain_segments.full_segment_slices)
-    if len(groups[-1]) != len(groups[0]):
-        logging.warn('PSD recalculation does not divide equally among analysis'
-                     'segments. Make sure that this is what you want')
-
-    psds = []
-    for psegs in groups:
-        strain_part = gwstrain[psegs[0].start:psegs[-1].stop]
-        ppsd = psd.from_cli(opt, flen, delta_f, flow, strain_part, pycbc.DYN_RANGE_FAC)
-        psds.append(ppsd)
-        for seg in segments:
-            if seg.seg_slice in psegs:
-                seg.psd = ppsd.astype(float32)
-    return psds
-
 ctx = scheme.from_cli(opt)
 gwstrain = strain.from_cli(opt, pycbc.DYN_RANGE_FAC)
 strain_segments = strain.StrainSegments.from_cli(opt, gwstrain)
@@ -170,9 +148,9 @@ with ctx:
     segments = strain_segments.fourier_segments()
     
     logging.info("Calculating the PSDs")
-    psds = associate_psd(strain_segments, gwstrain, segments, 
-                         opt.psd_recalculate_segments, 
-                         flen, delta_f, flow)
+    psd.associate_psds_to_segments(opt, segments, gwstrain, flen, delta_f,
+                             flow, dyn_range_factor=pycbc.DYN_RANGE_FAC,
+                             precision='single')
 
     logging.info("Making template: %s" % opt.approximant)
     if opt.use_params_of_closest_injection:

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -49,8 +49,6 @@ parser.add_argument("--low-frequency-cutoff", type=float,
                   help="The low frequency cutoff to use for filtering (Hz)")
 parser.add_argument("--chisq-bins", default="0", type=str, help=
                     "Number of frequency bins to use for power chisq.")
-parser.add_argument("--psd-recalculate-segments", type=int, 
-                    help="Number of segments to use before recalculating the PSD", default=0)
 parser.add_argument("--trigger-time", type=float, default=0,
                   help="The central time of the trigger to use.")
 parser.add_argument("--use-params-of-closest-injection", action="store_true",

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -305,14 +305,42 @@ def generate_overlapping_psds(opt, gwstrain, flen, delta_f, flow,
 
     Parameters
     -----------
-    FIXME
+    opt : object
+        Result of parsing the CLI with OptionParser, or any object with the
+        required attributes (psd_model, psd_file, asd_file, psd_estimation,
+        psd_segment_length, psd_segment_stride, psd_inverse_length, psd_output).
+    gwstrain : Strain object
+        The timeseries of raw data on which to estimate PSDs.
+    flen : int
+        The length in samples of the output PSDs.
+    delta_f : float
+        The frequency step of the output PSDs.
+    flow: float
+        The low frequncy cutoff to use when calculating the PSD.
+    dyn_range_factor : {1, float}
+        For PSDs taken from models or text files, if `dyn_range_factor` is
+        not None, then the PSD is multiplied by `dyn_range_factor` ** 2.
+    precision : str, choices (None,'single','double')
+        If not specified, or specified as None, the precision of the returned
+        PSD will match the precision of the data, if measuring a PSD, or will
+        match the default precision of the model if using an analytical PSD.
+        If 'single' the PSD will be converted to float32, if not already in
+        that precision. If 'double' the PSD will be converted to float64, if
+        not already in that precision.
 
     Returns
     --------
-    FIXME
+    psd_and_times : list of (start, end, psd) tuples
+        This is a list of tuples containing one entry for each PSD. The first
+        and second entries (start, end) in each tuple represent the index 
+        range of the gwstrain data that was used to estimate that PSD. The
+        third entry (psd) contains the PSD estimate between that interval.
     """
-    # FIXME: If not estimating the PSD from data this is not needed and we
-    #        should just go straight to the PSD class *once*.
+    if not opt.psd_estimation:
+        psd = from_cli(opt, flen, delta_f, flow, strain=gwstrain,
+                       dyn_range_factor=dyn_range_factor, precision=precision)
+        psds_and_times = [ (0, len(gwstrain), psd) ]
+        return psds_and_times
 
     # Figure out the data length used for PSD generation
     seg_stride = opt.psd_segment_stride * gwstrain.sample_rate
@@ -363,13 +391,32 @@ def associate_psds_to_segments(opt, fd_segments, gwstrain, flen, delta_f, flow,
 
     Parameters
     -----------
-    FIXME
-
-    Returns
-    --------
-    FIXME
+    opt : object
+        Result of parsing the CLI with OptionParser, or any object with the
+        required attributes (psd_model, psd_file, asd_file, psd_estimation,
+        psd_segment_length, psd_segment_stride, psd_inverse_length, psd_output).
+    fd_segments : StrainSegments.fourier_segments() object
+        The fourier transforms of the various analysis segments. The psd
+        attribute of each segment is updated to point to the appropriate PSD.
+    gwstrain : Strain object
+        The timeseries of raw data on which to estimate PSDs.
+    flen : int
+        The length in samples of the output PSDs.
+    delta_f : float
+        The frequency step of the output PSDs.
+    flow: float
+        The low frequncy cutoff to use when calculating the PSD.
+    dyn_range_factor : {1, float}
+        For PSDs taken from models or text files, if `dyn_range_factor` is
+        not None, then the PSD is multiplied by `dyn_range_factor` ** 2.
+    precision : str, choices (None,'single','double')
+        If not specified, or specified as None, the precision of the returned
+        PSD will match the precision of the data, if measuring a PSD, or will
+        match the default precision of the model if using an analytical PSD.
+        If 'single' the PSD will be converted to float32, if not already in
+        that precision. If 'double' the PSD will be converted to float64, if
+        not already in that precision.
     """
-    # FIXME: If not estimating PSD, only generate *one* PSD
     psds_and_times = generate_overlapping_psds(opt, gwstrain, flen, delta_f,
                                        flow, dyn_range_factor=dyn_range_factor,
                                        precision=precision)

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -88,7 +88,7 @@ def from_cli(opt, length, delta_f, low_frequency_cutoff,
         psd = welch(strain, avg_method=opt.psd_estimation,
                     seg_len=int(opt.psd_segment_length * sample_rate),
                     seg_stride=int(opt.psd_segment_stride * sample_rate),
-                    num_segments=opt.num_segments,
+                    num_segments=opt.psd_num_segments,
                     require_exact_data_fit=False)
 
         if delta_f != psd.delta_f:
@@ -316,7 +316,7 @@ def generate_overlapping_psds(opt, gwstrain, flen, delta_f, flow,
     # Figure out the data length used for PSD generation
     seg_stride = opt.psd_segment_stride
     seg_len = opt.psd_segment_length
-    num_segments = opt.num_segments
+    num_segments = opt.psd_num_segments
     if num_segments is None:
         err_msg = "You must supply --num-segments."
         raise ValueError(err_msg)
@@ -332,7 +332,7 @@ def generate_overlapping_psds(opt, gwstrain, flen, delta_f, flow,
         err_msg += "estimated with %d seconds. " %(psd_data_len)
         err_msg += "Input data length is %d seconds. " %(input_data_len)
         raise ValueError(err_msg)
-    else if input_data_len == psd_data_len:
+    elif input_data_len == psd_data_len:
         num_psd_measurements = 1
         psd_stride = 0
     else:

--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -104,14 +104,13 @@ def welch(timeseries, seg_len=4096, seg_stride=2048, window='hann', \
         fs_dtype = numpy.complex128
         
     num_samples = len(timeseries)
-    if num_segments is not None:
+    if num_segments is None:
         num_segments = num_samples / seg_stride
         if (num_segments - 1) * seg_stride + seg_len > num_samples:
             num_segments -= 1
 
     if not require_exact_data_fit:
         data_len = (num_segments - 1) * seg_stride + seg_len
-        data_len = data_len * gwstrain.sample_rate
 
         # Get the correct amount of data
         if data_len < num_samples:
@@ -127,9 +126,10 @@ def welch(timeseries, seg_len=4096, seg_stride=2048, window='hann', \
         if data_len > num_samples:
             err_msg = "I was asked to estimate a PSD on %d " %(data_len)
             err_msg += "data samples. However the data provided only contains "
-            err_msg += "%d data samples." %(length)
+            err_msg += "%d data samples." %(num_samples)
 
     if num_samples != (num_segments - 1) * seg_stride + seg_len:
+        print num_samples, num_segments, seg_stride, seg_len, data_len
         raise ValueError('Incorrect choice of segmentation parameters')
         
     w = Array(window_map[window](seg_len).astype(timeseries.dtype))

--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -105,7 +105,8 @@ def welch(timeseries, seg_len=4096, seg_stride=2048, window='hann', \
         
     num_samples = len(timeseries)
     if num_segments is None:
-        num_segments = num_samples / seg_stride
+        num_segments = int(num_samples // seg_stride)
+        # NOTE: Is this not always true?
         if (num_segments - 1) * seg_stride + seg_len > num_samples:
             num_segments -= 1
 
@@ -129,7 +130,6 @@ def welch(timeseries, seg_len=4096, seg_stride=2048, window='hann', \
             err_msg += "%d data samples." %(num_samples)
 
     if num_samples != (num_segments - 1) * seg_stride + seg_len:
-        print num_samples, num_segments, seg_stride, seg_len, data_len
         raise ValueError('Incorrect choice of segmentation parameters')
         
     w = Array(window_map[window](seg_len).astype(timeseries.dtype))

--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -53,7 +53,7 @@ def median_bias(n):
     return ans
 
 def welch(timeseries, seg_len=4096, seg_stride=2048, window='hann', \
-        avg_method='median'):
+        avg_method='median', num_segments=None, require_exact_data_fit=False):
     """PSD estimator based on Welch's method.
 
     Parameters
@@ -104,10 +104,31 @@ def welch(timeseries, seg_len=4096, seg_stride=2048, window='hann', \
         fs_dtype = numpy.complex128
         
     num_samples = len(timeseries)
-    num_segments = num_samples / seg_stride
-    
-    if (num_segments - 1) * seg_stride + seg_len > num_samples:
-        num_segments -= 1
+    if num_segments is not None:
+        num_segments = num_samples / seg_stride
+        if (num_segments - 1) * seg_stride + seg_len > num_samples:
+            num_segments -= 1
+
+    if not require_exact_data_fit:
+        data_len = (num_segments - 1) * seg_stride + seg_len
+        data_len = data_len * gwstrain.sample_rate
+
+        # Get the correct amount of data
+        if data_len < num_samples:
+            diff = num_samples - data_len
+            start = diff // 2
+            end = num_samples - diff // 2
+            # Want this to be integers so if diff is odd, catch it here.
+            if diff % 2:
+                start = start + 1
+
+            timeseries = timeseries[start:end]
+            num_samples = len(timeseries)
+        if data_len > num_samples:
+            err_msg = "I was asked to estimate a PSD on %d " %(data_len)
+            err_msg += "data samples. However the data provided only contains "
+            err_msg += "%d data samples." %(length)
+
     if num_samples != (num_segments - 1) * seg_stride + seg_len:
         raise ValueError('Incorrect choice of segmentation parameters')
         

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -54,18 +54,8 @@ def detect_loud_glitches(strain, psd_duration=4., psd_stride=2.,
     pycbc.fft.fftw.set_measure_level(0)
 
     logging.info('Autogating: estimating PSD')
-    seg_len = int(psd_duration*strain.sample_rate)
-    seg_stride = int(psd_stride*strain.sample_rate)
-    remainder = (len(strain) - seg_len) % seg_stride
-    if remainder:
-        if remainder % 2:
-            psd_strain = strain[remainder//2:len(strain) - remainder//2 - 1]
-        else:
-            psd_strain = strain[remainder//2:len(strain) - remainder//2]
-    else:
-        psd_strain = strain
-
-    psd = pycbc.psd.welch(psd_strain, seg_len=seg_len, seg_stride=seg_stride,
+    psd = pycbc.psd.welch(strain, seg_len=int(psd_duration*strain.sample_rate),
+                          seg_stride=int(psd_stride*strain.sample_rate),
                           avg_method=psd_avg_method)
     psd = pycbc.psd.interpolate(psd, 1./strain.duration)
     psd = pycbc.psd.inverse_spectrum_truncation(

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -54,8 +54,18 @@ def detect_loud_glitches(strain, psd_duration=4., psd_stride=2.,
     pycbc.fft.fftw.set_measure_level(0)
 
     logging.info('Autogating: estimating PSD')
-    psd = pycbc.psd.welch(strain, seg_len=int(psd_duration*strain.sample_rate),
-                          seg_stride=int(psd_stride*strain.sample_rate),
+    seg_len = int(psd_duration*strain.sample_rate)
+    seg_stride = int(psd_stride*strain.sample_rate)
+    remainder = (len(strain) - seg_len) % seg_stride
+    if remainder:
+        if remainder % 2:
+            psd_strain = strain[remainder//2:len(strain) - remainder//2 - 1]
+        else:
+            psd_strain = strain[remainder//2:len(strain) - remainder//2]
+    else:
+        psd_strain = strain
+
+    psd = pycbc.psd.welch(psd_strain, seg_len=seg_len, seg_stride=seg_stride,
                           avg_method=psd_avg_method)
     psd = pycbc.psd.interpolate(psd, 1./strain.duration)
     psd = pycbc.psd.inverse_spectrum_truncation(


### PR DESCRIPTION
Here is step two of merging the functionality from the zero-padding branch. Specifically here we rework how the PSD structuring is performed in pycbc_inspiral, removing associate_psd, and replacing it with some new functions in the PSD module.

The basic ideas of this change:

 * Allow pycbc_inspiral to run even if the data length is not some specific multiple of the PSD length
 * Make the PSD estimation and the segmentation for analysis independent. (Now analysis segments just pick the best PSD, but no knowledge of the segmentation is used when generating PSDs).
 * With the --psd-num-segments option we can ensure that inspiral jobs use the same data length for PSD estimation even when the amount of data they read in is variable.
 * Remove PSD-related code from the top-level executable

PSDs will now be made overlapping each other (like data segments were in the old ihope method). This will ensure that, if the data-length and length-of-data-used-for-psd-estimation are the same, then a data segment will have at least 50% overlap with it's associated PSD data.

Currently this will run the standard workflow with no additional command-line arguments needed (the example workflow is running, I will post when complete). However, the --psd-recalculate-segments option is removed, and we temporarily will not allow [min/max]-analysis-segments to take different values in the [workflow-matchedfilter] section - that will be addressed in the final part of merging this branch, as that code needs updating to support zero-padding.