### PR TITLE
Bugfix for single template

### DIFF
--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -237,8 +237,12 @@ with ctx:
     snrs, chisqs = [], []  
     raw_bins = [[] for b in range(chisq_bins)]
     
-    start_time = opt.gps_start_time + opt.segment_start_pad
-    end_time = opt.gps_end_time - opt.segment_end_pad
+    if opt.trig_start_time:
+        start_time = opt.trig_start_time
+        end_time = opt.trig_end_time
+    else:
+        start_time = opt.gps_start_time + opt.segment_start_pad
+        end_time = opt.gps_end_time - opt.segment_end_pad
 
     if opt.window:
         start_time_wind = opt.trigger_time - opt.window
@@ -277,6 +281,12 @@ with ctx:
     
     sidx = int((start_time - snrs[0].start_time) / snr.delta_t)
     eidx = int((end_time - start_time) / snr.delta_t) + sidx
+
+    if sidx < 0:
+        err_msg = "Ian has probably broken single_template again. Please email "
+        err_msg += "with the command line that is raising this error and "
+        err_msg += "shout at him. Beer may speed up the fixing process."
+        raise ValueError(err_msg)
 
     for i in range(chisq_bins):
         key = 'chisq_bins/%s' % i

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -58,8 +58,13 @@ def select_segments(fname, anal_name, data_name, ifo, time):
         # largest overlap with anal_time
         overlap = None
         for start, end in zip(s2, e2):
+            if start > anal_time[0] or end < anal_time[1]:
+                # The analysis time must lie within the data time, otherwise
+                # this clearly is not the right data segment!
+                continue
+
             curr_nonoverlap = anal_time[0] - start
-            curr_nonoverlap = end - anal_time[1]
+            curr_nonoverlap += end - anal_time[1]
             if (overlap is None) or (curr_nonoverlap < overlap):
                 overlap = curr_nonoverlap
                 data_time = (start, end)


### PR DESCRIPTION
Hi Tito, here's the bugfix for single template. Basically before patch the start_time could be *less* than the trig_time and then sidx at line 278 would be negative and then [sidx:eidx] was basically unpredictable.

The patch ensures that if trig-start/end is given then start/end is equal to this value. I also added a check on sidx < 0 to make sure that if this happens again the code fails here and not in the plotting code later!

This is tested on your example, both with analysis segments, and with a manual gps-start/end.