### PR TITLE
do not require pylal for pycbc library

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -24,7 +24,7 @@ These instructions walk you through the process of
         * `Installing source from GitHub for development`_.
     * Optional additional installation steps
         * `Building and Installing Documentation`_.
-        * `Modifying pycbc-glue and pycbc-pylal`_.
+        * `Modifying pycbc-glue`_.
         * `Use of Intel MKL Optimized FFT libraries`_.
         * `Graphics Processing Unit support with CUDA`_
 

--- a/pycbc.spec
+++ b/pycbc.spec
@@ -7,7 +7,7 @@ Group:          Development/Libraries
 Source:         %{name}-%{version}.tar.gz
 Url:            http://www.lsc-group.phys.uwm.edu/daswg/projects/pycbc.html
 BuildRoot:      %{_tmppath}/%{name}-%{version}-root
-Requires:       python python-decorator python-pylal glue glue-segments lal lal-python lalframe lalframe-python lalsimulation lalsimulation-python lalinspiral lalinspiral-python numpy scipy
+Requires:       python python-decorator glue glue-segments lal lal-python lalframe lalframe-python lalsimulation lalsimulation-python lalinspiral lalinspiral-python numpy scipy
 BuildRequires:  python-devel lal-devel lalmetaio-devel lalframe-devel lalsimulation-devel lalinspiral-devel numpy pkgconfig
 %description
 PyCBC is a python toolkit for analysis of data from gravitational-wave

--- a/pycbc/results/legacy_grb.py
+++ b/pycbc/results/legacy_grb.py
@@ -28,17 +28,11 @@ from argparse import ArgumentParser
 import matplotlib; matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from glue import markup, segments
-from pylal import antenna, git_version
 from lal.gpstime import gps_to_utc, LIGOTimeGPS
 from matplotlib.patches import Rectangle
 from matplotlib.lines import Line2D
 from matplotlib.ticker import ScalarFormatter
 from pycbc.results.color import ifo_color
-
-__author__  = "Andrew Williamson <andrew.williamson@ligo.org>"
-__version__ = "git id %s" % git_version.id
-__date__    = git_version.date
-
 
 def initialize_page(title, style, script, header=None):
     """
@@ -129,6 +123,7 @@ def write_summary(page, args, ifos, skyError=None, ipn=False, ipnError=False):
     """
         Write summary of information to markup.page object page
     """
+    from pylal import antenna
 
     gps = args.start_time
     grbdate = gps_to_utc(LIGOTimeGPS(gps))\
@@ -199,6 +194,7 @@ def write_antenna(page, args, seg_plot=None, grid=False, ipn=False):
     Write antenna factors to merkup.page object page and generate John's
     detector response plot.
     """
+    from pylal import antenna
 
     page.h3()
     page.add('Antenna factors and sky locations')

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ try:
 except ImportError:
     pass
  
-requires = ['lal.lal', 'lalsimulation.lalsimulation', 'glue', 'pylal']
+requires = ['lal.lal', 'lalsimulation.lalsimulation', 'glue']
 setup_requires = []
 install_requires =  setup_requires + ['Mako>=1.0.1',
                       'argparse>=1.3.0',
@@ -64,7 +64,6 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'jinja2',
                       'mpld3>=0.3git',
                       'pyRXP>=2.1.0',
-                      'pycbc-pylal>=0.9.5',
                       'pycbc-glue>=0.9.8',
                       'kombine',
                       'emcee>=2.2.0',


### PR DESCRIPTION
This might be a bit provocative, but I'd like to remove pylal from the list of install requirements to PyCBC. It is not needed by the PyCBC library, except for a single function (pylal volume estimation) that we should be moving away from. The function, of course, will still work if pylal happens to be installed. For the time being, I think bundles should still be built with pylal, and some workflows (such as grb) will require pylal for scripts, etc. 

 @duncan-brown @a-r-williamson @spxiwh Can we remove pylal as a requirement for the pycbc library itself? Are there any showstoppers? 