### PR TITLE
Increment pycbc-pylal requirement to latest 0.9.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ pip==7.1.2
 psycopg2==2.6
 pyRXP==2.1.0
 pycbc-glue==0.9.8
-pycbc-pylal==0.9.5
+pycbc-pylal==0.9.6
 Pygments==2.0.2
 pyOpenSSL==0.13
 pyparsing==2.0.3


### PR DESCRIPTION
@ahnitz ,

I have uploaded [v0.9.6 of pycbc-pylal](https://pypi.python.org/pypi/pycbc-pylal/0.9.6) to PyPI, and tested by pip installing on a number of different machines, so can we increment the version listed in the requirements file?

Thanks