### PR TITLE
Daily pages export censored trigs

### DIFF
--- a/bin/sngl/pycbc_export_censored_trigs
+++ b/bin/sngl/pycbc_export_censored_trigs
@@ -134,7 +134,7 @@ if opts.cluster_window:
     cluster_idx = []
     
     # Run a loop over the time bins
-    for i in range(int(nbins)):
+    for i in range(int(numpy.ceil(nbins))):
         
         # find upper bound for the ith time bin
         t_hi = t_low + opts.cluster_window

--- a/bin/sngl/pycbc_export_censored_trigs
+++ b/bin/sngl/pycbc_export_censored_trigs
@@ -84,7 +84,7 @@ parser.add_argument("--min-stat", type=float, default=0.0,
 parser.add_argument("--n-loudest", type=int, default=0,
                   help="Read the nth loudest triggers from the input files.")
 parser.add_argument("--cluster-window", type=float, default=0.0,
-                  help="Enter a cluster window for applying clustering to coinc triggers.")
+                  help="Window for applying clustering to coinc triggers.")
 
 
 # parse command line
@@ -105,37 +105,66 @@ else:
     trigs_censored = ForegroundTriggers(opts.coinc_file, opts.bank_file,
                           sngl_files=opts.sngl_files, group=group)
 
-# apply clustering to censored_triggers if a cluster-window has been parsed in the command line else skip clustering. Then pick triggers above min-stat if one is parsed in the command line
 
-# The clustering picks the loudest trigger in each window
+# Apply clustering to censored_triggers if a cluster-window has been 
+# parsed in the command line.
+
+# Clustering picks the loudest trigger in each cluster-window
 
 if opts.cluster_window:
-    coinc_newsnr = numpy.array( trigs_censored.get_coincfile_array("stat") )
-
-    time1 = numpy.array( trigs_censored.get_coincfile_array("time1") )
-
+    
+    # get newsnr for all censored triggers
+    coinc_newsnr = trigs_censored.get_coincfile_array("stat")
+    
+    # get H1 trigger times from the coinc censored trigger file
+    time1 = trigs_censored.get_coincfile_array("time1")
+    
+    # get the minimum and maximum times for the triggers
     t_start = numpy.amin(time1)
     t_end = numpy.amax(time1)
-
+    
+    # Divide the time range in which the triggers are distributed into 
+    # bins using the cluster-window
     nbins = (t_end - t_start)/opts.cluster_window
 
-    i = 1
+    # set the lower-bound of the 1st time bin to the minimum time for 
+    # the set of triggers
     t_low = t_start
+
     cluster_idx = []
-    while i < (nbins + 1):
+    
+    # Run a loop over the time bins
+    for i in range(int(nbins)):
+        
+        # find upper bound for the ith time bin
         t_hi = t_low + opts.cluster_window
+ 
+        # find the indices of all triggers in the ith time bin
         trigs_bin_idx = numpy.where((t_low < time1) & (t_hi > time1))[0]
-        coinc_newsnr_bin = numpy.array(coinc_newsnr)[trigs_bin_idx]
+
+        # find values of newsnr for the censored triggers in the ith bin
+        coinc_newsnr_bin = coinc_newsnr[trigs_bin_idx]
+
+        # if there are triggers in the ith bin find the index of the 
+        # loudest trigger and append it to the array cluster_idx. If
+        # there are no triggers in the bin skip this step
         if len(coinc_newsnr_bin) > 0:
            max_idx = numpy.argmax(coinc_newsnr_bin)
            cluster_idx.append(max_idx)
-        t_low = t_hi
-        i = i + 1
-    cluster_idx = numpy.array(cluster_idx)
-    coinc_newsnr_trigs_clustered = numpy.array( trigs_censored.get_coincfile_array("stat") )[cluster_idx]
 
+        # Move one bin up in time
+        t_low = t_hi
+
+    # get newsnr of all clustered triggers
+    coinc_newsnr_trigs_clustered = trigs_censored.get_coincfile_array("stat")[cluster_idx]
+
+    # find triggers louder than min-stat if a value for it is parsed in
+    # the command line
     mask = numpy.where( coinc_newsnr_trigs_clustered > opts.min_stat )[0]
 
+
+# If no cluster-window provided clustering is skipped and triggers louder 
+# than min-stat is found if a value for it is parsed
 else:
     mask = numpy.where( trigs_censored.get_coincfile_array("stat") > opts.min_stat )[0]
 

--- a/bin/sngl/pycbc_export_censored_trigs
+++ b/bin/sngl/pycbc_export_censored_trigs
@@ -83,6 +83,9 @@ parser.add_argument("--min-stat", type=float, default=0.0,
                   help="Only add triggers above this stat to output XML file.")
 parser.add_argument("--n-loudest", type=int, default=0,
                   help="Read the nth loudest triggers from the input files.")
+parser.add_argument("--cluster-window", type=float, default=0.0,
+                  help="Enter a cluster window for applying clustering to coinc triggers.")
+
 
 # parse command line
 opts = parser.parse_args()
@@ -102,8 +105,39 @@ else:
     trigs_censored = ForegroundTriggers(opts.coinc_file, opts.bank_file,
                           sngl_files=opts.sngl_files, group=group)
 
-# find triggers above limit
-mask = numpy.where( trigs_censored.get_coincfile_array("stat") > opts.min_stat )[0]
+# apply clustering to censored_triggers if a cluster-window has been parsed in the command line else skip clustering. Then pick triggers above min-stat if one is parsed in the command line
+
+# The clustering picks the loudest trigger in each window
+
+if opts.cluster_window:
+    coinc_newsnr = numpy.array( trigs_censored.get_coincfile_array("stat") )
+
+    time1 = numpy.array( trigs_censored.get_coincfile_array("time1") )
+
+    t_start = numpy.amin(time1)
+    t_end = numpy.amax(time1)
+
+    nbins = (t_end - t_start)/opts.cluster_window
+
+    i = 1
+    t_low = t_start
+    cluster_idx = []
+    while i < (nbins + 1):
+        t_hi = t_low + opts.cluster_window
+        trigs_bin_idx = numpy.where((t_low < time1) & (t_hi > time1))[0]
+        coinc_newsnr_bin = numpy.array(coinc_newsnr)[trigs_bin_idx]
+        if len(coinc_newsnr_bin) > 0:
+           max_idx = numpy.argmax(coinc_newsnr_bin)
+           cluster_idx.append(max_idx)
+        t_low = t_hi
+        i = i + 1
+    cluster_idx = numpy.array(cluster_idx)
+    coinc_newsnr_trigs_clustered = numpy.array( trigs_censored.get_coincfile_array("stat") )[cluster_idx]
+
+    mask = numpy.where( coinc_newsnr_trigs_clustered > opts.min_stat )[0]
+
+else:
+    mask = numpy.where( trigs_censored.get_coincfile_array("stat") > opts.min_stat )[0]
 
 # dict to hold parameters
 param_dict = {}

--- a/bin/sngl/run_daily_pycbc_export_censored_trigs
+++ b/bin/sngl/run_daily_pycbc_export_censored_trigs
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-# Copyright (C) 2016 Christopher M. Biwer
+# Copyright (C) 2016 Soumi De
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -41,8 +41,8 @@ MONTH=`lalapps_tconvert -f "%Y%m" ${GPS_START_TIME}`
 # day subdir name in form of YYYYMMDD
 DAY=`lalapps_tconvert -f "%Y%m%d" ${GPS_START_TIME}`
 
-# number of loudest triggers to put in output files
-N_LOUDEST=1000000
+# specify the window for applying clustering to censored triggers
+CLUSTER_WINDOW=16.0 
 
 # location of run output dir
 RUN_DIR=/home/${USER}/projects/daily_cbc_offline/main/${MONTH}/${DAY}
@@ -95,7 +95,7 @@ for BIN in 0 1 2; do
             --coinc-file ${COINC_FILE} \
             --bank-file ${BANK_FILE} \
             --sngl-files ${SNGL_FILES} \
-            --n-loudest ${N_LOUDEST}
+            --cluster-window ${CLUSTER_WINDOW}
 
         # print statement
         echo

--- a/bin/sngl/run_daily_pycbc_export_censored_trigs
+++ b/bin/sngl/run_daily_pycbc_export_censored_trigs
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-# Copyright (C) 2016 Soumi De
+# Copyright (C) 2016 Christopher M. Biwer
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the


### PR DESCRIPTION
1. In bin/sngl/pycbc_export_censored triggers : Added clustering to censored triggers before picking up triggers about min-stat (if one is parsed in the command line)

2. In  bin/sngl/run_daily_pycbc_export_censored_trigs : Removed the condition of picking 1000000 loudest triggers to be written to xml file. Specified a cluster window = 16secs.