### PR TITLE
Fix broken PSD estimation workflow

### DIFF
--- a/bin/hdfcoinc/pycbc_make_psd_estimation_workflow
+++ b/bin/hdfcoinc/pycbc_make_psd_estimation_workflow
@@ -71,24 +71,42 @@ save_fig_with_metadata(time_str, time_file.storage_path, **kwds)
 result_plots += [(time_file,)]
 
 # Get segments and find where the data is
-science_segs, data_segs, science_seg_file = \
-        pycbc.workflow.get_analyzable_segments(workflow, "segments")
-datafind_files, science_segs = pycbc.workflow.setup_datafind_workflow(
-        workflow, science_segs, "datafind", science_seg_file)
+seg_dir = 'segments'
 
-cum_veto_files, veto_names, ind_cats = \
-        pycbc.workflow.get_cumulative_veto_group_files(
-                workflow, 'segments-veto-groups', 'segments')
+veto_cat_files = pycbc.workflow.get_files_for_vetoes(
+        workflow, seg_dir, runtime_names=['segments-science-veto'],
+        in_workflow_names=['segments-final-veto-group', 'segments-veto-groups'])
+
+science_seg_file, science_segs, _ = \
+        pycbc.workflow.get_science_segments(workflow, seg_dir)
+
+sci_ok_seg_file, sci_ok_segs, _ = \
+        pycbc.workflow.get_analyzable_segments(workflow, science_segs,
+                                                veto_cat_files, seg_dir)
+
+datafind_files, _, _, _ = \
+        pycbc.workflow.setup_datafind_workflow(workflow, sci_ok_segs,
+                                               'datafind',
+                                               seg_file=science_seg_file)
+cum_veto_files, veto_names, _ = \
+        pycbc.workflow.get_cumulative_veto_group_files(workflow,
+                                                       'segments-veto-groups',
+                                                       veto_cat_files,
+                                                       seg_dir,
+                                                       execute_now=False)
 final_veto_file, final_veto_name, ind_cats = \
-        pycbc.workflow.get_cumulative_veto_group_files(
-                workflow, 'segments-final-veto-group', "segments")
+        pycbc.workflow.get_cumulative_veto_group_files(workflow,
+                                                       'segments-final-veto-group',
+                                                       veto_cat_files,
+                                                       seg_dir,
+                                                       execute_now=False)
 
 psd_job_length = int(workflow.cp.get('workflow-matchedfilter', 'analysis-length'))
 pad_data = int(workflow.cp.get('calculate_psd', 'pad-data'))
 
 # calculate noise PSDs over SCIENCE_OK segments
 psd_files = []
-for ifo, segments in science_segs.items():
+for ifo, segments in sci_ok_segs.items():
     # break up SCIENCE_OK into small segments to use in pycbc_calculate_psd
     # FIXME use the same algorithm already in place for inspiral jobs
     broken_segments = []
@@ -104,7 +122,7 @@ for ifo, segments in science_segs.items():
     broken_segments_file = pycbc.workflow.SegFile.from_segment_list(
                      'SCIENCE_OK_BROKEN', broken_segments, 'SCIENCE_OK_BROKEN',
                      ifo, valid_segment=workflow.analysis_time,
-                     extension='xml', directory='segments')
+                     extension='xml', directory=seg_dir)
 
     # create pycbc_calculate_psd job
     ifo_psd_files = pycbc.workflow.make_psd_file(
@@ -125,12 +143,13 @@ for ifo, files in zip(*ind_cats.categorize_by_attr('ifo')):
     pycbc.workflow.make_segments_plot(workflow, files, 'plots',
                           tags=['%s_VETO_SEGMENTS' % ifo])
 
-pycbc.workflow.make_segments_plot(workflow, science_seg_file, 'plots',
-                                  tags=['SCIENCE_MINUS_CAT1'])
+pycbc.workflow.make_segments_plot(workflow,
+                                  pycbc.workflow.FileList([science_seg_file]),
+                                  'plots', tags=['SCIENCE_MINUS_CAT1'])
 
 # get data segments to write to segment summary XML file
 seg_summ_names    = ['DATA', 'ANALYZABLE_DATA']
-seg_summ_seglists = [data_segs, science_segs]
+seg_summ_seglists = [science_segs, sci_ok_segs]
 
 # declare comparasion segments for table on summary page
 veto_summ_names = ['ANALYZABLE_DATA&CUMULATIVE_CAT_1H',
@@ -147,7 +166,7 @@ for segment_list,segment_name in zip(seg_summ_seglists, seg_summ_names):
 seg_summ_file = pycbc.workflow.SegFile.from_multi_segment_list(
                    'WORKFLOW_SEGMENT_SUMMARY', seg_list, names, ifos,
                    valid_segment=workflow.analysis_time, extension='xml',
-                   directory='segments')
+                   directory=seg_dir)
 
 # make segment table for summary page
 seg_summ_table = pycbc.workflow.make_seg_table(workflow, [seg_summ_file],
@@ -163,9 +182,6 @@ veto_summ_table = pycbc.workflow.make_seg_table(
 result_plots += [(seg_summ_table, veto_summ_table)]
 
 two_column_layout('plots', result_plots)
-
-for psd_file in psd_files:
-    os.symlink(psd_file.storage_path, os.path.join('plots', psd_file.name))
 
 pycbc.workflow.make_results_web_page(finalize_workflow,
                                      os.path.join(os.getcwd(),

--- a/bin/hdfcoinc/pycbc_make_psd_estimation_workflow
+++ b/bin/hdfcoinc/pycbc_make_psd_estimation_workflow
@@ -74,90 +74,94 @@ result_plots += [(time_file,)]
 seg_dir = 'segments'
 
 veto_cat_files = pycbc.workflow.get_files_for_vetoes(
-        workflow, seg_dir, runtime_names=['segments-science-veto'],
-        in_workflow_names=['segments-final-veto-group', 'segments-veto-groups'])
+        workflow, seg_dir, runtime_names=['segments-science-veto'])
 
 science_seg_file, science_segs, _ = \
         pycbc.workflow.get_science_segments(workflow, seg_dir)
 
-sci_ok_seg_file, sci_ok_segs, _ = \
+sci_ok_seg_file, science_ok_segs, _ = \
         pycbc.workflow.get_analyzable_segments(workflow, science_segs,
                                                 veto_cat_files, seg_dir)
 
-datafind_files, _, _, _ = \
-        pycbc.workflow.setup_datafind_workflow(workflow, sci_ok_segs,
+datafind_files, analyzable_file, analyzable_segs, analyzable_name = \
+        pycbc.workflow.setup_datafind_workflow(workflow, science_ok_segs,
                                                'datafind',
                                                seg_file=science_seg_file)
-cum_veto_files, veto_names, _ = \
-        pycbc.workflow.get_cumulative_veto_group_files(workflow,
-                                                       'segments-veto-groups',
-                                                       veto_cat_files,
-                                                       seg_dir,
-                                                       execute_now=False)
-final_veto_file, final_veto_name, ind_cats = \
-        pycbc.workflow.get_cumulative_veto_group_files(workflow,
-                                                       'segments-final-veto-group',
-                                                       veto_cat_files,
-                                                       seg_dir,
-                                                       execute_now=False)
 
 psd_job_length = int(workflow.cp.get('workflow-matchedfilter', 'analysis-length'))
 pad_data = int(workflow.cp.get('calculate_psd', 'pad-data'))
+max_segs_per_job = 100
 
-# calculate noise PSDs over SCIENCE_OK segments
-psd_files = []
-for ifo, segments in sci_ok_segs.items():
-    # break up SCIENCE_OK into small segments to use in pycbc_calculate_psd
+# calculate noise PSDs over analyzable segments
+psd_files = {}
+for ifo, segments in analyzable_segs.items():
+    # break up long segments into short ones to use in pycbc_calculate_psd
     # FIXME use the same algorithm already in place for inspiral jobs
-    broken_segments = []
+    partial_broken_segments = []
+    all_broken_segments = []
+    job_index = 0
     for seg in segments:
         start_time = seg[0] + pad_data
         while start_time + psd_job_length + pad_data <= seg[1]:
             end_time = start_time + psd_job_length
-            broken_segments.append(glue.segments.segment(start_time, end_time))
+            s = glue.segments.segment(start_time, end_time)
+            partial_broken_segments.append(s)
+            all_broken_segments.append(s)
             start_time = end_time
-    broken_segments = glue.segments.segmentlist(broken_segments)
-    logging.info('%.1f s of SCIENCE_OK data reduced to %.1f s after segmentation',
-                 abs(segments), abs(broken_segments))
-    broken_segments_file = pycbc.workflow.SegFile.from_segment_list(
-                     'SCIENCE_OK_BROKEN', broken_segments, 'SCIENCE_OK_BROKEN',
-                     ifo, valid_segment=workflow.analysis_time,
-                     extension='xml', directory=seg_dir)
 
-    # create pycbc_calculate_psd job
-    ifo_psd_files = pycbc.workflow.make_psd_file(
-            workflow, datafind_files.find_output_with_ifo(ifo),
-            broken_segments_file, 'SCIENCE_OK_BROKEN', 'psds')
-    psd_files.append(ifo_psd_files)
+            if len(partial_broken_segments) >= max_segs_per_job:
+                # save this batch of broken segments to file
+                tag = 'PART%.4d' % job_index
+                name = 'ANALYZABLE_BROKEN_' + tag
+                broken_segments_file = pycbc.workflow.SegFile.from_segment_list(
+                    name, partial_broken_segments, name, ifo,
+                    valid_segment=workflow.analysis_time, extension='xml',
+                    directory=seg_dir)
+
+                # create pycbc_calculate_psd job
+                ifo_psd_file = pycbc.workflow.make_psd_file(
+                    workflow, datafind_files.find_output_with_ifo(ifo),
+                    broken_segments_file, name, 'psds', tags=[tag])
+
+                if ifo not in psd_files:
+                    psd_files[ifo] = []
+                psd_files[ifo].append(ifo_psd_file)
+
+                job_index += 1
+                partial_broken_segments = []
+
+    all_broken_segments = glue.segments.segmentlist(all_broken_segments)
+    logging.info('%.1f s of analyzable data reduced to %.1f s after segmentation',
+                 abs(segments), abs(all_broken_segments))
+
+# merge all PSDs for each detector
+merged_psd_files = []
+for ifo, ifo_psd_files in psd_files.items():
+    merged_psd_file = pycbc.workflow.merge_psds(workflow, ifo_psd_files, ifo,
+                                                'psds')
+    merged_psd_files.append(merged_psd_file)
 
 # average noise PSDs and save to .txt and .xml
-pycbc.workflow.make_average_psd(workflow, psd_files, 'psds',
+pycbc.workflow.make_average_psd(workflow, merged_psd_files, 'psds',
                                 output_fmt='.txt')
-pycbc.workflow.make_average_psd(workflow, psd_files, 'psds',
+pycbc.workflow.make_average_psd(workflow, merged_psd_files, 'psds',
                                 output_fmt='.xml.gz')
 
-s = pycbc.workflow.make_spectrum_plot(workflow, psd_files, 'plots')
+s = pycbc.workflow.make_spectrum_plot(workflow, merged_psd_files, 'plots')
 result_plots += [(s,)]
-
-for ifo, files in zip(*ind_cats.categorize_by_attr('ifo')):
-    pycbc.workflow.make_segments_plot(workflow, files, 'plots',
-                          tags=['%s_VETO_SEGMENTS' % ifo])
 
 pycbc.workflow.make_segments_plot(workflow,
                                   pycbc.workflow.FileList([science_seg_file]),
                                   'plots', tags=['SCIENCE_MINUS_CAT1'])
 
 # get data segments to write to segment summary XML file
-seg_summ_names    = ['DATA', 'ANALYZABLE_DATA']
-seg_summ_seglists = [science_segs, sci_ok_segs]
-
-# declare comparasion segments for table on summary page
-veto_summ_names = ['ANALYZABLE_DATA&CUMULATIVE_CAT_1H',
-                   'ANALYZABLE_DATA&CUMULATIVE_CAT_12H',
-                   'ANALYZABLE_DATA&CUMULATIVE_CAT_123H']
+seg_summ_names    = ['DATA', 'SCIENCE_OK', 'ANALYZABLE_DATA']
+seg_summ_seglists = [science_segs, science_ok_segs, analyzable_segs]
 
 # write segment summary XML file
-seg_list = []; names = []; ifos = []
+seg_list = []
+names = []
+ifos = []
 for segment_list,segment_name in zip(seg_summ_seglists, seg_summ_names):
     for ifo in workflow.ifos:
         seg_list.append(segment_list[ifo])
@@ -170,16 +174,10 @@ seg_summ_file = pycbc.workflow.SegFile.from_multi_segment_list(
 
 # make segment table for summary page
 seg_summ_table = pycbc.workflow.make_seg_table(workflow, [seg_summ_file],
-        seg_summ_names, 'plots',
-        ['SUMMARY'],
+        seg_summ_names, 'plots', ['SUMMARY'],
         title_text='Input and output time',
-        description='This shows the total amount of input data, analyzable data, and the time for which triggers are produced.')
-veto_summ_table = pycbc.workflow.make_seg_table(
-        workflow, [seg_summ_file] + final_veto_file + cum_veto_files,
-        veto_summ_names, 'plots', ['VETO_SUMMARY'],
-        title_text='Time removed by vetoes',
-        description='This shows the time removed from the output time by the vetoes applied to the triggers.')
-result_plots += [(seg_summ_table, veto_summ_table)]
+        description='This shows the total amount of input data, analyzable data, and the time for which PSDs are produced.')
+result_plots += [(seg_summ_table,)]
 
 two_column_layout('plots', result_plots)
 


### PR DESCRIPTION
PSD estimation workflow is currently broken by some of the recent changes to the segment APIs. This patch gets it to a state where it works and produces results again. However the segment functions are not completely straightforward to me. I tried to apply the same changes that I think went into `pycbc_make_coinc_search_workflow`. Ian/Alex, could you take a look and see if you spot some obviously wrong usage?

There are two additional issues that I want to address next (parallelization of calculate_psd jobs and size of summary page) but I'll deal with those in separate commits.