### PR TITLE
Einsteinathome upstream

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -61,6 +61,7 @@ def init_logging(verbose=False):
         initial_level = logging.DEBUG
     else:
         initial_level = logging.WARN
+    logging.getLogger().setLevel(initial_level)
     logging.basicConfig(format='%(asctime)s %(message)s', level=initial_level)
 
 
@@ -101,6 +102,8 @@ PYCBC_ALIGNMENT = 32
 
 DYN_RANGE_FAC =  5.9029581035870565e+20
 
+if os.environ.get("INITIAL_LOG_LEVEL", None):
+    logging.basicConfig(format='%(asctime)s %(message)s', level=int(os.environ["INITIAL_LOG_LEVEL"]))
 
 # Make sure we use a user specific, machine specific compiled cache location
 _python_name =  "python%d%d_compiled" % tuple(sys.version_info[:2])
@@ -114,8 +117,12 @@ _cache_dir_path = os.path.join(_tmp_dir, _cache_dir_name)
 # of all the arguments to weave.
 _cache_dir_path = os.path.join(_cache_dir_path, pycbc_version)
 _cache_dir_path = os.path.join(_cache_dir_path, git_hash)
-try: os.makedirs(_cache_dir_path)
-except OSError: pass
+if os.environ.get("NO_TMPDIR", None):
+    print >>sys.stderr, "__init__: Skipped creating %s as NO_TEMPDIR is set" % _cache_dir_path
+else:
+    try: os.makedirs(_cache_dir_path)
+    except OSError: pass
+    print >>sys.stderr, "__init__: Setting weave cache to %s" % _cache_dir_path
 os.environ['PYTHONCOMPILED'] = _cache_dir_path
 
 # Check for MKL capability

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -135,10 +135,12 @@ except ImportError as e:
     
 
 # Check for site-local flags to pass to gcc
-WEAVE_FLAGS = ''
-
+WEAVE_FLAGS = '-march=native -O3 -w '
 if 'WEAVE_FLAGS' in os.environ:
-    WEAVE_FLAGS = os.environ['WEAVE_FLAGS'] + ' '
+    if '-march=' in os.environ['WEAVE_FLAGS']:
+        WEAVE_FLAGS = os.environ['WEAVE_FLAGS']
+    else:
+        WEAVE_FLAGS += os.environ['WEAVE_FLAGS']
 
 def multiprocess_cache_dir():
     import multiprocessing

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -139,7 +139,7 @@ def findchirp_cluster_over_window(times, values, window_length):
         k[0] = j;
     """
     inline(code, ['times', 'absvalues', 'window_length', 'indices', 'tlen', 'k'],
-                 extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'])
+                 extra_compile_args=[WEAVE_FLAGS])
     return indices[0:k[0]+1]
 
 def cluster_reduce(idx, snr, window_size):

--- a/pycbc/events/simd_threshold.py
+++ b/pycbc/events/simd_threshold.py
@@ -710,7 +710,7 @@ class MaxOnlyObject(object):
         nstart = self.nstart
         howmany = self.howmany
         inline(self.code, ['inarr', 'mval', 'norm', 'mloc', 'nstart', 'howmany'],
-               extra_compile_args = [WEAVE_FLAGS + '-march=native -O3 -w'],
+               extra_compile_args = [WEAVE_FLAGS],
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
                #extra_compile_args = ['-msse4.1 -O3 -w'],
                support_code = self.support, auto_downcast = 1, verbose = self.verbose)
@@ -749,7 +749,7 @@ class WindowedMaxObject(object):
         winsize = self.winsize
         startoffset = self.startoffset
         inline(self.code, ['inarr', 'arrlen', 'cvals', 'norms', 'locs', 'winsize', 'startoffset'],
-               extra_compile_args = [WEAVE_FLAGS + '-march=native -O3 -w'],
+               extra_compile_args = [WEAVE_FLAGS],
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
                #extra_compile_args = ['-msse4.1 -O3 -w'],
                support_code = self.support, auto_downcast = 1, verbose = self.verbose)
@@ -802,7 +802,7 @@ class ThreshClusterObject(object):
         window = self.window
         segsize = self.segsize
         nthr = inline(self.code, ['series', 'slen', 'values', 'locs', 'thresh', 'window', 'segsize'],
-                      extra_compile_args = [WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
+                      extra_compile_args = [WEAVE_FLAGS] + omp_flags,
                       #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
                       #extra_compile_args = ['-msse4.1 -O3 -w'],
                       support_code = self.support, libraries = omp_libs,

--- a/pycbc/events/threshold_cpu.py
+++ b/pycbc/events/threshold_cpu.py
@@ -82,7 +82,7 @@ def threshold_inline(series, value):
         count[0] = t;
     """
     inline(code, ['N', 'arr', 'outv', 'outl', 'count', 'threshold'],
-                    extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=[WEAVE_FLAGS] + omp_flags,
                     libraries=omp_libs
           )
     num = count[0]
@@ -114,7 +114,7 @@ class CPUThresholdCluster(_BaseThresholdCluster):
         locs = self.outl
         segsize = self.segsize
         self.count = inline(self.code, ['series', 'slen', 'values', 'locs', 'threshold', 'window', 'segsize'],
-                            extra_compile_args = [WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
+                            extra_compile_args = [WEAVE_FLAGS] + omp_flags,
                             #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'] + omp_flags,
                             #extra_compile_args = ['-msse3 -O3 -w'] + omp_flags,
                             support_code = self.support, libraries = omp_libs,

--- a/pycbc/fft/fftw_pruned.py
+++ b/pycbc/fft/fftw_pruned.py
@@ -223,7 +223,7 @@ def fast_second_phase(invec, indices, N1, N2):
         }
     """
     scipy.weave.inline(code, ['N1', 'N2', 'NI', 'indices', 'out', 'invec'],
-                       extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'])
+                       extra_compile_args=[WEAVE_FLAGS])
     return out
 
 _thetransposeplan = None

--- a/pycbc/filter/matchedfilter_cpu.py
+++ b/pycbc/filter/matchedfilter_cpu.py
@@ -66,7 +66,7 @@ def correlate_inline(x, y, z):
     ya = numpy.array(y.data, copy=False)
     N = len(x) 
     inline(the_code, ['xa', 'ya', 'za', 'N'], 
-                    extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=[WEAVE_FLAGS] + omp_flags,
                     support_code = support,
                     libraries=omp_libs
           )
@@ -91,7 +91,7 @@ class CPUCorrelator(_BaseCorrelator):
         arrlen = self.arrlen
         segsize = self.segsize
         inline(self.code, ['htilde', 'stilde', 'qtilde', 'arrlen', 'segsize'],
-               extra_compile_args = [WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
+               extra_compile_args = [WEAVE_FLAGS] + omp_flags,
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'] + omp_flags,
                #extra_compile_args = ['-msse3 -O3 -w'] + omp_flags,
                libraries = omp_libs, support_code = self.support, auto_downcast = 1)

--- a/pycbc/filter/simd_correlate.py
+++ b/pycbc/filter/simd_correlate.py
@@ -425,7 +425,7 @@ def correlate_simd(ht, st, qt):
     qtilde = _np.array(qt.data, copy = False).view(dtype = float32)
     arrlen = len(htilde)
     inline(corr_simd_code, ['htilde', 'stilde', 'qtilde', 'arrlen'],
-           extra_compile_args = [WEAVE_FLAGS + '-march=native -O3 -w'],
+           extra_compile_args = [WEAVE_FLAGS],
            #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
            #extra_compile_args = ['-msse3 -O3 -w'],
            support_code = corr_support, auto_downcast = 1)
@@ -459,7 +459,7 @@ def correlate_parallel(ht, st, qt):
     arrlen = len(htilde)
     segsize = default_segsize
     inline(corr_parallel_code, ['htilde', 'stilde', 'qtilde', 'arrlen', 'segsize'],
-           extra_compile_args = [WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags, libraries = omp_libs,
+           extra_compile_args = [WEAVE_FLAGS] + omp_flags, libraries = omp_libs,
            #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
            #extra_compile_args = ['-msse3 -O3 -w'],
            support_code = corr_support, auto_downcast = 1)

--- a/pycbc/libutils.py
+++ b/pycbc/libutils.py
@@ -116,7 +116,7 @@ def get_libpath_from_dirlist(libname, dirs):
         # Our directory might be no good, so try/except
         try:
             for libfile in os.listdir(nextdir):
-                if fnmatch.fnmatch(libfile,'lib'+libname+'.so*') or fnmatch.fnmatch(libfile,'lib'+libname+'.dylib*'):
+                if fnmatch.fnmatch(libfile,'lib'+libname+'.so*') or fnmatch.fnmatch(libfile,'lib'+libname+'.dylib*') or fnmatch.fnmatch(libfile,libname+'.dll') or fnmatch.fnmatch(libfile,'cyg'+libname+'-*.dll'):
                     possible.append(libfile)
         except OSError:
             pass

--- a/pycbc/libutils.py
+++ b/pycbc/libutils.py
@@ -81,6 +81,12 @@ def pkg_config_libdirs(packages):
     that the package may be found in the standard system locations, irrespective of
     pkg-config.
     """
+
+    # don't try calling pkg-config if NO_PKGCONFIG is set in environment
+    if os.environ.get("NO_PKGCONFIG", None):
+        print >>sys.stderr, "libutils: skip calling pkg-config as NO_PKGCONFIG is set"
+        return []
+
     # First, check that we can call pkg-config on each package in the list
     for pkg in packages:
         if not pkg_config_check_exists(pkg):

--- a/pycbc/libutils.py
+++ b/pycbc/libutils.py
@@ -19,7 +19,7 @@ This module provides a simple interface for loading a shared library via ctypes,
 allowing it to be specified in an OS-independent way and searched for preferentially
 according to the paths that pkg-config specifies.
 """
-import os, fnmatch, ctypes, commands, sys
+import os, fnmatch, ctypes, commands, sys, subprocess
 from ctypes.util import find_library
 from collections import deque
 
@@ -84,7 +84,15 @@ def pkg_config_libdirs(packages):
 
     # don't try calling pkg-config if NO_PKGCONFIG is set in environment
     if os.environ.get("NO_PKGCONFIG", None):
-        print >>sys.stderr, "libutils: skip calling pkg-config as NO_PKGCONFIG is set"
+        return []
+
+    # if calling pkg-config failes, don't continue and don't try again.
+    try:
+        FNULL = open(os.devnull, 'w')
+        subprocess.check_call(["pkg-config", "--version"], stdout=FNULL, close_fds=True)
+    except:
+        print >>sys.stderr, "PyCBC.libutils: pkg-config call failed, setting NO_PKGCONFIG=1"
+        os.environ['NO_PKGCONFIG'] = "1"
         return []
 
     # First, check that we can call pkg-config on each package in the list

--- a/pycbc/opt.py
+++ b/pycbc/opt.py
@@ -26,9 +26,7 @@ import pycbc
 # info on hardware cache sizes
 _USE_SUBPROCESS = False
 HAVE_GETCONF = False
-if os.environ.get("NO_GETCONF", None):
-    # don't try getconf if NO_GETCONF is set in environment
-    print >>sys.stderr, "opt: skip calling getconf as NO_GETCONF is set"
+if os.environ.get("LEVEL2_CACHE_SIZE", None) or os.environ.get("NO_GETCONF", None):
     HAVE_GETCONF = False
 elif sys.platform == 'darwin':
     # Mac has getconf, but we can do nothing useful with it

--- a/pycbc/opt.py
+++ b/pycbc/opt.py
@@ -26,7 +26,11 @@ import pycbc
 # info on hardware cache sizes
 _USE_SUBPROCESS = False
 HAVE_GETCONF = False
-if sys.platform == 'darwin':
+if os.environ.get("NO_GETCONF", None):
+    # don't try getconf if NO_GETCONF is set in environment
+    print >>sys.stderr, "opt: skip calling getconf as NO_GETCONF is set"
+    HAVE_GETCONF = False
+elif sys.platform == 'darwin':
     # Mac has getconf, but we can do nothing useful with it
     HAVE_GETCONF = False
 elif sys.version_info >= (2, 7):
@@ -100,7 +104,10 @@ simd_intel_intrin_support = """
 
 """
 
-if HAVE_GETCONF:
+if os.environ.get("LEVEL2_CACHE_SIZE", None):
+    LEVEL2_CACHE_SIZE = int(os.environ["LEVEL2_CACHE_SIZE"])
+    logging.info("opt: using LEVEL2_CACHE_SIZE %d from environment" % LEVEL2_CACHE_SIZE)
+elif HAVE_GETCONF:
     if _USE_SUBPROCESS:
         def getconf(confvar):
             return int(subprocess.check_output(['getconf', confvar]))

--- a/pycbc/vetoes/chisq_cpu.py
+++ b/pycbc/vetoes/chisq_cpu.py
@@ -48,7 +48,7 @@ def chisq_accum_bin_inline(chisq, q):
         }
     """
     inline(code, ['chisq', 'q', 'N'], 
-                    extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=[WEAVE_FLAGS] + omp_flags,
                     libraries=omp_libs
           )
           
@@ -167,7 +167,7 @@ def shift_sum(v1, shifts, bins):
     chisq =  numpy.zeros(n, dtype=real_type)
     
     inline(code, ['v1', 'n', 'chisq', 'slen', 'shifts', 'bins', 'blen'],
-                    extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=[WEAVE_FLAGS] + omp_flags,
                     libraries=omp_libs
           )
           

--- a/pycbc/waveform/spa_tmplt_cpu.py
+++ b/pycbc/waveform/spa_tmplt_cpu.py
@@ -193,7 +193,7 @@ def spa_tmplt_engine(htilde,  kmin,  phase_order, delta_f, piM,  pfaN,
                    'piM',  'pfaN', 'amp_factor', 'kfac',
                    'pfa2',  'pfa3',  'pfa4',  'pfa5',  'pfl5',
                    'pfa6',  'pfl6',  'pfa7', 'length'],
-                    extra_compile_args=[pycbc.WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=[pycbc.WEAVE_FLAGS] + omp_flags,
                     support_code = support,
                     libraries=omp_libs
                 )

--- a/pycbc/weave.py
+++ b/pycbc/weave.py
@@ -54,6 +54,11 @@ def insert_weave_option_group(parser):
                     help="If given, delete the contents of the weave cache "
                          "when the process exits")
 
+    optimization_group.add_argument("--fixed-weave-cache",
+                    action="store_true",
+                    default=False,
+                    help="If given, use fixed directory PWD/pycbc_inspiral for "
+                         " the weave cache")
 
 def _clear_weave_cache():
     """Deletes the weave cache specified in os.environ['PYTHONCOMPILED']"""
@@ -79,6 +84,15 @@ def verify_weave_options(opt, parser):
 
     # PYTHONCOMPILED is initially set in pycbc.__init__
     cache_dir = os.environ['PYTHONCOMPILED']
+
+    # Check whether to use a fixed directory for scipy.weave
+    if opt.fixed_weave_cache:
+        cache_dir = os.path.join(os.getcwd(),"pycbc_inspiral")
+        os.environ['PYTHONCOMPILED'] = cache_dir
+        logging.debug("fixed_weave_cache: Setting weave cache to %s" % cache_dir)
+        sys.path = [cache_dir] + sys.path
+        try: os.makedirs(cache_dir)
+        except OSError: pass
 
     # Check whether to use a private directory for scipy.weave
     if opt.per_process_weave_cache:

--- a/tools/einsteinathome/check_GW150914_detection.py
+++ b/tools/einsteinathome/check_GW150914_detection.py
@@ -1,0 +1,37 @@
+# Read a pycbc_inspiral HDF5 trigger file and check that it contains triggers
+# compatible with GW150914
+# 2016 Tito Dal Canton
+
+import sys
+import h5py
+import numpy as np
+
+
+# GW150914 params from my run
+# https://www.atlas.aei.uni-hannover.de/~tito/LSC/er8/er8b_c00_1.2.0_run1
+gw150914_time = 1126259462.4
+gw150914_snr = {'H1': 19.71, 'L1': 13.28}
+gw150914_chi2r = {'H1': 1.05, 'L1': 0.45}
+
+f = h5py.File(sys.argv[1], 'r')
+detector = f.keys()[0]
+end_times = f[detector]['end_time'][:]
+snrs = f[detector]['snr'][:]
+chi2rs = f[detector]['chisq'][:] / (2 * f[detector]['chisq_dof'][:] - 2)
+
+# search for trigs compatible with GW150914
+mask = np.logical_and.reduce([abs(end_times - gw150914_time) < 0.1,
+                              snrs > 0.8 * gw150914_snr[detector],
+                              snrs < 1.2 * gw150914_snr[detector],
+                              chi2rs > 0.8 * gw150914_chi2r[detector],
+                              chi2rs < 1.2 * gw150914_chi2r[detector]])
+                      
+if mask.any():
+    print('Pass: %d GW150914-like triggers' % sum(mask))
+    print('end_time snr reduced_chi2')
+    for t, s, c in zip(end_times[mask], snrs[mask], chi2rs[mask]):
+        print('%.3f %.3f %.3f' % (t, s, c))
+    sys.exit(0)
+else:
+    print('Fail: no GW150914-like triggers')
+    sys.exit(1)

--- a/tools/einsteinathome/fstab.c
+++ b/tools/einsteinathome/fstab.c
@@ -1,0 +1,61 @@
+#include <stdio.h>
+#include <string.h>
+#include <limits.h>
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+char path[PATH_MAX];
+
+int main(int argc, char*argv[]) {
+  char* c = argv[1];
+  char *n, *proj;
+  unsigned int i=0;
+
+  // replace all "\" with "/" in argv[1]
+  while (*c) {
+    if (*c == '\\') {
+      *c = '/';
+    }
+    c++;
+  }
+
+  // point proj to second-last "/"
+  while (i<2) {
+    c--;
+    if (*c == '/')
+      i++;
+  }
+  proj = c;
+
+  // copy argv[1] to path, replacing " " with "\040"
+  c = argv[1];
+  while ((n = strchr(c,' '))) {
+    *n = '\0'; // end the string to copy here
+    strcat(path, c);
+    strcat(path, "\\040");
+    *n = ' '; // restore the original value
+    c = n + 1;
+  }
+  strcat(path, c);
+
+#ifdef _WIN32
+  CreateDirectory ("etc", NULL);
+  FILE* fp = fopen("etc\\fstab", "w");
+#else
+  mkdir("etc",0755);;
+  FILE* fp = fopen("etc/fstab", "w");
+#endif
+  if (!fp)
+    return(1);
+  fprintf(fp, "%s /project dummy binary 0 0\n", path);
+  fprintf(fp, "%s %s dummy binary 0 0\n", path, proj);
+  fclose(fp);
+  return(0);
+}

--- a/tools/einsteinathome/progress.c
+++ b/tools/einsteinathome/progress.c
@@ -1,0 +1,105 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, char*argv[]) {
+  int debug = 0;
+  int filter = 0;
+  int arg = 1;
+  char*fname = "stderr.txt";
+  FILE*fp=NULL;
+  FILE*fw=NULL;
+  long new=0, old=0;
+  double progress = 0.0001;
+  int delay = 1;
+
+  // parse command-line options
+  while (argc >= arg) {
+    // -v: verbose
+    if (!strcmp("-v",argv[arg])) {
+      debug++;
+    }
+    // -f: 'filter' input file, write non-matching lines to stdout
+    if (!strcmp("-f",argv[arg])) {
+	filter = 1;
+    }
+    // -s <seconds>: set sleep period
+    if (!strcmp("-s",argv[arg])) {
+      arg++;
+      delay = atoi(argv[arg]);
+    }
+    // -p <fraction>: initial progress value
+    if (!strcmp("-p",argv[arg])) {
+      arg++;
+      progress = atof(argv[arg]);
+    }
+    arg++;
+  }
+  if (argc >= arg) {
+    fname = argv[arg];
+  }
+
+  if (debug) fprintf(stderr, "writing initial progress file\n");
+  if((fw = fopen("progress.txt", "w"))) {
+    fprintf(fw,"%f\n", progress);
+    fclose(fw);
+  }
+
+  // wait for the file to appear
+  while(!fp) {
+    if (debug) fprintf(stderr, "waiting for '%s' to appear\n", fname);
+    sleep(delay);
+    fp=fopen(fname,"r");
+  }
+
+  while(progress < 1.0) {
+    float a, b, c, d;
+    int found=0;
+    char buf[1024];
+
+    // wait for the file to be extended
+    while(new <= old) {
+      if (debug) fprintf(stderr, "waiting for stderr.txt to be extended\n");
+      sleep(delay);
+      fseek(fp, 0, SEEK_END);
+      new = ftell(fp);
+    }
+    fseek(fp, old, SEEK_SET);
+
+    // scan the last line that matches the format
+    // "2016-02-04 22:29:03,745 Filtering template 2045/12454 segment 2/15"
+    // - scan matching lines
+    // - skip non-matching lines
+    // - end scanning on eof
+    found = 0;
+    while (1) {
+      if(fgets(buf, sizeof(buf), fp)) {
+	if (4 == sscanf(buf, "%*s %*s Filtering template %f/%f segment %f/%f", &a, &b, &c, &d)) {
+	  if (debug) fprintf(stderr, "parsed values from line: %f %f %f %f\n", a, b, c, d);
+	  found = 1;
+	} else if (filter) {
+	  printf("%s\n",buf);
+	} else if (debug) {
+	  fprintf(stderr, "non matching line: '%s'\n", buf);
+	}
+	old = ftell(fp);
+      } else {
+	break;
+      }
+    }
+
+    // write progress file
+    if (found) {
+      if (debug) fprintf(stderr, "writing progress file\n");
+      progress = (a-1) / b + (c-1) / (b * d);
+      if((fw = fopen("progress.txt", "w"))) {
+	fprintf(fw,"%f\n", progress);
+	fclose(fw);
+      }
+    }
+  }
+  fclose(fp);
+
+  return 0;
+}

--- a/tools/static/hooks/hook-pycbc.py
+++ b/tools/static/hooks/hook-pycbc.py
@@ -8,7 +8,10 @@
 #-----------------------------------------------------------------------------
 
 import os
-from PyInstaller.hooks.hookutils import (collect_data_files, collect_submodules)
+try:
+    from PyInstaller.utils.hooks import (collect_data_files, collect_submodules)
+except ImportError:
+    from PyInstaller.hooks.hookutils import (collect_data_files, collect_submodules)
 
 # Executables that need MKL
 needs_mkl = ['pycbc_inspiral','pycbc_single_template']

--- a/tools/static/hooks/hook-scipy.weave.py
+++ b/tools/static/hooks/hook-scipy.weave.py
@@ -8,7 +8,10 @@
 #-----------------------------------------------------------------------------
 
 import os.path
-from PyInstaller.hooks.hookutils import (collect_data_files, collect_submodules)
+try:
+    from PyInstaller.utils.hooks import (collect_data_files, collect_submodules)
+except ImportError:
+    from PyInstaller.hooks.hookutils import (collect_data_files, collect_submodules)
 from distutils.sysconfig import get_python_inc
 
 


### PR DESCRIPTION
Push the changes for running PyCBC_inspiral on Einstein@Home upstream.

This adds a directory tools/einsteinathome to the source, containing a bit of code useful for Einstein@Home.

The behavior of pycbc_inspiral under normal circumstances is unchanged as long as the environment variables PROJECT_DIR, NO_PKGCONFIG, NO_GETCONF, LEVEL2_CACHE_SIZE, INITIAL_LOG_LEVEL and WEAVE_FLAGS are not set and the command-line option --fixed-weave-cache is not given. If set, the behavior is modified in the way described in the individual commit messages.