### PR TITLE
Single template fix

### DIFF
--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -325,18 +325,18 @@ layout.two_column_layout(rdir['detector_sensitivity'],
 
 # run minifollowups on the output of the loudest events 
 wf.setup_foreground_minifollowups(workflow, final_bg_file,
-                                full_insps,  hdfbank[0], insp_files_seg_file,
-                                data_analysed_name, 'daxes',
-                                rdir['open_box_result/loudest_event_followup'],
-                                tags=final_bg_file.tags)
+                              full_insps,  hdfbank[0], insp_files_seg_file,
+                              data_analysed_name, trig_generated_name, 'daxes',
+                              rdir['open_box_result/loudest_event_followup'],
+                              tags=final_bg_file.tags)
     
 for bin_file in bin_files:
     if hasattr(bin_file, 'bin_name'):
         currdir = rdir['open_box_result/loudest_in_%s_bin' % bin_file.bin_name]
         wf.setup_foreground_minifollowups(workflow, bin_file, full_insps,
                                   hdfbank[0], insp_files_seg_file,
-                                  data_analysed_name, 'daxes', currdir,
-                                  tags=bin_file.tags)
+                                  data_analysed_name, trig_generated_name,
+                                  'daxes', currdir, tags=bin_file.tags)
 
 # Also run minifollowups on loudest sngl detector events
 for insp_file in full_insps:
@@ -344,7 +344,8 @@ for insp_file in full_insps:
     currdir = rdir['single_triggers/%s_loudest_triggers' %(curr_ifo,)]
     wf.setup_single_det_minifollowups(workflow, insp_file, hdfbank[0],
                                   insp_files_seg_file, data_analysed_name,
-                                  'daxes', currdir, veto_file=censored_veto,
+                                  trig_generated_name, 'daxes', currdir,
+                                  veto_file=censored_veto,
                                   veto_segment_name='closed_box',
                                   tags=insp_file.tags)
 
@@ -476,8 +477,8 @@ for inj_file, tag in zip(inj_files, inj_tags):
     currdir = rdir['injections/followup_of_missed_%s' % tag]
     wf.setup_injection_minifollowups(workflow, found_inj, small_inj_file,
                                      insps,  hdfbank[0], insp_files_seg_file,
-                                     data_analysed_name, 'daxes', currdir,
-                                     tags=[tag])
+                                     data_analysed_name, trig_generated_name,
+                                     'daxes', currdir, tags=[tag])
         
 # Make combined injection plots
 inj_summ = []

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -43,8 +43,12 @@ parser.add_argument('--single-detector-triggers', nargs='+', action=MultiDetOpti
                     help="HDF format merged single detector trigger files")
 parser.add_argument('--inspiral-segments', 
                     help="xml segment files containing the inspiral analysis times")
-parser.add_argument('--inspiral-segment-name',
-                    help="Name of inspiral segmentlist to read from segment files")
+parser.add_argument('--inspiral-data-read-name',
+                    help="Name of inspiral segmentlist containing data read in "
+                         "by each analysis job.")
+parser.add_argument('--inspiral-data-analyzed-name',
+                    help="Name of inspiral segmentlist containing data "
+                         "analyzed by each analysis job.")
 parser.add_argument('--output-map')
 parser.add_argument('--output-file')
 parser.add_argument('--tags', nargs='+', default=[])
@@ -118,7 +122,8 @@ for num_event in range(num_events):
     params['spin1z'] = bank_data['spin1z'][bank_id]
     params['spin2z'] = bank_data['spin2z'][bank_id]
     files += mini.make_single_template_plots(workflow, insp_segs,
-                                    args.inspiral_segment_name, params,
+                                    args.inspiral_data_read_name,
+                                    args.inspiral_data_analyzed_name,  params,
                                     args.output_dir, tags=args.tags + [str(num_event)])
     
     for single in single_triggers:

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -48,8 +48,12 @@ parser.add_argument('--single-detector-triggers', nargs='+', action=MultiDetOpti
                     help="HDF format merged single detector trigger files")
 parser.add_argument('--inspiral-segments',
                     help="xml segment files containing the inspiral analysis times")
-parser.add_argument('--inspiral-segment-name',
-                    help="Name of inspiral segmentlist to read from segment files")
+parser.add_argument('--inspiral-data-read-name',
+                    help="Name of inspiral segmentlist containing data read in "
+                         "by each analysis job.")
+parser.add_argument('--inspiral-data-analyzed-name',
+                    help="Name of inspiral segmentlist containing data "
+                         "analyzed by each analysis job.")
 parser.add_argument('--inj-window', type=int, default=0.5,
                     help="Time window in which to look for injection triggers")
 parser.add_argument('--output-map')
@@ -141,7 +145,8 @@ for num_event in range(num_events):
                                 tags=args.tags + [str(num_event)])
 
     files += mini.make_single_template_plots(workflow, insp_segs,
-                            args.inspiral_segment_name, inj_params,
+                            args.inspiral_data_read_name,
+                            args.inspiral_data_analyzed_name, inj_params,
                             args.output_dir, inj_file=injection_xml_file,
                             tags=args.tags+['INJ_PARAMS',str(num_event)],
                             params_str='injection parameters as template, ' +\
@@ -149,7 +154,8 @@ for num_event in range(num_events):
                             use_exact_inj_params=True)
 
     files += mini.make_single_template_plots(workflow, insp_segs,
-                            args.inspiral_segment_name, inj_params,
+                            args.inspiral_data_read_name,
+                            args.inspiral_data_analyzed_name, inj_params,
                             args.output_dir, inj_file=injection_xml_file,
                             tags=args.tags+['INJ_PARAMS_INVERTED',
                                             str(num_event)],
@@ -158,7 +164,8 @@ for num_event in range(num_events):
                             use_exact_inj_params=True)
 
     files += mini.make_single_template_plots(workflow, insp_segs,
-                            args.inspiral_segment_name, inj_params,
+                            args.inspiral_data_read_name,
+                            args.inspiral_data_analyzed_name, inj_params,
                             args.output_dir, inj_file=injection_xml_file,
                             tags=args.tags+['INJ_PARAMS_NOINJ',
                                             str(num_event)],
@@ -188,7 +195,8 @@ for num_event in range(num_events):
         curr_tags = ['TMPLT_PARAMS_%s' %(curr_ifo,)]
         curr_tags += [str(num_event)]
         files += mini.make_single_template_plots(workflow, insp_segs,
-                                args.inspiral_segment_name, curr_params,
+                                args.inspiral_data_read_name,
+                                args.inspiral_data_analyzed_name, curr_params,
                                 args.output_dir, inj_file=injection_xml_file,
                                 tags=args.tags + curr_tags,
                                 params_str='loudest template in %s' % curr_ifo )

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -49,9 +49,12 @@ parser.add_argument('--veto-segment-name',
 parser.add_argument('--inspiral-segments',
                     help="xml segment file containing the inspiral analysis "
                          "times")
-parser.add_argument('--inspiral-segment-name',
-                    help="Name of inspiral segmentlist to read from segment "
-                         "file")
+parser.add_argument('--inspiral-data-read-name',
+                    help="Name of inspiral segmentlist containing data read in "
+                         "by each analysis job.")
+parser.add_argument('--inspiral-data-analyzed-name',
+                    help="Name of inspiral segmentlist containing data "
+                         "analyzed by each analysis job.")
 parser.add_argument('--ranking-statistic',
                 help="How to rank triggers when determining loudest triggers.")
 parser.add_argument('--output-map')
@@ -120,7 +123,8 @@ for num_event in range(num_events):
     curr_params['spin2z'] = trigs.spin2z[num_event]
     curr_params[args.instrument + '_end_time'] = time
     files += mini.make_single_template_plots(workflow, insp_segs,
-                            args.inspiral_segment_name, curr_params,
+                            args.inspiral_data_read_name,
+                            args.inspiral_data_analyzed_name, curr_params,
                             args.output_dir, 
                             tags=args.tags+[str(num_event)])
 

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -24,19 +24,47 @@ from pycbc.filter import resample_to_delta_t
 from pycbc.types import zeros, float32, complex64, TimeSeries, FrequencySeries
 from pycbc.types import complex_same_precision_as
 
-def select_segment(fname, segment, ifo, time, start_pad, end_pad):
-    segs = events.select_segments_by_definer(fname, segment, ifo)
+def select_segments(fname, anal_name, data_name, ifo, time):
+    anal_segs = events.select_segments_by_definer(fname, anal_name, ifo)
+    data_segs = events.select_segments_by_definer(fname, data_name, ifo)
 
-    s = numpy.array([t[0] for t in segs])
-    e = numpy.array([t[1] for t in segs])
-
+    # Anal segs should be disjoint, so first find the seg containing time
+    s = numpy.array([t[0] for t in anal_segs])
+    e = numpy.array([t[1] for t in anal_segs])
     #ensure sorted
     sorting = s.argsort()    
-    s = s[sorting] + start_pad
-    e = e[sorting] - end_pad
-
+    s = s[sorting]
+    e = e[sorting]
     idx = numpy.searchsorted(s, time) - 1
-    return (s[idx] - start_pad, e[idx] + end_pad)
+    anal_time = (s[idx], e[idx])
+
+    # Now need to find the corresponding data_seg. This could be complicated
+    # as in edge cases the anal_time tuple could be completely contained within
+    # *two* data blocks (think analysis chunk slightly longer than minimum).
+    # We need to choose the *right* block to reproduce what the search did.
+
+    s2 = numpy.array([t[0] for t in data_segs])
+    e2 = numpy.array([t[1] for t in data_segs])
+    lgc = (s2 < time) & (e2 > time)
+    s2 = s2[lgc]
+    e2 = e2[lgc]
+    if len(s2) == 0:
+        err_msg = "Cannot find a data segment within %s" %(str(time))
+        raise ValueError(err_msg)
+    if len(s2) == 1:
+        data_time = (s2[0], e2[0])
+    if len(s2) > 1:
+        # The tricksy case. The corresponding data segment should have the
+        # largest overlap with anal_time
+        overlap = None
+        for start, end in zip(s2, e2):
+            curr_nonoverlap = anal_time[0] - start
+            curr_nonoverlap = end - anal_time[1]
+            if (overlap is None) or (curr_nonoverlap < overlap):
+                overlap = curr_nonoverlap
+                data_time = (start, end)
+
+    return anal_time, data_time
 
 parser = argparse.ArgumentParser(usage='',
     description="Single template gravitational-wave followup")
@@ -88,8 +116,12 @@ parser.add_argument("--taper-template", choices=["start","end","startend"],
 parser.add_argument("--inspiral-segments",
         help="XML file containing the inspiral analysis segments. "
              "Only used with the --statmap-file option")
-parser.add_argument("--segment-name", 
-        help="name of the segmentlist to read from the inspiral segment file")
+parser.add_argument("--data-read-name",
+        help="name of the segmentlist containing the data read in by each job "
+             "from the inspiral segment file")
+parser.add_argument("--data-analyzed-name",
+        help="name of the segmentlist containing the data analysed by each job "
+             "from the inspiral segment file")
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -104,12 +136,16 @@ ifo = opt.channel_name[0:2]
 
 # If we are choosing start/end times from XML file ############################
 if opt.inspiral_segments:
-    start_pad = opt.pad_data + opt.segment_start_pad
-    end_pad = opt.pad_data + opt.segment_end_pad
-    seg = select_segment(opt.inspiral_segments, opt.segment_name, ifo,
-                         opt.trigger_time, start_pad, end_pad)
-    opt.gps_start_time, opt.gps_end_time = \
-                                   seg[0] + opt.pad_data, seg[1] - opt.pad_data
+    # Important for trig-start/end and data-start/end to match inspiral jobs.
+    # Zero-padding also will not zero-pad unless explicitly told to in the
+    # trig start/end times
+    anal_seg, data_seg = select_segments(opt.inspiral_segments,
+                                    opt.data_analyzed_name, opt.data_read_name,
+                                    ifo, opt.trigger_time)
+    opt.trig_start_time = anal_seg[0]
+    opt.trig_end_time = anal_seg[1]
+    opt.gps_start_time = data_seg[0] + opt.pad_data
+    opt.gps_end_time = data_seg[1] - opt.pad_data
     f.attrs['event_time'] = opt.trigger_time
 
 ###############################################################################
@@ -216,7 +252,7 @@ with ctx:
         start = stilde.epoch + stilde.analyze.start / float(opt.sample_rate)
         end = stilde.epoch + stilde.analyze.stop / float(opt.sample_rate)
         
-        if  end < start_time:
+        if end < start_time:
             continue
             
         if start > end_time:

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -27,8 +27,9 @@ def grouper(iterable, n, fillvalue=None):
     args = [iter(iterable)] * n
     return izip_longest(*args, fillvalue=fillvalue)
 
-def setup_foreground_minifollowups(workflow, coinc_file, single_triggers, tmpltbank_file, 
-                       insp_segs, insp_seg_name, dax_output, out_dir, tags=None):
+def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
+                       tmpltbank_file, insp_segs, insp_data_name,
+                       insp_anal_name, dax_output, out_dir, tags=None):
     """ Create plots that followup the Nth loudest coincident injection
     from a statmap produced HDF file.
     
@@ -43,9 +44,12 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers, tmpltb
     tmpltbank_file: pycbc.workflow.File
         The file object pointing to the HDF format template bank
     insp_segs: SegFile
-       The segment file containing the data read by each inspiral job.
-    insp_segs_name: str 
-        The name of the segmentlist to read from the inspiral segment file
+       The segment file containing the data read and analyzed by each inspiral
+       job.
+    insp_data_name: str
+        The name of the segmentlist storing data read.
+    insp_anal_name: str
+        The name of the segmentlist storing data analyzed.
     out_dir: path
         The directory to store minifollowups result plots and files
     tags: {None, optional}
@@ -82,7 +86,8 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers, tmpltb
     node.add_input_opt('--statmap-file', coinc_file)
     node.add_multiifo_input_list_opt('--single-detector-triggers', single_triggers)
     node.add_input_opt('--inspiral-segments', insp_segs)
-    node.add_opt('--inspiral-segment-name', insp_seg_name)
+    node.add_opt('--inspiral-data-read-name', insp_data_name)
+    node.add_opt('--inspiral-data-analyzed-name', insp_anal_name)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file', tags=tags)
     node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map', tags=tags)
 
@@ -106,8 +111,8 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers, tmpltb
     logging.info('Leaving minifollowups module')
 
 def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
-                                  insp_segs, insp_seg_name, dax_output,
-                                  out_dir, veto_file=None,
+                                  insp_segs, insp_data_name, insp_anal_name,
+                                  dax_output, out_dir, veto_file=None,
                                   veto_segment_name=None, tags=None):
     """ Create plots that followup the Nth loudest clustered single detector
     triggers from a merged single detector trigger HDF file.
@@ -122,8 +127,10 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
         The file object pointing to the HDF format template bank
     insp_segs: SegFile
        The segment file containing the data read by each inspiral job.
-    insp_segs_name: str 
-        The name of the segmentlist to read from the inspiral segment file
+    insp_data_name: str
+        The name of the segmentlist storing data read.
+    insp_anal_name: str
+        The name of the segmentlist storing data analyzed.
     out_dir: path
         The directory to store minifollowups result plots and files
     tags: {None, optional}
@@ -163,7 +170,8 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     node.add_input_opt('--bank-file', tmpltbank_file)
     node.add_input_opt('--single-detector-file', single_trig_file)
     node.add_input_opt('--inspiral-segments', insp_segs)
-    node.add_opt('--inspiral-segment-name', insp_seg_name)
+    node.add_opt('--inspiral-data-read-name', insp_data_name)
+    node.add_opt('--inspiral-data-analyzed-name', insp_anal_name)
     node.add_opt('--instrument', curr_ifo)
     if veto_file is not None:
         assert(veto_segment_name is not None)
@@ -194,8 +202,8 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
 
 
 def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
-                                  single_triggers, 
-                                  tmpltbank_file, insp_segs, insp_seg_name,
+                                  single_triggers, tmpltbank_file,
+                                  insp_segs, insp_data_name, insp_anal_name,
                                   dax_output, out_dir, tags=None):
     """ Create plots that followup the closest missed injections
     
@@ -211,8 +219,10 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
         The file object pointing to the HDF format template bank
     insp_segs: SegFile
        The segment file containing the data read by each inspiral job.
-    insp_segs_name: str 
-        The name of the segmentlist to read from the inspiral segment file
+    insp_data_name: str
+        The name of the segmentlist storing data read.
+    insp_anal_name: str
+        The name of the segmentlist storing data analyzed.
     out_dir: path
         The directory to store minifollowups result plots and files
     tags: {None, optional}
@@ -250,7 +260,8 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
     node.add_input_opt('--injection-xml-file', inj_xml_file)
     node.add_multiifo_input_list_opt('--single-detector-triggers', single_triggers)
     node.add_input_opt('--inspiral-segments', insp_segs)
-    node.add_opt('--inspiral-segment-name', insp_seg_name)
+    node.add_opt('--inspiral-data-read-name', insp_data_name)
+    node.add_opt('--inspiral-data-analyzed-name', insp_anal_name)
     node.new_output_file_opt(workflow.analysis_time, '.dax', '--output-file', tags=tags)
     node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map', tags=tags)
 
@@ -273,10 +284,10 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
     workflow._adag.addDependency(dep)
     logging.info('Leaving injection minifollowups module')
 
-def make_single_template_plots(workflow, segs, seg_name, params,
-                                   out_dir, inj_file=None, exclude=None,
-                                   require=None, tags=None, params_str=None,
-                                   use_exact_inj_params=False):
+def make_single_template_plots(workflow, segs, data_read_name, analyzed_name,
+                                  params, out_dir, inj_file=None, exclude=None,
+                                  require=None, tags=None, params_str=None,
+                                  use_exact_inj_params=False):
     tags = [] if tags is None else tags
     makedir(out_dir)
     name = 'single_template_plot'
@@ -301,7 +312,8 @@ def make_single_template_plots(workflow, segs, seg_name, params,
             node.add_input_opt('--inspiral-segments', segs)
             if inj_file is not None:
                 node.add_input_opt('--injection-file', inj_file)
-            node.add_opt('--segment-name', seg_name)
+            node.add_opt('--data-read-name', data_read_name)
+            node.add_opt('--data-analyzed-name', analyzed_name)
             node.new_output_file_opt(workflow.analysis_time, '.hdf',
                                      '--output-file', store_file=False)
             data = node.output_files[0]


### PR DESCRIPTION
This was a pre-existing edge-case bug. It was previously possible, in the case of a science segment *slightly* longer than the minimum (say 2100s long, which means two analysis jobs, with data times almost overlapping) that pycbc_single_template would take the *other* data time overlapping the trigger time, and not the one that was actually used.

Making this problem worse is the fact that job segmentation now depends (or will soon depend, if I haven't yet opened that as a PR) on the values chosen for trig-start-time and trig-end-time (esp. when zero padding).

Therefore pycbc_single_template should also look at the analysed times when figuring out data to read in and use the data and analysed times matching the original inspiral job. This is not such a large change in pycbc_single_template (and you can still specify start/end times directly bypassing this), but all the minifollowups setup tools need to pass the two names down, so lots of small changes.

This is tested on the test workflow and runs end-to-end.