### PR TITLE
workflow: set unmerged inspiral and psd files as non critical

### DIFF
--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -443,7 +443,7 @@ def setup_coincidence_workflow_ligolw_thinca(
 class PyCBCBank2HDFExecutable(Executable):
     """ This converts xml tmpltbank to an hdf format
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def create_node(self, bank_file):
         node = Node(self)
         node.add_input_opt('--bank-file', bank_file)
@@ -453,7 +453,7 @@ class PyCBCBank2HDFExecutable(Executable):
 class PyCBCTrig2HDFExecutable(Executable):
     """ This converts xml triggers to an hdf format, grouped by template hash
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def create_node(self, trig_files, bank_file):
         node = Node(self)
         node.add_input_opt('--bank-file', bank_file)
@@ -465,7 +465,7 @@ class PyCBCTrig2HDFExecutable(Executable):
 class PyCBCFindCoincExecutable(Executable):
     """ Find coinc triggers using a folded interval method
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.ALL_TRIGGERS
     def create_node(self, trig_files, bank_file, veto_file, veto_name, template_str, tags=[]):
         segs = trig_files.get_times_covered_by_files()
         seg = segments.segment(segs[0][0], segs[-1][1])
@@ -483,7 +483,7 @@ class PyCBCFindCoincExecutable(Executable):
 class PyCBCStatMapExecutable(Executable):
     """ Calculate FAP, IFAR, etc
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def create_node(self, coinc_files, tags=[]):
         segs = coinc_files.get_times_covered_by_files()
         seg = segments.segment(segs[0][0], segs[-1][1])
@@ -497,7 +497,7 @@ class PyCBCStatMapExecutable(Executable):
 class PyCBCStatMapInjExecutable(Executable):
     """ Calculate FAP, IFAR, etc
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def create_node(self, zerolag, full_data, injfull, fullinj, tags=[]):
         segs = zerolag.get_times_covered_by_files()
         seg = segments.segment(segs[0][0], segs[-1][1])
@@ -514,7 +514,7 @@ class PyCBCStatMapInjExecutable(Executable):
 class PyCBCHDFInjFindExecutable(Executable):
     """ Find injections in the hdf files output
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def create_node(self, inj_coinc_file, inj_xml_file, veto_file, veto_name, tags=[]):
         node = Node(self)        
         node.add_input_list_opt('--trigger-file', inj_coinc_file)
@@ -528,7 +528,7 @@ class PyCBCHDFInjFindExecutable(Executable):
 
 class PyCBCDistributeBackgroundBins(Executable):
     """ Distribute coinc files amoung different background bins """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.ALL_TRIGGERS
     def create_node(self, coinc_files, bank_file, background_bins, tags=[]):
         node = Node(self)
         node.add_input_list_opt('--coinc-files', coinc_files)
@@ -548,7 +548,7 @@ class PyCBCDistributeBackgroundBins(Executable):
         return node
         
 class PyCBCCombineStatmap(Executable):
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def create_node(self, stat_files, tags=[]):
         node = Node(self)
         node.add_input_list_opt('--statmap-files', stat_files)
@@ -556,10 +556,10 @@ class PyCBCCombineStatmap(Executable):
         return node
  
 class MergeExecutable(Executable):
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
 
 class CensorForeground(Executable):
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
 
 def make_foreground_censored_veto(workflow, bg_file, veto_file, veto_name, 
                                   censored_name, out_dir, tags=None):

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -109,8 +109,8 @@ def is_condor_exec(exe_path):
 class Executable(pegasus_workflow.Executable):
     # These are the file retention levels
     INTERMEDIATE_PRODUCT = 1
-    NON_CRITICAL = 2
-    CRITICAL = 3
+    ALL_TRIGGERS = 2
+    MERGED_TRIGGERS = 3
     FINAL_RESULT = 4
     
     # This is the default value. It will give a warning if a class is
@@ -271,20 +271,21 @@ class Executable(pegasus_workflow.Executable):
             cp.set("workflow", "file-retention-level", "all_files")
         else:
             # FIXME: Are these names suitably descriptive?
-            if global_retention_level == 'all_files':
-                self.global_retention_threshold = 1
-            elif global_retention_level == 'no_intermediates':
-                self.global_retention_threshold = 2
-            elif global_retention_level == 'all_triggers':
-                self.global_retention_threshold = 3
-            elif global_retention_level == 'results_only':
-                self.global_retention_threshold = 4
-            else:
+            retention_choices = {
+                                 'all_files' : 1,
+                                 'all_triggers' : 2,
+                                 'merged_triggers' : 3,
+                                 'results' : 4
+                                }
+            try:
+                self.global_retention_threshold = \
+                      retention_choices[global_retention_level]
+            except KeyError:
                 err_msg = "Cannot recognize the file-retention-level in the "
                 err_msg += "[workflow] section of the ini file. "
                 err_msg += "Got : %s." %(global_retention_level,)
-                err_msg += "Valid options are: 'all_files', 'no_intermediates',"
-                err_msg += "'all_triggers' or 'results_only' "
+                err_msg += "Valid options are: 'all_files', 'all_triggers',"
+                err_msg += "'merged_triggers' or 'results' "
                 raise ValueError(err_msg)
             if self.current_retention_level == 5:
                 self.retain_files = True

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -709,7 +709,7 @@ class JobSegmenter(object):
 class PyCBCInspiralExecutable(Executable):
     """ The class used to create jobs for pycbc_inspiral Executable. """
     
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.NON_CRITICAL
     def __init__(self, cp, exe_name, ifo=None, out_dir=None, injection_file=None, 
                  gate_files=None, tags=[]):
         super(PyCBCInspiralExecutable, self).__init__(cp, exe_name, None, ifo, out_dir, tags=tags)

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -708,8 +708,8 @@ class JobSegmenter(object):
 
 class PyCBCInspiralExecutable(Executable):
     """ The class used to create jobs for pycbc_inspiral Executable. """
-    
-    current_retention_level = Executable.NON_CRITICAL
+
+    current_retention_level = Executable.ALL_TRIGGERS
     def __init__(self, cp, exe_name, ifo=None, out_dir=None, injection_file=None, 
                  gate_files=None, tags=[]):
         super(PyCBCInspiralExecutable, self).__init__(cp, exe_name, None, ifo, out_dir, tags=tags)
@@ -876,7 +876,7 @@ class PyCBCTmpltbankExecutable(Executable):
     any other Executables using the same command line option groups.
     """
     
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def __init__(self, cp, exe_name, ifo=None, out_dir=None,
                  tags=[], write_psd=False, psd_files=None):
         super(PyCBCTmpltbankExecutable, self).__init__(cp, exe_name, 'vanilla', ifo, out_dir, tags=tags)
@@ -1013,8 +1013,8 @@ class LigolwAddExecutable(Executable):
 
 class LigolwSSthincaExecutable(Executable):
     """ The class responsible for making jobs for ligolw_sstinca. """
-    
-    current_retention_level = Executable.CRITICAL
+
+    current_retention_level = Executable.MERGED_TRIGGERS
     def __init__(self, cp, exe_name, universe=None, ifo=None, out_dir=None,
                  dqVetoName=None, tags=[]):
         super(LigolwSSthincaExecutable, self).__init__(cp, exe_name, universe, ifo, out_dir, tags=tags)
@@ -1051,7 +1051,7 @@ class LigolwSSthincaExecutable(Executable):
 class PycbcSqliteSimplifyExecutable(Executable):
     """ The class responsible for making jobs for pycbc_sqlite_simplify. """
     
-    current_retention_level = Executable.NON_CRITICAL
+    current_retention_level = Executable.INTERMEDIATE_PRODUCT
     def __init__(self, cp, exe_name, universe=None, ifo=None, out_dir=None, tags=[]):
         super(PycbcSqliteSimplifyExecutable, self).__init__(cp, exe_name, universe, ifo, out_dir, tags=tags)
         self.set_memory(2000)
@@ -1074,6 +1074,7 @@ class PycbcSqliteSimplifyExecutable(Executable):
             count = 0
             testing = 0
             curr_node = Node(self)
+            # hack the retention level ..
             if self.global_retention_threshold > \
                                  Executable.INTERMEDIATE_PRODUCT:
                 curr_store_file = False
@@ -1114,7 +1115,7 @@ class SQLInOutExecutable(Executable):
     The class responsible for making jobs for SQL codes taking one input and
     one output.
     """
-    current_retention_level=Executable.NON_CRITICAL
+    current_retention_level=Executable.ALL_TRIGGERS
     def __init__(self, cp, exe_name, universe=None, ifo=None, out_dir=None, tags=[]):
         super(SQLInOutExecutable, self).__init__(cp, exe_name, universe, ifo, out_dir, tags=tags)
 
@@ -1154,7 +1155,6 @@ class ExtractToXMLExecutable(Executable):
         node.new_output_file_opt(job_segment, '.xml', '--extract',
                                  tags=self.tags, store_file=self.retain_files)
         return node
-
 
 class ComputeDurationsExecutable(SQLInOutExecutable):
     """
@@ -1348,7 +1348,6 @@ class GstlalFarfromsnrchisqhistExecutable(Executable):
                                   store_file=self.retain_files)
         return node
 
-
 class GstlalPlotSensitivity(Executable):
     """
     The class responsible for running gstlal_plot_sensitivity
@@ -1499,7 +1498,7 @@ class LigolwCBCJitterSkylocExecutable(Executable):
     """
     The class used to create jobs for the ligolw_cbc_skyloc_jitter executable.
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def __init__(self, cp, exe_name, universe=None, ifos=None, out_dir=None,
                  tags=[]):
         Executable.__init__(self, cp, exe_name, universe, ifos, out_dir,
@@ -1525,7 +1524,7 @@ class LigolwCBCAlignTotalSpinExecutable(Executable):
     """
     The class used to create jobs for the ligolw_cbc_skyloc_jitter executable.
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def __init__(self, cp, exe_name, universe=None, ifos=None, out_dir=None,
                  tags=[]):
         Executable.__init__(self, cp, exe_name, universe, ifos, out_dir,
@@ -1537,7 +1536,7 @@ class LigolwCBCAlignTotalSpinExecutable(Executable):
     def create_node(self, parent, segment, tags=[]):
         if not parent:
             raise ValueError("Must provide an input file.")
-        
+
         node = Node(self)
         output_file = File(parent.ifo_list, self.exe_name, segment,
                            extension='.xml', store_file=self.retain_files,
@@ -1561,7 +1560,7 @@ class PycbcTimeslidesExecutable(Executable):
 class PycbcSplitBankExecutable(Executable):
     """ The class responsible for creating jobs for pycbc_splitbank. """
     
-    current_retention_level = Executable.NON_CRITICAL
+    current_retention_level = Executable.ALL_TRIGGERS
     def __init__(self, cp, exe_name, num_banks,
                  ifo=None, out_dir=None, universe=None):
         super(PycbcSplitBankExecutable, self).__init__(cp, exe_name, universe,

--- a/pycbc/workflow/legacy_ihope.py
+++ b/pycbc/workflow/legacy_ihope.py
@@ -103,7 +103,7 @@ class LegacyAnalysisExecutable(Executable):
     The class responsible for setting up jobs for legacy lalapps C-code
     Executables.
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def __init__(self, cp, name, universe=None, ifo=None, tags=[], out_dir=None):
         super(LegacyAnalysisExecutable, self).__init__(cp, name, universe, ifo, out_dir, tags=tags)
 
@@ -146,14 +146,14 @@ class LegacyAnalysisExecutable(Executable):
     get_valid_times = legacy_get_valid_times
     
 class LegacyTmpltbankExecutable(LegacyAnalysisExecutable):
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
         
 class LegacyInspiralExecutable(LegacyAnalysisExecutable):
     """
     The class responsible for setting up jobs for legacy lalapps_inspiral
     Executable.
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def __init__(self, cp, name, universe=None, ifo=None, injection_file=None, 
                        gate_files=None, out_dir=None, tags=[]):
         super(LegacyInspiralExecutable, self).__init__(cp, name, universe, ifo, 
@@ -175,7 +175,7 @@ class LegacySplitBankExecutable(Executable):
     """
     The class responsible for creating jobs for lalapps_splitbank.
     """
-    current_retention_level = Executable.NON_CRITICAL
+    current_retention_level = Executable.ALL_TRIGGERS
     def __init__(self, cp,name, universe, numBanks,
                  ifo=None, out_dir=None, tags=[]):
         Job.__init__(self, cp, name, universe, ifo, out_dir, tags=tags)
@@ -248,7 +248,7 @@ class LegacyCohPTFInspiralExecutable(LegacyAnalysisExecutable):
     The class responsible for setting up jobs for legacy
     lalapps_coh_PTF_inspiral executable.
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def __init__(self, cp, name, universe=None, ifo=None, injection_file=None,
                  gate_files=None, out_dir=None, tags=[]):
         super(LegacyCohPTFInspiralExecutable, self).__init__(cp, name, universe,
@@ -398,7 +398,7 @@ class LegacyCohPTFTrigCluster(LegacyAnalysisExecutable):
     The class responsible for setting up jobs for legacy coh_PTF_trig_cluster
     executable.
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def __init__(self, cp, name, universe=None, ifo=None, injection_file=None,
                  out_dir=None, tags=[]):
         super(LegacyCohPTFTrigCluster, self).__init__(cp, name, universe,
@@ -431,7 +431,7 @@ class LegacyCohPTFInjfinder(LegacyAnalysisExecutable):
     The class responsible for setting up jobs for legacy coh_PTF_injfinder
     executable.
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def __init__(self, cp, name, universe=None, ifo=None, injection_file=None,
                  out_dir=None, tags=[]):
         super(LegacyCohPTFInjfinder, self).__init__(cp, name, universe,
@@ -471,7 +471,7 @@ class LegacyCohPTFInjcombiner(LegacyAnalysisExecutable):
     The class responsible for setting up jobs for legacy coh_PTF_injcombiner
     executable.
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
     def __init__(self, cp, name, universe=None, ifo=None, injection_file=None,
                  out_dir=None, tags=[]):
         super(LegacyCohPTFInjcombiner, self).__init__(cp, name, universe,
@@ -508,7 +508,7 @@ class LegacyCohPTFSbvPlotter(LegacyAnalysisExecutable):
     The class responsible for setting up jobs for legacy coh_PTF_sbv_plotter
     executable.
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.FINAL_RESULT
     def __init__(self, cp, name, universe=None, ifo=None, injection_file=None,
                  out_dir=None, tags=[]):
         super(LegacyCohPTFSbvPlotter, self).__init__(cp, name, universe,
@@ -550,7 +550,7 @@ class LegacyCohPTFEfficiency(LegacyAnalysisExecutable):
     The class responsible for setting up jobs for legacy coh_PTF_efficiency
     executable.
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.FINAL_RESULT
     def __init__(self, cp, name, universe=None, ifo=None, injection_file=None,
                  out_dir=None, tags=[]):
         super(LegacyCohPTFEfficiency, self).__init__(cp, name, universe,
@@ -612,7 +612,7 @@ class PyGRBMakeSummaryPage(LegacyAnalysisExecutable):
     The class responsible for setting up the summary page generation job for
     the PyGRB workflow.
     """
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.FINAL_RESULT
     def __init__(self, cp, name, universe=None, ifo=None, injection_file=None,
                  out_dir=None, tags=[]):
         super(PyGRBMakeSummaryPage, self).__init__(cp, name, universe, ifo=ifo,

--- a/pycbc/workflow/psd.py
+++ b/pycbc/workflow/psd.py
@@ -22,10 +22,10 @@ from pycbc.workflow.core import SegFile
 from glue.segments import segmentlist
 
 class CalcPSDExecutable(Executable):
-    current_retention_level = Executable.NON_CRITICAL
+    current_retention_level = Executable.ALL_TRIGGERS
 
 class MergePSDFiles(Executable):
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.MERGED_TRIGGERS
 
 def chunks(l, n):
     """ Yield n successive chunks from l.

--- a/pycbc/workflow/psd.py
+++ b/pycbc/workflow/psd.py
@@ -22,7 +22,7 @@ from pycbc.workflow.core import SegFile
 from glue.segments import segmentlist
 
 class CalcPSDExecutable(Executable):
-    current_retention_level = Executable.CRITICAL
+    current_retention_level = Executable.NON_CRITICAL
 
 class MergePSDFiles(Executable):
     current_retention_level = Executable.CRITICAL


### PR DESCRIPTION
The merged files contain all info necessary to proceed with the rest of the pipeline, so dont store the individula inspiral files by default.  This should make NFS happier not to have to deal with 100000's of files ad infinitum. 