### PR TITLE
Fix to collision between kernel name and function name "norm"

### DIFF
--- a/pycbc/types/array_cuda.py
+++ b/pycbc/types/array_cuda.py
@@ -121,7 +121,7 @@ def get_norm_kernel(dtype_x, dtype_out):
                 "tp_z": dtype_to_ctype(dtype_out),
                 },
             "z[i] = norm(x[i])",
-            "normalsize")
+            "normalize")
 
 def squared_norm(self):
     a = self.data

--- a/pycbc/types/array_cuda.py
+++ b/pycbc/types/array_cuda.py
@@ -121,7 +121,7 @@ def get_norm_kernel(dtype_x, dtype_out):
                 "tp_z": dtype_to_ctype(dtype_out),
                 },
             "z[i] = norm(x[i])",
-            "norm")
+            "normalsize")
 
 def squared_norm(self):
     a = self.data


### PR DESCRIPTION
This is a fix to the kernel name which collides with the function name "norm" and returns an error for GPU normalization.