### PR TITLE
make measure level 0 the default

### DIFF
--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -162,7 +162,7 @@ def import_sys_wisdom():
 # By default 1, which does some but not much planning,
 # but we provide functions to read and set it
 
-_default_measurelvl = 1
+_default_measurelvl = 0
 def get_measure_level():
     """
     Get the current 'measure level' used in deciding how much effort to put into


### PR DESCRIPTION
For simple scripts or for parts of the code that are complex and can be amortized it makes a lot more sense for the default measure level to be 0. If you have a tight loop with FFTs we already have configuration tools for that which should make it straightforward to have a higher measure level. 