### PR TITLE
PyCBC Page Sensitivity has wrong captions

### DIFF
--- a/bin/hdfcoinc/pycbc_page_sensitivity
+++ b/bin/hdfcoinc/pycbc_page_sensitivity
@@ -261,10 +261,10 @@ pycbc.results.save_fig_with_metadata(fig, args.output_file,
      title="Sensitive %s vs %s: binned by %s using %s method"
             % (args.dist_type.title(), args.sig_type.upper(), 
                args.bin_type, args.integration_method),
-     caption="Sensitive %s as a function of significance:"
-             "Darker lines represent the significance without including "
-             "injections in their own background, while lighter lines "
-             "include each injection individually in the background "
+     caption="Sensitive %s as a function of Significance:"
+             "Darker lines represent the significance including "
+             "injections in the background estimation, while lighter lines "
+             "exclude each injection individually in the background "
              "estimation for that signal."
              "The integration method used is " 
              "based on %s." % (args.dist_type.title(), args.integration_method),


### PR DESCRIPTION
The caption as originally written states for the sensitive X vs Significance plot that the darker lines are for dogs out, but in fact it should be a darker line for dogs in (hence the smaller sensitive distance). The lighter lines are said to be for dogs in, but in fact it means they should be for dogs out (hence the larger sensitive distance).