### PR TITLE
Only fix axes if there are points to plot.

### DIFF
--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -179,7 +179,7 @@ if opts.open_box and len(fore_cumnum) > 100:
     # If we have > 100 foreground triggers, scale the plot around the foreground
     pylab.ylim(0.8, 1.1 * len(fore_cumnum))
     pylab.xlim(0.9 * min(fore_ifar))
-else:
+elif len(allbkg_cumnum) > 0:
     # If we have < 100 foreground triggers (or this is closed box), scale the
     # plot around the cumulative background (the green line).
     pylab.ylim(0.8, 1.1 * len(allbkg_cumnum))


### PR DESCRIPTION
Right now ``pycbc_page_ifar`` will fail if there are no plots to point when it tries to set the axes. This PR skips that step if there are no points to plot.