### PR TITLE
Adding numrel_data argument for hwinj code

### DIFF
--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -158,6 +158,10 @@ parser.add_argument('--spin2y', type=float, default=0.0,
 parser.add_argument('--spin2x', type=float, default=0.0,
                   help='(optional) Spin in x direction for mass2.')
 
+# Use this for NR injections
+parser.add_argument('--numrel-data', type=str, default='',
+                  help="Location of NR data file if using NR injections.")
+
 # end time options
 parser.add_argument('--geocentric-end-time', type=float, required=True,
                   help='The geocentric GPS end time of the injection.')
@@ -262,6 +266,7 @@ sim.spin2x = opts.spin2x
 sim.polarization = opts.polarization
 sim.taper = opts.taper
 sim.distance = distance
+sim.numrel_data = opts.numrel_data
 
 # construct waveform string that can be parsed by lalsimulation
 waveform_string = opts.approximant


### PR DESCRIPTION
The examples for the NR injection infrastructure include using the generate_hwinj code to add an injection to frame data:

https://www.lsc-group.phys.uwm.edu/ligovirgo/cbcnote/Waveforms/NR/InjectionInfrastructure

However, on master, this will produce an invalid injection XML file as the numrel_data column will not be populated. This simple patch adds a command-line option to set this, which defaults to the standard empty string value when not given.

If we are still doing HW injections in O2 we really should consider NR injections! This will ensure that valid XML files are produced if doing that.