### PR TITLE
Adds in table for 50% exclusion distances in PyGRB

### DIFF
--- a/pycbc/results/legacy_grb.py
+++ b/pycbc/results/legacy_grb.py
@@ -628,22 +628,22 @@ def write_exclusion_distances(page , trial, injList, massbins, reduced=False,
 
     page = write_table(page, th, td)
 
-    page.h3()
-    page.add('90% confidence exclusion distances (Mpc)')
-    th = injList
-    td = []
-    d = []
-    for inj in injList:
-        file = open('%s/efficiency_%s/exclusion_distance.txt' % (inj, trial),
-                    'r')
-        for line in file:
-            line = line.replace('\n','')
-            excl_dist = float(line)
-        d.append(excl_dist)
-        file.close()
-    td.append(d)
-
-    page = write_table(page, th, td)
+    for percentile in [90, 50]:
+        page.h3()
+        page.add('%d%% confidence exclusion distances (Mpc)' % percentile)
+        th = injList
+        td = []
+        d = []
+        for inj in injList:
+            file = open('%s/efficiency_%s/exclusion_distance_%d.txt'
+                        % (inj, trial, percentile), 'r')
+            for line in file:
+                line = line.replace('\n','')
+                excl_dist = float(line)
+            d.append(excl_dist)
+            file.close()
+        td.append(d)
+        page = write_table(page, th, td)
 
     page.h3.close()
 


### PR DESCRIPTION
Hi Steve,

This change gets the PyGRB result page to display the 50% exclusion distances. I have tested this [here](https://geo2.arcca.cf.ac.uk/~c1239174/LVC/ER8/pygrb/GRB150906944/GRB150906944_CLOSED/summary.html).

Cheers,
Andrew