### PR TITLE
dont put the legend on top of the curves..

### DIFF
--- a/bin/hdfcoinc/pycbc_page_sensitivity
+++ b/bin/hdfcoinc/pycbc_page_sensitivity
@@ -225,7 +225,8 @@ for j in range(len(args.bins)-1):
         elif args.dist_type == 'vt':
             ylabel = "Volume $\\times$ Time (yr Mpc$^3$)"
             pylab.ticklabel_format(style='sci', axis='y', scilimits=(0,0))
-            t = f.attrs['foreground_time_exc'] * 3.16888e-8
+            # Hard-coded Julian Year
+            t = f.attrs['foreground_time_exc'] / (365.25 * 24 * 3600)
             reach, ehigh, elow = vols * t, vol_errors * t, vol_errors * t
 
         label = labels[args.bin_type] % (left, right) if do_label else None
@@ -254,7 +255,7 @@ pylab.ylabel(ylabel)
 pylab.xlabel(xlabel)
 
 pylab.grid()
-pylab.legend(loc='lower left')
+pylab.legend(loc='best')
 
 pycbc.results.save_fig_with_metadata(fig, args.output_file,
      title="Sensitive %s vs %s: binned by %s using %s method"

--- a/pycbc/sensitivity.py
+++ b/pycbc/sensitivity.py
@@ -26,6 +26,9 @@ def volume_montecarlo(found_d, missed_d, found_mchirp, missed_mchirp,
                       distribution_param, distribution, limits_param,
                       max_param=None, min_param=None):
     """
+    TODO : Replace this function by Collin's formula given in Usman et al .. ? 
+    OR get that coded as a new function? 
+
     Compute the sensitive volume and standard error using a direct Monte Carlo
     integral.  For the result to be useful injections should be made over a
     range of distances D such that sensitive volume due to signals closer than
@@ -118,8 +121,6 @@ def volume_montecarlo(found_d, missed_d, found_mchirp, missed_mchirp,
     all_weights = numpy.concatenate((found_weights, missed_weights))
 
     # measured weighted efficiency is w_i for a found inj and 0 for missed
-    mc_weight_samples = numpy.concatenate((found_weights, 0*missed_weights))
-
     # MC integral is volume of sphere * (sum of found weights)/(sum of all weights)
     # over injections covering the sphere
     mc_weight_samples = numpy.concatenate((found_weights, 0 * missed_weights))


### PR DESCRIPTION
Legend lower left often led to the data being more or less invisible, eg 
https://www.atlas.aei.uni-hannover.de/~tdent/LSC/o1/IMBH/sensitivity_plots/SENSITIVITY_ALLINJ_MCHIRP_VOLUME_TITOPHENOM2.png 

'Best' may not be best, but at least give matplotlib a chance ..

Also a more comprehensible hard-coded Julian year formula. 