### PR TITLE
Zero-padding changes

### DIFF
--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -828,22 +828,11 @@ class PyCBCInspiralExecutable(Executable):
         start_pad = int(self.get_opt( 'segment-start-pad'))
         end_pad = int(self.get_opt('segment-end-pad'))
 
-        # FIXME: This needs updating. Recalculate segments has gone!
-        constant_psd_segs = self.get_opt('psd-recalculate-segments')
-        if constant_psd_segs is None:
-            constant_psd_segs = min_analysis_segs
-            max_analysis_segs = min_analysis_segs
-        else:
-            constant_psd_segs = int(constant_psd_segs)
-        
-        if min_analysis_segs % constant_psd_segs != 0:
-            raise ValueError('Constant PSD segments does not evenly divide the '
-                             'number of analysis segments') 
-        
-        if max_analysis_segs is None:
-            max_analysis_segs = min_analysis_segs
-        
-        seg_ranges = range(min_analysis_segs, max_analysis_segs + 1, constant_psd_segs)
+        # NOTE: Assuming here that the data-length for max-analysis-segs is
+        #       a multiple of min-analysis-segs, and then only allow data
+        #       lengths that *are* multiples of min-analysis-segs
+        seg_ranges = range(min_analysis_segs, max_analysis_segs + 1,
+                           min_analysis_segs+1)
         data_lengths = []
         valid_regions = []
         for nsegs in seg_ranges:


### PR DESCRIPTION
Here are the changes needed to do zero-padding. This basically comes in 3 parts:

 * First the code needed to actually do zero-padding, this requires tapering the first and last second of data read in (after removing pad-data) to 0 and then, when creating analysis segments, if asked to construct a segment using times before "0" or after "len(data)" it will append or prepend zeroes allowing the full data-set to be analysed.

 * Second the code needed to construct strain segments is altered so that strain segments outside of the data length can be constructed if zero-padding is enabled. This is done by using the trig-start/trig-end options. The code will only do zero-padding if the use-zero-padding option is enabled *and* the trig-start or trig-end time is set such that zero-padding is needed to actually analyse that time. This certainly means that the constructed data segments now depend on gps-times *and* trig-start/end times, even if zero-padding is not being used. ***Ian needs to check if this means injection runs use different analysis segments than full_data, I'm now not actually convinced that is true, as long as the injection jobs take the same trig-start/end as the full_data***

 * Third we add code to workflow/jobsetup.py to allow code to understand about zero-padding and correctly send options to do this such that all data gets analysed.

An example page is here:

https://galahad.aei.mpg.de/~spxiwh/LVC/aLIGO/O1/analyses/workflow_testT5/

I increased the time with respect to the standard test to get some times where instruments come up and down. Here the coincident science time is 106204s and we analyse 106140s. Here is also the normal test workflow with this enabled:

https://galahad.aei.mpg.de/~spxiwh/LVC/aLIGO/O1/analyses/workflow_testT4/

and the test workflow run without zero-padding enabled:

https://galahad.aei.mpg.de/~spxiwh/LVC/aLIGO/O1/analyses/workflow_testT3/

To do zero-padding requires a set of ini file changes. Where should I post these? (given here for completeness) I add the minimum data length such that time lost due to too short segments will be lost between SCIENCE and SCIENCE_OK and then only pad-data is lost between SCIENCE_AVAILABLE and TRIGGERS_GENERATED.

```
[workflow-segments]
; Minimum data length = 528s (3 segments = (128*3 + 128) + 16s padding)
segments-minimum-segment-length = 528

[workflow-matchedfilter]
min-analysis-segments = 3
max-analysis-segments = 15


[inspiral]
; Force PSD length to stay constant (512s)
psd-num-segments = 63
; Allow use of zero padding
allow-zero-padding =
taper-data = 1

[calculate_psd]
taper-data = ${inspiral|taper-data}
psd-num-segments = ${inspiral|psd-num-segments}

[single_template]
psd-num-segments = ${inspiral|psd-num-segments}
taper-data = ${inspiral|taper-data}
allow-zero-padding =

[workflow]
start-time = 1128466607
end-time = 1128686607
```