### PR TITLE
Fixes bug when not using lalapps_coh_PTF_inspiral

### DIFF
--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -147,14 +147,14 @@ datafind_files, _, sciSegs, _ = _workflow.setup_datafind_workflow(wflow, sciSegs
 ifo = sciSegs.keys()[0]
 ifos = ''.join(sciSegs.keys())
 wflow.ifos = ifos
+datafind_veto_files = _workflow.FileList([])
+datafind_veto_files.extend(datafind_files)
 
 # If using coh_PTF_inspiral we need bank_veto_bank.xml
 if os.path.basename(wflow.cp.get("executables", "inspiral")) \
                     == "lalapps_coh_PTF_inspiral":
-    datafind_veto_files = _workflow.FileList([])
     bank_veto_file = _workflow.get_coh_PTF_files(wflow.cp, ifos, runDir,
                                                  bank_veto=True)
-    datafind_veto_files.extend(datafind_files)
     datafind_veto_files.extend(bank_veto_file)
     
     # Make ExtTrig xml file (needed for lalapps_inspinj and summary pages)


### PR DESCRIPTION
The FileList `datafind_veto_files` was not initialised in the case of `lalapps_coh_PTF_inspiral` not being the inspiral executable, leading to an error at line 165.