### PR TITLE
increment dev version 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -258,7 +258,7 @@ def get_version_info():
             
     # If this is a release or another kind of source distribution of PyCBC
     except:
-        version = '1.4.dev0'
+        version = '1.5.dev0'
         release = 'False'
         date = hash = branch = tag = author = committer = status = builder = build_date = ''
     


### PR DESCRIPTION
This increments the dev version to 1.5.dev0. For people's reference, this needs to always be beyond the latest release number. (1.4.dev0 < 1.4.0).