### PR TITLE
fix bug in roll, reset memoize of views

### DIFF
--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -735,6 +735,7 @@ class Array(object):
     def roll(self, shift):
         """shift vector
         """
+        self._saved = {}
         new_arr = zeros(len(self), dtype=self.dtype)
 
         if shift == 0:


### PR DESCRIPTION
If you use roll multiple times of the same size it will mistakenly cache the views and not do what you want after the first time. 