### PR TITLE
Add inference module

### DIFF
--- a/pycbc/inference/__init__.py
+++ b/pycbc/inference/__init__.py
@@ -1,0 +1,1 @@
+from pycbc.inference.likelihood import *

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -1,0 +1,192 @@
+# Copyright (C) 2016  Collin Capano
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""
+This modules provides classes and functions for evaluating the log likelihood
+for parameter estimation.
+"""
+
+from pycbc import filter
+from pycbc.types import Array
+import numpy
+
+class _BaseLikelihoodEvaluator:
+    """Base container class for generating waveforms, storing the data, and
+    computing log likelihoods. The likelihood function defined here does
+    nothing. The likelihood function either needs to be monkey patched, or
+    other classes inherit from this class and define their own
+    likelihood functions.
+
+    Parameters
+    ----------
+    waveform_generator : generator class
+        A generator class that creates waveforms. This must have a generate
+        function which takes a set of parameter values as arguments, and a
+        detectors attribute which is a dictionary of detectors keyed by their
+        names.
+    data : dict
+        A dictionary of data, in which the keys are the detector names and the
+        values are the data (assumed to be unwhitened). The list of keys must
+        match the waveform generator's detectors keys.
+    f_lower : float
+        The starting frequency to use for computing inner products.
+    psd : {None, FrequencySeries}
+        If provided, the inner products will be weighted by 1/psd.
+    f_upper : {None, float}
+        The ending frequency to use for computing inner products. If not
+        provided, the minimum of the largest frequency stored in the data
+        and a given waveform will be used.
+    norm : {None, float or array}
+        An extra normalization weight to apply to the inner products. Can be
+        either a float or an array. If None, 4*data.values()[0].delta_f will be
+        used.
+    """
+
+    def __init__(self, waveform_generator, data, f_lower, psd=None, f_upper=None,
+            norm=None):
+        self._waveform_generator = waveform_generator
+        self._data = data
+        # check that the data and waveform generator have the same detectors
+        if sorted(waveform_generator.detectors.keys()) != \
+                sorted(self._data.keys()):
+            raise ValueError("waveform generator's detectors (%s) " %(
+                ','.join(sorted(waveform_generator.detector_names))) +
+                "does not match data (%s)" %(
+                ','.join(sorted(self._data.keys()))))
+        # check that the data sets all have the same lengths
+        dlens = numpy.array([len(d) for d in data.values()])
+        if not all(dlens == dlens[0]):
+            raise ValueError("all data must be of the same length")
+        N = dlens[0]
+        # we'll use the first data set for setting values
+        d = data.values()[0]
+        # figure out the kmin, kmax to use
+        kmin, kmax = filter.get_cutoff_indices(f_lower, f_upper, d.delta_f,
+            (N-1)*2)
+        self._kmin = kmin
+        self._kmax = kmax
+        if norm is None:
+            norm = 4*d.delta_f
+        # we'll store the weight to apply to the inner product
+        if psd is None:
+            self._weight = norm*Array(numpy.ones(N))
+        else:
+            # temporarily suppress numpy divide by 0 warning
+            numpy.seterr(divide='ignore')
+            self._weight = norm/psd
+            numpy.seterr(divide='warn')
+        # compute <d, d>
+        self._dd = {det:
+            d[kmin:kmax].inner(d[kmin:kmax]*self._weight[kmin:kmax]).real/2.
+            for det,d in self._data.items()}
+
+
+    @property
+    def waveform_generator(self):
+        """Returns the waveform generator that was set."""
+        return self._waveform_generator
+
+    @property
+    def data(self):
+        """Returns the data that was set."""
+        return self._data
+
+    def loglikelihood(self, params):
+        """This function should return the log likelihood of the given params.
+        """
+        raise ValueError("Likelihood function not set.")
+
+
+class GaussianLikelihood(_BaseLikelihoodEvaluator):
+    r"""Computes the log likelihood for the given parameters using:
+
+    .. math:: \log \mathcal{L} \propto -\frac{1}{2}\sum_{i} \left<\mathbf{h}_i(\mathbf{\theta}) - \mathbf{s}_i | \mathbf{h}_i(\mathbf{\theta}) - \mathbf{s}_i \right>
+
+    where :math:`\mathbf{h}_i(\mathbf{\theta})` and :math:`\mathbf{s}_i`
+    are the model waveform vector with parameters :math:`\mathbf{\theta}`
+    and the data, respectively, in the :math:`i`th detector (the sum is
+    over the detectors), and the inner product is given by:
+
+    .. math:: \left<a | b\right> = 4\Re \int \tilde{a}(f) \tilde{b}(f) \mathrm{d}f.
+
+    No analytic marginalization is done, and the data is assumed to not be
+    whitened.
+
+    For details on initialization parameters, see _BaseLikelihoodEvaluator.
+
+    Examples
+    --------
+    Create a signal, and compute the log likelihood for a template with the same
+    parameters at the same time (the log likelihood should be zero in this case):
+    >>> from pycbc import psd as pypsd, inference, waveform
+    >>> seglen = 4
+    >>> m1, m2, s1z, s2z, tsig, ra, dec, pol = 38.6, 29.3, 0.33, -0.94, 3.1, 1.37, -1.26, 2.76
+    >>> generator = waveform.FDomainDetFrameGenerator(waveform.FDomainCBCGenerator, variable_args=['tc'], detectors=['H1', 'L1'], delta_f=1./seglen, f_lower=20., approximant='SEOBNRv2_ROM_DoubleSpin', mass1=m1, mass2=m2, spin1z=s1z, spin2z=s2z, ra=ra, dec=dec, polarization=pol)
+    >>> signal = generator.generate(tsig)
+    >>> psd = pypsd.aLIGOZeroDetHighPower(seglen*2048/2+1, 1./seglen, 20.)
+    >>> likelihood_eval = inference.GaussianLikelihood(generator, signal, 20., psd=psd)
+    >>> likelihood_eval.loglikelihood(tsig)
+    ArrayWithAligned(0.0)
+
+    Using the same likelihood evaluator, evaluate the log likelihood at several
+    points in time, check that the max is at tsig, and plot:
+    >>> times = numpy.arange(seglen*2048)/2048.
+    >>> lls = numpy.array([likelihood_eval.loglikelihood(t) for t in times])
+    >>> times[lls.argmax()]
+    3.10009765625
+    >>> fig = pyplot.figure(); ax = fig.add_subplot(111)
+    >>> ax.plot(times, lls)
+    [<matplotlib.lines.Line2D at 0x12780ff90>]
+    >>> fig.show()
+    """
+
+    def loglikelihood(self, *params):
+        """Computes the log-likelihood at the given point in parameter space.
+
+        Parameters
+        ----------
+        params: array-like
+            An array of numerical values to pass to the waveform generator.
+
+        Returns
+        -------
+        float
+            The value of the log-likelhood evaluated at the given point in
+            parameter space.
+        """
+        hs = self._waveform_generator.generate(*params)
+        # the kmax of the waveforms may be different than internal kmax
+        kmax = min(len(hs.values()[0]), self._kmax)
+        w = self._weight[self._kmin:kmax]
+        return sum([
+            # <h, d>
+            self.data[det][self._kmin:kmax].inner(h[self._kmin:kmax]*w).real
+            # - <h, h>/2.
+            - h[self._kmin:kmax].inner(h[self._kmin:kmax]*w).real/2.
+            # - <d, d>/2.
+            - self._dd[det]
+            for det,h in hs.items()])
+
+likelihood_evaluators = {'gaussian': GaussianLikelihood}
+
+__all__ = ['GaussianLikelihood', 'likelihood_evaluators']

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -93,16 +93,24 @@ class _BaseLikelihoodEvaluator:
         # we'll store the weight to apply to the inner product
         if psds is None:
             w = norm*Array(numpy.ones(N))
-            self._weight = {det: w for det in data} 
+            # FIXME: use the following when we've switched to 2.7
+            #self._weight = {det: w for det in data} 
+            self._weight = dict([(det, w) for det in data])
         else:
             # temporarily suppress numpy divide by 0 warning
             numpy.seterr(divide='ignore')
-            self._weight = {det: norm/psds[det] for det in data}
+            # FIXME: use the following when we've switched to 2.7
+            #self._weight = {det: norm/psds[det] for det in data}
+            self._weight = dict([(det, norm/psds[det]) for det in data])
             numpy.seterr(divide='warn')
         # compute <d, d>
-        self._dd = {det:
-            d[kmin:kmax].inner(d[kmin:kmax]*self._weight[det][kmin:kmax]).real/2.
-            for det,d in self._data.items()}
+        # FIXME: use the following when we've switched to 2.7
+        #self._dd = {det:
+        #    d[kmin:kmax].inner(d[kmin:kmax]*self._weight[det][kmin:kmax]).real/2.
+         #   for det,d in self._data.items()}
+        self._dd = dict([(det,
+            d[kmin:kmax].inner(d[kmin:kmax]*self._weight[det][kmin:kmax]).real/2.)
+            for det,d in self._data.items()])
 
 
     @property

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -238,7 +238,9 @@ class FDomainDetFrameGenerator(object):
         # if detectors are provided, convert to detector type; also ensure that
         # location variables are specified
         if detectors is not None:
-            self.detectors = {det: Detector(det) for det in detectors}
+            # FIXME: use the following when we switch to 2.7
+            #self.detectors = {det: Detector(det) for det in detectors}
+            self.detectors = dict([(det, Detector(det)) for det in detectors])
             missing_args = [arg for arg in self.location_args if not
                 (arg in self.current_params or arg in self.variable_args)]
             if any(missing_args):
@@ -254,8 +256,11 @@ class FDomainDetFrameGenerator(object):
         """Generates a waveform, applies a time shift and the detector response
         function."""
         self.current_params.update(dict(zip(self.variable_args, args)))
-        rfparams = {param: self.current_params[param]
-            for param in self.rframe_generator.variable_args}
+        # FIXME: use the following when we switch to 2.7
+        #rfparams = {param: self.current_params[param]
+        #    for param in self.rframe_generator.variable_args}
+        rfparams = dict([(param, self.current_params[param])
+            for param in self.rframe_generator.variable_args])
         hp, hc = self.rframe_generator.generate_from_kwargs(**rfparams)
         h = {}
         if self.detector_names != ['RF']:

--- a/setup.py
+++ b/setup.py
@@ -475,6 +475,7 @@ setup (
                'pycbc.workflow',
                'pycbc.results',
                'pycbc.io',
+               'pycbc.inference',
                ],
      package_data = {'pycbc.workflow': find_package_data('pycbc/workflow'), 
 	             'pycbc.results': find_package_data('pycbc/results'),


### PR DESCRIPTION
This adds an "inference" module to pycbc, which contains likelihood.py. This file stores classes for estimating likelihood for parameter estimation. Currently, there are two classes, a _BaseLikelihoodEvaluator and a GaussianLikelihood, which inherits from _Base. The base class sets up the general structure, which is to have a data attribute, a waveform_generator attribute, etc. GaussianLikelihood adds a log_likelihood function to this which computes the standard likelihood for Gaussian noise. No marginalization is done, nor is there any PSD fitting. When we want likelihood evaluators that do more fancy things like PSD fitting and/or some internal marginalization (e.g., phase), the intent is these can be added as new classes that inherit from the _Base class and add their own loglikelihood function.

Since the likelihood evaluator just expects an instance of a waveform generator, it is agnostic to the types of waveforms that are being estimated. It can therefore be used for CBC PE, or ringdown PE, or any other PE for which a generator exists (sine Gaussians, say).

An example usage is included in the GaussianLikelihood doc string. The plot created in that example can be found here:

https://www.atlas.aei.uni-hannover.de/~cdcapano/likelihood_eval_test.png

The peak in the log likelihood occurs at 3.1s, which is where the example signal was placed.