### PR TITLE
Fix float issue in psd module

### DIFF
--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -343,9 +343,9 @@ def generate_overlapping_psds(opt, gwstrain, flen, delta_f, flow,
         return psds_and_times
 
     # Figure out the data length used for PSD generation
-    seg_stride = opt.psd_segment_stride * gwstrain.sample_rate
-    seg_len = opt.psd_segment_length * gwstrain.sample_rate
-    num_segments = opt.psd_num_segments
+    seg_stride = int(opt.psd_segment_stride * gwstrain.sample_rate)
+    seg_len = int(opt.psd_segment_length * gwstrain.sample_rate)
+    num_segments = int(opt.psd_num_segments)
     input_data_len = len(gwstrain)
 
     if num_segments is None:


### PR DESCRIPTION
In #824 @josh-willis reports that there are float-valued indices floating around in the psd module. The psd_data_len operation should be integer arithmetic. I think the solution is just to force the 3 input quantities to be integers when declared. To my knowledge PyCBC does not support non-integer sample-rate or data lengths, so by declaring these as ints up front should solve the problem.

@josh-willis does this solve the problem for you?