### PR TITLE
Adds table of posterior values for MCMC HTML page

### DIFF
--- a/bin/inference/pycbc_make_inference_workflow
+++ b/bin/inference/pycbc_make_inference_workflow
@@ -189,6 +189,11 @@ for num_event in range(num_events):
                           opts.output_dir, tags=opts.tags + [str(num_event)])]
 
     # add files from corner plot for this event
+    layouts += [mcf.make_inference_summary_table(workflow, mcmc_file,
+                          opts.output_dir, analysis_seg=analysis_time,
+                          tags=opts.tags + [str(num_event)])]
+
+    # add files from corner plot for this event
     layouts += [mcf.make_inference_corner_plot(workflow, mcmc_file,
                           opts.output_dir, opts.inference_config_file,
                           analysis_seg=analysis_time,

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -212,13 +212,13 @@ with ctx:
 
         # generate more samples
         logging.info("Generating more MCMC samples")
-        p, post, q = sampler.run_mcmc(opts.niterations)
+        sampler.run_mcmc(opts.niterations)
 
     else:
 
         # generate samples
         logging.info("Generating MCMC samples")
-        p, post, q = sampler.run_mcmc(opts.niterations, p0=p0)
+        sampler.run_mcmc(opts.niterations, p0=p0)
 
 # get all past samples as an niterations x nwalker x ndim array
 logging.info("Writing output file")

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -17,7 +17,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import argparse
-import h5py
 import kombine
 import logging
 import numpy
@@ -25,6 +24,7 @@ import pycbc.opt
 import pycbc.weave
 import random
 from pycbc import fft, inference, psd, scheme, strain, waveform
+from pycbc.io.mcmc import MCMCFile
 from pycbc.types import MultiDetOptionAction
 from pycbc.workflow import WorkflowConfigParser
 
@@ -228,30 +228,10 @@ chain = sampler.chain
 chain = numpy.transpose(chain)
 
 # save samples to file
-fp = h5py.File(opts.output_file, "w")
-
-# save MCMC parameters
-fp.attrs["nwalkers"] = opts.nwalkers
-fp.attrs["niterations"] = opts.niterations
-
-# loop over number of dimensions
-for i,dim_name in zip(range(ndim), variable_args):
-
-    # create a group in the output file for this dimension
-    group_dim = fp.create_group(dim_name)
-
-    # loop over number of walkers
-    for j in range(opts.nwalkers):
-
-        # get all samples from this walker for this dimension
-        samples = chain[i,j,:]
-
-        # write to output file
-        dataset_name = "walker%d"%j
-        group_dim.create_dataset(dataset_name, data=samples)
-
-# create a dataset for the acceptance fraction
-fp.create_dataset("acceptance_fraction", data=sampler.acceptance_fraction)
+fp = MCMCFile(opts.output_file, "w")
+fp.write(variable_args, chain,
+         acceptance_fraction=sampler.acceptance_fraction)
+fp.close()
 
 # exit
 logging.info("Done")

--- a/bin/inference/pycbc_mcmc_table_summary
+++ b/bin/inference/pycbc_mcmc_table_summary
@@ -73,7 +73,7 @@ for param in opts.variable_args:
                            thin_interval=opts.thin_interval)
 
     # calculate the score at a given percentile
-    # 50 is the median, 16 and 84 correspond to 68 percentile
+    # eg. 50 is the median, 16 and 84 correspond to 68 percentile
     param_quantiles = []
     for q in opts.quantiles:
         param_quantiles.append( numpy.percentile(data, 100*q) )

--- a/bin/inference/pycbc_mcmc_table_summary
+++ b/bin/inference/pycbc_mcmc_table_summary
@@ -31,7 +31,7 @@ parser = argparse.ArgumentParser(usage="pycbc_mcmc_table_summary [--options]",
 # add data options
 parser.add_argument("--input-file", type=str, required=True,
     help="Path to input HDF file.")
-parser.add_argument("--variable-args", type=str, nargs="+", required=True,
+parser.add_argument("--variable-args", type=str, nargs="+", default=[],
     help="Name of parameters varied in MCMC.")
 
 # output plot options
@@ -67,9 +67,15 @@ logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 logging.info("Reading input file")
 fp = MCMCFile(opts.input_file, "r")
 
+# check if command line specifies variable parameters
+if opts.variable_args:
+    variable_args = opts.variable_args
+else:
+    variable_args = fp.attrs["variable_args"]
+
 # get thinned samples for each parameter
 table = []
-for param in opts.variable_args:
+for param in variable_args:
     samples = fp.read_samples(param, thin_start=opts.thin_start,
                               thin_interval=opts.thin_interval)
 

--- a/bin/inference/pycbc_mcmc_table_summary
+++ b/bin/inference/pycbc_mcmc_table_summary
@@ -1,0 +1,89 @@
+#! /usr/bin/env python
+
+# Copyright (C) 2016 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import argparse
+import h5py
+import logging
+import numpy
+
+# command line usage
+parser = argparse.ArgumentParser(usage="pycbc_mcmc_table_summary [--options]",
+    description="Makes a table of MCMC posterior results.")
+
+# add data options
+parser.add_argument("--input-file", type=str, required=True,
+    help="Path to input HDF file.")
+parser.add_argument("--variable-args", type=str, nargs="+", required=True,
+    help="Name of parameters varied in MCMC.")
+
+# output plot options
+parser.add_argument("--output-file", type=str, required=True,
+    help="Path to output plot.")
+
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+    help="")
+
+# parse the command line
+opts = parser.parse_args()
+
+# setup log
+if opts.verbose:
+    log_level = logging.DEBUG
+else:
+    log_level = logging.WARN
+logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
+
+# read input file
+logging.info("Reading input file")
+fp = h5py.File(opts.input_file, "r")
+
+# loop over each parameter
+samples_dict = []
+for param in opts.variable_args:
+
+    # loop over each walker
+    for i in range(fp.attrs["nwalkers"]):
+
+        # derived parameters
+        if param == "mchirp":
+            idx1 = opts.variable_args.index("mass1")
+            idx2 = opts.variable_args.index("mass2")
+            mchirp, _ = pnutils.mass1_mass2_to_mchirp_eta(samples[idx1], samples[idx2])
+            samples.append( mchirp )
+        elif param == "eta":
+            idx1 = opts.variable_args.index("mass1")
+            idx2 = opts.variable_args.index("mass2")
+            _, eta = pnutils.mass1_mass2_to_mchirp_eta(samples[idx1], samples[idx2])
+            samples.append( eta )
+
+        # MCMC parameters
+        else:
+            samples.append( fp[param]["walker%d"%i][opts.thin_start::opts.thin_interval] )
+
+#! FIXME: no data
+# calculate the score at a given percentile
+# 50 is the median, 16 and 84 correspond to 68 percentile
+low = numpy.percentile(data, 16)
+median = numpy.percentile(data, 50)
+high = numpy.percentile(data, 84)
+
+
+
+
+

--- a/bin/inference/pycbc_mcmc_table_summary
+++ b/bin/inference/pycbc_mcmc_table_summary
@@ -66,17 +66,16 @@ logging.info("Reading input file")
 fp = MCMCFile(opts.input_file, "r")
 
 # get thinned samples for each parameter
-samples = {}
 quantiles = {}
 for param in opts.variable_args:
-    samples[param] = fp.read_samples(param, thin_start=opts.thin_start,
-                           thin_interval=opts.thin_interval)
+    samples = fp.read_samples(param, thin_start=opts.thin_start,
+                              thin_interval=opts.thin_interval)
 
     # calculate the score at a given percentile
     # eg. 50 is the median, 16 and 84 correspond to 68 percentile
     param_quantiles = []
     for q in opts.quantiles:
-        param_quantiles.append( numpy.percentile(data, 100*q) )
+        param_quantiles.append( numpy.percentile(samples, 100*q) )
     quantiles[param] = param_quantiles
 
 

--- a/bin/inference/pycbc_mcmc_table_summary
+++ b/bin/inference/pycbc_mcmc_table_summary
@@ -20,7 +20,7 @@ import argparse
 import h5py
 import logging
 import numpy
-from pycbc.io.hdf import MCMCFile
+from pycbc.io.mcmc import MCMCFile
 
 # command line usage
 parser = argparse.ArgumentParser(usage="pycbc_mcmc_table_summary [--options]",
@@ -37,15 +37,15 @@ parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
 
 # add thinning options
-parser.add_argument("--thin-start", type=int, required=True,
+parser.add_argument("--thin-start", type=int, default=0,
     help="Sample number to start collecting samples to plot.")
-parser.add_argument("--thin-interval", type=int, required=True,
+parser.add_argument("--thin-interval", type=int, default=1,
     help="Interval to use for thinning samples.")
 
 # add quantile options
 parser.add_argument("--quantiles", type=float, nargs="+",
     default=[0.16,0.50,0.84],
-    help="Path to output plot.")
+    help="Quantiles to calculate.")
 
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
@@ -69,7 +69,7 @@ fp = MCMCFile(opts.input_file, "r")
 samples = {}
 quantiles = {}
 for param in opts.variable_args:
-    samples[param] = fp.read_samples(variable_arg, thin_start=opts.thin_start,
+    samples[param] = fp.read_samples(param, thin_start=opts.thin_start,
                            thin_interval=opts.thin_interval)
 
     # calculate the score at a given percentile

--- a/bin/inference/pycbc_mcmc_table_summary
+++ b/bin/inference/pycbc_mcmc_table_summary
@@ -20,6 +20,7 @@ import argparse
 import h5py
 import logging
 import numpy
+from pycbc.io.hdf import MCMCFile
 
 # command line usage
 parser = argparse.ArgumentParser(usage="pycbc_mcmc_table_summary [--options]",
@@ -33,6 +34,17 @@ parser.add_argument("--variable-args", type=str, nargs="+", required=True,
 
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
+    help="Path to output plot.")
+
+# add thinning options
+parser.add_argument("--thin-start", type=int, required=True,
+    help="Sample number to start collecting samples to plot.")
+parser.add_argument("--thin-interval", type=int, required=True,
+    help="Interval to use for thinning samples.")
+
+# add quantile options
+parser.add_argument("--quantiles", type=float, nargs="+",
+    default=[0.16,0.50,0.84],
     help="Path to output plot.")
 
 # verbose option
@@ -51,38 +63,21 @@ logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 
 # read input file
 logging.info("Reading input file")
-fp = h5py.File(opts.input_file, "r")
+fp = MCMCFile(opts.input_file, "r")
 
-# loop over each parameter
-samples_dict = []
+# get thinned samples for each parameter
+samples = {}
+quantiles = {}
 for param in opts.variable_args:
+    samples[param] = fp.read_samples(variable_arg, thin_start=opts.thin_start,
+                           thin_interval=opts.thin_interval)
 
-    # loop over each walker
-    for i in range(fp.attrs["nwalkers"]):
-
-        # derived parameters
-        if param == "mchirp":
-            idx1 = opts.variable_args.index("mass1")
-            idx2 = opts.variable_args.index("mass2")
-            mchirp, _ = pnutils.mass1_mass2_to_mchirp_eta(samples[idx1], samples[idx2])
-            samples.append( mchirp )
-        elif param == "eta":
-            idx1 = opts.variable_args.index("mass1")
-            idx2 = opts.variable_args.index("mass2")
-            _, eta = pnutils.mass1_mass2_to_mchirp_eta(samples[idx1], samples[idx2])
-            samples.append( eta )
-
-        # MCMC parameters
-        else:
-            samples.append( fp[param]["walker%d"%i][opts.thin_start::opts.thin_interval] )
-
-#! FIXME: no data
-# calculate the score at a given percentile
-# 50 is the median, 16 and 84 correspond to 68 percentile
-low = numpy.percentile(data, 16)
-median = numpy.percentile(data, 50)
-high = numpy.percentile(data, 84)
-
+    # calculate the score at a given percentile
+    # 50 is the median, 16 and 84 correspond to 68 percentile
+    param_quantiles = []
+    for q in opts.quantiles:
+        param_quantiles.append( numpy.percentile(data, 100*q) )
+    quantiles[param] = param_quantiles
 
 
 

--- a/bin/inference/pycbc_mcmc_table_summary
+++ b/bin/inference/pycbc_mcmc_table_summary
@@ -20,6 +20,8 @@ import argparse
 import h5py
 import logging
 import numpy
+import sys
+from pycbc import results
 from pycbc.io.mcmc import MCMCFile
 
 # command line usage
@@ -66,18 +68,32 @@ logging.info("Reading input file")
 fp = MCMCFile(opts.input_file, "r")
 
 # get thinned samples for each parameter
-quantiles = {}
+table = []
 for param in opts.variable_args:
     samples = fp.read_samples(param, thin_start=opts.thin_start,
                               thin_interval=opts.thin_interval)
 
+    # get label and set as first column in table
+    row = [fp.read_label(param)]
+
     # calculate the score at a given percentile
     # eg. 50 is the median, 16 and 84 correspond to 68 percentile
-    param_quantiles = []
+    quantiles = []
     for q in opts.quantiles:
-        param_quantiles.append( numpy.percentile(samples, 100*q) )
-    quantiles[param] = param_quantiles
+        quantiles.append( numpy.percentile(samples, 100*q) )
 
+    # add qunatiles to row
+    row += ["%.2f"%val for val in quantiles]
 
+    # add row to table
+    table.append(row)
 
+# make HTML table
+headers = ["Parameter"] + ["%.2f Quantile"%val for val in opts.quantiles]
+html = str( results.static_table(table, headers) )
 
+# save HTML table
+results.save_fig_with_metadata(html, opts.output_file, {},
+                 cmd=" ".join(sys.argv),
+                 title="Table of posterior parameters",
+                 caption="Table with quantiles for variable MCMC parameters.")

--- a/pycbc/io/mcmc.py
+++ b/pycbc/io/mcmc.py
@@ -152,7 +152,7 @@ class MCMCFile(h5py.File):
         # create a dataset for the acceptance fraction
         if acceptance_fraction is not None:
             self.create_dataset("acceptance_fraction",
-                                data=sampler.acceptance_fraction)
+                                data=acceptance_fraction)
 
 
 

--- a/pycbc/io/mcmc.py
+++ b/pycbc/io/mcmc.py
@@ -62,7 +62,7 @@ class MCMCFile(h5py.File):
         """
 
         nwalkers = self.attrs["nwalkers"]
-        return numpy.array([self.read_samples_from_walker(variable_arg, j, thin_start, thin_interval) for j in nwalkers])
+        return numpy.array([self.read_samples_from_walker(variable_arg, j, thin_start, thin_interval) for j in range(nwalkers)])
 
     def read_samples_from_walker(self, variable_arg, nwalker,
                                  thin_start=0, thin_interval=1):

--- a/pycbc/io/mcmc.py
+++ b/pycbc/io/mcmc.py
@@ -150,7 +150,7 @@ class MCMCFile(h5py.File):
                 group_dim.create_dataset(dataset_name, data=samples_subset)
 
         # create a dataset for the acceptance fraction
-        if acceptance_fraction:
+        if acceptance_fraction is not None:
             self.create_dataset("acceptance_fraction",
                                 data=sampler.acceptance_fraction)
 

--- a/pycbc/workflow/mcmcfollowups.py
+++ b/pycbc/workflow/mcmcfollowups.py
@@ -159,7 +159,7 @@ def make_inference_summary_table(workflow, mcmc_file, output_dir,
 
     # add command line options
     node.add_input_opt("--input-file", mcmc_file)
-    node.new_output_file_opt(analysis_seg, ".png", "--output-file")
+    node.new_output_file_opt(analysis_seg, ".html", "--output-file")
 
     # add node to workflow
     workflow += node

--- a/setup.py
+++ b/setup.py
@@ -469,6 +469,7 @@ setup (
                'bin/inference/pycbc_mcmc_plot_acf',
                'bin/inference/pycbc_mcmc_plot_corner',
                'bin/inference/pycbc_mcmc_plot_samples',
+               'bin/inference/pycbc_mcmc_table_summary',
                'bin/plotting/pycbc_plot_waveform',
                ],
     packages = [


### PR DESCRIPTION
This PR requires #849 and #862.

This PR:
  * It adds a table to the HTML page for the MCMC workflow that has the quantiles for each variable args.
  * Removes unpacking of ``sampler.run_mcmc`` and ``sampler.burn_in``.
  * Implements ``pycbc.io.mcmc.MCMCFile`` in ``pycbc_mcmc`` and ``pycbc_mcmc_table_summary``.

Example page is here: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/tmp_workflow_3/