### PR TITLE
Add support for precessing bank params

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_bank2hdf
+++ b/bin/hdfcoinc/pycbc_coinc_bank2hdf
@@ -25,9 +25,14 @@ m1 = numpy.array(sngl_table.get_column('mass1'), dtype=numpy.float32)
 m2 = numpy.array(sngl_table.get_column('mass2'), dtype=numpy.float32)
 s1 = numpy.array(sngl_table.get_column('spin1z'), dtype=numpy.float32)
 s2 = numpy.array(sngl_table.get_column('spin2z'), dtype=numpy.float32)
-
+# How to not store these in the case of not precession?
+s1x = numpy.array(sngl_table.get_column('spin1x'), dtype=numpy.float32)
+s1y = numpy.array(sngl_table.get_column('spin1y'), dtype=numpy.float32)
+s2x = numpy.array(sngl_table.get_column('spin2x'), dtype=numpy.float32)
+s2y = numpy.array(sngl_table.get_column('spin2y'), dtype=numpy.float32)
+incl = numpy.array(sngl_table.get_column('alpha3'), dtype=numpy.float32)
 th = numpy.zeros(len(m1), dtype=int)
-for j, v in enumerate(zip(m1, m2, s1, s2)):
+for j, v in enumerate(zip(m1, m2, s1, s2, s1x, s1y, s2x, s2y, incl)):
     th[j] = hash(v)
 
 # Store the templates by sorted id
@@ -36,6 +41,11 @@ m1 = m1[sorted_ind]
 m2 = m2[sorted_ind]
 s1 = s1[sorted_ind]
 s2 = s2[sorted_ind]
+s1x = s1x[sorted_ind]
+s1y = s1y[sorted_ind]
+s2x = s2x[sorted_ind]
+s2y = s2y[sorted_ind]
+incl = incl[sorted_ind]
 th = th[sorted_ind]
     
 f = h5py.File(args.output_file, "w")
@@ -43,5 +53,10 @@ f.create_dataset("mass1", data=m1)
 f.create_dataset("mass2", data=m2)
 f.create_dataset("spin1z", data=s1)
 f.create_dataset("spin2z", data=s2)
+f.create_dataset("spin1x", data=s1x)
+f.create_dataset("spin2x", data=s2x)
+f.create_dataset("spin1y", data=s1y)
+f.create_dataset("spin2y", data=s2y)
+f.create_dataset("inclination", data=incl)
 f.create_dataset("template_hash", data=th)
 f.close()

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -391,8 +391,14 @@ class EventManager(object):
         m2 = numpy.array([p['tmplt'].mass2 for p in self.template_params], dtype=numpy.float32)
         s1 = numpy.array([p['tmplt'].spin1z for p in self.template_params], dtype=numpy.float32)
         s2 = numpy.array([p['tmplt'].spin2z for p in self.template_params], dtype=numpy.float32)
+        # How to not store these in the case of not precession?
+        s1x = numpy.array([p['tmplt'].spin1x for p in self.template_params], dtype=numpy.float32)
+        s1y = numpy.array([p['tmplt'].spin1y for p in self.template_params], dtype=numpy.float32)
+        s2x = numpy.array([p['tmplt'].spin2x for p in self.template_params], dtype=numpy.float32)
+        s2y = numpy.array([p['tmplt'].spin2y for p in self.template_params], dtype=numpy.float32)
+        incl = numpy.array([p['tmplt'].alpha3 for p in self.template_params], dtype=numpy.float32)
         th = numpy.zeros(len(m1), dtype=int)
-        for j, v in enumerate(zip(m1, m2, s1, s2)):
+        for j, v in enumerate(zip(m1, m2, s1, s2, s1x, s1y, s2x, s2y, incl)):
             th[j] = hash(v)
 
         tid = self.events['template_id']
@@ -400,7 +406,13 @@ class EventManager(object):
 
         if len(self.events):
             f['snr'] = abs(self.events['snr'])
-            f['coa_phase'] = numpy.angle(self.events['snr'])
+            try:
+                # Precessing
+                f['u_vals'] = self.events['u_vals']
+                f['coa_phase'] = self.events['coa_phase']
+            except:
+                # Not precessing
+                f['coa_phase'] = numpy.angle(self.events['snr'])
             f['chisq'] = self.events['chisq']
             f['bank_chisq'] = self.events['bank_chisq']
             f['bank_chisq_dof'] = self.events['bank_chisq_dof']
@@ -572,6 +584,12 @@ class EventManager(object):
             row.end_time_ns = int(end_time.gpsNanoSeconds)
             row.process_id = proc_id
             row.coa_phase = numpy.angle(snr)
+            try:
+                # Good old alpha columns for hacking
+                row.alpha6 = event['u_vals']
+                row.coa_phase = event['coa_phase']
+            except:
+                pass
             row.sigmasq = sigmasq
 
             row.event_id = glue.ligolw.lsctables.SnglInspiralID(event_num)

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -438,6 +438,31 @@ class SingleDetTriggers(object):
         return np.array(self.bank['spin2z'])[self.template_id]
 
     @property
+    def spin2x(self):
+        self.checkbank('spin2x')
+        return np.array(self.bank['spin2x'])[self.template_id]
+
+    @property
+    def spin2y(self):
+        self.checkbank('spin2y')
+        return np.array(self.bank['spin2y'])[self.template_id]
+
+    @property
+    def spin1x(self):
+        self.checkbank('spin1x')
+        return np.array(self.bank['spin1x'])[self.template_id]
+
+    @property
+    def spin1y(self):
+        self.checkbank('spin1y')
+        return np.array(self.bank['spin1y'])[self.template_id]
+
+    @property
+    def inclination(self):
+        self.checkbank('inclination')
+        return np.array(self.bank['inclination'])[self.template_id]
+
+    @property
     def mtotal(self):
         return self.mass1 + self.mass2
 
@@ -478,6 +503,10 @@ class SingleDetTriggers(object):
     @property
     def snr(self):
         return np.array(self.trigs['snr'])[self.mask]
+
+    @property
+    def u_vals(self):
+        return np.array(self.trigs['u_vals'])[self.mask]
 
     @property
     def rchisq(self):


### PR DESCRIPTION
I'm starting to merge functionality from the precessing branch back to master. The first of these commits is to add the support for storing precessing bank parameters (the other 4 spins and inclination angle) into the template bank. Currently this is done also for non-precessing searches. I don't think this is a problem, as the new columns will not be read by downstream codes unless altered to do so, and so don't really add any sort of memory/storage burden.

The property "u_val" is also added for triggers *only in the case of precession*. This, along with coa_phase, is used to reconstruct the specific h(t) from h+ and hx.