### PR TITLE
Add stubs for precessing auto and bank chisqs

### DIFF
--- a/pycbc/vetoes/autochisq.py
+++ b/pycbc/vetoes/autochisq.py
@@ -277,3 +277,18 @@ class SingleDetAutoChisq(object):
                                maxvalued=self.take_maximum_value)
             self.dof = dof
             return achi_list
+
+class SingleDetSkyMaxAutoChisq(SingleDetAutoChisq):
+    """Stub for precessing auto chisq if anyone ever wants to code it up.
+    """
+    def __init__(self, **kwds):
+        super(SingleDetSkyMaxAutoChisq, self).__init__(**kwds)
+
+    def values(self, *args, **kwargs):
+        if self.do:
+            err_msg = "Precessing single detector sky-max auto chisq has not "
+            err_msg += "been written. If you want to use it, why not help "
+            err_msg += "write it?"
+            raise NotImplementedError(err_msg)
+        else:
+            return None, None

--- a/pycbc/vetoes/bank_chisq.py
+++ b/pycbc/vetoes/bank_chisq.py
@@ -231,4 +231,18 @@ class SingleDetBankVeto(object):
             return chisq, dof
         else:
             return None, None      
-                  
+
+class SingleDetSkyMaxBankVeto(SingleDetBankVeto):
+    """Stub for precessing bank veto if anyone ever wants to code it up.
+    """
+    def __init__(self, **kwds):
+        super(SingleDetSkyMaxBankVeto, self).__init__(**kwds)
+
+    def values(self, *args, **kwargs):
+        if self.do:
+            err_msg = "Precessing single detector sky-max bank veto has not "
+            err_msg += "been written. If you want to use it, why not help "
+            err_msg += "write it?"
+            raise NotImplementedError(err_msg)
+        else:
+            return None, None


### PR DESCRIPTION
More precessing stuff, this one should be trivial.

Add stubs for the precessing auto and bank chi-squareds. This just raises NotImplemented Errors now, but we can at least hook them up in inspiral_skymax.