### PR TITLE
Add helper function for reading distribution from config file.

### DIFF
--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -157,37 +157,9 @@ with ctx:
 
     # get prior distribution for each variable parameter
     logging.info("Setting up priors for each parameter")
-    special_args = ["name", "min", "max"]
     distributions = []
     for param in variable_args:
-
-        # get name of prior distribution to use
-        name = cp.get_opt_tag("prior", "name", param)
-
-        # get a dict with bounds as value
-        low = float(cp.get_opt_tag("prior", "min", param))
-        high = float(cp.get_opt_tag("prior", "max", param))
-        dist_args = { param : (low,high) }
-
-        # add any additional options that user put in that section
-        for key in cp.options( "-".join(["prior",param]) ):
-
-            # ignore options that are already included
-            if key in special_args:
-                continue
-
-            # check if option can be cast as a float
-            val = cp.get_opt_tag("prior",key,param)
-            try:
-                val = float(val)
-            except:
-                pass
-
-            # add option
-            dist_args.update({key:val})
-
-        # construction distribution and add to list
-        distributions.append( inference.priors[name](**dist_args) )
+        distributions.append( inference.distribution_from_config(cp, "prior", param) )
 
     # construct class that will return the prior
     prior = inference.PriorEvaluator(variable_args, *distributions)
@@ -213,15 +185,22 @@ with ctx:
                                                nwalkers=opts.nwalkers,
                                                processes=opts.nprocesses)
 
-    # starting parameters of walkers
+    # get distribution to draw from for each walker initial position
     logging.info("Setting walkers initial conditions for varying parameters")
 
+    # get distribution to draw from for each walker initial condition
+    initial_distributions = []
+    for param in variable_args:
+        if cp.has_section("initial-%s"%param):
+            initial_distributions.append( inference.distribution_from_config(cp, "initial", param) )
+        else:
+            initial_distributions.append( inference.distribution_from_config(cp, "prior", param) )
+
     #loop over number of walkers
+    # set initial values for variable parameters for this walker
     p0 = numpy.ones(shape=(opts.nwalkers, ndim))
     for i,_ in enumerate(p0):
-
-        # set initial values for variable parameters for this walker
-        p0[i] = [distributions[j].rvs(size=1, param=variable_args[j])[0][0] \
+        p0[i] = [initial_distributions[j].rvs(size=1, param=variable_args[j])[0][0] \
                                                           for j in range(ndim)]
 
     # check if user wants to skip the burn in
@@ -276,6 +255,3 @@ fp.create_dataset("acceptance_fraction", data=sampler.acceptance_fraction)
 
 # exit
 logging.info("Done")
-
-
-

--- a/examples/inference/inference.ini
+++ b/examples/inference/inference.ini
@@ -12,6 +12,24 @@ dec = 0.00715585006
 polarization = 2.56616092
 f_lower = 40.0
 
+[initial-tc]
+; initial conditions for coalescnce time
+name = uniform
+min = 1024.98
+max = 1024.99
+
+[initial-mass1]
+; initial conditions for compoennt mass
+name = uniform
+min = 1.399
+max = 1.401
+
+[initial-mass2]
+; initial conditions for component mass
+name = uniform
+min = 1.399
+max = 1.401
+
 [prior-tc]
 ; prior for coalescence time
 name = uniform

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -171,6 +171,55 @@ class Uniform(object):
 
 priors = {Uniform.name: Uniform}
 
+def distribution_from_config(cp, section, tag):
+    """ Returns a distribution based on a configuration file.
+
+    Parameters
+     ----------
+     cp : pycbc.workflow.WorkflowConfigParser
+         A parsed configuration file that contains the distribution options.
+     section : str
+         Name of the section in the configuration file.
+     tag : str
+         Name of the tag in the configuration file to use, eg. the
+         configuration file has a [section-tag] section.
+
+     Returns
+     -------
+     distribution
+         A distribution instance from the pycbc.inference.prior module.
+    """
+
+    # list of args that are used to construct distribution
+    special_args = ["name", "min", "max"]
+
+    # get name of distribution to use
+    name = cp.get_opt_tag(section, "name", tag)
+
+    # get a dict with bounds as value
+    low = float(cp.get_opt_tag(section, "min", tag))
+    high = float(cp.get_opt_tag(section, "max", tag))
+    dist_args = { tag : (low,high) }
+
+    # add any additional options that user put in that section
+    for key in cp.options( "-".join([section,tag]) ):
+
+        # ignore options that are already included
+        if key in special_args:
+            continue
+
+        # check if option can be cast as a float
+        val = cp.get_opt_tag("prior",key,tag)
+        try:
+            val = float(val)
+        except:
+            pass
+
+        # add option
+        dist_args.update({key:val})
+
+    # construction distribution and add to list
+    return priors[name](**dist_args)
 
 class PriorEvaluator(object):
     """
@@ -223,3 +272,4 @@ class PriorEvaluator(object):
         """
         params = dict(zip(self.variable_args, params))
         return sum([d(**params) for d in self.distributions])
+


### PR DESCRIPTION
This PR replaces #847. It adds a function in ```inference.prior``` that takes the inference configuration file and returns an instance of the distribution class.