### PR TITLE
Ensure signals are injected into the analysed seg

### DIFF
--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -124,9 +124,18 @@ else:
 # Update analysis time after coherent segment calculation
 ifo = sciSegs.keys()[0]
 padding = int(wflow.cp.get("inspiral", "pad-data"))
-deadtime = int(wflow.cp.get("inspiral", "segment-duration")) / 4
-wflow.analysis_time = segment(int(sciSegs[ifo][0][0]) + deadtime + padding,
-                              int(sciSegs[ifo][0][1]) - deadtime - padding)
+if wflow.cp.has_option("inspiral", "analyse-segment-end"):
+    safety = 1
+    deadtime = int(wflow.cp.get("inspiral", "segment-duration")) / 2
+    spec_len = int(wflow.cp.get("inspiral", "inverse-spec-length")) / 2
+    wflow.analysis_time = segment(int(sciSegs[ifo][0][0]) + deadtime - \
+                                      spec_len + padding - safety,
+                                  int(sciSegs[ifo][0][1]) - spec_len - \
+                                      padding - safety)
+else:
+    deadtime = int(wflow.cp.get("inspiral", "segment-duration")) / 4
+    wflow.analysis_time = segment(int(sciSegs[ifo][0][0]) + deadtime + padding,
+                                  int(sciSegs[ifo][0][1]) - deadtime - padding)
 wflow.cp = _workflow.set_grb_start_end(wflow.cp, int(sciSegs[ifo][0][0]),
                                        int(sciSegs[ifo][0][1]))
 ext_file = None

--- a/pycbc/workflow/legacy_ihope.py
+++ b/pycbc/workflow/legacy_ihope.py
@@ -218,13 +218,20 @@ class LegacyCohPTFInspiralExecutable(LegacyAnalysisExecutable):
         return node
 
     def get_valid_times(self):
-        overlap = int(self.get_opt('segment-duration')) / 4
         pad_data = int(self.get_opt('pad-data'))
+        if self.has_opt('analyse-segment-end'):
+            safety = 1
+            deadtime = int(self.get_opt('segment-duration')) / 2
+            spec_len = int(self.get_opt('inverse-spec-length')) / 2
+            valid_start = self.data_seg[0] + deadtime - spec_len + pad_data \
+                    - safety
+            valid_end = self.data_seg[1] - spec_len - pad_data - safety
+        else:
+            overlap = int(self.get_opt('segment-duration')) / 4
+            valid_start = self.data_seg[0] + overlap + pad_data
+            valid_end = self.data_seg[1] - overlap - pad_data
         
-        valid_start = self.data_seg[0] + pad_data + overlap
-        valid_end = self.data_seg[1] - pad_data - overlap
         return self.data_seg, segments.segment(valid_start, valid_end)
-
 
 class LegacyCohPTFTrigCombiner(LegacyAnalysisExecutable):
     """


### PR DESCRIPTION
Hi Steve,

This is the change to have PyGRB treat the analysable part of the data in the same way as coh_PTF_inspiral does. This includes the 1 second safety buffer, which is back in coh_PTF with a clearer explanation of what it is for. The pipeline is now consistent when using analyse-segment-end.

Andrew