### PR TITLE
Calculating data requirements at runtime

### DIFF
--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -78,6 +78,19 @@ segDir = os.path.join(currDir, "segments")
 sciSegs, segsFileList = _workflow.setup_segment_generation(wflow, segDir)
 
 # Make coherent network segments
+if wflow.cp.has_option("inspiral", "analyse-segment-end"):
+    safety = 1
+    deadtime = int(wflow.cp.get("inspiral", "segment-duration")) / 2
+    spec_len = int(wflow.cp.get("inspiral", "inverse-spec-length")) / 2
+    wflow.cp.set("workflow-exttrig_segments", "min-before",
+                 str(deadtime - spec_len - safety))
+    wflow.cp.set("workflow-exttrig_segments", "min-after",
+                 str(spec_len + safety))
+else:
+    deadtime = int(wflow.cp.get("inspiral", "segment-duration")) / 4
+    wflow.cp.set("workflow-exttrig_segments", "min-before", str(deadtime))
+    wflow.cp.set("workflow-exttrig_segments", "min-after", str(deadtime))
+
 single_ifo = wflow.cp.has_option("workflow", "allow-single-ifo-search")
 if len(sciSegs.keys()) == 0:
     plot_met = make_grb_segments_plot(wflow, segmentlistdict(), triggertime,
@@ -125,17 +138,14 @@ else:
 ifo = sciSegs.keys()[0]
 padding = int(wflow.cp.get("inspiral", "pad-data"))
 if wflow.cp.has_option("inspiral", "analyse-segment-end"):
-    safety = 1
-    deadtime = int(wflow.cp.get("inspiral", "segment-duration")) / 2
-    spec_len = int(wflow.cp.get("inspiral", "inverse-spec-length")) / 2
     wflow.analysis_time = segment(int(sciSegs[ifo][0][0]) + deadtime - \
                                       spec_len + padding - safety,
                                   int(sciSegs[ifo][0][1]) - spec_len - \
                                       padding - safety)
 else:
-    deadtime = int(wflow.cp.get("inspiral", "segment-duration")) / 4
     wflow.analysis_time = segment(int(sciSegs[ifo][0][0]) + deadtime + padding,
                                   int(sciSegs[ifo][0][1]) - deadtime - padding)
+
 wflow.cp = _workflow.set_grb_start_end(wflow.cp, int(sciSegs[ifo][0][0]),
                                        int(sciSegs[ifo][0][1]))
 ext_file = None

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1093,8 +1093,8 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
     else:
         offsrc = offsrclist[0]
 
-    if (triggertime - minbefore - padding not in offsrc) or (
-            triggertime + minafter + padding not in offsrc):
+    if (triggertime - onbefore - minbefore - padding not in offsrc) or (
+            triggertime + onafter + minafter + padding not in offsrc):
         if sngl_ifo:
             logging.warning("Not enough data either side of trigger time in "
                             "coherent segment. Falling back on single IFO "
@@ -1102,8 +1102,10 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
             return get_triggered_single_ifo_segment(workflow, out_dir,
                                                     sciencesegs)
         else:
-            fail = segments.segment([triggertime - minbefore - padding,
-                                     triggertime + minbefore + padding])
+            fail = segments.segment([triggertime - onbefore - minbefore - \
+                                     padding,
+                                     triggertime + onafter + minafter + \
+                                     padding])
             logging.error("Not enough data either side of trigger time. If "
                           "you wish to enable single IFO running add the "
                           "option 'allow-single-ifo-search' to the [workflow] "
@@ -1300,14 +1302,15 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
             offsrc[key] = snglsegs[key][0]
 
     for key in offsrc.keys():
-        if (triggertime - minbefore - padding not in offsrc[key]) or \
-                (triggertime + minafter + padding not in offsrc[key]):
+        if (triggertime - onbefore - minbefore - padding not in offsrc[key]) \
+                or (triggertime + onafter + minafter + padding not in \
+                    offsrc[key]):
             logging.info("Not enough data either side of trigger time in %s."
                          % key)
             offsrc.pop(key)
     if len(offsrc.keys()) == 0:
-        fail = segments.segment([triggertime - minbefore,
-                                 triggertime + minafter])
+        fail = segments.segment([triggertime - onbefore - minbefore,
+                                 triggertime + +onafter + minafter])
         logging.error("Not enough data either side of trigger time in any "
                       "IFO. Exiting.")
         return None, fail


### PR DESCRIPTION
The minimum amounts of data before and after the onsource differ
depending on whether --analyse-segment-end is used. This change adds the
calculation of these quantities to the workflow. They can be removed
from the config files.