### PR TITLE
Add some MCMC plotting executables

### DIFF
--- a/bin/inference/pycbc_mcmc_plot_acceptance_rate
+++ b/bin/inference/pycbc_mcmc_plot_acceptance_rate
@@ -48,7 +48,7 @@ else:
     log_level = logging.WARN
 logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 
-# get all past samples as an niterations x nwalker x ndim array
+# read input file
 logging.info("Reading input file")
 fp = h5py.File(opts.input_file, "r")
 

--- a/bin/inference/pycbc_mcmc_plot_acceptance_rate
+++ b/bin/inference/pycbc_mcmc_plot_acceptance_rate
@@ -1,0 +1,66 @@
+#! /usr/bin/evn python
+
+# Copyright (C) 2016 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import argparse
+import h5py
+import logging
+import matplotlib as mpl; mpl.use("Agg")
+import matplotlib.pyplot as plt
+
+# command line usage
+parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_acceptance_rate [--options]",
+    description="Plots fraction of walkers that accepted each step.")
+
+# add data options
+parser.add_argument("--input-file", type=str, required=True,
+    help="Path to input HDF file.")
+
+# output plot options
+parser.add_argument("--output-file", type=str, required=True,
+    help="Path to output plot.")
+
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+    help="")
+
+# parse the command line
+opts = parser.parse_args()
+
+# setup log
+if opts.verbose:
+    log_level = logging.DEBUG
+else:
+    log_level = logging.WARN
+logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
+
+# get all past samples as an niterations x nwalker x ndim array
+logging.info("Reading input file")
+fp = h5py.File(opts.input_file, "r")
+
+# plot acceptance rate and drawn values
+logging.info("Plotting acceptance fraction")
+acceptance_fraction = fp["acceptance_fraction"][:]
+plt.plot(acceptance_fraction, 'k', alpha=.5)
+plt.ylabel("Mean Acceptance Rate")
+
+# save plot
+plt.savefig(opts.output_file)
+plt.close()
+
+# exit
+logging.info("Done")

--- a/bin/inference/pycbc_mcmc_plot_acf
+++ b/bin/inference/pycbc_mcmc_plot_acf
@@ -60,7 +60,7 @@ logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 # get number of dimensions
 ndim = len(opts.variable_args)
 
-# get all past samples as an niterations x nwalker x ndim array
+# read input file
 logging.info("Reading input file")
 fp = h5py.File(opts.input_file, "r")
 

--- a/bin/inference/pycbc_mcmc_plot_acf
+++ b/bin/inference/pycbc_mcmc_plot_acf
@@ -1,0 +1,117 @@
+#! /usr/bin/evn python
+
+# Copyright (C) 2016 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import argparse
+import h5py
+import logging
+import matplotlib as mpl; mpl.use("Agg")
+import matplotlib.pyplot as plt
+import numpy
+
+# command line usage
+parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_acf [--options]",
+    description="Plots autocorrelation function from MCMC.")
+
+# add data options
+parser.add_argument("--input-file", type=str, required=True,
+    help="Path to input HDF file.")
+parser.add_argument("--variable-args", type=str, nargs="+", required=True,
+    help="Name of parameters varied in MCMC.")
+
+# add plotting options
+parser.add_argument("--ymin", type=float,
+    help="Minimum value to plot on y-axis.")
+parser.add_argument("--ymax", type=float,
+    help="Maximum value to plot on y-axis.")
+
+# output plot options
+parser.add_argument("--output-file", type=str, required=True,
+    help="Path to output plot.")
+
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+    help="")
+
+# parse the command line
+opts = parser.parse_args()
+
+# setup log
+if opts.verbose:
+    log_level = logging.DEBUG
+else:
+    log_level = logging.WARN
+logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
+
+# get number of dimensions
+ndim = len(opts.variable_args)
+
+# get all past samples as an niterations x nwalker x ndim array
+logging.info("Reading input file")
+fp = h5py.File(opts.input_file, "r")
+
+# calculate autocorrelation function for each walker
+logging.info("Calculating autocorrelation functions")
+all_acfs = []
+for param_name in opts.variable_args:
+
+    # loop over walkers and save an autocorrelation function
+    # for each walker
+    param_acfs = []
+    for i in range(fp.attrs["nwalkers"]):
+
+        # get all the past samples for this walker
+        y = fp[param_name]["walker%d"%i][:]
+
+        # subtract mean
+        z =  y - y.mean()
+
+        # autocorrelate
+        acf = numpy.correlate(z, z, mode="full")
+
+        # take only the second half of the autocorrelation time series
+        acf = acf[acf.size/2:]
+
+        # normalize
+        acf /= y.var() * numpy.arange(y.size, 0, -1)
+
+        # add to list of autocorrelation time series
+        param_acfs.append(acf)
+
+    # add list with parameters ACF to list of all ACFs
+    all_acfs.append(param_acfs)
+
+# plot autocorrelation
+logging.info("Plotting autocorrelation functions")
+for param_acfs in all_acfs:
+    for acf in param_acfs:
+        plt.plot(range(len(acf)), acf, alpha=0.5)
+plt.ylabel("Autocorrelation Function")
+plt.xlabel("iteration")
+
+# format plot
+if opts.ymin:
+    plt.ylim(ymin=opts.ymin)
+if opts.ymax:
+    plt.ylim(ymax=opts.ymax)
+
+# save plot
+plt.savefig(opts.output_file)
+plt.close()
+
+# exit
+logging.info("Done")

--- a/bin/inference/pycbc_mcmc_plot_corner
+++ b/bin/inference/pycbc_mcmc_plot_corner
@@ -1,0 +1,117 @@
+#! /usr/bin/evn python
+
+# Copyright (C) 2016 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import argparse
+import corner
+import h5py
+import logging
+import matplotlib as mpl; mpl.use("Agg")
+import matplotlib.pyplot as plt
+import numpy
+from pycbc import pnutils
+
+# command line usage
+parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_corner [--options]",
+    description="Plots corner plot of posteriors from MCMC.")
+
+# add data options
+parser.add_argument("--input-file", type=str, required=True,
+    help="Path to input HDF file.")
+parser.add_argument("--variable-args", type=str, nargs="+", required=True,
+    help="Name of parameters varied in MCMC.")
+
+# output plot options
+parser.add_argument("--output-file", type=str, required=True,
+    help="Path to output plot.")
+parser.add_argument("--labels", type=str, nargs="+",
+    help="Label for each parameter.")
+
+# add thinning options
+parser.add_argument("--thin-start", type=int, required=True,
+    help="Sample number to start collecting samples to plot.")
+parser.add_argument("--thin-interval", type=int, required=True,
+    help="Interval to use for thinning samples.")
+
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+    help="")
+
+# parse the command line
+opts = parser.parse_args()
+
+# setup log
+if opts.verbose:
+    log_level = logging.DEBUG
+else:
+    log_level = logging.WARN
+logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
+
+# get all past samples as an niterations x nwalker x ndim array
+logging.info("Reading input file")
+fp = h5py.File(opts.input_file, "r")
+
+# thin samples to get independent samples from each sampler
+logging.info("Thinning samples")
+x = []
+
+# loop over each walkers
+for i in range(fp.attrs["nwalkers"]):
+
+    # loop over each parameter
+    samples = []
+    for param in opts.variable_args:
+
+        # derived parameters
+        if param == "mchirp":
+            idx1 = opts.variable_args.index("mass1")
+            idx2 = opts.variable_args.index("mass2")
+            mchirp, _ = pnutils.mass1_mass2_to_mchirp_eta(samples[idx1], samples[idx2])
+            samples.append( mchirp )
+        elif param == "eta":
+            idx1 = opts.variable_args.index("mass1")
+            idx2 = opts.variable_args.index("mass2")
+            _, eta = pnutils.mass1_mass2_to_mchirp_eta(samples[idx1], samples[idx2])
+            samples.append( eta )
+
+        # MCMC parameters
+        else:
+            samples.append( fp[param]["walker%d"%i][opts.thin_start::opts.thin_interval] )
+
+    # transpose walker samples to get an ndim x nwalker x niteration array
+    # add iteration to x
+    samples = numpy.array(samples)
+    samples = numpy.transpose(samples)
+    x.append(samples)
+
+# concatenate arrays so that all iterations are in a single array
+logging.info("Concatenating samples together")
+x = numpy.concatenate(x)
+
+# plot posterior
+logging.info("Plot posteriors")
+quantiles = [0.16, 0.5, 0.84]
+if opts.labels:
+    labels = [r"%s"%label for label in opts.labels]
+else:
+    labels = opts.variable_args
+fig = corner.corner(x, labels=labels, quantiles=quantiles)
+fig.savefig(opts.output_file)
+plt.close()
+
+# exit
+logging.info("Done")

--- a/bin/inference/pycbc_mcmc_plot_corner
+++ b/bin/inference/pycbc_mcmc_plot_corner
@@ -61,7 +61,7 @@ else:
     log_level = logging.WARN
 logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 
-# get all past samples as an niterations x nwalker x ndim array
+# read input file
 logging.info("Reading input file")
 fp = h5py.File(opts.input_file, "r")
 

--- a/bin/inference/pycbc_mcmc_plot_samples
+++ b/bin/inference/pycbc_mcmc_plot_samples
@@ -1,0 +1,85 @@
+#! /usr/bin/evn python
+
+# Copyright (C) 2016 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import argparse
+import h5py
+import logging
+import matplotlib as mpl; mpl.use("Agg")
+import matplotlib.pyplot as plt
+
+# command line usage
+parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_samples [--options]",
+    description="Plots samples from MCMC.")
+
+# add data options
+parser.add_argument("--input-file", type=str, required=True,
+    help="Path to input HDF file.")
+parser.add_argument("--variable-args", type=str, nargs="+", required=True,
+    help="Name of parameters varied in MCMC.")
+
+# output plot options
+parser.add_argument("--output-file", type=str, required=True,
+    help="Path to output plot.")
+parser.add_argument("--labels", type=str, nargs="+", required=True,
+    help="Label for each parameter.")
+
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+    help="")
+
+# parse the command line
+opts = parser.parse_args()
+
+# setup log
+if opts.verbose:
+    log_level = logging.DEBUG
+else:
+    log_level = logging.WARN
+logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
+
+# get number of dimensions
+ndim = len(opts.variable_args)
+
+# get all past samples as an niterations x nwalker x ndim array
+logging.info("Reading input file")
+fp = h5py.File(opts.input_file, "r")
+
+# plot samples
+# plot each variable arg has a different subplot
+logging.info("Plotting samples")
+fig, axs = plt.subplots(ndim, sharex=True)
+plt.xlabel("iterations")
+
+# loop over variable args
+for i,arg in enumerate(opts.variable_args):
+
+    # loop over walkers
+    for j in range(fp.attrs["nwalkers"]):
+
+        # plot each walker as a different line on the subplot
+        axs[i].plot(fp[arg]["walker%d"%j][:], alpha=0.1)
+
+        # y-axis label
+        axs[i].set_ylabel(r"%s"%opts.labels[i])
+
+# save plot
+plt.savefig(opts.output_file)
+plt.close()
+
+# exit
+logging.info("Done")

--- a/bin/inference/pycbc_mcmc_plot_samples
+++ b/bin/inference/pycbc_mcmc_plot_samples
@@ -55,7 +55,7 @@ logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 # get number of dimensions
 ndim = len(opts.variable_args)
 
-# get all past samples as an niterations x nwalker x ndim array
+# read input file
 logging.info("Reading input file")
 fp = h5py.File(opts.input_file, "r")
 

--- a/setup.py
+++ b/setup.py
@@ -463,6 +463,10 @@ setup (
                'bin/hdfcoinc/pycbc_plot_gating',
                'bin/pycbc_condition_strain',
                'bin/inference/pycbc_mcmc',
+               'bin/inference/pycbc_mcmc_plot_acceptance_rate',
+               'bin/inference/pycbc_mcmc_plot_acf',
+               'bin/inference/pycbc_mcmc_plot_corner',
+               'bin/inference/pycbc_mcmc_plot_samples',
                'bin/plotting/pycbc_plot_waveform'
                ],
     packages = [


### PR DESCRIPTION
This PR replaces #838.

This PR adds 4 executables to ```bin/inference```, they are:
   * ```pycbc_mcmc_plot_acceptance_rate```: plots fraction of samples accepted at each iteration
   * ```pycbc_mcmc_plot_acf```: plots autocorrelation function for a parameter
   * ```pycbc_mcmc_plot_corner```: plots posteriors as a corner plot
   * ```pycbc_mcmc_plot_samples```: plots all samples for a parameter