### PR TITLE
Add handler for MCMC samplers.

### DIFF
--- a/pycbc/inference/__init__.py
+++ b/pycbc/inference/__init__.py
@@ -1,1 +1,2 @@
 from pycbc.inference.likelihood import *
+from pycbc.inference.sampler import *

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -1,0 +1,135 @@
+# Copyright (C) 2016  Christopher M. Biwer
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""
+This modules provides classes and functions for using different sampler
+packages for parameter estimation.
+"""
+
+import kombine
+
+class _BaseSampler(object):
+    """ Base container class for running the MCMC sampler.
+
+    Parameters
+    ----------
+    sampler : sampler class
+        An instance of the sampler class from its package.
+    """
+
+    def __init__(self, sampler):
+        self.sampler = sampler
+
+    @property
+    def acceptance_fraction(self):
+        """ This function should return the fraction of walkers that accepted
+        each step as an array.
+        """
+        return ValueError("acceptance_fraction function not set.")
+
+    @property
+    def chain(self):
+        """ This function should return the past samples as a
+        initerations x nwalker x ndim array.
+        """
+        return ValueError("chain function not set.")
+
+    def burn_in(self, initial_values):
+        """ This function should burn in the MCMC.
+        """
+        raise ValueError("burn_in function not set.")
+
+    def run_mcmc(self, niterations):
+        """ This function should run the MCMC for the number of samples.
+        """
+        raise ValueError("run_mcmc function not set.")
+
+class KombineSampler(_BaseSampler):
+    """ This class is used to construct the sampler from the kombine package.
+
+    Parameters
+    ----------
+    likelihood_evaluator : likelihood class
+        An instance of the likelihood class from the
+        pycbc.inference.likelihood module.
+    nwalkers : int
+        Number of walkers to use in MCMC.
+    ndim : int
+        Number of dimensions in the parameter space. If transd is True this is
+        the number of unique dimensions across the parameter spaces.
+    transd : bool
+        If True, the sampler will operate across parameter spaces using a
+        kombine.clustered_kde.TransdimensionalKDE proposal distribution. In
+        this mode a masked array with samples in each of the possible sets of
+        dimensions must be given for the initial ensemble distribution.
+    nprocesses : {None, int}
+        Number of processes to use with multiprocessing. If None, all available
+        cores are used.
+    """
+
+    def __init__(self, likelihood_evaluator, nwalkers=0, ndim=0,
+                        transd=False, nprocess=None):
+
+        # construct sampler 
+        sampler = kombine.Sampler(nwalkers, ndim, self.likelihood_evaluator,
+                                          transd=transd, processes=nprocesses)
+        super(KombineSampler, self).__init__(self, sampler)
+
+    @property
+    def acceptance_fraction(self):
+        """ Get the fraction of walkers that accepted each step as an arary.
+        """
+        return self.sampler.acceptance_fraction
+
+    @property
+    def chain(self):
+        """ Get all past samples as an niterations x nwalker x ndim array.
+        """
+        return self.sampler.chain
+
+    def burn_in(self, initial_values):
+        """ Evolve an ensemble until the acceptance rate becomes roughly
+        constant. This is done by splitting acceptances in half and checking
+        for statistical consistency. This isn’t guaranteed to return a fully
+        burned-in ensemble, but usually does.
+
+        Parameters
+        ----------
+        initial_values : numpy.array
+            An nwalkers x ndim array of initial values for walkers.
+        """
+        self.sampler.burn_in(initial_values)
+
+    def run_mcmc(self, niterations):
+        """ Advance the MCMC for a number of samples.
+
+        Parameters
+        ----------
+        niterations : int
+            Number of samples to get from MCMC.
+        """
+        self.sampler.run_mcmc(niterations)
+
+samplers = {
+    "kombine" : KombineSampler,
+}

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -86,7 +86,7 @@ class KombineSampler(_BaseSampler):
     """
 
     def __init__(self, likelihood_evaluator, nwalkers=0, ndim=0,
-                        transd=False, process=None):
+                        transd=False, processes=None):
 
         try:
             import kombine
@@ -94,9 +94,9 @@ class KombineSampler(_BaseSampler):
             raise ImportError("kombine is not installed.")
 
         # construct sampler 
-        sampler = kombine.Sampler(nwalkers, ndim, self.likelihood_evaluator,
+        sampler = kombine.Sampler(nwalkers, ndim, likelihood_evaluator,
                                           transd=transd, processes=processes)
-        super(KombineSampler, self).__init__(self, sampler)
+        super(KombineSampler, self).__init__(sampler)
 
     @property
     def acceptance_fraction(self):

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -134,13 +134,14 @@ class KombineSampler(_BaseSampler):
         """
         return self.sampler.burnin(initial_values)
 
-    def run_mcmc(self, niterations):
+    def run_mcmc(self, niterations, **kwargs):
         """ Advance the MCMC for a number of samples.
 
         Parameters
         ----------
         niterations : int
             Number of samples to get from MCMC.
+        
 
         Returns
         -------
@@ -153,7 +154,7 @@ class KombineSampler(_BaseSampler):
             The list of log proposal densities for the walkers at positions p,
             with shape (nwalkers, ndim).
         """
-        return self.sampler.run_mcmc(niterations)
+        return self.sampler.run_mcmc(niterations, **kwargs)
 
 samplers = {
     "kombine" : KombineSampler,

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -26,8 +26,6 @@ This modules provides classes and functions for using different sampler
 packages for parameter estimation.
 """
 
-import kombine
-
 class _BaseSampler(object):
     """ Base container class for running the MCMC sampler.
 
@@ -89,6 +87,11 @@ class KombineSampler(_BaseSampler):
 
     def __init__(self, likelihood_evaluator, nwalkers=0, ndim=0,
                         transd=False, nprocess=None):
+
+        try:
+            import kombine
+        except ImportError:
+            raise ImportError("kombine is not installed.")
 
         # construct sampler 
         sampler = kombine.Sampler(nwalkers, ndim, self.likelihood_evaluator,

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -120,8 +120,19 @@ class KombineSampler(_BaseSampler):
         ----------
         initial_values : numpy.array
             An nwalkers x ndim array of initial values for walkers.
+
+        Returns
+        -------
+        p : numpy.array
+            An array of current walker positions with shape (nwalkers, ndim).
+        lnpost : numpy.array
+            The list of log posterior probabilities for the walkers at
+            positions p, with shape (nwalkers, ndim).
+        lnprop : numpy.array
+            The list of log proposal densities for the walkers at positions p,
+            with shape (nwalkers, ndim).
         """
-        self.sampler.burn_in(initial_values)
+        return self.sampler.burnin(initial_values)
 
     def run_mcmc(self, niterations):
         """ Advance the MCMC for a number of samples.
@@ -130,8 +141,19 @@ class KombineSampler(_BaseSampler):
         ----------
         niterations : int
             Number of samples to get from MCMC.
+
+        Returns
+        -------
+        p : numpy.array
+            An array of current walker positions with shape (nwalkers, ndim).
+        lnpost : numpy.array
+            The list of log posterior probabilities for the walkers at
+            positions p, with shape (nwalkers, ndim).
+        lnprop : numpy.array
+            The list of log proposal densities for the walkers at positions p,
+            with shape (nwalkers, ndim).
         """
-        self.sampler.run_mcmc(niterations)
+        return self.sampler.run_mcmc(niterations)
 
 samplers = {
     "kombine" : KombineSampler,

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -80,13 +80,13 @@ class KombineSampler(_BaseSampler):
         kombine.clustered_kde.TransdimensionalKDE proposal distribution. In
         this mode a masked array with samples in each of the possible sets of
         dimensions must be given for the initial ensemble distribution.
-    nprocesses : {None, int}
+    processes : {None, int}
         Number of processes to use with multiprocessing. If None, all available
         cores are used.
     """
 
     def __init__(self, likelihood_evaluator, nwalkers=0, ndim=0,
-                        transd=False, nprocess=None):
+                        transd=False, process=None):
 
         try:
             import kombine
@@ -95,7 +95,7 @@ class KombineSampler(_BaseSampler):
 
         # construct sampler 
         sampler = kombine.Sampler(nwalkers, ndim, self.likelihood_evaluator,
-                                          transd=transd, processes=nprocesses)
+                                          transd=transd, processes=processes)
         super(KombineSampler, self).__init__(self, sampler)
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'pyRXP>=2.1.0',
                       'pycbc-pylal>=0.9.5',
                       'pycbc-glue>=0.9.8',
-                      'kombine',
                       ]
 links = ['https://github.com/ligo-cbc/mpld3/tarball/master#egg=mpld3-0.3git']
 

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'pyRXP>=2.1.0',
                       'pycbc-pylal>=0.9.5',
                       'pycbc-glue>=0.9.8',
+                      'kombine',
                       ]
 links = ['https://github.com/ligo-cbc/mpld3/tarball/master#egg=mpld3-0.3git']
 


### PR DESCRIPTION
This PR adds a module to handle using different samplers. At the moment it has a handler class for kombine.

Also adds kombine to ```setup.py``` install.