### PR TITLE
Fix to avoid request memory config override to give an error

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -111,7 +111,13 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
 
         self.read_ini_file(configFiles)
 
-        # Do overrides first
+        # Replace exe macros with full paths
+        self.perform_exe_expansion()
+
+        # Split sections like [inspiral&tmplt] into [inspiral] and [tmplt]
+        self.split_multi_sections() 
+
+        # Do overrides from command line
         for override in overrideTuples:
             if len(override) not in [2,3]:
                 print override
@@ -128,11 +134,6 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
                 self.add_section(section)
             self.set(section, option, value)
 
-        # Replace exe macros with full paths
-        self.perform_exe_expansion()
-
-        # Split sections like [inspiral&tmplt] into [inspiral] and [tmplt]
-        self.split_multi_sections()
 
         # Check for any substitutions that can be made
         # FIXME: The python 3 version of ConfigParser can do this automatically


### PR DESCRIPTION
Rearranged parts of the code pycbc/pycbc/workflow.configuration.py so that sections like [inspiral&tmplt] get split into [inspiral] and [tmplt] first and then the code does any config-overrides. When the reverse was done, the code gave an error for the case when a config-override is specified for one of the sections, say [inspiral] only. In that case the code stops, because [inspiral] and [tmplt] are merged when it tries to do the override, and therefore thinks that an option has been given twice. Splitting the sections first serves the purpose of a config-override in the required section without the other section intervening.