### PR TITLE
Add function for thresholding a real SNR timeseries

### DIFF
--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -45,6 +45,13 @@ def threshold_only(series, value):
        larger (in absolute value) than value
     """
 
+#FIXME: This should be under schemed, but I don't understand that yet!
+def threshold_real_numpy(series, value):
+    arr = series.data
+    locs = numpy.where(arr > value)[0]
+    vals = arr[locs]
+    return locs, vals
+
 @schemed("pycbc.events.threshold_")
 def threshold_and_cluster(series, threshold, window):
     """Return list of values and indices values over threshold in series.
@@ -1030,4 +1037,5 @@ class EventManagerMultiDet(EventManager):
 __all__ = ['threshold_and_cluster', 'newsnr', 'effsnr',
            'findchirp_cluster_over_window',
            'threshold', 'cluster_reduce', 'ThresholdCluster',
+           'threshold_real_numpy',
            'EventManager', 'EventManagerMultiDet']


### PR DESCRIPTION
More precessing stuff. This fix adds a short function to threshold on a *real* SNR timeseries. This is needed as the precessing SNR is already maximized over phase. Undoubtedly this is not the best way to do this, but it is not a major time concern when doing CPU precessing search, so I did not bother to optimize further.