### PR TITLE
Precessing search changes to minifollowups

### DIFF
--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -70,9 +70,11 @@ coinc_file = to_file(args.statmap_file)
 insp_segs = to_file(args.inspiral_segments)
 
 single_triggers = []
+fsdt = {}
 for ifo in args.single_detector_triggers:
     fname = args.single_detector_triggers[ifo]
     single_triggers.append(to_file(fname, ifo=ifo))
+    fsdt[ifo] = h5py.File(args.single_detector_triggers[ifo], 'r')
     
 num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
 f = h5py.File(args.statmap_file, 'r')
@@ -116,15 +118,28 @@ for num_event in range(num_events):
     params = {}                          
     for ifo in times:
         params['%s_end_time' % ifo] = times[ifo][num_event]
+        try:
+            # Only present for precessing case
+            params['u_vals_%s'%ifo] = \
+                                 fsdt[ifo][ifo]['u_vals'][tids[ifo][num_event]]
+        except:
+            pass
 
     params['mass1'] = bank_data['mass1'][bank_id]
     params['mass2'] = bank_data['mass2'][bank_id]
     params['spin1z'] = bank_data['spin1z'][bank_id]
     params['spin2z'] = bank_data['spin2z'][bank_id]
+    params['spin1x'] = bank_data['spin1x'][bank_id]
+    params['spin1y'] = bank_data['spin1y'][bank_id]
+    params['spin2x'] = bank_data['spin2x'][bank_id]
+    params['spin2y'] = bank_data['spin2y'][bank_id]
+    params['inclination'] = bank_data['inclination'][bank_id]
+
     files += mini.make_single_template_plots(workflow, insp_segs,
                                     args.inspiral_data_read_name,
                                     args.inspiral_data_analyzed_name,  params,
-                                    args.output_dir, tags=args.tags + [str(num_event)])
+                                    args.output_dir,
+                                    tags=args.tags + [str(num_event)])
     
     for single in single_triggers:
         time = times[single.ifo][num_event]

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -192,6 +192,17 @@ for num_event in range(num_events):
         curr_params['mass2'] = hd_sngl.mass2
         curr_params['spin1z'] = hd_sngl.spin1z
         curr_params['spin2z'] = hd_sngl.spin2z
+        curr_params['spin1x'] = hd_sngl.spin1x
+        curr_params['spin2x'] = hd_sngl.spin2x
+        curr_params['spin1y'] = hd_sngl.spin1y
+        curr_params['spin2y'] = hd_sngl.spin2y
+        curr_params['inclination'] = hd_sngl.inclination
+        try:
+            # Only present for precessing search
+            curr_params['u_vals'] = hd_sngl.u_vals
+        except:
+            pass
+
         curr_tags = ['TMPLT_PARAMS_%s' %(curr_ifo,)]
         curr_tags += [str(num_event)]
         files += mini.make_single_template_plots(workflow, insp_segs,

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -122,6 +122,23 @@ for num_event in range(num_events):
     curr_params['spin1z'] = trigs.spin1z[num_event]
     curr_params['spin2z'] = trigs.spin2z[num_event]
     curr_params[args.instrument + '_end_time'] = time
+    curr_params['spin1x'] = trigs.spin1x[num_event]
+    curr_params['spin2x'] = trigs.spin2x[num_event]
+    curr_params['spin1y'] = trigs.spin1y[num_event]
+    curr_params['spin2y'] = trigs.spin2y[num_event]
+    curr_params['inclination'] = trigs.inclination[num_event]
+    try:
+        # Only present for precessing search
+        curr_params['u_vals'] = trigs.u_vals[num_event]
+    except:
+        pass
+
+    files += mini.make_plot_waveform_plot(workflow, curr_params,
+                                        args.output_dir, [args.instrument],
+                                        tags=args.tags + [str(num_event)])
+    files += mini.make_trigger_timeseries(workflow, [sngl_file],
+                              ifo_time, args.output_dir, special_tids=ifo_tid,
+                              tags=args.tags + [str(num_event)])
     files += mini.make_single_template_plots(workflow, insp_segs,
                             args.inspiral_data_read_name,
                             args.inspiral_data_analyzed_name, curr_params,

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -106,6 +106,26 @@ parser.add_argument("--spin1z", type=float, default=0,
 parser.add_argument("--spin2z", type=float, default=0,
                   help="The aligned pin of the second component object. "
                       "Do not use if using --use-params-of-closest-injection.")
+# Optional arguments for precessing templates
+parser.add_argument("--spin1x", type=float, default=0,
+                  help="The non-aligned spin of the first component object. "
+                    "Default = 0.")
+parser.add_argument("--spin2x", type=float, default=0,
+                  help="The non-aligned spin of the second component object. "
+                    "Default = 0.")
+parser.add_argument("--spin1y", type=float, default=0,
+                  help="The non-aligned spin of the first component object. "
+                    "Default = 0.")
+parser.add_argument("--spin2y", type=float, default=0,
+                  help="The non-aligned spin of the second component object. "
+                    "Default = 0.")
+parser.add_argument("--inclination", type=float, default=0,
+                  help="The inclination of the source w.r.t the observer. "
+                    "Default = 0.")
+parser.add_argument("--u-val", type=float, default=None,
+                  help="The ratio between hplus and hcross to use in the "
+                    "template, according to h(t) = hplus * u_val + hcross. "
+                    "If not given only hplus is used.")
 parser.add_argument("--window", type=float, 
                   help="Time to save around the trigger time (if given)")
 parser.add_argument("--order", type=int,
@@ -228,13 +248,33 @@ with ctx:
             opt.approximant = waveform.FilterBank.parse_option(row,
                                                                opt.approximant)
         logging.info("Making template: %s" % opt.approximant)
-        template = waveform.get_waveform_filter(zeros(flen, dtype=complex64), 
+        if opt.u_val is None:
+            template = waveform.get_waveform_filter(
+                                    zeros(flen, dtype=complex64),
                                     approximant=opt.approximant,
                                     mass1=opt.mass1, mass2=opt.mass2,
                                     spin1z=opt.spin1z, spin2z=opt.spin2z,
+                                    spin1y=opt.spin1y, spin2y=opt.spin2y,
+                                    spin1x=opt.spin1x, spin2x=opt.spin2x,
+                                    inclination=opt.inclination,
                                     taper=opt.taper_template, 
                                     f_lower=flow, delta_f=delta_f,
                                     delta_t=gwstrain.delta_t)
+        else:
+            tp, tc = waveform.get_two_pol_waveform_filter(
+                                    zeros(flen, dtype=complex64),
+                                    zeros(flen, dtype=complex64), None,
+                                    approximant=opt.approximant,
+                                    mass1=opt.mass1, mass2=opt.mass2,
+                                    spin1z=opt.spin1z, spin2z=opt.spin2z,
+                                    spin1y=opt.spin1y, spin2y=opt.spin2y,
+                                    spin1x=opt.spin1x, spin2x=opt.spin2x,
+                                    inclination=opt.inclination,
+                                    taper=opt.taper_template,
+                                    f_lower=flow, delta_f=delta_f,
+                                    delta_t=gwstrain.delta_t)
+            template = tc.multiply_and_add(tp, opt.u_val)
+
     chisq_bins = int(vetoes.SingleDetPowerChisq.parse_option(row,
                                                                opt.chisq_bins))
 


### PR DESCRIPTION
Here are the changes to minifollowups from the precessing search. Specifically:

 * Hook up the plot_waveform code (for aligned-spin searches too!) to give template waveform plots on the sngl minifollowups pages.
 * Add support for precessing filters in pycbc_single_template
 * Hook up functionality throughout the 3 minifollowups generators.

Here is a result page with all this present:

https://galahad.aei.mpg.de/~spxiwh/LVC/aLIGO/O1/analyses/precessing/NSBH/smallrun_run2/

(Yes, one of the chisq values is recorded as negative for *one* trigger. I don't know why yet, but it's nothing to do with this code!)