### PR TITLE
Add script for making inference workflow.

### DIFF
--- a/bin/inference/pycbc_make_inference_workflow
+++ b/bin/inference/pycbc_make_inference_workflow
@@ -68,12 +68,6 @@ parser.add_argument("--single-detector-triggers", nargs="+", required=True,
 parser.add_argument("--inference-config-file", type=str, required=True,
     help="workflow.WorkflowConfigParser parsable file with proir information.")
 
-# segment options
-parser.add_argument("--inspiral-data-read-name", required=True,
-    help="Name of inspiral segmentlist containing data read in by each analysis job.")
-parser.add_argument("--inspiral-data-analyzed-name", required=True,
-    help="Name of inspiral segmentlist containing data analyzed by each analysis job.")
-
 # add option groups
 wf.add_workflow_command_line_group(parser)
 

--- a/bin/inference/pycbc_make_inference_workflow
+++ b/bin/inference/pycbc_make_inference_workflow
@@ -142,6 +142,8 @@ for ifo in workflow.ifos:
                                       "datafind-%s-frame-type"%ifo.lower(), "")
     channel_names[ifo] = workflow.cp.get_opt_tags("workflow",
                                       "%s-channel-name"%ifo.lower(), "")
+frame_types_str = " ".join([key+":"+val for key,val in frame_types.iteritems()])
+channel_names_str = " ".join([key+":"+val for key,val in channel_names.iteritems()])
 
 # construct Executable for performing MCMC
 mcmc_exe = wf.Executable(workflow.cp, "mcmc", ifos=workflow.ifos,
@@ -177,8 +179,8 @@ for num_event in range(num_events):
     node.add_opt("--instruments", " ".join(workflow.ifos))
     node.add_opt("--gps-start-time", gps_start_time)
     node.add_opt("--gps-end-time", gps_end_time)
-    node.add_opt("--frame-type", frame_types[ifo])
-    node.add_opt("--channel-name", frame_types[ifo])
+    node.add_opt("--frame-type", frame_types_str)
+    node.add_opt("--channel-name", channel_names_str)
     node.add_input_opt("--config-file", config_file)
     analysis_time = segments.segment(gps_start_time, gps_end_time)
     mcmc_file = node.new_output_file_opt(analysis_time, ".hdf",

--- a/bin/inference/pycbc_make_inference_workflow
+++ b/bin/inference/pycbc_make_inference_workflow
@@ -196,7 +196,8 @@ for num_event in range(num_events):
 
     # add files from corner plot for this event
     layouts += [mcf.make_inference_corner_plot(workflow, mcmc_file,
-                          opts.output_dir, analysis_seg=analysis_time,
+                          opts.output_dir, opts.inference_config_file,
+                          analysis_seg=analysis_time,
                           tags=opts.tags + [str(num_event)])]
 
     # add files from plotting acceptance rate plot for this event
@@ -207,7 +208,8 @@ for num_event in range(num_events):
     # add files from plotting parameter samples and autocorrelation
     # function for this event
     files = mcf.make_inference_single_parameter_plots(workflow, mcmc_file,
-                          opts.output_dir, opts.inference_config_file, analysis_seg=analysis_time,
+                          opts.output_dir, opts.inference_config_file,
+                          analysis_seg=analysis_time,
                           tags=opts.tags + [str(num_event)]) 
     layouts += list(layout.grouper(files, 2))
 

--- a/bin/inference/pycbc_make_inference_workflow
+++ b/bin/inference/pycbc_make_inference_workflow
@@ -1,0 +1,219 @@
+#!/bin/env python
+# Copyright (C) 2016 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+""" Creates a DAX for a parameter estimation workflow.
+"""
+
+import os, argparse, logging, h5py
+import pycbc.workflow as wf
+import pycbc.workflow.mcmcfollowups as mcf
+import pycbc.workflow.minifollowups as mini
+import pycbc.workflow.pegasus_workflow as wdax
+import pycbc.version
+from glue import segments
+from pycbc.results import layout
+from pycbc.types import MultiDetOptionAction
+
+def to_file(path, ifo=None):
+    """ Takes a str and returns a pycbc.workflow.pegasus_workflow.File
+    instance.
+    """
+    fil = wdax.File(os.path.basename(path))
+    fil.ifo = ifo
+    path = os.path.abspath(path)
+    fil.PFN(path, "local")
+    return fil
+
+# command line parser
+parser = argparse.ArgumentParser(description=__doc__[1:])
+
+# version option
+parser.add_argument("--version", action="version",
+    version=pycbc.version.git_verbose_msg, 
+    help="Prints version information.")
+
+# workflow options
+parser.add_argument("--workflow-name", default="my_unamed_inference_run",
+    help="Name of the workflow to append in various places.")
+parser.add_argument("--tags", nargs="+", default=[],
+    help="Tags to apend in various places.")
+parser.add_argument("--output-dir", default=None,
+    help="Path to output directory.")
+parser.add_argument("--output-map", required=True,
+    help="Path to output map file.")
+parser.add_argument("--output-file", required=True,
+    help="Path to DAX file.")
+
+# input file options
+parser.add_argument("--bank-file", required=True,
+    help="HDF format template bank file.")
+parser.add_argument("--statmap-file", required=True,
+    help="HDF format clustered coincident trigger result file.")
+parser.add_argument("--single-detector-triggers", nargs="+", required=True,
+    action=MultiDetOptionAction,
+    help="HDF format merged single detector trigger files")
+parser.add_argument("--inspiral-segments", required=True,
+    help="XML segment files containing the inspiral analysis times.")
+parser.add_argument("--inference-config-file", type=str, required=True,
+    help="workflow.WorkflowConfigParser parsable file with proir information.")
+
+# segment options
+parser.add_argument("--inspiral-data-read-name", required=True,
+    help="Name of inspiral segmentlist containing data read in by each analysis job.")
+parser.add_argument("--inspiral-data-analyzed-name", required=True,
+    help="Name of inspiral segmentlist containing data analyzed by each analysis job.")
+
+# add option groups
+wf.add_workflow_command_line_group(parser)
+
+# parser command line
+opts = parser.parse_args()
+
+# setup log
+logging.basicConfig(format="%(asctime)s:%(levelname)s : %(message)s", 
+                    level=logging.INFO)
+
+# create workflow
+workflow = wf.Workflow(opts, opts.workflow_name)
+
+# create output directory
+wf.makedir(opts.output_dir)
+
+# create a list that will contain all output files
+layouts = []
+
+# typecast str from command line to File instances
+tmpltbank_file = to_file(opts.bank_file)
+coinc_file = to_file(opts.statmap_file)
+insp_segs = to_file(opts.inspiral_segments)
+single_triggers = []
+for ifo in opts.single_detector_triggers:
+    fname = opts.single_detector_triggers[ifo]
+    single_triggers.append( to_file(fname, ifo=ifo) )
+config_file = to_file(opts.inference_config_file)
+
+# get number of events to analyze
+num_events = int(workflow.cp.get_opt_tags("workflow-inference", "num-events", ""))
+
+# get detection statistic from statmap file
+f = h5py.File(opts.statmap_file, "r")
+stat = f["foreground/stat"][:]
+
+# get index for sorted detection statistic
+sorting = stat.argsort()[::-1]
+
+# if less events that requested to analyze in config file then analyze
+# all events
+if len(stat) < num_events:
+    num_events = len(stat)
+
+# get ranking statistic in order of highest (index=0) to lowest
+# and grab the loudest events we will analyze
+stat = stat[sorting][0:num_events]
+
+# get times for loudest events
+times = {f.attrs["detector_1"]: f["foreground/time1"][:][sorting][0:num_events],
+         f.attrs["detector_2"]: f["foreground/time2"][:][sorting][0:num_events],
+        }
+
+# get trigger_id for the loudest events
+tids = {f.attrs["detector_1"]: f["foreground/trigger_id1"][:][sorting][0:num_events],
+         f.attrs["detector_2"]: f["foreground/trigger_id2"][:][sorting][0:num_events],
+        }
+
+# read template bank file
+bank_data = h5py.File(opts.bank_file, "r")
+
+# get frame type and channel name as a dict with IFO as keys
+frame_types = {}
+channel_names = {}
+for ifo in workflow.ifos:
+    frame_types[ifo] = workflow.cp.get_opt_tags("workflow-datafind",
+                                      "datafind-%s-frame-type"%ifo.lower(), "")
+    channel_names[ifo] = workflow.cp.get_opt_tags("workflow",
+                                      "%s-channel-name"%ifo.lower(), "")
+
+# construct Executable for performing MCMC
+mcmc_exe = wf.Executable(workflow.cp, "mcmc", ifos=workflow.ifos,
+                         out_dir=opts.output_dir)
+
+# loop over number of loudest events to be analyzed
+for num_event in range(num_events):
+
+    # get template_id
+    bank_id = f['foreground/template_id'][:][sorting][num_event]
+
+    # get a dict that holds event parameters
+    params = {}
+    for ifo in times:
+        params["%s_end_time" % ifo] = times[ifo][num_event]
+    params["mass1"] = bank_data["mass1"][bank_id]
+    params["mass2"] = bank_data["mass2"][bank_id]
+    params["spin1z"] = bank_data["spin1z"][bank_id]
+    params["spin2z"] = bank_data["spin2z"][bank_id]
+
+    # set GPS times for reading in data around the event
+    avg_end_time = sum([end_times[num_event] \
+                          for end_times in times.values()]) / len(times.keys())
+    seconds_before_time = int(workflow.cp.get_opt_tags("workflow-inference",
+                                            "data-seconds-before-trigger", ""))
+    seconds_after_time = int(workflow.cp.get_opt_tags("workflow-inference",
+                                            "data-seconds-after-trigger", ""))
+    gps_start_time = int(avg_end_time) - seconds_before_time
+    gps_end_time = int(avg_end_time) + seconds_after_time
+
+    # make node for performing MCMC
+    node = mcmc_exe.create_node()
+    node.add_opt("--instruments", " ".join(workflow.ifos))
+    node.add_opt("--gps-start-time", gps_start_time)
+    node.add_opt("--gps-end-time", gps_end_time)
+    node.add_opt("--frame-type", frame_types[ifo])
+    node.add_opt("--channel-name", frame_types[ifo])
+    node.add_input_opt("--config-file", config_file)
+    analysis_time = segments.segment(gps_start_time, gps_end_time)
+    mcmc_file = node.new_output_file_opt(analysis_time, ".hdf",
+                                 "--output-file", tags=[str(num_event)])
+
+    # add node to workflow
+    workflow += node
+
+    # add file that prints information about the event
+    layouts += [mini.make_coinc_info(workflow, single_triggers, tmpltbank_file,
+                          coinc_file, num_event, 
+                          opts.output_dir, tags=opts.tags + [str(num_event)])]
+
+    # add files from corner plot for this event
+    layouts += [mcf.make_inference_corner_plot(workflow, mcmc_file,
+                          opts.output_dir, analysis_seg=analysis_time,
+                          tags=opts.tags + [str(num_event)])]
+
+    # add files from plotting acceptance rate plot for this event
+    layouts += [mcf.make_inference_acceptance_rate_plot(workflow, mcmc_file, 
+                          opts.output_dir, analysis_seg=analysis_time,
+                          tags=opts.tags + [str(num_event)])]
+
+    # add files from plotting parameter samples and autocorrelation
+    # function for this event
+    files = mcf.make_inference_single_parameter_plots(workflow, mcmc_file,
+                          opts.output_dir, opts.inference_config_file, analysis_seg=analysis_time,
+                          tags=opts.tags + [str(num_event)]) 
+    layouts += list(layout.grouper(files, 2))
+
+# write dax
+workflow.save(filename=opts.output_file, output_map=opts.output_map)
+
+# write html well
+layout.two_column_layout(opts.output_dir, layouts)

--- a/bin/inference/pycbc_make_inference_workflow
+++ b/bin/inference/pycbc_make_inference_workflow
@@ -1,5 +1,5 @@
 #!/bin/env python
-# Copyright (C) 2016 Christopher M. Biwer
+# Copyright (C) 2016 Christopher M. Biwer, Alexander Harvey Nitz
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the

--- a/bin/inference/pycbc_make_inference_workflow
+++ b/bin/inference/pycbc_make_inference_workflow
@@ -65,8 +65,6 @@ parser.add_argument("--statmap-file", required=True,
 parser.add_argument("--single-detector-triggers", nargs="+", required=True,
     action=MultiDetOptionAction,
     help="HDF format merged single detector trigger files")
-parser.add_argument("--inspiral-segments", required=True,
-    help="XML segment files containing the inspiral analysis times.")
 parser.add_argument("--inference-config-file", type=str, required=True,
     help="workflow.WorkflowConfigParser parsable file with proir information.")
 
@@ -98,7 +96,6 @@ layouts = []
 # typecast str from command line to File instances
 tmpltbank_file = to_file(opts.bank_file)
 coinc_file = to_file(opts.statmap_file)
-insp_segs = to_file(opts.inspiral_segments)
 single_triggers = []
 for ifo in opts.single_detector_triggers:
     fname = opts.single_detector_triggers[ifo]

--- a/bin/inference/pycbc_mcmc_plot_samples
+++ b/bin/inference/pycbc_mcmc_plot_samples
@@ -66,6 +66,7 @@ fig, axs = plt.subplots(ndim, sharex=True)
 plt.xlabel("iterations")
 
 # loop over variable args
+axs = [axs] if type(axs) is not list else axs
 for i,arg in enumerate(opts.variable_args):
 
     # loop over walkers

--- a/pycbc/workflow/mcmcfollowups.py
+++ b/pycbc/workflow/mcmcfollowups.py
@@ -204,7 +204,7 @@ def make_inference_acceptance_rate_plot(workflow, mcmc_file, output_dir,
     # make the directory that will contain the output files
     makedir(output_dir)
 
-    # make a node for plotting the posterior as a corner plot
+    # make a node for plotting the acceptance rate
     node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
                       out_dir=output_dir, tags=tags).create_node()
 
@@ -280,7 +280,7 @@ def make_inference_single_parameter_plots(workflow, mcmc_file, output_dir,
         samples_node.add_opt("--variable-args", arg)
         samples_node.add_opt("--labels", arg)
 
-        # make node for plotting the auto-correlation function for each walker
+        # make node for plotting the autocorrelation function for each walker
         auto_node = PlotExecutable(workflow.cp, auto_name, ifos=workflow.ifos,
                           out_dir=output_dir, tags=tags + [arg]).create_node()
 

--- a/pycbc/workflow/mcmcfollowups.py
+++ b/pycbc/workflow/mcmcfollowups.py
@@ -158,7 +158,8 @@ def make_inference_corner_plot(workflow, mcmc_file, output_dir,
 
     # make a node for plotting the posterior as a corner plot
     node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
-                      out_dir=output_dir, tags=tags).create_node()
+                      out_dir=output_dir, universe="local",
+                      tags=tags).create_node()
 
     # add command line options
     node.add_input_opt("--input-file", mcmc_file)

--- a/pycbc/workflow/mcmcfollowups.py
+++ b/pycbc/workflow/mcmcfollowups.py
@@ -1,0 +1,300 @@
+# Copyright (C) 2016 Christopher M. Biwer, Alexander Harvey Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Module that contains functions for setting up the inference workflow.
+"""
+
+import logging, os.path
+from pycbc.workflow.core import Executable, FileList, Node, makedir, File, Workflow
+from pycbc.workflow.plotting import PlotExecutable, requirestr, excludestr
+from pycbc.workflow import WorkflowConfigParser
+from itertools import izip_longest
+from Pegasus import DAX3 as dax
+from pycbc.workflow import pegasus_workflow as wdax
+
+def setup_foreground_inference(workflow, coinc_file, single_triggers,
+                       tmpltbank_file, insp_segs, insp_data_name,
+                       insp_anal_name, dax_output, out_dir, tags=None):
+    """ Creates workflow node that will run the inference workflow.
+
+    Parameters
+    ----------
+    workflow: pycbc.workflow.Workflow
+        The core workflow instance we are populating
+    coinc_file: pycbc.workflow.File
+        The file associated with coincident triggers.
+    single_triggers: list of pycbc.workflow.File
+        A list cointaining the file objects associated with the merged
+        single detector trigger files for each ifo.
+    tmpltbank_file: pycbc.workflow.File
+        The file object pointing to the HDF format template bank
+    insp_segs: SegFile
+       The segment file containing the data read and analyzed by each inspiral
+       job.
+    insp_data_name: str
+        The name of the segmentlist storing data read.
+    insp_anal_name: str
+        The name of the segmentlist storing data analyzed.
+    dax_output : str
+        The name of the output DAX file.
+    out_dir: path
+        The directory to store minifollowups result plots and files
+    tags: {None, optional}
+        Tags to add to the minifollowups executables
+    """
+
+    logging.info("Entering inference module")
+
+    # check if configuration file has inference section    
+    if not workflow.cp.has_section("workflow-inference"):
+        logging.info("There is no [workflow-inference] section in configuration file")
+        logging.info("Leaving inference module")
+        return
+
+    # default tags is a list
+    tags = [] if tags is None else tags
+
+    # make the directory that will contain the dax file
+    makedir(dax_output)
+    
+    # turn the config file into a File class
+    config_path = os.path.abspath(dax_output + "/" + "_".join(tags) \
+                                        + "foreground_inference.ini")
+    workflow.cp.write(open(config_path, "w"))
+    config_file = wdax.File(os.path.basename(config_path))
+    config_file.PFN(config_path, "local")
+
+    # create an Executable for the inference workflow generator
+    exe = Executable(workflow.cp, "foreground_inference", ifos=workflow.ifos,
+                     out_dir=dax_output)
+
+    # create the node that will run in the workflow
+    node = exe.create_node()
+    node.add_input_opt("--config-files", config_file)
+    node.add_input_opt("--bank-file", tmpltbank_file)
+    node.add_input_opt("--statmap-file", coinc_file)
+    node.add_multiifo_input_list_opt("--single-detector-triggers",
+                                     single_triggers)
+    node.add_input_opt("--inspiral-segments", insp_segs)
+    node.add_opt("--inspiral-data-read-name", insp_data_name)
+    node.add_opt("--inspiral-data-analyzed-name", insp_anal_name)
+    node.new_output_file_opt(workflow.analysis_time, ".dax", "--output-file",
+                                     tags=tags)
+    node.new_output_file_opt(workflow.analysis_time, ".dax.map",
+                                     "--output-map", tags=tags)
+
+    # get dax name and use it for the workflow name
+    name = node.output_files[0].name
+    node.add_opt("--workflow-name", name)
+
+    # get output map name and use it for the output dir name
+    map_loc = node.output_files[1].name
+    node.add_opt("--output-dir", out_dir)
+
+    # add this node to the workflow
+    workflow += node
+
+    # create job for dax that will run a sub-workflow
+    # and add it to the workflow
+    fil = node.output_files[0]
+    job = dax.DAX(fil)
+    job.addArguments("--basename %s" % os.path.splitext(os.path.basename(name))[0])
+    Workflow.set_job_properties(job, map_loc)
+    workflow._adag.addJob(job)
+
+    # make dax a child of the inference workflow generator node
+    dep = dax.Dependency(parent=node._dax_node, child=job)
+    workflow._adag.addDependency(dep)
+
+    logging.info("Leaving inference module")
+
+def make_inference_corner_plot(workflow, mcmc_file, output_dir,
+                    name="mcmc_corner", analysis_seg=None, tags=None):
+    """ Sets up the corner plot of the posteriors in the workflow.
+
+    Parameters
+    ----------
+    workflow: pycbc.workflow.Workflow
+        The core workflow instance we are populating
+    mcmc_file: pycbc.workflow.File
+        The file with MCMC samples.
+    output_dir: str
+        The directory to store result plots and files.
+    name: str
+        The name in the [executables] section of the configuration file
+        to use.
+    analysis_segs: {None, glue.segments.Segment}
+       The segment this job encompasses. If None then use the total analysis
+       time from the workflow.
+    tags: {None, optional}
+        Tags to add to the minifollowups executables.
+
+    Returns
+    -------
+    pycbc.workflow.FileList
+        A list of result and output files. 
+    """
+
+    # default values
+    tags = [] if tags is None else tags
+    analysis_seg = workflow.analysis_time \
+                       if analysis_seg is None else analysis_seg
+
+    # make the directory that will contain the output files
+    makedir(output_dir)
+
+    # make a node for plotting the posterior as a corner plot
+    node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
+                      out_dir=output_dir, tags=tags).create_node()
+
+    # add command line options
+    node.add_input_opt("--input-file", mcmc_file)
+    node.new_output_file_opt(analysis_seg, ".png", "--output-file")
+
+    # add node to workflow
+    workflow += node
+
+    return node.output_files
+
+def make_inference_acceptance_rate_plot(workflow, mcmc_file, output_dir,
+                    name="mcmc_rate", analysis_seg=None, tags=None):
+    """ Sets up the acceptance rate plot in the workflow.
+
+    Parameters
+    ----------
+    workflow: pycbc.workflow.Workflow
+        The core workflow instance we are populating
+    mcmc_file: pycbc.workflow.File
+        The file with MCMC samples.
+    output_dir: str
+        The directory to store result plots and files.
+    name: str
+        The name in the [executables] section of the configuration file
+        to use.
+    analysis_segs: {None, glue.segments.Segment}
+       The segment this job encompasses. If None then use the total analysis
+       time from the workflow.
+    tags: {None, optional}
+        Tags to add to the minifollowups executables.
+
+    Returns
+    -------
+    pycbc.workflow.FileList
+        A list of result and output files. 
+    """
+
+    # default values
+    tags = [] if tags is None else tags
+    analysis_seg = workflow.analysis_time \
+                       if analysis_seg is None else analysis_seg
+
+    # make the directory that will contain the output files
+    makedir(output_dir)
+
+    # make a node for plotting the posterior as a corner plot
+    node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
+                      out_dir=output_dir, tags=tags).create_node()
+
+    # add command line options
+    node.add_input_opt("--input-file", mcmc_file)
+    node.new_output_file_opt(analysis_seg, ".png", "--output-file")
+
+    # add node to workflow
+    workflow += node
+
+    return node.output_files
+
+def make_inference_single_parameter_plots(workflow, mcmc_file, output_dir,
+                    config_file, samples_name="mcmc_samples",
+                    auto_name="mcmc_auto", analysis_seg=None, tags=None):
+    """ Sets up single-parameter plots from MCMC in the workflow.
+
+    Parameters
+    ----------
+    workflow: pycbc.workflow.Workflow
+        The core workflow instance we are populating
+    mcmc_file: pycbc.workflow.File
+        The file with MCMC samples.
+    output_dir: str
+        The directory to store result plots and files.
+    config_file: str
+        The path to the inference configuration file that has a
+        [variable_args] section.
+    samples_name: str
+        The name in the [executables] section of the configuration file
+        to use for the plot that shows all samples.
+    auto_name: str
+        The name in the [executables] section of the configuration file
+        to use for the autocorrelation function plot.
+    analysis_segs: {None, glue.segments.Segment}
+       The segment this job encompasses. If None then use the total analysis
+       time from the workflow.
+    tags: {None, optional}
+        Tags to add to the minifollowups executables.
+
+    Returns
+    -------
+    files: pycbc.workflow.FileList
+        A list of result and output files. 
+    """
+
+    # default values
+    tags = [] if tags is None else tags
+    analysis_seg = workflow.analysis_time \
+                       if analysis_seg is None else analysis_seg
+
+    # read config file to get variables that vary
+    cp = WorkflowConfigParser([config_file])
+    variable_args = cp.options("variable_args")
+
+    # make the directory that will contain the output files
+    makedir(output_dir)
+
+    # list of all output files
+    files = FileList()
+
+    # make a set of plots for each parameter
+    for arg in variable_args:
+
+        # make a node for plotting all the samples
+        samples_node = PlotExecutable(workflow.cp, samples_name,
+                          ifos=workflow.ifos, out_dir=output_dir,
+                          tags=tags + [arg]).create_node()
+
+        # add command line options
+        samples_node.add_input_opt("--input-file", mcmc_file)
+        samples_node.new_output_file_opt(analysis_seg, ".png", "--output-file")
+        samples_node.add_opt("--variable-args", arg)
+        samples_node.add_opt("--labels", arg)
+
+        # make node for plotting the auto-correlation function for each walker
+        auto_node = PlotExecutable(workflow.cp, auto_name, ifos=workflow.ifos,
+                          out_dir=output_dir, tags=tags + [arg]).create_node()
+
+        # add command line options
+        auto_node.add_input_opt("--input-file", mcmc_file)
+        auto_node.new_output_file_opt(analysis_seg, ".png", "--output-file")
+        auto_node.add_opt("--variable-args", arg)
+
+        # add nodes to workflow
+        workflow += samples_node
+        workflow += auto_node
+
+        # add files to output files list
+        files += samples_node.output_files
+        files += auto_node.output_files
+
+    return files

--- a/pycbc/workflow/mcmcfollowups.py
+++ b/pycbc/workflow/mcmcfollowups.py
@@ -88,9 +88,6 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
     node.add_input_opt("--statmap-file", coinc_file)
     node.add_multiifo_input_list_opt("--single-detector-triggers",
                                      single_triggers)
-    node.add_input_opt("--inspiral-segments", insp_segs)
-    node.add_opt("--inspiral-data-read-name", insp_data_name)
-    node.add_opt("--inspiral-data-analyzed-name", insp_anal_name)
     node.new_output_file_opt(workflow.analysis_time, ".dax", "--output-file",
                                      tags=tags)
     node.new_output_file_opt(workflow.analysis_time, ".dax.map",

--- a/pycbc/workflow/mcmcfollowups.py
+++ b/pycbc/workflow/mcmcfollowups.py
@@ -121,7 +121,7 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
 
     logging.info("Leaving inference module")
 
-def make_inference_corner_plot(workflow, mcmc_file, output_dir,
+def make_inference_corner_plot(workflow, mcmc_file, output_dir, config_file,
                     name="mcmc_corner", analysis_seg=None, tags=None):
     """ Sets up the corner plot of the posteriors in the workflow.
 
@@ -133,6 +133,9 @@ def make_inference_corner_plot(workflow, mcmc_file, output_dir,
         The file with MCMC samples.
     output_dir: str
         The directory to store result plots and files.
+    config_file: str
+        The path to the inference configuration file that has a
+        [variable_args] section.
     name: str
         The name in the [executables] section of the configuration file
         to use.
@@ -152,6 +155,14 @@ def make_inference_corner_plot(workflow, mcmc_file, output_dir,
     tags = [] if tags is None else tags
     analysis_seg = workflow.analysis_time \
                        if analysis_seg is None else analysis_seg
+
+    # read config file to get variables that vary
+    cp = WorkflowConfigParser([config_file])
+    variable_args = cp.options("variable_args")
+
+    # add derived mass parameters if mass1 and mass2 in variable_args
+    if "mass1" in variable_args and "mass2" in variable_args:
+        variable_args += ["mchirp", "eta"]
 
     # make the directory that will contain the output files
     makedir(output_dir)

--- a/pycbc/workflow/mcmcfollowups.py
+++ b/pycbc/workflow/mcmcfollowups.py
@@ -220,7 +220,7 @@ def make_inference_acceptance_rate_plot(workflow, mcmc_file, output_dir,
 
 def make_inference_single_parameter_plots(workflow, mcmc_file, output_dir,
                     config_file, samples_name="mcmc_samples",
-                    auto_name="mcmc_auto", analysis_seg=None, tags=None):
+                    auto_name="mcmc_acf", analysis_seg=None, tags=None):
     """ Sets up single-parameter plots from MCMC in the workflow.
 
     Parameters

--- a/setup.py
+++ b/setup.py
@@ -467,7 +467,7 @@ setup (
                'bin/inference/pycbc_mcmc_plot_acf',
                'bin/inference/pycbc_mcmc_plot_corner',
                'bin/inference/pycbc_mcmc_plot_samples',
-               'bin/plotting/pycbc_plot_waveform'
+               'bin/plotting/pycbc_plot_waveform',
                ],
     packages = [
                'pycbc',

--- a/setup.py
+++ b/setup.py
@@ -462,6 +462,7 @@ setup (
                'bin/hdfcoinc/pycbc_merge_psds',
                'bin/hdfcoinc/pycbc_plot_gating',
                'bin/pycbc_condition_strain',
+               'bin/inference/pycbc_make_inference_workflow',
                'bin/inference/pycbc_mcmc',
                'bin/inference/pycbc_mcmc_plot_acceptance_rate',
                'bin/inference/pycbc_mcmc_plot_acf',


### PR DESCRIPTION
This PR adds an executable ```bin/inference/pycbc_make_inference_workflow``` that is similar to ```pycbc_foreground_minifollowups```, in order to run a sub-workflow for parameter estimation.

It also adds a ```pycbc.workflow.mcmcfollowups``` module that handles setting up the plotting jobs and has a function ```setup_foreground_inference``` that can be used in another workflow generator (eg. ```pycbc_make_coinc_search_workflow```) to run the inference workflow as a sub-workflow.

This PR only adds this code, it does not add it to the coincidence search yet.

An example workflow configuration file would have the sections:
```
[workflow-inference]
num-events = ${workflow-minifollowups|num-events}
data-seconds-before-trigger = 30
data-seconds-after-trigger = 2
```

Where the data seconds options tell the workflow how much data to use around the time of the trigger.

And then of course the other sections for the executables like:
```
[mcmc]
sample-rate = 2048
low-frequency-cutoff = 40
strain-high-pass = 30
pad-data = 8
psd-estimation = median
psd-segment-length = 16
psd-segment-stride = 8
psd-inverse-length = 16
processing-scheme = mkl
sampler = kombine
likelihood-evaluator = gaussian
nwalkers = 20
niterations = 1000

[mcmc_samples]
thin-start = 300
thin-interval = 1000
```

I've added the on-hold until #838 and #826 are merged.

@ahnitz @cdcapano 