### PR TITLE
Update install script to check for nose before HDF5 install

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -125,6 +125,7 @@ If you need to install the HDF5 library (i.e. you are on a CentOS 6 cluster), ru
 
     mkdir -p $VIRTUAL_ENV/src
     cd $VIRTUAL_ENV/src
+    pip install nose>=1.0.0
     curl https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.12/src/hdf5-1.8.12.tar.gz > hdf5-1.8.12.tar.gz
     tar -zxvf hdf5-1.8.12.tar.gz
     cd hdf5-1.8.12

--- a/install_pycbc.sh
+++ b/install_pycbc.sh
@@ -421,6 +421,7 @@ pip $cache install "numpy>=1.6.4" unittest2 python-cjson Cython
 #Install HDF5
 echo "--- installing HDF5 libraries -----------------------------------"
 cd $VIRTUAL_ENV/src
+pip install nose>=1.0.0 
 curl https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.12/src/hdf5-1.8.12.tar.gz > hdf5-1.8.12.tar.gz
 tar -zxvf hdf5-1.8.12.tar.gz
 rm hdf5-1.8.12.tar.gz


### PR DESCRIPTION
This PR adds ``pip install nose>=1.0.0`` to the ``install_pycbc.sh`` script. This is a requirement for installing the HDF5 tar.

Both Swetha and I have encountered this problem already.

This PR updates the install docs with the same line as well.