### PR TITLE
simplify phase, time, amp correlation code

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -116,17 +116,21 @@ class PhaseTDStatistic(NewSNRStatistic):
         """
         td = s1[:,2] - s2[:,2] - slide * step
         pd = (s1[:,1] - s2[:,1]) % (numpy.pi * 2)
+        rd = s1[:, 3] / s2[:, 3]
+        rd[rd > 1] = 1.0 / rd[rd > 1]
 
         # These are the bin boundaries stored in the hdf file        
         tbins = self.files['phasetd_newsnr']['tbins'][:]
         pbins = self.files['phasetd_newsnr']['pbins'][:]
         sbins = self.files['phasetd_newsnr']['sbins'][:]
+        rbins = self.files['phasetd_newsnr']['rbins'][:]
 
         # Find which bin each coinc falls into        
         tv = numpy.searchsorted(tbins, td) - 1 
         pv = numpy.searchsorted(pbins, pd) - 1
         s1v = numpy.searchsorted(sbins, s1[:,4]) - 1
-        s2v = numpy.searchsorted(sbins, s2[:,4]) - 1     
+        s2v = numpy.searchsorted(sbins, s2[:,4]) - 1    
+        rv = numpy.searchsorted(rbins, rd) - 1  
 
         # The following just enforces that the point fits into the bin boundaries        
         tv[tv < 0] = 0
@@ -137,8 +141,10 @@ class PhaseTDStatistic(NewSNRStatistic):
         s1v[s1v >= len(sbins) - 1] = len(sbins) - 2
         s2v[s2v < 0] = 0
         s2v[s2v >= len(sbins) - 1] = len(sbins) - 2
+        rv[rv < 0] = 0
+        rv[rv >= len(rbins) - 1] = len(rbins) - 2
         
-        m = self.hist[tv, pv, s1v, s2v]
+        m = self.hist[tv, pv, s1v, s2v, rv]
         rstat = s1[:,0]**2.0 + s2[:,0]**2.0
         cstat = rstat + 2.0 * m
         cstat[cstat < 0] = 0        

--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -105,11 +105,6 @@ class PhaseTDStatistic(NewSNRStatistic):
 
         #normalize so that peak has no effect on newsnr
         self.hist = self.hist / top
-
-        #set 0 to smallest value
-        self.m = (self.hist == 0)
-        self.hist[self.m] = 1.0 / top
-
         self.hist = numpy.log(self.hist) 
 
     def single(self, trigs):
@@ -121,35 +116,33 @@ class PhaseTDStatistic(NewSNRStatistic):
         """
         td = s1[:,2] - s2[:,2] - slide * step
         pd = (s1[:,1] - s2[:,1]) % (numpy.pi * 2)
-        rd = numpy.log(s1[:,4] / s2[:,4]) + numpy.log(s2[:,3] / s1[:,3])
-        md = (s1[:,4]**2.0 + s2[:,4]**2.0) ** 0.5
 
         # These are the bin boundaries stored in the hdf file        
         tbins = self.files['phasetd_newsnr']['tbins'][:]
         pbins = self.files['phasetd_newsnr']['pbins'][:]
-        rbins = self.files['phasetd_newsnr']['rbins'][:]
-        mbins = self.files['phasetd_newsnr']['mbins'][:]
+        sbins = self.files['phasetd_newsnr']['sbins'][:]
 
         # Find which bin each coinc falls into        
         tv = numpy.searchsorted(tbins, td) - 1 
         pv = numpy.searchsorted(pbins, pd) - 1
-        rv = numpy.searchsorted(rbins, rd) - 1
-        mv = numpy.searchsorted(mbins, md) - 1     
+        s1v = numpy.searchsorted(sbins, s1[:,4]) - 1
+        s2v = numpy.searchsorted(sbins, s2[:,4]) - 1     
 
         # The following just enforces that the point fits into the bin boundaries        
         tv[tv < 0] = 0
         tv[tv >= len(tbins) - 1] = len(tbins) - 2
         pv[pv < 0] = 0
         pv[pv >= len(pbins) - 1] = len(pbins) - 2
-        rv[rv < 0] = 0
-        rv[rv >= len(rbins) - 1] = len(rbins) - 2
-        mv[mv < 0] = 0
-        mv[mv >= len(mbins) - 1] = len(mbins) - 2
+        s1v[s1v < 0] = 0
+        s1v[s1v >= len(sbins) - 1] = len(sbins) - 2
+        s2v[s2v < 0] = 0
+        s2v[s2v >= len(sbins) - 1] = len(sbins) - 2
         
-        m = self.hist[tv, pv, rv, mv]
-        
-        cstat = (s1[:,0]**2.0 + s2[:,0]**2.0 + 2.0 * m) ** 0.5
-        return cstat
+        m = self.hist[tv, pv, s1v, s2v]
+        rstat = s1[:,0]**2.0 + s2[:,0]**2.0
+        cstat = rstat + 2.0 * m
+        cstat[cstat < 0] = 0        
+        return cstat ** 0.5
 
 class MaxContTradNewSNRStatistic(NewSNRStatistic):
     def single(self, trigs):

--- a/bin/hdfcoinc/pycbc_stat_dtphase
+++ b/bin/hdfcoinc/pycbc_stat_dtphase
@@ -46,7 +46,9 @@ def bcount(left, right, error):
     return num, width, bins
 
 snr_error = args.snr_error * 2 ** 0.5
-phase_error = .4
+
+# Phase error is approximated for SNR ~ snr threshold
+phase_error = numpy.arctan(snr_error / args.min_snr)
 detector_error = 0.2
 
 tnum, twidth, tbins = bcount(-maxdt, maxdt, args.timing_error)

--- a/bin/hdfcoinc/pycbc_stat_dtphase
+++ b/bin/hdfcoinc/pycbc_stat_dtphase
@@ -100,7 +100,7 @@ def generate_samples(size):
     fsize = f * size
     dist = power(3, fsize) / args.min_snr
    
-    r = uniform(.5, 1, size=len(dist))
+    r = uniform(args.min_detector_ratio, 1, size=len(dist))
     sp1 = numpy.resize(fp1 * ip, len(dist)) / dist * r
     sp2 = numpy.resize(fp2 * ip, len(dist)) / dist * r
     sc1 = numpy.resize(fc1 * ic, len(dist)) / dist

--- a/bin/hdfcoinc/pycbc_stat_dtphase
+++ b/bin/hdfcoinc/pycbc_stat_dtphase
@@ -46,11 +46,13 @@ phase_error = .4
 tnum, twidth, tbins = bcount(-maxdt, maxdt, args.timing_error)
 pnum, pwidth, pbins = bcount(0, 2.0 * numpy.pi, phase_error)
 snum, swidth, sbins = bcount(args.min_snr, args.max_snr, snr_error)
+rnum, rwidth, rbins = bcount(.5, 1, .2)
 
-hist_bins = (tbins, pbins, sbins, sbins)
+hist_bins = (tbins, pbins, sbins, sbins, rbins)
 print tbins
 print pbins
 print sbins
+print rbins
 pycbc.init_logging(args.verbose)
 
 def generate_hist(size):
@@ -95,11 +97,12 @@ def generate_samples(size):
     f = 1000
     fsize = f * size
     dist = power(3, fsize) / args.min_snr
-    
-    sp1 = numpy.resize(fp1 * ip, len(dist)) / dist
-    sp2 = numpy.resize(fp2 * ip, len(dist)) / dist
+   
+    r = uniform(.5, 1, size=len(dist))
+    sp1 = numpy.resize(fp1 * ip, len(dist)) / dist * r
+    sp2 = numpy.resize(fp2 * ip, len(dist)) / dist * r
     sc1 = numpy.resize(fc1 * ic, len(dist)) / dist
-    sc2 = numpy.resize(fc2 * ic, len(dist)) / dist
+    sc2 = numpy.resize(fc2 * ic, len(dist)) / dist 
     td = numpy.resize(td, fsize)
 
     # Remove points below the SNR threshold
@@ -110,6 +113,7 @@ def generate_samples(size):
     sp2 = sp2[t]
     sc1 = sc1[t]
     sc2 = sc2[t]
+    r = r[t]
 
     s1 = (sp1**2.0 + sc1**2.0)**0.5
     s2 = (sp2**2.0 + sc2**2.0)**0.5
@@ -118,7 +122,8 @@ def generate_samples(size):
     phase_diff = (numpy.arctan2(sc1, sp1) - numpy.arctan2(sc2, sp2)) % (numpy.pi * 2)
     
     logging.info('keeping %s values' % len(s1))
-    return td, phase_diff, s1, s2
+
+    return td, phase_diff, s1, s2, r
 
 # This just makes sure that 3 chunks are submitted to each process
 fiddle = 1
@@ -139,12 +144,14 @@ f = h5py.File(args.output_file, 'w')
 errors = (args.timing_error / twidth, 
           phase_error / pwidth,
           snr_error / swidth,
-          snr_error / swidth)
+          snr_error / swidth,
+          .5)
 print errors
 f['map'] = gaussian_filter(h, errors, mode='nearest', truncate=8).astype(numpy.float32)
 f['tbins'] = tbins
 f['pbins'] = pbins
 f['sbins'] = sbins
+f['rbins'] = rbins
 f.attrs['ifo0'] = args.ifos[0]
 f.attrs['ifo1'] = args.ifos[1]
 f.attrs['stat'] = "phasetd_newsnr"

--- a/bin/hdfcoinc/pycbc_stat_dtphase
+++ b/bin/hdfcoinc/pycbc_stat_dtphase
@@ -15,13 +15,17 @@ parser.add_argument('--min-snr', type=float,
                     help="SNR cutoff to apply to the drawn SNR values.")
 parser.add_argument('--max-snr', type=float, default=100,
                     help="Maximum snr to draw signals out to")
-parser.add_argument('--timing-error', type=float)
-parser.add_argument('--min-detector-ratio', type=float, default=0.5)
-parser.add_argument('--snr-error', type=float)
+parser.add_argument('--timing-error', type=float,
+                    help="Error on timing measurement in seconds")
+parser.add_argument('--min-detector-ratio', type=float, default=0.5,
+                    help="The minimum ratio between detector sensitivities to bin")
+parser.add_argument('--snr-error', type=float,
+                    help="Error on the SNR recovery.")
 parser.add_argument('--coinc-threshold', default=0, type=float,
                     help="seconds to add to the TOF coinc window")
 parser.add_argument('--seed', type=int, default=124)
-parser.add_argument('--bin-density', type=int, default=2)
+parser.add_argument('--bin-density', type=int, default=2,
+                    help="Density of bins to make as a multiplicity of errors in each bin paramter")
 parser.add_argument('--output-file')
 parser.add_argument('--cores', default=1, type=int)
 parser.add_argument('--verbose', action='store_true')

--- a/bin/hdfcoinc/pycbc_stat_dtphase
+++ b/bin/hdfcoinc/pycbc_stat_dtphase
@@ -3,30 +3,24 @@
 correlations between two detectors by
 doing a simple monte-carlo
 """
-
 import argparse, h5py, numpy.random, pycbc.detector, logging, multiprocessing
 from numpy.random import normal, uniform, power
+from scipy.ndimage.filters import gaussian_filter
+
 parser = argparse.ArgumentParser()
 parser.add_argument('--ifos', nargs=2, help="The two ifos to generate a histogram for")
 parser.add_argument('--sample-size', type=int, 
                     help="Approximant number of independent samples to draw for the distribution")
-parser.add_argument('--snr-threshold', type=float, 
+parser.add_argument('--min-snr', type=float, 
                     help="SNR cutoff to apply to the drawn SNR values.")
-parser.add_argument('--phase-bins', type=int, default=100,
-                    help="Number of bins to distribute phase differences into")
-parser.add_argument('--sample-rate', type=int, default=4096, 
-                    help="Sample rate used to determine the bin size in the time difference")
-parser.add_argument('--max-combined-snr', type=float, default=100,
-                    help="Maximum combine newsnr to draw signals out to")
-parser.add_argument('--amplitude-ratio-bins', type=int, default=50,
-                    help="Number of bins to use for storing amplitude ratios")
-parser.add_argument('--amplitude-magnitude-bins', type=int, default=50,
-                    help="Number of bins to use for storing the combined SNR magnitudes")
-parser.add_argument('--fixed-timing-error', default=1.0/4096, type=float,
-                    help="Fixed value for a timing error")
+parser.add_argument('--max-snr', type=float, default=100,
+                    help="Maximum snr to draw signals out to")
+parser.add_argument('--timing-error', type=float)
+parser.add_argument('--snr-error', type=float)
 parser.add_argument('--coinc-threshold', default=0, type=float,
                     help="seconds to add to the TOF coinc window")
 parser.add_argument('--seed', type=int, default=124)
+parser.add_argument('--bin-density', type=int, default=2)
 parser.add_argument('--output-file')
 parser.add_argument('--cores', default=1, type=int)
 parser.add_argument('--verbose', action='store_true')
@@ -38,18 +32,25 @@ d2 = pycbc.detector.Detector(str(args.ifos[1]))
 maxdt = d1.light_travel_time_to_detector(d2) + args.coinc_threshold
 
 # Calculate the edges of the bins
-max_csnr = args.max_combined_snr
-max_ratio = numpy.log((max_csnr**2.0- args.snr_threshold**2.0) ** 0.5 / args.snr_threshold)
-tbins = numpy.linspace(- maxdt, maxdt, num=int(args.sample_rate * 2 * maxdt))
-pbins = numpy.linspace(0, 2.0 * numpy.pi, num=args.phase_bins + 1)
-rbins = numpy.linspace(-max_ratio, max_ratio, num=args.amplitude_ratio_bins + 1)
-mbins = numpy.logspace(numpy.log(args.snr_threshold * 2 ** 0.5), numpy.log(max_csnr),
-                       num=args.amplitude_magnitude_bins + 1, base=numpy.e)
-hist_bins = (tbins, pbins, rbins, mbins)
+
+def bcount(left, right, error):
+    bin_density = args.bin_density
+    num = int((right - left) / float(error) * bin_density)
+    width = (right - left) / float(num)
+    bins = numpy.linspace(left, right, num=num)
+    return num, width, bins
+
+snr_error = args.snr_error * 2 ** 0.5
+phase_error = .4
+
+tnum, twidth, tbins = bcount(-maxdt, maxdt, args.timing_error)
+pnum, pwidth, pbins = bcount(0, 2.0 * numpy.pi, phase_error)
+snum, swidth, sbins = bcount(args.min_snr, args.max_snr, snr_error)
+
+hist_bins = (tbins, pbins, sbins, sbins)
 print tbins
 print pbins
-print rbins
-print mbins
+print sbins
 pycbc.init_logging(args.verbose)
 
 def generate_hist(size):
@@ -93,17 +94,17 @@ def generate_samples(size):
     # add on gaussian errors in SNR
     f = 1000
     fsize = f * size
-    dist = power(3, fsize) / args.snr_threshold
+    dist = power(3, fsize) / args.min_snr
     
-    sp1 = numpy.resize(fp1 * ip, len(dist)) / dist + numpy.resize(normal(0, scale=1.0, size=size), fsize)
-    sp2 = numpy.resize(fp2 * ip, len(dist)) / dist + numpy.resize(normal(0, scale=1.0, size=size), fsize)
-    sc1 = numpy.resize(fc1 * ic, len(dist)) / dist + numpy.resize(normal(0, scale=1.0, size=size), fsize)
-    sc2 = numpy.resize(fc2 * ic, len(dist)) / dist + numpy.resize(normal(0, scale=1.0, size=size), fsize)
-    td = numpy.resize(td, fsize) + normal(0, scale=args.fixed_timing_error, size=fsize)
+    sp1 = numpy.resize(fp1 * ip, len(dist)) / dist
+    sp2 = numpy.resize(fp2 * ip, len(dist)) / dist
+    sc1 = numpy.resize(fc1 * ic, len(dist)) / dist
+    sc2 = numpy.resize(fc2 * ic, len(dist)) / dist
+    td = numpy.resize(td, fsize)
 
     # Remove points below the SNR threshold
-    t = sp1**2.0 + sc1**2.0 > args.snr_threshold ** 2.0
-    t2 = sp2**2.0 + sc2**2.0 > args.snr_threshold ** 2.0
+    t = sp1**2.0 + sc1**2.0 > args.min_snr ** 2.0
+    t2 = sp2**2.0 + sc2**2.0 > args.min_snr ** 2.0
     t = numpy.logical_and(t, t2)
     sp1 = sp1[t]
     sp2 = sp2[t]
@@ -115,14 +116,12 @@ def generate_samples(size):
 
     td = td[t]
     phase_diff = (numpy.arctan2(sc1, sp1) - numpy.arctan2(sc2, sp2)) % (numpy.pi * 2)
-    ratio = numpy.log(s1 / s2)
-    mag = (s1**2.0 + s2**2.0)**0.5
     
-    logging.info('keeping %s values' % len(ratio))
-    return td, phase_diff, ratio, mag
+    logging.info('keeping %s values' % len(s1))
+    return td, phase_diff, s1, s2
 
 # This just makes sure that 3 chunks are submitted to each process
-fiddle = 3
+fiddle = 1
 core_size = int(args.sample_size / args.cores) / fiddle
 chunk_data = [core_size] * args.cores * fiddle
 
@@ -135,11 +134,17 @@ else:
 h = numpy.sum(h, axis=0)
 f = h5py.File(args.output_file, 'w')
 
-f['map'] = h
+# Convert the errors to units of number of histogram bins and apply using
+# a gaussian filter
+errors = (args.timing_error / twidth, 
+          phase_error / pwidth,
+          snr_error / swidth,
+          snr_error / swidth)
+print errors
+f['map'] = gaussian_filter(h, errors, mode='nearest', truncate=8).astype(numpy.float32)
 f['tbins'] = tbins
 f['pbins'] = pbins
-f['rbins'] = rbins
-f['mbins'] = mbins
+f['sbins'] = sbins
 f.attrs['ifo0'] = args.ifos[0]
 f.attrs['ifo1'] = args.ifos[1]
 f.attrs['stat'] = "phasetd_newsnr"

--- a/bin/hdfcoinc/pycbc_stat_dtphase
+++ b/bin/hdfcoinc/pycbc_stat_dtphase
@@ -16,6 +16,7 @@ parser.add_argument('--min-snr', type=float,
 parser.add_argument('--max-snr', type=float, default=100,
                     help="Maximum snr to draw signals out to")
 parser.add_argument('--timing-error', type=float)
+parser.add_argument('--min-detector-ratio', type=float, default=0.5)
 parser.add_argument('--snr-error', type=float)
 parser.add_argument('--coinc-threshold', default=0, type=float,
                     help="seconds to add to the TOF coinc window")
@@ -42,11 +43,12 @@ def bcount(left, right, error):
 
 snr_error = args.snr_error * 2 ** 0.5
 phase_error = .4
+detector_error = 0.2
 
 tnum, twidth, tbins = bcount(-maxdt, maxdt, args.timing_error)
 pnum, pwidth, pbins = bcount(0, 2.0 * numpy.pi, phase_error)
 snum, swidth, sbins = bcount(args.min_snr, args.max_snr, snr_error)
-rnum, rwidth, rbins = bcount(.5, 1, .2)
+rnum, rwidth, rbins = bcount(args.min_detector_ratio, 1, detector_error)
 
 hist_bins = (tbins, pbins, sbins, sbins, rbins)
 print tbins


### PR DESCRIPTION
This simplifies the file format and the generation of the phase / time / correlation code. It also removes some of the manual settings related to number of bins etc, and replaces them with choices based on expected errors, etc. 

The format no longer stores ratio and magnitude, and instead stores the individual SNRs directly. This removes one of the failure modes for compensating for unequal detector sensitivity. It also makes it clearer how to do the smoothing of the distribution along this axis. 

Another axis for the ratio of detector sensitivity is instead added to simplify the interpretation. 

The code now can be run much faster and produce a viable file, in large part due to the introduction of the smoothing of values across the dimensions. 

The following runs in ~20 minutes on a head node and returns a reasonable file. (getting more points doesn't seem to affect recovery). 

'''
pycbc_stat_dtphase \
--ifos H1 L1 \
--sample-size 10000000 \
--min-snr 5.5 \
--max-snr 30 \
--timing-error .0005 \
--snr-error 1 \
--cores 14 \
--bin-density 3 \
--coinc-threshold .005 \
--output-file test.hdf \
--verbose
'''
