### PR TITLE
Fixing bug in the dag generator

### DIFF
--- a/tools/static/build_dag.sh
+++ b/tools/static/build_dag.sh
@@ -43,7 +43,7 @@ do
 done > build_static.dag
 
 echo "JOB ligolw_segment_query_dqsegdb ${PWD}/build_one.sub DIR ${PWD}" >> build_static.dag
-echo "VARS ligolw_segment_query_dqsegdb prog=../../../../bin/ligolw_segment_query_dqsegdb" >> build_static.dag
+echo "VARS ligolw_segment_query_dqsegdb prog=\"../../../../bin/ligolw_segment_query_dqsegdb\"" >> build_static.dag
 
 echo "JOB ligolw_segments_from_cats_dqsegdb ${PWD}/build_one.sub DIR ${PWD}" >> build_static.dag
-echo "VARS ligolw_segments_from_cats_dqsegdb prog=../../../../bin/ligolw_segments_from_cats_dqsegdb" >> build_static.dag
+echo "VARS ligolw_segments_from_cats_dqsegdb prog=\"../../../../bin/ligolw_segments_from_cats_dqsegdb\"" >> build_static.dag


### PR DESCRIPTION
@lppekows I tried to generate and submit the dag for building static binaries and this failed. It turned out to be due to missing quotation marks around the executable path after `prog=` for the two `ligolw` executables the shell script adds to the dag.

I've tested this and have 100% success submitting the dag on `sugar-dev3` with a [proposed v1.4.1 branch](a-r-williamson/pycbc/tree/v1.4). There are some failures running this from master due to some recent additions (MCMC executables, for example).