### PR TITLE
Change default_args in waveform to allowed args, and make get_t(f)d_waveform check that kwargs are in the allowed args.

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -46,7 +46,7 @@ allowed_args = {# intrinsic parameters
                 'inclination':0, 'distance':1, 'coa_phase':0,
                 # generation parameters
                 'f_lower':None, 'delta_t':None, 'delta_f':None,
-                'f_final':0, 'f_ref':0,
+                'f_final':0, 'f_ref':0, 'taper': None,
                 'approximant':None,
                 'amplitude_order':-1, 'phase_order':-1,
                 'spin_order':-1, 'tidal_order':-1, 'numrel_data':""}
@@ -338,7 +338,7 @@ def get_td_waveform(template=None, **kwargs):
     input_params = props(template,**kwargs)
     wav_gen = td_wav[type(_scheme.mgr.state)]
 
-    missing_args = [arg for arg in td_required_args \
+    missing_args = [arg for arg in td_required_args
                         if input_params[arg] is None]
     if any(missing_args):
         raise ValueError("Please provide %s" %(', '.join(missing_args)))
@@ -420,7 +420,7 @@ def get_fd_waveform(template=None, **kwargs):
     input_params = props(template,**kwargs)
     wav_gen = fd_wav[type(_scheme.mgr.state)]
 
-    missing_args = [arg for arg in fd_required_args \
+    missing_args = [arg for arg in fd_required_args
                         if input_params[arg] is None]
     if any(missing_args):
         raise ValueError("Please provide %s" %(', '.join(missing_args)))

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -46,7 +46,7 @@ allowed_args = {# intrinsic parameters
                 'inclination':0, 'distance':1, 'coa_phase':0,
                 # generation parameters
                 'f_lower':None, 'delta_t':None, 'delta_f':None,
-                'f_final':0, 'f_ref':0, 'taper': None,
+                'f_final':0, 'f_ref':0, 'taper':None, 'duration':None,
                 'approximant':None,
                 'amplitude_order':-1, 'phase_order':-1,
                 'spin_order':-1, 'tidal_order':-1, 'numrel_data':""}


### PR DESCRIPTION
Currently, `get_t(f)d_waveform` will happily produce a waveform even if you accidentally pass it a kwarg that is misspelled; in this case, the argument is just ignored and the default is used. For example:

`>>> hp, hc = waveform.get_fd_waveform(mass1=10., mass2=10., f_lower=30., approximant='TaylorF2', delta_f=1./128, spin1=0.5)
`
This will generate even though "spin1" is not a recognized argument. In this case, you'll actually get a non-spinning waveform.

This patch fixes this by changing "default_args" to an "allowed_args". When a waveform is called with keyword arguments, a ValueError is raised if an unrecognized argument is passed. So, in the case above, we'd get:

`>>> hp, hc = waveform.get_fd_waveform(mass1=10., mass2=10., f_lower=30., approximant='TaylorF2', delta_f=1./128, spin1=0.5)
`
...Traceback stuff...
`
ValueError: unrecognized argument spin1; see waveform.allowed_args for possible arguments
`

The allowed arguments and their defaults can be retrieved:
`>>> waveform.allowed_args
`
`{'amplitude_order': -1,
 'approximant': None,
 'coa_phase': 0,
 'delta_f': None,
 'delta_t': None,
 'distance': 1,
 'f_final': 0,
 'f_lower': None,
 'f_ref': 0,
 'inclination': 0,
 'lambda1': 0,
 'lambda2': 0,
 'mass1': None,
 'mass2': None,
 'numrel_data': '',
 'phase_order': -1,
 'spin1x': 0,
 'spin1y': 0,
 'spin1z': 0,
 'spin2x': 0,
 'spin2y': 0,
 'spin2z': 0,
 'spin_order': -1,
 'tidal_order': -1}
`
Changing "spin1" to "spin1z" we can generate:
`
In [13]: hp, hc = waveform.get_fd_waveform(mass1=10., mass2=10., f_lower=30., approximant='TaylorF2', delta_f=1./128, spin1z=0.5)
`

If an object is passed with unrecognized attributes, those attributes will be ignored, as was the case previously.

I tested this with both get_td_waveform and get_fd_waveform.
