### PR TITLE
Ringdown module 

### DIFF
--- a/pycbc/waveform/__init__.py
+++ b/pycbc/waveform/__init__.py
@@ -2,3 +2,4 @@ from pycbc.waveform.waveform import *
 from pycbc.waveform.utils import *
 from pycbc.waveform.bank import *
 from pycbc.waveform.generator import *
+from pycbc.waveform.ringdown import *

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -143,7 +143,7 @@ class TDomainCBCGenerator(BaseGenerator):
             variable_args=variable_args, **frozen_params)
 
 class FDomainRingdownGenerator(BaseGenerator):
-    """Uses ringdown.get_fd_ringdown as a generator function to create frequency-
+    """Uses ringdown.get_fd_qnm as a generator function to create frequency-
     domain ringdown waveforms in the radiation frame; i.e., with no detector response
     function applied. For more details, see BaseGenerator.
 
@@ -158,7 +158,7 @@ class FDomainRingdownGenerator(BaseGenerator):
      <pycbc.types.frequencyseries.FrequencySeries at 0x1110c1510>)
     """
     def __init__(self, variable_args=(), **frozen_params):
-        super(FDomainRingdownGenerator, self).__init__(ringdown.get_fd_ringdown,
+        super(FDomainRingdownGenerator, self).__init__(ringdown.get_fd_qnm,
             variable_args=variable_args, **frozen_params)
 
 class FDomainDetFrameGenerator(object):

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -27,6 +27,7 @@ This modules provides classes for generating waveforms.
 
 import functools
 import waveform
+import ringdown
 from pycbc.waveform.utils import apply_fd_time_shift
 from pycbc.detector import Detector
 import lal as _lal
@@ -141,6 +142,24 @@ class TDomainCBCGenerator(BaseGenerator):
         super(TDomainCBCGenerator, self).__init__(waveform.get_td_waveform,
             variable_args=variable_args, **frozen_params)
 
+class FDomainRingdownGenerator(BaseGenerator):
+    """Uses ringdown.get_fd_ringdown as a generator function to create frequency-
+    domain ringdown waveforms in the radiation frame; i.e., with no detector response
+    function applied. For more details, see BaseGenerator.
+
+    Examples
+    --------
+    Initialize a generator:
+    >>> generator = waveform.FDomainRingdownGenerator(variable_args=['tau', 'f_0'], delta_f=1./32, f_lower=30., f_final=500)
+
+    Create a ringdown with the variable arguments (in this case, tau, f_0):
+    >>> generator.generate(5, 100)
+    (<pycbc.types.frequencyseries.FrequencySeries at 0x1110c1450>,
+     <pycbc.types.frequencyseries.FrequencySeries at 0x1110c1510>)
+    """
+    def __init__(self, variable_args=(), **frozen_params):
+        super(FDomainRingdownGenerator, self).__init__(ringdown.get_fd_ringdown,
+            variable_args=variable_args, **frozen_params)
 
 class FDomainDetFrameGenerator(object):
     """Generates a waveform using the given radiation frame generator class,

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -76,7 +76,7 @@ def qnm_time_decay(tau, decay):
         ringdown falls to decay of the peak amplitude.
     """
 
-    return t_decay = - tau * numpy.log(decay)
+    return - tau * numpy.log(decay)
 
 def qnm_freq_decay(f_0, tau, decay):
     """Return the frequency at which the amplitude of the 
@@ -105,7 +105,7 @@ def qnm_freq_decay(f_0, tau, decay):
     # Expression obtained analytically under the assumption
     # that alpha_sq, q_0^2 >> 1
     q_sq = (alpha_sq + 4*q_0*q_0 + alpha*numpy.sqrt(alpha_sq + 16*q_0*q_0)) / 4.
-    return f_decay = numpy.sqrt(q_sq) / numpy.pi / tau
+    return numpy.sqrt(q_sq) / numpy.pi / tau
 
 def get_td_qnm(template=None, delta_t=None, t_lower=None, t_final=None, **kwargs):
     """Return a time domain damped sinusoid.

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -1,0 +1,126 @@
+# Copyright (C) 2016 Miriam Cabero Mueller
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""Generate ringdown templates in the frequency domain.
+"""
+
+import numpy, lal
+from pycbc.types import FrequencySeries, complex64, zeros
+
+default_ringdown_args = {'t_0':0, 'phi_0':0, 'Amp':1}
+
+def props_ringdown(obj, **kwargs):
+    """ DOCUMENT ME !!
+    """
+    pr = {}
+    if obj is not None:
+        if hasattr(obj, '__dict__'):
+            pr = obj.__dict__
+        elif hasattr(obj, '__slots__'):
+            for slot in obj.__slots__:
+                if hasattr(obj, slot):
+                    pr[slot] = getattr(obj, slot)
+        else:
+            for name in dir(obj):
+                try:
+                    value = getattr(obj, name)
+                    if not name.startswith('__') and not inspect.ismethod(value):
+                        pr[name] = value
+                except:
+                    continue
+
+    # Get the parameters to generate the waveform
+    # Note that keyword arguments override values in the template object
+    input_params = default_ringdown_args.copy()
+    input_params.update(pr)
+    input_params.update(kwargs)
+
+    return input_params
+
+def get_fd_ringdown(template=None,**kwargs):
+    """Return a frequency domain ringdown.
+
+    Parameters
+    ----------
+    template: object
+        An object that has attached properties. This can be used to substitute
+        for keyword arguments. A common example would be a row in an xml table.
+    f_0 : float
+        The ringdown-frequency.
+    tau : float
+        The damping time of the sinusoid.
+    t_0 :  {0, float}, optional
+        The starting time of the ringdown.
+    phi_0 : {0, float}, optional
+        The initial phase of the ringdown.
+    Amp : {1, float}
+        The amplitude of the ringdown (constant for now).
+    delta_f : float
+        The frequency step used to generate the ringdown.
+    f_lower: float
+        The starting frequency of the output frequency series.
+    f_final : float
+        The ending frequency of the output frequency series.
+
+        Returns
+    -------
+    hplustilde: FrequencySeries
+        The plus phase of the ringdown in frequency domain.
+    hcrosstilde: FrequencySeries
+        The cross phase of the ringdown in frequency domain.
+    """
+
+    input_params = props_ringdown(template,**kwargs)
+    #wav_gen = fd_wav[type(_scheme.mgr.state)]
+
+    f_0 = input_params['f_0']
+    f_lower = input_params['f_lower']
+    f_final = input_params['f_final']
+    delta_f = input_params['delta_f']
+    tau = input_params['tau']
+    t_0 = input_params['t_0']
+    phi_0 = input_params['phi_0']
+    Amp = input_params['Amp']
+
+    pi = numpy.pi
+    two_pi = 2 * numpy.pi
+    pi_sq = numpy.pi * numpy.pi
+
+    freqs = numpy.arange( f_lower, f_final, delta_f)
+    kmin = int(f_lower / delta_f)
+    kmax = int(f_final / delta_f)
+    n = int(f_final / delta_f) + 1
+
+    denominator = 1 + ( 4j * pi * freqs * tau ) - ( 4 * pi_sq * ( freqs*freqs - f_0*f_0) * tau*tau )
+    time_shift = [ numpy.exp( -1j * two_pi * f * t_0 ) for f in freqs ]
+
+    hp_tilde = Amp * tau * ( ( 1 + 2j * pi * freqs * tau ) * numpy.cos(phi_0) - two_pi * f_0 * tau * numpy.sin(phi_0) ) * time_shift / denominator
+    hc_tilde = Amp * tau * ( ( 1 + 2j * pi * freqs * tau ) * numpy.sin(phi_0) + two_pi * f_0 * tau * numpy.cos(phi_0) ) * time_shift / denominator
+
+    hplustilde = FrequencySeries(zeros(n, dtype=complex64), delta_f=delta_f)
+    hcrosstilde = FrequencySeries(zeros(n, dtype=complex64), delta_f=delta_f)
+    hplustilde.data[kmin:kmax] = hp_tilde
+    hcrosstilde.data[kmin:kmax] = hc_tilde
+
+    return hplustilde, hcrosstilde

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -26,7 +26,7 @@
 """
 
 import numpy, lal
-from pycbc.types import FrequencySeries, complex64, zeros
+from pycbc.types import FrequencySeries, complex128, zeros
 
 default_ringdown_args = {'t_0':0, 'phi_0':0, 'Amp':1}
 
@@ -92,7 +92,6 @@ def get_fd_ringdown(template=None,**kwargs):
     """
 
     input_params = props_ringdown(template,**kwargs)
-    #wav_gen = fd_wav[type(_scheme.mgr.state)]
 
     f_0 = input_params['f_0']
     f_lower = input_params['f_lower']
@@ -118,8 +117,8 @@ def get_fd_ringdown(template=None,**kwargs):
     hp_tilde = Amp * tau * ( ( 1 + 2j * pi * freqs * tau ) * numpy.cos(phi_0) - two_pi * f_0 * tau * numpy.sin(phi_0) ) * time_shift / denominator
     hc_tilde = Amp * tau * ( ( 1 + 2j * pi * freqs * tau ) * numpy.sin(phi_0) + two_pi * f_0 * tau * numpy.cos(phi_0) ) * time_shift / denominator
 
-    hplustilde = FrequencySeries(zeros(n, dtype=complex64), delta_f=delta_f)
-    hcrosstilde = FrequencySeries(zeros(n, dtype=complex64), delta_f=delta_f)
+    hplustilde = FrequencySeries(zeros(n, dtype=complex128), delta_f=delta_f)
+    hcrosstilde = FrequencySeries(zeros(n, dtype=complex128), delta_f=delta_f)
     hplustilde.data[kmin:kmax] = hp_tilde
     hcrosstilde.data[kmin:kmax] = hc_tilde
 

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -60,7 +60,7 @@ def props_ringdown(obj, **kwargs):
 
 def qnm_time_decay(tau, decay):
     """Return the time at which the amplitude of the 
-    ringdown falls to 1/decay of the peak amplitude.
+    ringdown falls to decay of the peak amplitude.
 
     Parameters
     ----------
@@ -73,15 +73,14 @@ def qnm_time_decay(tau, decay):
     -------
     t_decay: float
         The time at which the amplitude of the time-domain
-        ringdown is 1/decay of the peak amplitude.
+        ringdown falls to decay of the peak amplitude.
     """
 
-    t_decay = tau * numpy.log(decay)
-    return t_decay
+    return t_decay = - tau * numpy.log(decay)
 
 def qnm_freq_decay(f_0, tau, decay):
     """Return the frequency at which the amplitude of the 
-    ringdown falls to 1/decay of the peak amplitude.
+    ringdown falls to decay of the peak amplitude.
 
     Parameters
     ----------
@@ -96,17 +95,17 @@ def qnm_freq_decay(f_0, tau, decay):
     -------
     f_decay: float
         The frequency at which the amplitude of the frequency-domain
-        ringdown is 1/decay of the peak amplitude.
+        ringdown falls to decay of the peak amplitude.
     """
 
     q_0 = numpy.pi * f_0 * tau
-    decay_sq = decay*decay
+    alpha = 1. / decay
+    alpha_sq = 1. / decay / decay
 
     # Expression obtained analytically under the assumption
-    # that decay^2, q_0^2 >> 1
-    q_sq = (decay_sq + 4*q_0*q_0 + decay*numpy.sqrt(decay_sq + 16*q_0*q_0)) / 4.
-    f_decay = numpy.sqrt(q_sq) / numpy.pi / tau
-    return f_decay
+    # that alpha_sq, q_0^2 >> 1
+    q_sq = (alpha_sq + 4*q_0*q_0 + alpha*numpy.sqrt(alpha_sq + 16*q_0*q_0)) / 4.
+    return f_decay = numpy.sqrt(q_sq) / numpy.pi / tau
 
 def get_td_qnm(template=None, delta_t=None, t_lower=None, t_final=None, **kwargs):
     """Return a time domain damped sinusoid.
@@ -129,7 +128,7 @@ def get_td_qnm(template=None, delta_t=None, t_lower=None, t_final=None, **kwargs
     delta_t : {None, float}, optional
         The time step used to generate the ringdown.
         If None, it will be set to the inverse of the frequency at which the
-        amplitude is a 1/100 of the peak amplitude.
+        amplitude is 1/100 of the peak amplitude.
     t_lower: {None, float}, optional
         The starting time of the output time series.
         If None, it will be set to delta_t.
@@ -154,14 +153,14 @@ def get_td_qnm(template=None, delta_t=None, t_lower=None, t_final=None, **kwargs
     phi_0 = input_params['phi_0']
     Amp = input_params['Amp']
     if delta_t is None:
-        delta_t = 1. / qnm_freq_decay(f_0, tau, 100.)
+        delta_t = 1. / qnm_freq_decay(f_0, tau, 1./100)
     if t_lower is None:
         t_lower = delta_t
         kmin = 0
     else:
         kmin=int(t_lower / delta_t)
     if t_final is None:
-        t_final = qnm_time_decay(tau, 1000.)
+        t_final = qnm_time_decay(tau, 1./1000)
     kmax = int(t_final / delta_t)
     n = int(t_final / delta_t) + 1
 
@@ -200,7 +199,7 @@ def get_fd_qnm(template=None, delta_f=None, f_lower=None, f_final=None, **kwargs
     delta_f : {None, float}, optional
         The frequency step used to generate the ringdown.
         If None, it will be set to the inverse of the time at which the
-        amplitude is a 1/1000 of the peak amplitude.
+        amplitude is 1/1000 of the peak amplitude.
     f_lower: {None, float}, optional
         The starting frequency of the output frequency series.
         If None, it will be set to delta_f.
@@ -225,14 +224,14 @@ def get_fd_qnm(template=None, delta_f=None, f_lower=None, f_final=None, **kwargs
     phi_0 = input_params['phi_0']
     Amp = input_params['Amp']
     if delta_f is None:
-        delta_f = 1. / qnm_time_decay(tau, 1000.)
+        delta_f = 1. / qnm_time_decay(tau, 1./1000)
     if f_lower is None:
         f_lower = delta_f
         kmin = 0
     else:
         kmin = int(f_lower / delta_f)
     if f_final is None:
-        f_final = qnm_freq_decay(f_0, tau, 100.)
+        f_final = qnm_freq_decay(f_0, tau, 1./100)
     kmax = int(f_final / delta_f)
     n = int(f_final / delta_f) + 1
 

--- a/pycbc/waveform/utils.py
+++ b/pycbc/waveform/utils.py
@@ -24,7 +24,7 @@
 #
 """This module contains convenience utilities for manipulating waveforms
 """
-from pycbc.types import TimeSeries, Array, float32, float64
+from pycbc.types import TimeSeries, Array, float32, float64, complex_same_precision_as
 import lal
 import lalsimulation as sim
 from math import frexp
@@ -270,7 +270,8 @@ def apply_fd_time_shift(htilde, shifttime, fseries=None, copy=True):
     dt = float(shifttime - htilde.epoch)
     if fseries is None:
         fseries = htilde.sample_frequencies.numpy()
-    shift = Array(numpy.exp(-2j*numpy.pi*dt*fseries))
+    shift = Array(numpy.exp(-2j*numpy.pi*dt*fseries), 
+                dtype=complex_same_precision_as(htilde))
     if copy:
         htilde = 1. * htilde
     htilde *= shift


### PR DESCRIPTION
Module that generates frequency domain damped sinusoids for ringdown searches, and new class in generator.py.
Right now the ringdown module only incorporates the fundamental quasi-normal mode, and it takes the frequency and the damping time as input parameters (amplitude, phase, and starting time can also be given, but they are set to 1, 0, and 0 by default). 
