### PR TITLE
Waveform module changes for precessing search

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -733,7 +733,10 @@ def td_waveform_to_fd_waveform(waveform, out=None, length=None,
     return htilde
 
 def get_two_pol_waveform_filter(outplus, outcross, template, **kwargs):
-    """Return a frequency domain waveform filter for the specified approximant
+    """Return a frequency domain waveform filter for the specified approximant.
+    Unlike get_waveform_filter this function returns both h_plus and h_cross
+    components of the waveform, which are needed for searches where h_plus
+    and h_cross are not related by a simple phase shift.
     """
     n = len(outplus)
 


### PR DESCRIPTION
These are the changes to the waveform module needed for the precessing search:

 * We add a two-polarization waveform generation routine, allowing a template to return both h+ and hx (using the same ideas and methods as the single-polarization call)
 * We add in length estimates for IMRPhenomPv2 and SpinTaylorF2. Currently this is not great (as it uses an aligned-spin estimator), but can be improved in the future.
 * We add a fall-back hack for SpinTaylorF2, such that if the system is aligned-spin, *and* spin2z is non-zero the approximant will fall back to TaylorF2. This allows us to have a template bank containing aligned-spin spin2!=0 waveforms and precessing spin2=0 waveforms with the [Spin]TaylorF2 approximant.