### PR TITLE
Out of bounds if windowing is too close to the end points

### DIFF
--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -67,6 +67,9 @@ center = int((time - start_time) / delta_t)
 left = center - int(args.window / delta_t)
 right = center + int(args.window / delta_t)
 
+left = max(left,0)
+right = min(right,len(f['snr']))
+
 snr = abs(f['snr'][left:right][:])
 chisq = f['chisq'][left:right][:]
 


### PR DESCRIPTION
These two lines should fix an error if the plotting code tries to plot outside of the beginning or the end bounds of a time segment. The plotting code attempts to plot some time window around the injection, but doesn't consider the bounds well. so if you're too close to the boundaries just let the left or right end of the window equal those bounds.