### PR TITLE
Fix to last commit of apply_td_shifts

### DIFF
--- a/pycbc/waveform/utils.py
+++ b/pycbc/waveform/utils.py
@@ -272,7 +272,6 @@ def apply_fd_time_shift(htilde, shifttime, fseries=None, copy=True):
         fseries = htilde.sample_frequencies.numpy()
     shift = Array(numpy.exp(-2j*numpy.pi*dt*fseries))
     if copy:
-        htilde = shift * htilde
-    else:
-        htilde *= shift
+        htilde = 1. * htilde
+    htilde *= shift
     return htilde


### PR DESCRIPTION
The last commit of apply_td_shifts caused it to return an Array instead of a FrequencySeries if a copy was made. This fixes that by using the kludge Alex suggested.