### PR TITLE
Added dqsegdb and ligo-gracedb dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,4 +51,5 @@ SQLAlchemy==0.8.0
 traceback2==1.4.0
 Werkzeug==0.9.3
 WTForms==1.0.3
-
+https://github.com/duncan-brown/dqsegdb.git@pypi_release#egg=dqsegdb
+ligo-gracedb


### PR DESCRIPTION
Added the dqsegdb and ligo-gracedb dependencies to the requirements.txt file. Without these, jobs running the executables pycbc_coinc_time and pycbc_upload_xml_to_gracedb fail while building the bundle executables, so that the dqsegdb and ligo-gracedb tools have to be installed in the bundle environment if those jobs are to be run. Including those two options in the requirements.txt file would let the dependencies to be automatically included.