### PR TITLE
Fixes for recent PSD changes

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -200,16 +200,20 @@ with ctx:
                }
     names = sorted(out_vals.keys())
 
-    event_mgr = events.EventManager(
-            opt, names, [out_types[n] for n in names], psd=segments[0].psd,
-            gating_info=gwstrain.gating_info)
-
     if len(strain_segments.segment_slices) == 0:
         logging.info("--filter-inj-only specified and no injections in analysis time")
+        event_mgr = events.EventManager(
+              opt, names, [out_types[n] for n in names], psd=None,
+              gating_info=gwstrain.gating_info)
         event_mgr.finalize_template_events()
         event_mgr.write_events(opt.output)
         logging.info("Finished")
         sys.exit(0)
+
+    # FIXME: Maybe we should use the PSD corresponding to each trigger
+    event_mgr = events.EventManager(
+            opt, names, [out_types[n] for n in names], psd=segments[0].psd,
+            gating_info=gwstrain.gating_info)
 
     template_mem = zeros(tlen, dtype = complex64)
     cluster_window = int(opt.cluster_window * gwstrain.sample_rate)

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -368,7 +368,7 @@ def generate_overlapping_psds(opt, gwstrain, flen, delta_f, flow,
         num_psd_measurements = 1
         psd_stride = 0
     else:
-        num_psd_measurements = 2 * int((input_data_len-1) / psd_data_len) - 1
+        num_psd_measurements = int(2 * (input_data_len-1) / psd_data_len)
         psd_stride = int((input_data_len - psd_data_len) / num_psd_measurements)
 
     for idx in range(num_psd_measurements):


### PR DESCRIPTION
The recent removal of associate_psds broke pycbc_inspiral in the case that an injection job is a no-op job because no injections are present in the analysis window. These jobs really shouldn't be in the workflow, but this is still a simple fix. Tested and works.

A slightly more serious problem was in my arithmetic to compute num_psd_measurements, which caused there to be less PSD measurements than jobs (a reminder to Alex that we agreed that the *minimum* overlap between PSDs would be 50%). In the limit of a very short segment, *and* when doing zero-padding this could cause a segment to overlap no PSDs at all! The fix fixes this and is tested.