### PR TITLE
Adding the dark v bright data files to build

### DIFF
--- a/tools/static/cant_be_built
+++ b/tools/static/cant_be_built
@@ -5,4 +5,5 @@ pycbc_mvsc_dag
 pycbc_inspinjfind
 pycbc_get_loudest_params
 pycbc_randomize_inj_dist_by_optsnr
+pycbc_coinc_time
 

--- a/tools/static/hooks/hook-pycbc.py
+++ b/tools/static/hooks/hook-pycbc.py
@@ -60,7 +60,7 @@ hiddenimports = ['pycbc.fft.fft_cpu',
                  'mpld3'
                  ]
 
-datas = [] 
+datas = []
 
 # Add html assets to all executables
 cwd     = os.getcwd()
@@ -71,6 +71,17 @@ for root, subdirs, files in os.walk(rootdir):
     for filename in files:
         if not filename.endswith('.py') and not filename.endswith('.pyc'):
             file_path  = os.path.join(root, filename)
+            store_path = '/'.join(file_path.split('/')[:-1])
+            store_path = store_path.replace(basedir, '')
+            datas.append( (file_path, store_path) )
+
+# Add em-bright data files
+rootdir = basedir + 'pycbc/tmpltbank/ns_sequences'
+
+for root, subdirs, files in os.walk(rootdir):
+    for filename in files:
+        if not filename.endswith('.py') and not filename.endswith('.pyc'):
+            file_path = os.path.join(root, filename)
             store_path = '/'.join(file_path.split('/')[:-1])
             store_path = store_path.replace(basedir, '')
             datas.append( (file_path, store_path) )

--- a/tools/static/hooks/hook-pycbc.py
+++ b/tools/static/hooks/hook-pycbc.py
@@ -75,16 +75,11 @@ for root, subdirs, files in os.walk(rootdir):
             store_path = store_path.replace(basedir, '')
             datas.append( (file_path, store_path) )
 
-# Add em-bright data files
-rootdir = basedir + 'pycbc/tmpltbank/ns_sequences'
-
-for root, subdirs, files in os.walk(rootdir):
-    for filename in files:
-        if not filename.endswith('.py') and not filename.endswith('.pyc'):
-            file_path = os.path.join(root, filename)
-            store_path = '/'.join(file_path.split('/')[:-1])
-            store_path = store_path.replace(basedir, '')
-            datas.append( (file_path, store_path) )
+# Add em-bright data file
+file_path = basedir + 'pycbc/tmpltbank/ns_sequences/equil_2H.dat'
+store_path = '/'.join(file_path.split('/')[:-1])
+store_path = store_path.replace(basedir, '')
+datas.append( (file_path, store_path) )
 
 if os.environ["NOW_BUILDING"] in needs_mkl:
     # pull in all the mkl .so files

--- a/tools/static/needs_full_build
+++ b/tools/static/needs_full_build
@@ -91,4 +91,4 @@ pycbc_plot_psd_timefreq
 pycbc_write_results_page
 pycbc_randomize_inj_dist_by_optsnr
 pycbc_page_snrratehist
-
+pycbc_export_censored_trigs


### PR DESCRIPTION
Hi @spxiwh 

This commit is to fix a few issues I had in bundling v1.4, particularly adding the *.dat file(s) that live in pycbc/tmpltbank/ns_sequences into the bundling so that a bundled binary of `pycbc_dark_vs_bright_injections` will run.