### PR TITLE
tweak to prevent the timefreq code from plotting vast numbers of gates

### DIFF
--- a/bin/hdfcoinc/pycbc_page_sensitivity
+++ b/bin/hdfcoinc/pycbc_page_sensitivity
@@ -255,7 +255,7 @@ pylab.ylabel(ylabel)
 pylab.xlabel(xlabel)
 
 pylab.grid()
-pylab.legend(loc='best')
+pylab.legend(loc='lower left')
 
 pycbc.results.save_fig_with_metadata(fig, args.output_file,
      title="Sensitive %s vs %s: binned by %s using %s method"

--- a/bin/hdfcoinc/pycbc_plot_singles_timefreq
+++ b/bin/hdfcoinc/pycbc_plot_singles_timefreq
@@ -188,6 +188,9 @@ for gate_type, hatch_style in [('file', '\\'), ('auto', '/')]:
     except KeyError:
         continue
     for gt, gw, gp in zip(gate_time, gate_width, gate_pad):
+        # only try to plot gates within the time window
+        if gt + gw < opts.gps_start_time or gt - gw > opts.gps_end_time:
+            continue
         ax.axvspan(gt - gw - center_time, gt + gw - center_time,
                    hatch=hatch_style, facecolor='none', edgecolor='#00ff00')
 


### PR DESCRIPTION
also change the sensitivity caption location back to 'bottom left' as it's the least worst default location