### PR TITLE
Aesthetic changes to matched_filter function

### DIFF
--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -706,12 +706,12 @@ def smear(idx, factor):
         s += [idx + a]
     return numpy.unique(numpy.concatenate(s))
            
-def matched_filter(template, data, psd, low_frequency_cutoff=None,
-                  high_frequency_cutoff=None):
-    """ Return the complex snr and normalization. 
-    
-    Return the complex snr, along with its associated normalization of the template,
-    matched filtered against the data. 
+def matched_filter(template, data, psd=None, low_frequency_cutoff=None,
+                  high_frequency_cutoff=None, sigmasq=None):
+    """ Return the complex snr and normalization.
+
+    Return the complex snr, along with its associated normalization of the
+    template, matched filtered against the data.
 
     Parameters
     ----------
@@ -727,13 +727,18 @@ def matched_filter(template, data, psd, low_frequency_cutoff=None,
     high_frequency_cutoff : {None, float}, optional
         The frequency to stop the filter calculation. If None, continue to the 
         the nyquist frequency.
+    sigmasq : {None, float}, optional
+        The template normalization. If none, this value is calculated
+        internally.
 
     Returns
     -------
     snr : TimeSeries
         A time series containing the complex snr. 
     """
-    snr, corr, norm = matched_filter_core(template, data, psd, low_frequency_cutoff, high_frequency_cutoff)
+    snr, corr, norm = matched_filter_core(template, data, psd=psd,
+            low_frequency_cutoff=low_frequency_cutoff,
+            high_frequency_cutoff=high_frequency_cutoff, h_norm=sigmasq)
     return snr * norm
     
 _snr = None 


### PR DESCRIPTION
Aesthetic changes coming from precessing branch:

 * Fix whitespace and line wrapping issues
 * A personal bugbear: Kwargs *must* be declared as kwargs and should not pretend to be args! This makes changing functions dangerous as then kwargs and args get confused when called like this elsewhere!
 * Allow the h_norm kwarg to be passed through matched_filter function.