### PR TITLE
Add helper function to get prior distribution from config file

### DIFF
--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -191,7 +191,10 @@ with ctx:
     # get distribution to draw from for each walker initial condition
     initial_distributions = []
     for param in variable_args:
-        initial_distributions.append( inference.distribution_from_config(cp, "initial", param) )
+        if cp.has_section("initial-%s"%param):
+            initial_distributions.append( inference.distribution_from_config(cp, "initial", param) )
+        else:
+            initial_distributions.append( inference.distribution_from_config(cp, "prior", param) )
 
     #loop over number of walkers
     # set initial values for variable parameters for this walker

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -207,24 +207,6 @@ with ctx:
     likelihood = inference.GaussianLikelihood(generator, stilde_dict,
                         opts.low_frequency_cutoff, psds=psd_dict, prior=prior)
 
-    #! FIXME: leave in for development purposes and take out when read to merge
-    # if you just want a time series
-    if 0:
-        idx = opts.variable_args.index("tc")
-        tc_min = opts.prior_min[idx]
-        tc_max = opts.prior_max[idx]
-        x = numpy.arange(tc_min, tc_max, 0.001)
-        y = []
-        for tc in x:
-            val = likelihood([tc,1.4,1.4])
-            print val
-            y.append( val )
-        import matplotlib.pyplot as plt
-        plt.plot(x,y)
-        plt.savefig("/home/cbiwer/public_html/tmp/test.png")
-        import sys
-        sys.exit()
-
     # create sampler that will run MCMC
     ndim = len(variable_args)
     sampler = inference.samplers[opts.sampler](likelihood, ndim=ndim,

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -281,7 +281,7 @@ fp.attrs["nwalkers"] = opts.nwalkers
 fp.attrs["niterations"] = opts.niterations
 
 # loop over number of dimensions
-for i,dim_name in zip(range(ndim), opts.variable_args):
+for i,dim_name in zip(range(ndim), variable_args):
 
     # create a group in the output file for this dimension
     group_dim = fp.create_group(dim_name)

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -38,12 +38,6 @@ def select_waveform_generator(approximant):
     else:
         raise ValueError("%s is not a valid approximant."%approximant)
 
-# get all parameters and their default values for waveform generation
-# from waveform module
-waveform_params = dict([(param,None) for param in waveform.waveform.base_required_args])
-waveform_params.update( waveform.waveform.default_args )
-waveform_params.update( dict([(param,None) for param in waveform.FDomainDetFrameGenerator.location_args]) )
-
 # command line usage
 parser = argparse.ArgumentParser(usage="pycbc_mcmc [--options]",
                   description="Runs an MCMC.")

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -1,0 +1,278 @@
+#! /usr/bin/env python
+
+# Copyright (C) 2016 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import argparse
+import h5py
+import kombine
+import logging
+import numpy
+import pycbc.opt
+import pycbc.weave
+import random
+from pycbc import fft, inference, psd, scheme, strain, waveform
+from pycbc.types import MultiDetOptionAction
+
+def select_waveform_generator(approximant):
+    """ Returns the generator for the approximant.
+    """
+    if approximant in waveform.td_approximants():
+        return waveform.TDomainCBCGenerator
+    elif approximant in waveform.fd_approximants():
+        return waveform.FDomainCBCGenerator
+    else:
+        raise ValueError("%s is not a valid approximant."%approximant)
+
+# get all parameters and their default values for waveform generation
+# from waveform module
+waveform_params = dict([(param,None) for param in waveform.waveform.base_required_args])
+waveform_params.update( waveform.waveform.default_args )
+waveform_params.update( dict([(param,None) for param in waveform.FDomainDetFrameGenerator.location_args]) )
+
+# command line usage
+parser = argparse.ArgumentParser(usage="pycbc_mcmc [--options]",
+                  description="Runs an MCMC.")
+
+# add data options
+parser.add_argument("--instruments", type=str, nargs="+", required=True,
+    help="IFOs, eg. H1 L1.")
+parser.add_argument("--frame-type", type=str, nargs="+",
+    action=MultiDetOptionAction, metavar="IFO:FRAME_TYPE",
+    help="Frame type for each IFO.")
+parser.add_argument("--low-frequency-cutoff", type=float, required=True,
+    help="Low frequency cutoff for each IFO.")
+
+# add MCMC options
+parser.add_argument("--sampler", required=True,
+    choices=inference.samplers.keys(),
+    help="Sampler class to use for MCMC.")
+parser.add_argument("--likelihood-evaluator", required=True,
+    choices=inference.likelihood_evaluators.keys(),
+    help="Evaluator class to use to calculate the likelihood.")
+parser.add_argument("--nwalkers", type=int, required=True,
+    help="Number of walkers to use in MCMC.")
+parser.add_argument("--niterations", type=int, required=True,
+    help="Number of iterations to perform after burn in.")
+parser.add_argument("--nprocesses", type=int, default=None,
+    help="Number of processes to use. If not given then use maximum.")
+parser.add_argument("--skip-burn-in", action="store_true", default=False,
+    help="Do not burn in MCMC.")
+
+# add prior options
+parser.add_argument("--prior-min", type=float, nargs="+", required=True,
+    help="Lower limit of acceptable values for variable args.")
+parser.add_argument("--prior-max", type=float, nargs="+", required=True,
+    help="Upper limit of acceptable values for variable args.")
+parser.add_argument("--prior-dist", type=str, nargs="+",
+    help="Name of distribution to use.")
+
+# add waveform options
+parser.add_argument("--variable-args", type=str, nargs="+", required=True,
+    choices=waveform_params,
+    help="Parameters to change in MCMC.")
+parser.add_argument("--approximant", required=True,
+    choices=waveform.td_approximants()+waveform.fd_approximants(),
+    help="Name of approximant.")
+for param,val in waveform_params.iteritems():
+    dtype = type(val)
+    if val is not None:
+        parser.add_argument("--"+param.replace("_", "-"), default=val, type=dtype)
+    else:
+        parser.add_argument("--"+param.replace("_", "-"), default=val, type=float)
+
+# output options
+parser.add_argument("--output-file", type=str, required=True,
+    help="Output file path.")
+
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+    help="")
+
+# add module pre-defined options
+fft.insert_fft_option_group(parser)
+pycbc.opt.insert_optimization_option_group(parser)
+psd.insert_psd_option_group_multi_ifo(parser)
+scheme.insert_processing_option_group(parser)
+strain.insert_strain_option_group_multi_ifo(parser)
+pycbc.weave.insert_weave_option_group(parser)
+
+# parse command line
+opts = parser.parse_args()
+
+# verify options are sane
+fft.verify_fft_options(opts, parser)
+pycbc.opt.verify_optimization_options(opts, parser)
+#psd.verify_psd_options(opts, parser)
+scheme.verify_processing_options(opts, parser)
+#strain.verify_strain_options(opts, parser)
+pycbc.weave.verify_weave_options(opts, parser)
+
+# get variables for waveform generation that will not change in MCMC
+static_args = dict([(param,getattr(opts, param)) for param in waveform_params \
+                           if param not in opts.variable_args])
+
+# setup log
+if opts.verbose:
+    log_level = logging.DEBUG
+else:
+    log_level = logging.WARN
+logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
+
+# change measure level for FFT to 0
+fft.fftw.set_measure_level(0)
+
+# get scheme
+ctx = scheme.from_cli(opts)
+fft.from_cli(opts)
+
+# get strain time series
+strain_dict = strain.from_cli_multi_ifos(opts, opts.instruments,
+                                         precision="double")
+
+with ctx:
+
+    # FFT strain and save each of the length of the FFT, delta_f, and
+    # low frequency cutoff to a dict
+    logging.info("FFT strain")
+    stilde_dict = {}
+    length_dict = {}
+    delta_f_dict = {}
+    low_frequency_cutoff_dict = {}
+    for ifo in opts.instruments:
+        stilde_dict[ifo] = strain_dict[ifo].to_frequencyseries()
+        length_dict[ifo] = len(stilde_dict[ifo])
+        delta_f_dict[ifo] = stilde_dict[ifo].delta_f
+        low_frequency_cutoff_dict[ifo] = opts.low_frequency_cutoff
+
+    # get PSD as frequency series
+    psd_dict = psd.from_cli_multi_ifos(opts, length_dict, delta_f_dict,
+                                   low_frequency_cutoff_dict, opts.instruments,
+                                   strain_dict=strain_dict, precision="double")
+
+    # select generator that will generate waveform
+    # for likelihood evaluator
+    logging.info("Setting up sampler")
+    generator_function = select_waveform_generator(opts.approximant)
+
+    # construct class that will generate waveforms
+    generator = waveform.FDomainDetFrameGenerator(generator_function,
+                        variable_args=opts.variable_args,
+                        detectors=opts.instruments,
+                        delta_f=delta_f_dict.values()[0],
+                        approximant=opts.approximant, **static_args)
+
+    # construct class that will return the prior
+    if opts.prior_dist:
+        prior = inference.PriorEvaluator(opts.variable_args, opts.prior_dist,
+                        params_min=opts.prior_min, params_max=opts.prior_max)
+    else:
+        prior = None
+
+    # construct class that will return the natural logarithm of likelihood
+    likelihood = inference.GaussianLikelihood(generator, stilde_dict,
+                        opts.low_frequency_cutoff, psds=psd_dict, prior=prior)
+
+    #! FIXME: leave in for development purposes and take out when read to merge
+    # if you just want a time series
+    if 0:
+        idx = opts.variable_args.index("tc")
+        tc_min = opts.prior_min[idx]
+        tc_max = opts.prior_max[idx]
+        x = numpy.arange(tc_min, tc_max, 0.001)
+        y = []
+        for tc in x:
+            val = likelihood([tc,1.4,1.4])
+            print val
+            y.append( val )
+        import matplotlib.pyplot as plt
+        plt.plot(x,y)
+        plt.savefig("/home/cbiwer/public_html/tmp/test.png")
+        import sys
+        sys.exit()
+
+    # create sampler that will run MCMC
+    ndim = len(opts.variable_args)
+    sampler = inference.samplers[opts.sampler](likelihood, ndim=ndim,
+                                               nwalkers=opts.nwalkers,
+                                               processes=opts.nprocesses)
+
+    # starting parameters of walkers
+    logging.info("Setting walkers initial conditions for varying parameters")
+
+    #loop over number of walkers
+    p0 = numpy.ones(shape=(opts.nwalkers, ndim))
+    for i,_ in enumerate(p0):
+
+        # set initial values for variable parameters for this walker
+        # initial values are uniformly drawn from an interval given
+        # on the command line
+        p0[i] = [random.uniform(opts.prior_min[j],opts.prior_max[j]) for j in range(ndim)]
+
+    if not opts.skip_burn_in:
+
+        # burn in
+        logging.info("MCMC burn in")
+        p, post, q = sampler.burn_in(p0)
+
+        # generate more samples
+        logging.info("Generating more MCMC samples")
+        p, post, q = sampler.run_mcmc(opts.niterations)
+
+    else:
+
+        # generate samples
+        logging.info("Generating MCMC samples")
+        p, post, q = sampler.run_mcmc(opts.niterations, p0=p0)
+
+# get all past samples as an niterations x nwalker x ndim array
+logging.info("Writing output file")
+chain = sampler.chain
+
+# transpose past samples to get an ndim x nwalker x niteration array
+chain = numpy.transpose(chain)
+
+# save samples to file
+fp = h5py.File(opts.output_file, "w")
+
+# save MCMC parameters
+fp.attrs["nwalkers"] = opts.nwalkers
+fp.attrs["niterations"] = opts.niterations
+
+# loop over number of dimensions
+for i,dim_name in zip(range(ndim), opts.variable_args):
+
+    # create a group in the output file for this dimension
+    group_dim = fp.create_group(dim_name)
+
+    # loop over number of walkers
+    for j in range(opts.nwalkers):
+
+        # get all samples from this walker for this dimension
+        samples = chain[i,j,:]
+
+        # write to output file
+        dataset_name = "walker%d"%j
+        group_dim.create_dataset(dataset_name, data=samples)
+
+# create a dataset for the acceptance fraction
+fp.create_dataset("acceptance_fraction", data=sampler.acceptance_fraction)
+
+# exit
+logging.info("Done")
+
+
+

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -26,6 +26,7 @@ import pycbc.weave
 import random
 from pycbc import fft, inference, psd, scheme, strain, waveform
 from pycbc.types import MultiDetOptionAction
+from pycbc.workflow import WorkflowConfigParser
 
 def select_waveform_generator(approximant):
     """ Returns the generator for the approximant.
@@ -72,27 +73,9 @@ parser.add_argument("--nprocesses", type=int, default=None,
 parser.add_argument("--skip-burn-in", action="store_true", default=False,
     help="Do not burn in MCMC.")
 
-# add prior options
-parser.add_argument("--prior-min", type=float, nargs="+", required=True,
-    help="Lower limit of acceptable values for variable args.")
-parser.add_argument("--prior-max", type=float, nargs="+", required=True,
-    help="Upper limit of acceptable values for variable args.")
-parser.add_argument("--prior-dist", type=str, nargs="+",
-    help="Name of distribution to use.")
-
-# add waveform options
-parser.add_argument("--variable-args", type=str, nargs="+", required=True,
-    choices=waveform_params,
-    help="Parameters to change in MCMC.")
-parser.add_argument("--approximant", required=True,
-    choices=waveform.td_approximants()+waveform.fd_approximants(),
-    help="Name of approximant.")
-for param,val in waveform_params.iteritems():
-    dtype = type(val)
-    if val is not None:
-        parser.add_argument("--"+param.replace("_", "-"), default=val, type=dtype)
-    else:
-        parser.add_argument("--"+param.replace("_", "-"), default=val, type=float)
+# add config options
+parser.add_argument("--config-files", type=str, nargs="+", required=True,
+    help="A file parsable by pycbc.workflow.WorkflowConfigParser.")
 
 # output options
 parser.add_argument("--output-file", type=str, required=True,
@@ -120,10 +103,6 @@ pycbc.opt.verify_optimization_options(opts, parser)
 scheme.verify_processing_options(opts, parser)
 #strain.verify_strain_options(opts, parser)
 pycbc.weave.verify_weave_options(opts, parser)
-
-# get variables for waveform generation that will not change in MCMC
-static_args = dict([(param,getattr(opts, param)) for param in waveform_params \
-                           if param not in opts.variable_args])
 
 # setup log
 if opts.verbose:
@@ -163,24 +142,72 @@ with ctx:
                                    low_frequency_cutoff_dict, opts.instruments,
                                    strain_dict=strain_dict, precision="double")
 
+    # read configuration file
+    logging.info("Reading configuration file")
+    cp = WorkflowConfigParser(opts.config_files)
+
+    # sanity check that each parameter in [variable_args] has a priors section
+    variable_args = cp.options("variable_args")
+    subsections = cp.get_subsections("prior")
+    if not all(param in subsections for param in variable_args):
+        raise KeyError("You are missing a priors section in the config file.")
+
+    # get parameters that do not change in MCMC
+    static_args = dict([(key,cp.get_opt_tags("static_args",key,[])) \
+                                         for key in cp.options("static_args")])
+    for key,val in static_args.iteritems():
+        try:
+            static_args[key] = float(val)
+        except:
+            pass
+
+    # get prior distribution for each variable parameter
+    logging.info("Setting up priors for each parameter")
+    special_args = ["name", "min", "max"]
+    distributions = []
+    for param in variable_args:
+
+        # get name of prior distribution to use
+        name = cp.get_opt_tag("prior", "name", param)
+
+        # get a dict with bounds as value
+        low = float(cp.get_opt_tag("prior", "min", param))
+        high = float(cp.get_opt_tag("prior", "max", param))
+        dist_args = { param : (low,high) }
+
+        # add any additional options that user put in that section
+        for key in cp.options( "-".join(["prior",param]) ):
+
+            # ignore options that are already included
+            if key in special_args:
+                continue
+
+            # check if option can be cast as a float
+            val = cp.get_opt_tag("prior",key,param)
+            try:
+                val = float(val)
+            except:
+                pass
+
+            # add option
+            dist_args.update({key:val})
+
+        # construction distribution and add to list
+        distributions.append( inference.priors[name](**dist_args) )
+
+    # construct class that will return the prior
+    prior = inference.PriorEvaluator(variable_args, *distributions)
+
     # select generator that will generate waveform
     # for likelihood evaluator
     logging.info("Setting up sampler")
-    generator_function = select_waveform_generator(opts.approximant)
+    generator_function = select_waveform_generator(static_args["approximant"])
 
     # construct class that will generate waveforms
     generator = waveform.FDomainDetFrameGenerator(generator_function,
-                        variable_args=opts.variable_args,
+                        variable_args=variable_args,
                         detectors=opts.instruments,
-                        delta_f=delta_f_dict.values()[0],
-                        approximant=opts.approximant, **static_args)
-
-    # construct class that will return the prior
-    if opts.prior_dist:
-        prior = inference.PriorEvaluator(opts.variable_args, opts.prior_dist,
-                        params_min=opts.prior_min, params_max=opts.prior_max)
-    else:
-        prior = None
+                        delta_f=delta_f_dict.values()[0], **static_args)
 
     # construct class that will return the natural logarithm of likelihood
     likelihood = inference.GaussianLikelihood(generator, stilde_dict,
@@ -205,7 +232,7 @@ with ctx:
         sys.exit()
 
     # create sampler that will run MCMC
-    ndim = len(opts.variable_args)
+    ndim = len(variable_args)
     sampler = inference.samplers[opts.sampler](likelihood, ndim=ndim,
                                                nwalkers=opts.nwalkers,
                                                processes=opts.nprocesses)
@@ -220,7 +247,8 @@ with ctx:
         # set initial values for variable parameters for this walker
         # initial values are uniformly drawn from an interval given
         # on the command line
-        p0[i] = [random.uniform(opts.prior_min[j],opts.prior_max[j]) for j in range(ndim)]
+        p0[i] = [distributions[j].rvs(size=1, param=variable_args[j])[0][0] \
+                                                          for j in range(ndim)]
 
     if not opts.skip_burn_in:
 

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -245,11 +245,10 @@ with ctx:
     for i,_ in enumerate(p0):
 
         # set initial values for variable parameters for this walker
-        # initial values are uniformly drawn from an interval given
-        # on the command line
         p0[i] = [distributions[j].rvs(size=1, param=variable_args[j])[0][0] \
                                                           for j in range(ndim)]
 
+    # check if user wants to skip the burn in
     if not opts.skip_burn_in:
 
         # burn in

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -157,37 +157,9 @@ with ctx:
 
     # get prior distribution for each variable parameter
     logging.info("Setting up priors for each parameter")
-    special_args = ["name", "min", "max"]
     distributions = []
     for param in variable_args:
-
-        # get name of prior distribution to use
-        name = cp.get_opt_tag("prior", "name", param)
-
-        # get a dict with bounds as value
-        low = float(cp.get_opt_tag("prior", "min", param))
-        high = float(cp.get_opt_tag("prior", "max", param))
-        dist_args = { param : (low,high) }
-
-        # add any additional options that user put in that section
-        for key in cp.options( "-".join(["prior",param]) ):
-
-            # ignore options that are already included
-            if key in special_args:
-                continue
-
-            # check if option can be cast as a float
-            val = cp.get_opt_tag("prior",key,param)
-            try:
-                val = float(val)
-            except:
-                pass
-
-            # add option
-            dist_args.update({key:val})
-
-        # construction distribution and add to list
-        distributions.append( inference.priors[name](**dist_args) )
+        distributions.append( inference.distribution_from_config(cp, "prior", param) )
 
     # construct class that will return the prior
     prior = inference.PriorEvaluator(variable_args, *distributions)
@@ -213,15 +185,19 @@ with ctx:
                                                nwalkers=opts.nwalkers,
                                                processes=opts.nprocesses)
 
-    # starting parameters of walkers
+    # get distribution to draw from for each walker initial position
     logging.info("Setting walkers initial conditions for varying parameters")
 
+    # get distribution to draw from for each walker initial condition
+    initial_distributions = []
+    for param in variable_args:
+        initial_distributions.append( inference.distribution_from_config(cp, "initial", param) )
+
     #loop over number of walkers
+    # set initial values for variable parameters for this walker
     p0 = numpy.ones(shape=(opts.nwalkers, ndim))
     for i,_ in enumerate(p0):
-
-        # set initial values for variable parameters for this walker
-        p0[i] = [distributions[j].rvs(size=1, param=variable_args[j])[0][0] \
+        p0[i] = [initial_distributions[j].rvs(size=1, param=variable_args[j])[0][0] \
                                                           for j in range(ndim)]
 
     # check if user wants to skip the burn in

--- a/examples/inference/inference.ini
+++ b/examples/inference/inference.ini
@@ -12,6 +12,24 @@ dec = 0.00715585006
 polarization = 2.56616092
 f_lower = 40.0
 
+[initial-tc]
+; initial conditions for coalescnce time
+name = uniform
+min = 1024.98
+max = 1024.99
+
+[initial-mass1]
+; initial conditions for compoennt mass
+name = uniform
+min = 1.399
+max = 1.401
+
+[initial-mass2]
+; initial conditions for component mass
+name = uniform
+min = 1.399
+max = 1.401
+
 [prior-tc]
 ; prior for coalescence time
 name = uniform

--- a/examples/inference/inference.ini
+++ b/examples/inference/inference.ini
@@ -1,0 +1,31 @@
+[variable_args]
+; waveform parameters that will vary in MCMC
+tc =
+mass1 =
+mass2 =
+
+[static_args]
+; waveform parameters that will not change in MCMC
+approximant = TaylorF2
+ra = 0.0247836709
+dec = 0.00715585006
+polarization = 2.56616092
+f_lower = 40.0
+
+[prior-tc]
+; prior for coalescence time
+name = uniform
+min = 1024.92
+max = 1025.04
+
+[prior-mass1]
+; prior for component mass
+name = uniform
+min = 1.3
+max = 10.0
+
+[prior-mass2]
+; prior for component mass
+name = uniform
+min = 1.3
+max = 10.0

--- a/examples/inference/run_pycbc_mcmc.sh
+++ b/examples/inference/run_pycbc_mcmc.sh
@@ -1,0 +1,49 @@
+#! /bin/bash
+
+TRIGGER_TIME=1137215767.988
+
+MASS1=1.4
+MASS2=1.4
+SPIN1Z=0
+SPIN2Z=0
+
+TRIGGER_TIME_INT=${TRIGGER_TIME%.*}
+
+GPS_START_TIME=$((${TRIGGER_TIME_INT} - 1024))
+GPS_END_TIME=$((${TRIGGER_TIME_INT} + 1024))
+
+CHANNEL_NAME=H1:DCS-CALIB_STRAIN_C02
+FRAME_TYPE=H1:H1_HOFT_C02
+
+pycbc_mcmc --verbose \
+    --instruments H1 \
+    --gps-start-time ${GPS_START_TIME} \
+    --gps-end-time ${GPS_END_TIME} \
+    --frame-type ${FRAME_TYPE} \
+    --channel-name ${CHANNEL_NAME} \
+    --sample-rate 2048 \
+    --low-frequency-cutoff 40 \
+    --strain-high-pass 30 \
+    --pad-data 8 \
+    --psd-estimation median \
+    --psd-segment-length 16 \
+    --psd-segment-stride 8 \
+    --psd-inverse-length 16 \
+    --processing-scheme mkl \
+    --sampler kombine \
+    --likelihood-evaluator gaussian \
+    --nwalkers 8 \
+    --niterations 1000 \
+    --approximant TaylorF2 \
+    --variable-args tc mass1 mass2 \
+    --prior-min 1024.92 1.30 1.30 \
+    --prior-max 1025.04 10.00 10.00 \
+    --prior-dist flat flat flat \
+    --ra 0.0247836709 \
+    --dec 0.00715585006 \
+    --polarization 2.56616092 \
+    --f-lower 40.0 \
+    --output-file test_cli.hdf
+
+
+

--- a/examples/inference/run_pycbc_mcmc.sh
+++ b/examples/inference/run_pycbc_mcmc.sh
@@ -15,7 +15,7 @@ GPS_END_TIME=$((${TRIGGER_TIME_INT} + 1024))
 CHANNEL_NAME=H1:DCS-CALIB_STRAIN_C02
 FRAME_TYPE=H1:H1_HOFT_C02
 
-CONFIG_FILE=inference.ini
+CONFIG_PATH=inference.ini
 
 pycbc_mcmc --verbose \
     --instruments H1 \

--- a/examples/inference/run_pycbc_mcmc.sh
+++ b/examples/inference/run_pycbc_mcmc.sh
@@ -15,6 +15,8 @@ GPS_END_TIME=$((${TRIGGER_TIME_INT} + 1024))
 CHANNEL_NAME=H1:DCS-CALIB_STRAIN_C02
 FRAME_TYPE=H1:H1_HOFT_C02
 
+CONFIG_FILE=inference.ini
+
 pycbc_mcmc --verbose \
     --instruments H1 \
     --gps-start-time ${GPS_START_TIME} \
@@ -34,15 +36,7 @@ pycbc_mcmc --verbose \
     --likelihood-evaluator gaussian \
     --nwalkers 8 \
     --niterations 1000 \
-    --approximant TaylorF2 \
-    --variable-args tc mass1 mass2 \
-    --prior-min 1024.92 1.30 1.30 \
-    --prior-max 1025.04 10.00 10.00 \
-    --prior-dist flat flat flat \
-    --ra 0.0247836709 \
-    --dec 0.00715585006 \
-    --polarization 2.56616092 \
-    --f-lower 40.0 \
+    --config-file ${CONFIG_PATH} \
     --output-file test_cli.hdf
 
 

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -194,15 +194,15 @@ def distribution_from_config(cp, section, tag):
     special_args = ["name", "min", "max"]
 
     # get name of distribution to use
-    name = cp.get_opt_tag("prior", "name", tag)
+    name = cp.get_opt_tag(section, "name", tag)
 
     # get a dict with bounds as value
-    low = float(cp.get_opt_tag("prior", "min", tag))
-    high = float(cp.get_opt_tag("prior", "max", tag))
+    low = float(cp.get_opt_tag(section, "min", tag))
+    high = float(cp.get_opt_tag(section, "max", tag))
     dist_args = { tag : (low,high) }
 
     # add any additional options that user put in that section
-    for key in cp.options( "-".join(["prior",tag]) ):
+    for key in cp.options( "-".join([section,tag]) ):
 
         # ignore options that are already included
         if key in special_args:

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -171,6 +171,55 @@ class Uniform(object):
 
 priors = {Uniform.name: Uniform}
 
+def distribution_from_config(cp, section, tag):
+    """ Returns a distribution based on a configuration file.
+
+    Parameters
+     ----------
+     cp : pycbc.workflow.WorkflowConfigParser
+         A parsed configuration file that contains the distribution options.
+     section : str
+         Name of the section in the configuration file.
+     tag : str
+         Name of the tag in the configuration file to use, eg. the
+         configuration file has a [section-tag] section.
+
+     Returns
+     -------
+     distribution
+         A distribution instance from the pycbc.inference.prior module.
+    """
+
+    # list of args that are used to construct distribution
+    special_args = ["name", "min", "max"]
+
+    # get name of distribution to use
+    name = cp.get_opt_tag("prior", "name", tag)
+
+    # get a dict with bounds as value
+    low = float(cp.get_opt_tag("prior", "min", tag))
+    high = float(cp.get_opt_tag("prior", "max", tag))
+    dist_args = { tag : (low,high) }
+
+    # add any additional options that user put in that section
+    for key in cp.options( "-".join(["prior",tag]) ):
+
+        # ignore options that are already included
+        if key in special_args:
+            continue
+
+        # check if option can be cast as a float
+        val = cp.get_opt_tag("prior",key,tag)
+        try:
+            val = float(val)
+        except:
+            pass
+
+        # add option
+        dist_args.update({key:val})
+
+    # construction distribution and add to list
+    return priors[name](**dist_args)
 
 class PriorEvaluator(object):
     """

--- a/setup.py
+++ b/setup.py
@@ -462,6 +462,7 @@ setup (
                'bin/hdfcoinc/pycbc_merge_psds',
                'bin/hdfcoinc/pycbc_plot_gating',
                'bin/pycbc_condition_strain'
+               'bin/inference/pycbc_mcmc',
                ],
     packages = [
                'pycbc',

--- a/setup.py
+++ b/setup.py
@@ -461,7 +461,7 @@ setup (
                'bin/pygrb/pycbc_make_grb_summary_page',
                'bin/hdfcoinc/pycbc_merge_psds',
                'bin/hdfcoinc/pycbc_plot_gating',
-               'bin/pycbc_condition_strain'
+               'bin/pycbc_condition_strain',
                'bin/inference/pycbc_mcmc',
                ],
     packages = [


### PR DESCRIPTION
This PR depends on #826. It adds a function in ```inference.prior``` that takes the inference configuration file and returns an instance of the distribution class.

Needs #826 to be merged first.