### PR TITLE
Adds two libraries needed to use MKL in bundles

### DIFF
--- a/tools/static/hooks/hook-pycbc.py
+++ b/tools/static/hooks/hook-pycbc.py
@@ -79,6 +79,8 @@ if os.environ["NOW_BUILDING"] in needs_mkl:
     datas += find_lib_path('mkl_intel_lp64', [])
     datas += find_lib_path('mkl_avx2', [])
     datas += find_lib_path('mkl_def', [])
+    datas += find_lib_path('iomp5', [])
+    datas += find_lib_path('mkl_mc3', [])
 
 # try to pull in the openmp fftw files
 #datas += find_lib_path('fftw3', ['fftw3'])


### PR DESCRIPTION
These libraries allow MKL to be used in bundles, although it is necessary to specify `--fft-backends mkl` to force MKL use.

This will need to be cherry-picked onto the 1.3 branch for the 1.3.8 release.