### PR TITLE
Fix min-segment-length option in segment module

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -1494,7 +1494,7 @@ class SegFile(File):
                     newsegment_list.append(seg)
             newsegment_list.coalesce()
             self.segment_dict[key] = newsegment_list
-        self.to_segment_xml()
+        self.to_segment_xml(override_file_if_exists=True)
 
     def return_union_seglist(self):
         return self.segment_dict.union(self.segment_dict.keys())
@@ -1510,7 +1510,7 @@ class SegFile(File):
             err_msg = "Key should be of the format 'ifo:name', got %s." %(key,)
             raise ValueError(err_msg)
 
-    def to_segment_xml(self):
+    def to_segment_xml(self, override_file_if_exists=False):
         """
         Write the segment list in self.segmentList to self.storage_path.
         """
@@ -1538,8 +1538,12 @@ class SegFile(File):
                 xmlsegs.insert_from_segmentlistdict({ifo : fsegs}, name,
                                                     valid = {ifo : vsegs})
         # write file
+        if override_file_if_exists and \
+                                 self.has_pfn(self.storage_path, site='local'):
+            pass
+        else:
+            self.PFN(self.storage_path, site='local')
         ligolw_utils.write_filename(outdoc, self.storage_path)
-        self.PFN(self.storage_path, site='local')
 
 
 def make_external_call(cmdList, out_dir=None, out_basename='external_call',

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -414,6 +414,13 @@ class File(DataStorage, dax.File):
             return '%s %s pool="%s"' % (self.name, self.storage_path, 'local')
         else:
             raise ValueError('This file does not have a storage path')
+
+    def has_pfn(self, url, site=None):
+        """ Wrapper of the pegasus hasPFN function, that allows it to be called
+        outside of specific pegasus functions.
+        """
+        curr_pfn = dax.PFN(url, site)
+        return self.hasPFN(curr_pfn)
         
     def insert_into_dax(self, dax):
         dax.addFile(self)

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -249,7 +249,7 @@ def get_analyzable_segments(workflow, sci_segs, cat_files, out_dir, tags=None):
 
     if workflow.cp.has_option_tags("workflow-segments",
                           "segments-minimum-segment-length", tags):
-        min_seg_length = int( cp.get_opt_tags("workflow-segments",
+        min_seg_length = int( workflow.cp.get_opt_tags("workflow-segments",
                               "segments-minimum-segment-length", tags) )
         sci_ok_seg_file.remove_short_sci_segs(min_seg_length)
 


### PR DESCRIPTION
The minimum segment length option in the workflow is currently broken as it will try to duplicate a pegasus PFN. The fix seemed trivial but did eventually involve adding a small function in pegasus_workflow.py to expose correctly the pegasus hasPFN function. This is tested and does what it should do now.