### PR TITLE
plot_singles_timefreq: enable SEOBNRv2 inspiral tracks

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_singles_timefreq
+++ b/bin/hdfcoinc/pycbc_plot_singles_timefreq
@@ -58,6 +58,11 @@ parser.add_argument('--interesting-trig', type=int,
 parser.add_argument('--detector', type=str, required=True)
 parser.add_argument('--center-time', type=float,
                     help='Center plot on the given GPS time')
+parser.add_argument('--approximant', type=str, default='TaylorF2',
+                    help='Waveform model used for computing inspiral tracks.'
+                         ' Python expressions can be used to specify a '
+                         'parameter-dependent approximant as done in '
+                         'pycbc_inspiral.')
 pycbc.strain.insert_strain_option_group(parser)
 opts = parser.parse_args()
 
@@ -137,15 +142,13 @@ if mask.any():
     logging.info('Loading bank')
     bank = h5py.File(opts.bank_file, 'r')
     mass1s, mass2s = np.array(bank['mass1']), np.array(bank['mass2'])
-
-    f_highs = pycbc.pnutils.f_SchwarzISCO(
-            mass1s[sorted_template_ids] + mass2s[sorted_template_ids])
+    spin1s, spin2s = np.array(bank['spin1z']), np.array(bank['spin2z'])
 
     logging.info('Plotting %d trigs', len(sorted_end_time))
-    for tc, rho, tid, f_high in zip(sorted_end_time, sorted_rank,
-                                    sorted_template_ids, f_highs):
+    for tc, rho, tid in zip(sorted_end_time, sorted_rank, sorted_template_ids):
         track_t, track_f = pycbc.pnutils.get_inspiral_tf(
-                tc - center_time, mass1s[tid], mass2s[tid], opts.f_low, f_high)
+                tc - center_time, mass1s[tid], mass2s[tid], spin1s[tid],
+                spin2s[tid], opts.f_low, approximant=opts.approximant)
         if max_rank and rho == max_rank:
             ax.plot(track_t, track_f, '-', color='#ff0000', zorder=3, lw=2)
         else:
@@ -157,9 +160,9 @@ if mask.any():
         rho = rank[interesting_id]
         interesting_trig_rank = rho
         tid = template_ids[interesting_id]
-        f_high = pycbc.pnutils.f_SchwarzISCO(mass1s[tid] + mass2s[tid])
         track_t, track_f = pycbc.pnutils.get_inspiral_tf(
-            tc - center_time, mass1s[tid], mass2s[tid], opts.f_low, f_high)
+            tc - center_time, mass1s[tid], mass2s[tid], spin1s[tid],
+            spin2s[tid], opts.f_low, approximant=opts.approximant)
         ax.plot(track_t, track_f, '-', color='#00ff00', zorder=3, lw=2)
     else:
         interesting_trig_rank = None
@@ -195,9 +198,6 @@ ax.grid(ls='solid', alpha=0.2)
 ax.set_xlabel('Time - %.3f (s)' % center_time)
 ax.set_ylabel('Frequency (Hz)')
 ax.set_title(title)
-note = ("Curves show the PN inspiral only and terminate at the Schwarzschild "
-        "ISCO. Spin effects neglected.")
-fig.text(0.05, 0.01, note, fontsize=7, transform=fig.transFigure)
 cb = fig.colorbar(pc, fraction=0.04, pad=0.01,
                   ticks=LogLocator(subs=range(10)))
 cb.set_label('Power density (normalized to its median over time)')
@@ -208,7 +208,6 @@ caption = ("This plot shows the power spectrogram of the strain data, "
            "curve. The red curve is the loudest trigger by %s. Only the "
            "loudest %d triggers by %s are shown. ") % \
         (opts.rank, opts.num_loudest, opts.rank)
-caption += note
 pycbc.results.save_fig_with_metadata(
         fig, opts.output_file, cmd=' '.join(sys.argv),
         title='Strain spectrogram and inspiral tracks for %s' % opts.detector,

--- a/bin/hdfcoinc/pycbc_plot_singles_timefreq
+++ b/bin/hdfcoinc/pycbc_plot_singles_timefreq
@@ -75,8 +75,8 @@ if opts.center_time is None:
 else:
     center_time = opts.center_time
 
-fig = pl.figure(figsize=(20,10))
-fig.subplots_adjust(left=0.05, right=0.95, bottom=0.05, top=0.95)
+fig = pl.figure(figsize=(11,5.5))
+fig.subplots_adjust(left=0.06, right=0.95, bottom=0.09, top=0.95)
 ax = fig.gca()
 
 logging.info('Plotting strain spectrogram')
@@ -152,7 +152,7 @@ if mask.any():
         if max_rank and rho == max_rank:
             ax.plot(track_t, track_f, '-', color='#ff0000', zorder=3, lw=2)
         else:
-            ax.plot(track_t, track_f, '-', color='#0000ff', zorder=2, alpha=0.02)
+            ax.plot(track_t, track_f, '-', color='#0000ff', zorder=2, lw=0.5, alpha=0.5)
 
     if opts.interesting_trig is not None and opts.interesting_trig in indices:
         interesting_id = np.where(indices == opts.interesting_trig)[0]
@@ -211,6 +211,6 @@ caption = ("This plot shows the power spectrogram of the strain data, "
 pycbc.results.save_fig_with_metadata(
         fig, opts.output_file, cmd=' '.join(sys.argv),
         title='Strain spectrogram and inspiral tracks for %s' % opts.detector,
-        caption=caption, fig_kwds={'dpi': 200})
+        caption=caption, fig_kwds={'dpi': 100})
 
 logging.info('Done')

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -515,18 +515,46 @@ def _get_seobnrrom_duration(m1, m2, s1z, s2z, f_low):
 
 get_seobnrrom_duration = numpy.vectorize(_get_seobnrrom_duration)
 
-def get_inspiral_tf(tc, mass1, mass2, f_low, f_high, n_points=50, pn_2order=7):
+def get_inspiral_tf(tc, mass1, mass2, spin1, spin2, f_low, n_points=50,
+        pn_2order=7, approximant='TaylorF2'):
     """Compute the time-frequency evolution of an inspiral signal.
 
     Return a tuple of time and frequency vectors tracking the evolution of an
     inspiral signal in the time-frequency plane.
     """
-    from pycbc.waveform.spa_tmplt import findchirp_chirptime
-    
-    # FIXME spins are not taken into account
-    track_f = numpy.logspace(numpy.log10(f_low), numpy.log10(f_high), n_points)
-    track_t = numpy.array([findchirp_chirptime(float(mass1), float(mass2), 
+    # handle param-dependent approximant specification
+    class Params:
+        pass
+    params = Params()
+    params.mass1 = mass1
+    params.mass2 = mass2
+    params.spin1z = spin1
+    params.spin2z = spin2
+    try:
+        approximant = eval(approximant, {'__builtins__': None},
+                           dict(params=params))
+    except NameError:
+        pass
+
+    if approximant in ['TaylorF2', 'SPAtmplt']:
+        from pycbc.waveform.spa_tmplt import findchirp_chirptime
+
+        # FIXME spins are not taken into account
+        f_high = f_SchwarzISCO(mass1 + mass2)
+        track_f = numpy.logspace(numpy.log10(f_low), numpy.log10(f_high),
+                                 n_points)
+        track_t = numpy.array([findchirp_chirptime(float(mass1), float(mass2), 
                                         float(f), pn_2order) for f in track_f])
+    elif approximant == 'SEOBNRv2_ROM_DoubleSpin':
+        f_high = get_final_freq('SEOBNRv2', mass1, mass2, spin1, spin2)
+        track_f = numpy.logspace(numpy.log10(f_low), numpy.log10(f_high),
+                                 n_points)
+        track_t = numpy.array([
+                lalsimulation.SimIMRSEOBNRv2ROMDoubleSpinTimeOfFrequency(f,
+                    solar_mass_to_kg(mass1), solar_mass_to_kg(mass2),
+                    float(spin1), float(spin2)) for f in track_f])
+    else:
+        raise ValueError('Approximant ' + approximant + ' not supported')
     return (tc - track_t, track_f)
 
 

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -515,7 +515,7 @@ def _get_seobnrrom_duration(m1, m2, s1z, s2z, f_low):
 
 get_seobnrrom_duration = numpy.vectorize(_get_seobnrrom_duration)
 
-def get_inspiral_tf(tc, mass1, mass2, spin1, spin2, f_low, n_points=50,
+def get_inspiral_tf(tc, mass1, mass2, spin1, spin2, f_low, n_points=100,
         pn_2order=7, approximant='TaylorF2'):
     """Compute the time-frequency evolution of an inspiral signal.
 


### PR DESCRIPTION
Enable using different approximants (currently TaylorF2 and SEOBNRv2_ROM_DoubleSpin) to compute the inspiral time-frequency curves. This improves the plot by taking into account spins and physical termination frequencies.