### PR TITLE
Inserted replica selection options to default pegasus properties file

### DIFF
--- a/pycbc/workflow/pegasus_files/pegasus-properties.conf
+++ b/pycbc/workflow/pegasus_files/pegasus-properties.conf
@@ -4,6 +4,14 @@ pegasus.dir.storage.mapper=Replica
 pegasus.dir.storage.mapper.replica=File
 pegasus.dir.storage.mapper.replica.file=output.map
 
+# Add Replica selection options so that it will try URLs first, then 
+# XrootD for OSG, then gridftp, then anything else
+pegasus.selector.replica=Regex
+pegasus.selector.replica.regex.rank.1=file://scratch.*
+pegasus.selector.replica.regex.rank.2=root://srm.unl.edu.*
+pegasus.selector.replica.regex.rank.3=gridftp://.*
+pegasus.selector.replica.regex.rank.4=.\*
+
 # Do not transfer files coming from outside the worklow, simply
 # create symbolic links
 pegasus.transfer.force=true


### PR DESCRIPTION
Inserted Replica Selection options to pegasus properties file. This will try file URLs first, then XrootD for OSG, then gridftp, then anything else that can be found.