### PR TITLE
Add meta-data to MCMC plots.

### DIFF
--- a/bin/inference/pycbc_mcmc_plot_acceptance_rate
+++ b/bin/inference/pycbc_mcmc_plot_acceptance_rate
@@ -21,6 +21,8 @@ import h5py
 import logging
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
+import sys
+from pycbc import results
 
 # command line usage
 parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_acceptance_rate [--options]",
@@ -55,11 +57,17 @@ fp = h5py.File(opts.input_file, "r")
 # plot acceptance rate and drawn values
 logging.info("Plotting acceptance fraction")
 acceptance_fraction = fp["acceptance_fraction"][:]
+fig = plt.figure()
 plt.plot(acceptance_fraction, 'k', alpha=.5)
 plt.ylabel("Mean Acceptance Rate")
 
-# save plot
-plt.savefig(opts.output_file)
+# save figure with meta-data
+caption = """This plot shows the fraction of samples accepted at each
+iteration."""
+results.save_fig_with_metadata(fig, opts.output_file,
+                               cmd=" ".join(sys.argv),
+                               title="Acceptance Rate",
+                               caption=caption)
 plt.close()
 
 # exit

--- a/bin/inference/pycbc_mcmc_plot_acceptance_rate
+++ b/bin/inference/pycbc_mcmc_plot_acceptance_rate
@@ -66,7 +66,7 @@ caption = """This plot shows the fraction of samples accepted at each
 iteration."""
 results.save_fig_with_metadata(fig, opts.output_file,
                                cmd=" ".join(sys.argv),
-                               title="Acceptance Rate",
+                               title="Acceptance rate",
                                caption=caption)
 plt.close()
 

--- a/bin/inference/pycbc_mcmc_plot_acf
+++ b/bin/inference/pycbc_mcmc_plot_acf
@@ -118,7 +118,7 @@ caption_kwargs = {
 }
 caption = """Autocorrelation function (ACF) from all the walker chains for the
 parameters {parameters}. Each line is an ACF for a chain of walker samples.""".format(**caption_kwargs)
-title = "Autocorrelation Function for {parameters}".format(**caption_kwargs)
+title = "Autocorrelation function for {parameters}".format(**caption_kwargs)
 results.save_fig_with_metadata(fig, opts.output_file,
                                cmd=" ".join(sys.argv),
                                title=title,

--- a/bin/inference/pycbc_mcmc_plot_acf
+++ b/bin/inference/pycbc_mcmc_plot_acf
@@ -22,6 +22,8 @@ import logging
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy
+import sys
+from pycbc import results
 
 # command line usage
 parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_acf [--options]",
@@ -97,6 +99,7 @@ for param_name in opts.variable_args:
 
 # plot autocorrelation
 logging.info("Plotting autocorrelation functions")
+fig = plt.figure()
 for param_acfs in all_acfs:
     for acf in param_acfs:
         plt.plot(range(len(acf)), acf, alpha=0.5)
@@ -109,8 +112,17 @@ if opts.ymin:
 if opts.ymax:
     plt.ylim(ymax=opts.ymax)
 
-# save plot
-plt.savefig(opts.output_file)
+# save figure with meta-data
+caption_kwargs = {
+    "parameters" : ", ".join(opts.variable_args),
+}
+caption = """Autocorrelation function (ACF) from all the walker chains for the
+parameters {parameters}. Each line is an ACF for a chain of walker samples.""".format(**caption_kwargs)
+title = "Autocorrelation Function for {parameters}".format(**caption_kwargs)
+results.save_fig_with_metadata(fig, opts.output_file,
+                               cmd=" ".join(sys.argv),
+                               title=title,
+                               caption=caption)
 plt.close()
 
 # exit

--- a/bin/inference/pycbc_mcmc_plot_corner
+++ b/bin/inference/pycbc_mcmc_plot_corner
@@ -23,7 +23,8 @@ import logging
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy
-from pycbc import pnutils
+import sys
+from pycbc import pnutils, results
 
 # command line usage
 parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_corner [--options]",
@@ -110,7 +111,23 @@ if opts.labels:
 else:
     labels = opts.variable_args
 fig = corner.corner(x, labels=labels, quantiles=quantiles)
-fig.savefig(opts.output_file)
+
+# save figure with meta-data
+caption_kwargs = {
+    "quantiles" : ", ".join(map(str, [q for q in quantiles])),
+    "thin_start" : opts.thin_start,
+    "thin_interval" : opts.thin_interval,
+    "niterations" : len(x[0]),
+}
+caption = """Posterior distributions for waveform parameters. The dashed
+vertical lines correspond to the {quantiles} quantiles. The thinning used to
+make this plot took samples beginning at the {thin_start} and then every
+{thin_interval}-th sample after that. Each chain of samples had {niterations}
+iterations.""".format(**caption_kwargs)
+results.save_fig_with_metadata(fig, opts.output_file,
+                               cmd=" ".join(sys.argv),
+                               title="Posterior Distributions",
+                               caption=caption)
 plt.close()
 
 # exit

--- a/bin/inference/pycbc_mcmc_plot_corner
+++ b/bin/inference/pycbc_mcmc_plot_corner
@@ -126,7 +126,7 @@ make this plot took samples beginning at the {thin_start} and then every
 iterations.""".format(**caption_kwargs)
 results.save_fig_with_metadata(fig, opts.output_file,
                                cmd=" ".join(sys.argv),
-                               title="Posterior Distributions",
+                               title="Posterior distributions",
                                caption=caption)
 plt.close()
 

--- a/bin/inference/pycbc_mcmc_plot_samples
+++ b/bin/inference/pycbc_mcmc_plot_samples
@@ -21,6 +21,8 @@ import h5py
 import logging
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
+import sys
+from pycbc import results
 
 # command line usage
 parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_samples [--options]",
@@ -66,6 +68,7 @@ fig, axs = plt.subplots(ndim, sharex=True)
 plt.xlabel("iterations")
 
 # loop over variable args
+axs = [axs] if type(axs) is not list else axs
 for i,arg in enumerate(opts.variable_args):
 
     # loop over walkers
@@ -77,8 +80,17 @@ for i,arg in enumerate(opts.variable_args):
         # y-axis label
         axs[i].set_ylabel(r"%s"%opts.labels[i])
 
-# save plot
-plt.savefig(opts.output_file)
+# save figure with meta-data
+caption_kwargs = {
+    "parameters" : ", ".join(opts.variable_args),
+}
+caption = """All samples from all the walker chains for the parameters
+{parameters}. Each line is a different chain of walker samples.""".format(**caption_kwargs)
+title = "Samples for {parameters}".format(**caption_kwargs)
+results.save_fig_with_metadata(fig, opts.output_file,
+                               cmd=" ".join(sys.argv),
+                               title=title,
+                               caption=caption)
 plt.close()
 
 # exit


### PR DESCRIPTION
This PR adds meta-data information (caption, title, command line) to the MCMC plots for the HTML pages.

Page will look like: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/tmp_workflow_2/