### PR TITLE
Add executable to plot the prior PDF

### DIFF
--- a/bin/inference/pycbc_mcmc_plot_prior
+++ b/bin/inference/pycbc_mcmc_plot_prior
@@ -46,38 +46,28 @@ parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_prior [--options]",
     description="Plots corner plot of prior from MCMC.")
 
 # add input options
-parser.add_argument("--input-file", type=str, required=True,
-    help="Path to input HDF file.")
+parser.add_argument("--config-file", type=str, required=True,
+    help="A file parsable by pycbc.workflow.WorkflowConfigParser.")
 parser.add_argument("--subsection", type=str, required=True,
     help="")
-
-# add thinning options
-parser.add_argument("--thin-start", type=int, default=0,
-    help="Sample number to start collecting samples to plot.")
-parser.add_argument("--thin-interval", type=int, default=1,
-    help="Interval to use for thinning samples.")
 
 # add prior options
 parser.add_argument("--variable-args", type=str, nargs="+",  default=[],
     help="Name of parameters varied in MCMC.")
-parser.add_argument("--config-file", type=str, required=True,
-    help="A file parsable by pycbc.workflow.WorkflowConfigParser.")
 parser.add_argument("--bins", type=int, required=True,
     help="Number of points to evaluator parameter distributions.")
-parser.add_argument("--iterations", type=int, required=True,
-    help="Number of samples to collect from each prior distribution.")
 
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
 parser.add_argument("--plot-test-points",
     action="store_true", default=False,
-    help="")
+    help="If true then use a small number of test points instead of prior values.")
 parser.add_argument("--plot-interpolation-points",
     action="store_true", default=False,
-    help="")
+    help="If true then plot points used to interpolate greyscale.")
 parser.add_argument("--levels", type=int, default=5,
-    help="")
+    help="Number of levels to use in contour plot.")
 
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,

--- a/bin/inference/pycbc_mcmc_plot_prior
+++ b/bin/inference/pycbc_mcmc_plot_prior
@@ -19,6 +19,8 @@
 import argparse
 import corner
 import logging
+import itertools
+import math
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy
@@ -26,6 +28,17 @@ import sys
 from pycbc import inference, pnutils, results
 from pycbc.io.mcmc import MCMCFile
 from pycbc.workflow import WorkflowConfigParser
+
+def binomial_coeff(x, y):
+    """ Returns the binomial coefficient: x! / (y! * (x - y)!)
+    """
+    return  math.factorial(x) // math.factorial(y) // math.factorial(x - y)
+
+def cartesian(arrays):
+    """ Returns a cartesian product from a list of iterables.
+    """
+    return [element for element in itertools.product(*arrays)]
+
 
 # command line usage
 parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_prior [--options]",
@@ -73,34 +86,78 @@ logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 logging.info("Reading configuration file")
 cp = WorkflowConfigParser([opts.config_file])
 
-# get variable parameters in MCMC from configuration file
-if len(opts.variable_args):
-    variable_args = opts.variable_args
-else:
-    variable_args = cp.options("variable_args")
+# get distribution from inference configuration file
+subsection = "mass1+mass2"
+name = cp.get_opt_tag("prior", "name", subsection)
+dist = inference.priors[name].from_config(cp, "prior", subsection)
 
-# get distribution to use for evaluating prior
-# construct class that will return the prior
-distributions = []
-for subsection in cp.get_subsections("prior"):
-    name = cp.get_opt_tag("prior", "name", subsection)
-    distributions.append( inference.priors[name].from_config(cp, "prior", subsection) )
+# find all unique combinations of parameters for subplots axes
+combos = itertools.combinations(dist.params, 2)
 
+# scale number of subplots with dimensions of the distribution
+fig, axs = plt.subplots( binomial_coeff(len(dist.params),2) )
+axs = [axs] if binomial_coeff(len(dist.params),2) is 1 else axs
+
+# get all points in space to calculate PDF
+vals = []
+for param in dist.params:
+    step = float(dist.bounds[param][1]-dist.bounds[param][0]) / opts.bins
+    vals.append( numpy.arange(dist.bounds[param][0],dist.bounds[param][1],step) )
+pts = cartesian(vals)
+
+# evaulate PDF between the bounds
+pdf = []
+for pt in pts:
+    pt_dict = dict([(param,pt[j]) for j,param in enumerate(dist.params)])
+    pdf.append( dist.pdf(**pt_dict) )
+
+print pts[0]
+
+# loop over all axes combinations
+for i,combo in enumerate(combos):
+
+    # select x and y axes
+    x_label = combo[0]
+    y_label = combo[1]
+
+    # get index for each parameter
+    x_idx = dist.params.index(x_label)
+    y_idx = dist.params.index(y_label)
+
+    x = [pt[x_idx] for pt in pts]
+    y = [pt[y_idx] for pt in pts]
+
+    print len(x), len(y), len(pts)
+
+    axs[i].contour(x,y,pdf)
+
+
+plt.savefig(opts.output_file)
+plt.close()
+
+
+sys.exit()
 # read input file
 logging.info("Reading input file")
 fp = MCMCFile(opts.input_file, "r")
 
 # make a subplot for each distribution
+#fig, axs = plt.subplots(len(distributions))
+#axs = [axs] if len(distributions) is 1 else axs
+
 fig, axs = plt.subplots(len(distributions))
-axs = [axs] if len(distributions) is 1 else axs
 
 # loop over distributions from prior
 for i,dist in enumerate(distributions):
 
-    # get bounds for each parameter
+    # if multi-parameter distribution
+    if len(dist.params) > 1:
+
+        
+        continue
+
+    # if single-parameter distribution
     params = dist.params
-    if len(params) > 1:
-        raise ValueError("Can only handle one variable parameter at a time")
     if params[0] not in variable_args:
         continue
     bounds = dist.bounds[params[0]]

--- a/bin/inference/pycbc_mcmc_plot_prior
+++ b/bin/inference/pycbc_mcmc_plot_prior
@@ -18,21 +18,34 @@
 
 import argparse
 import corner
-import h5py
 import logging
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy
-from pycbc import inference, pnutils
+import sys
+from pycbc import inference, pnutils, results
+from pycbc.io.mcmc import MCMCFile
 from pycbc.workflow import WorkflowConfigParser
 
 # command line usage
 parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_prior [--options]",
     description="Plots corner plot of prior from MCMC.")
 
+# add input options
+parser.add_argument("--input-file", type=str, required=True,
+    help="Path to input HDF file.")
+
+# add thinning options
+parser.add_argument("--thin-start", type=int, default=0,
+    help="Sample number to start collecting samples to plot.")
+parser.add_argument("--thin-interval", type=int, default=1,
+    help="Interval to use for thinning samples.")
+
 # add prior options
 parser.add_argument("--config-file", type=str, required=True,
     help="A file parsable by pycbc.workflow.WorkflowConfigParser.")
+parser.add_argument("--bins", type=int, required=True,
+    help="Number of points to evaluator parameter distributions.")
 parser.add_argument("--iterations", type=int, required=True,
     help="Number of samples to collect from each prior distribution.")
 
@@ -68,9 +81,74 @@ for param in variable_args:
     distributions.append( inference.distribution_from_config(cp, "prior", param) )
 prior = inference.PriorEvaluator(variable_args, *distributions)
 
-# loop over number of samples to draw from prior
-#for i in range(opts.iterations):
+# read input file
+logging.info("Reading input file")
+fp = MCMCFile(opts.input_file, "r")
 
+# make a subplot for each distribution
+fig, axs = plt.subplots(len(distributions))
+axs = [axs] if len(distributions) is 1 else axs
 
+# loop over distributions from prior
+for i,dist in enumerate(distributions):
+
+    # get bounds for each parameter
+    params = dist.params
+    if len(params) > 1:
+        raise ValueError("Can only handle one variable parameter at a time")
+    bounds = dist.bounds[params[0]]
+
+    # evaulate PDF between the bounds
+    pdf = []
+    x = []
+    step = float(bounds[1]-bounds[0])/opts.bins
+    for j in numpy.arange(bounds[0], bounds[1], step):
+        pdf.append( dist.pdf(**{params[0]:j}) )
+        x.append(j)
+
+    # plot each distribution as a different line on the subplot
+    axs[i].plot(x, pdf, label="PDF")
+
+    # read samples from file
+    samples = fp.read_samples(params[0], thin_start=opts.thin_start,
+                                    thin_interval=opts.thin_interval)
+    samples = numpy.concatenate(samples)
+
+    # plot histogram of samples
+    weights = numpy.ones(len(samples)) / float(len(samples))
+    axs[i].hist(samples, bins=opts.bins, weights=weights,
+                histtype="stepfilled", fc=(0, 0, 0, 0), label="Samples")
+
+    # y-axis label
+    axs[i].set_ylabel(", ".join([p for p in dist.params]))
+
+    # y-axis limits
+    axs[i].set_ylim(0, 1.1)
+
+    # x-axis limits
+    low = bounds[0] - 5 * step
+    high = bounds[1] + 5 * step
+    axs[i].set_xlim(low, high)
+
+    # legend
+    if i == 0:
+        axs[i].legend(loc="upper right")
+
+# save figure with meta-data
+caption_kwargs = {
+    "parameters" : ", ".join(variable_args),
+}
+caption = """The probability density function (PDF) is drawn in blue. Samples
+drawn from the MCMC are shown as a histogram outlined in black. The histogram
+is normalized to the total number of samples."""
+title = "Prior distribution for {parameters}".format(**caption_kwargs)
+results.save_fig_with_metadata(fig, opts.output_file,
+                               cmd=" ".join(sys.argv),
+                               title=title,
+                               caption=caption)
+plt.close()
+
+# exit
+logging.info("Done")
 
 

--- a/bin/inference/pycbc_mcmc_plot_prior
+++ b/bin/inference/pycbc_mcmc_plot_prior
@@ -1,0 +1,76 @@
+#! /usr/bin/evn python
+
+# Copyright (C) 2016 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import argparse
+import corner
+import h5py
+import logging
+import matplotlib as mpl; mpl.use("Agg")
+import matplotlib.pyplot as plt
+import numpy
+from pycbc import inference, pnutils
+from pycbc.workflow import WorkflowConfigParser
+
+# command line usage
+parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_prior [--options]",
+    description="Plots corner plot of prior from MCMC.")
+
+# add prior options
+parser.add_argument("--config-file", type=str, required=True,
+    help="A file parsable by pycbc.workflow.WorkflowConfigParser.")
+parser.add_argument("--iterations", type=int, required=True,
+    help="Number of samples to collect from each prior distribution.")
+
+# output plot options
+parser.add_argument("--output-file", type=str, required=True,
+    help="Path to output plot.")
+
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+    help="")
+
+# parse the command line
+opts = parser.parse_args()
+
+# setup log
+if opts.verbose:
+    log_level = logging.DEBUG
+else:
+    log_level = logging.WARN
+logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
+
+# read configuration file
+logging.info("Reading configuration file")
+cp = WorkflowConfigParser([opts.config_file])
+
+# get variable parameters in MCMC from configuration file
+variable_args = cp.options("variable_args")
+
+# get distribution to use for evaluating prior
+# construct class that will return the prior
+distributions = []
+for param in variable_args:
+    distributions.append( inference.distribution_from_config(cp, "prior", param) )
+prior = inference.PriorEvaluator(variable_args, *distributions)
+
+# loop over number of samples to draw from prior
+#for i in range(opts.iterations):
+
+
+
+

--- a/bin/inference/pycbc_mcmc_plot_prior
+++ b/bin/inference/pycbc_mcmc_plot_prior
@@ -82,9 +82,9 @@ else:
 # get distribution to use for evaluating prior
 # construct class that will return the prior
 distributions = []
-for param in variable_args:
-    distributions.append( inference.distribution_from_config(cp, "prior", param) )
-prior = inference.PriorEvaluator(variable_args, *distributions)
+for subsection in cp.get_subsections("prior"):
+    name = cp.get_opt_tag("prior", "name", subsection)
+    distributions.append( inference.priors[name].from_config(cp, "prior", subsection) )
 
 # read input file
 logging.info("Reading input file")
@@ -101,6 +101,8 @@ for i,dist in enumerate(distributions):
     params = dist.params
     if len(params) > 1:
         raise ValueError("Can only handle one variable parameter at a time")
+    if params[0] not in variable_args:
+        continue
     bounds = dist.bounds[params[0]]
 
     # evaulate PDF between the bounds

--- a/bin/inference/pycbc_mcmc_plot_prior
+++ b/bin/inference/pycbc_mcmc_plot_prior
@@ -48,6 +48,8 @@ parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_prior [--options]",
 # add input options
 parser.add_argument("--input-file", type=str, required=True,
     help="Path to input HDF file.")
+parser.add_argument("--subsection", type=str, required=True,
+    help="")
 
 # add thinning options
 parser.add_argument("--thin-start", type=int, default=0,
@@ -68,6 +70,14 @@ parser.add_argument("--iterations", type=int, required=True,
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
+parser.add_argument("--plot-test-points",
+    action="store_true", default=False,
+    help="")
+parser.add_argument("--plot-interpolation-points",
+    action="store_true", default=False,
+    help="")
+parser.add_argument("--levels", type=int, default=5,
+    help="")
 
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
@@ -75,6 +85,10 @@ parser.add_argument("--verbose", action="store_true", default=False,
 
 # parse the command line
 opts = parser.parse_args()
+
+# sanity check number of parameters to plot
+if len(opts.variable_args) > 2:
+    raise ValueError("You cannot plot more than two parameters.")
 
 # setup log
 if opts.verbose:
@@ -88,18 +102,15 @@ logging.info("Reading configuration file")
 cp = WorkflowConfigParser([opts.config_file])
 
 # get distribution from inference configuration file
-subsection = "mass1+mass2"
-name = cp.get_opt_tag("prior", "name", subsection)
-dist = inference.priors[name].from_config(cp, "prior", subsection)
-
-# find all unique combinations of parameters for subplots axes
-combos = itertools.combinations(dist.params, 2)
+name = cp.get_opt_tag("prior", "name", opts.subsection)
+dist = inference.priors[name].from_config(cp, "prior", opts.subsection)
 
 # scale number of subplots with dimensions of the distribution
 fig, axs = plt.subplots( binomial_coeff(len(dist.params),2) )
 axs = [axs] if binomial_coeff(len(dist.params),2) is 1 else axs
 
 # get all points in space to calculate PDF
+logging.info("Getting grid of points")
 vals = []
 for param in dist.params:
     step = float(dist.bounds[param][1]-dist.bounds[param][0]) / opts.bins
@@ -107,45 +118,66 @@ for param in dist.params:
 pts = cartesian(vals)
 
 # evaulate PDF between the bounds
+logging.info("Calculating PDF")
 pdf = []
 for pt in pts:
     pt_dict = dict([(param,pt[j]) for j,param in enumerate(dist.params)])
     pdf.append( dist.pdf(**pt_dict) )
 pdf = numpy.array(pdf)
 
-# Generate data:
-x = pts[:,0]
-y = pts[:,1]
-z = pdf
+# map data to (x,y,z) values
+# since we only have a uniform distribution
+# allow user to plot a set of test points
+logging.info("Plotting")
+if opts.plot_test_points:
+    x, y, z = 10 * numpy.random.random((3,10))
+else:
+    i = dist.params.index(opts.variable_args[0])
+    j = dist.params.index(opts.variable_args[1])
+    x = pts[:,i]
+    y = pts[:,j]
+    z = pdf
 
-
-x, y, z = 10 * numpy.random.random((3,10))
-
-# Set up a regular grid of interpolation points
-xi, yi = numpy.linspace(x.min(), x.max(), 100), numpy.linspace(y.min(), y.max(), 100)
+# create grid of interpolation points
+xi = numpy.linspace(x.min(), x.max(), opts.bins)
+yi = numpy.linspace(y.min(), y.max(), opts.bins)
 xi, yi = numpy.meshgrid(xi, yi)
 
-# Interpolate
+# interpolate
 rbf = scipy.interpolate.Rbf(x, y, z, function='linear')
 zi = rbf(xi, yi)
 
-xstep = float(dist.bounds["mass1"][1]-dist.bounds["mass1"][0])/opts.bins
-ystep = float(dist.bounds["mass2"][1]-dist.bounds["mass2"][0])/opts.bins
+# plot interpolation points
+if opts.plot_interpolation_points:
+    plt.scatter(x, y)
 
+# plot contours
 extent = [x.min(), x.max(), y.min(), y.max()]
-
-#plt.scatter(x, y, c=z)
 low = 0.9*min(z)
 high = 1.1*max(z)
-levels = numpy.arange(low, high, (high-low)/5)
+levels = numpy.arange(low, high, (high-low)/opts.levels)
 c = plt.contour(zi, levels, hold='on', colors='w',
         origin='lower', extent=extent)
 plt.clabel(c, inline=1, fontsize=10)
-hot = plt.get_cmap("Greys")
+
+# plot greyscale
+cmap = plt.get_cmap("Greys")
 plt.imshow(zi, vmin=z.min(), vmax=z.max(), origin='lower', aspect="auto",
-           extent=extent, cmap=hot)
-plt.colorbar()
+           extent=extent, cmap=cmap)
 
+# format plot
+if opts.plot_test_points:
+    plt.colorbar(label="random test variable")
+    plt.xlabel("random test variable")
+    plt.ylabel("random test variable")
+else:
+    plt.colorbar(label="Probability Density Function")
+    plt.xlabel(opts.variable_args[0])
+    plt.ylabel(opts.variable_args[1])
+
+# save
 plt.savefig(opts.output_file)
+plt.close()
 
-
+# exit
+logging.info("Finished")

--- a/bin/inference/pycbc_mcmc_plot_prior
+++ b/bin/inference/pycbc_mcmc_plot_prior
@@ -42,6 +42,8 @@ parser.add_argument("--thin-interval", type=int, default=1,
     help="Interval to use for thinning samples.")
 
 # add prior options
+parser.add_argument("--variable-args", type=str, nargs="+",  default=[],
+    help="Name of parameters varied in MCMC.")
 parser.add_argument("--config-file", type=str, required=True,
     help="A file parsable by pycbc.workflow.WorkflowConfigParser.")
 parser.add_argument("--bins", type=int, required=True,
@@ -72,7 +74,10 @@ logging.info("Reading configuration file")
 cp = WorkflowConfigParser([opts.config_file])
 
 # get variable parameters in MCMC from configuration file
-variable_args = cp.options("variable_args")
+if len(opts.variable_args):
+    variable_args = opts.variable_args
+else:
+    variable_args = cp.options("variable_args")
 
 # get distribution to use for evaluating prior
 # construct class that will return the prior

--- a/bin/inference/pycbc_mcmc_plot_prior
+++ b/bin/inference/pycbc_mcmc_plot_prior
@@ -24,6 +24,7 @@ import math
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy
+import scipy
 import sys
 from pycbc import inference, pnutils, results
 from pycbc.io.mcmc import MCMCFile
@@ -37,7 +38,7 @@ def binomial_coeff(x, y):
 def cartesian(arrays):
     """ Returns a cartesian product from a list of iterables.
     """
-    return [element for element in itertools.product(*arrays)]
+    return numpy.array([numpy.array(element) for element in itertools.product(*arrays)])
 
 
 # command line usage
@@ -110,109 +111,41 @@ pdf = []
 for pt in pts:
     pt_dict = dict([(param,pt[j]) for j,param in enumerate(dist.params)])
     pdf.append( dist.pdf(**pt_dict) )
+pdf = numpy.array(pdf)
 
-print pts[0]
+# Generate data:
+x = pts[:,0]
+y = pts[:,1]
+z = pdf
 
-# loop over all axes combinations
-for i,combo in enumerate(combos):
 
-    # select x and y axes
-    x_label = combo[0]
-    y_label = combo[1]
+x, y, z = 10 * numpy.random.random((3,10))
 
-    # get index for each parameter
-    x_idx = dist.params.index(x_label)
-    y_idx = dist.params.index(y_label)
+# Set up a regular grid of interpolation points
+xi, yi = numpy.linspace(x.min(), x.max(), 100), numpy.linspace(y.min(), y.max(), 100)
+xi, yi = numpy.meshgrid(xi, yi)
 
-    x = [pt[x_idx] for pt in pts]
-    y = [pt[y_idx] for pt in pts]
+# Interpolate
+rbf = scipy.interpolate.Rbf(x, y, z, function='linear')
+zi = rbf(xi, yi)
 
-    print len(x), len(y), len(pts)
+xstep = float(dist.bounds["mass1"][1]-dist.bounds["mass1"][0])/opts.bins
+ystep = float(dist.bounds["mass2"][1]-dist.bounds["mass2"][0])/opts.bins
 
-    axs[i].contour(x,y,pdf)
+extent = [x.min(), x.max(), y.min(), y.max()]
 
+#plt.scatter(x, y, c=z)
+low = 0.9*min(z)
+high = 1.1*max(z)
+levels = numpy.arange(low, high, (high-low)/5)
+c = plt.contour(zi, levels, hold='on', colors='w',
+        origin='lower', extent=extent)
+plt.clabel(c, inline=1, fontsize=10)
+hot = plt.get_cmap("Greys")
+plt.imshow(zi, vmin=z.min(), vmax=z.max(), origin='lower', aspect="auto",
+           extent=extent, cmap=hot)
+plt.colorbar()
 
 plt.savefig(opts.output_file)
-plt.close()
-
-
-sys.exit()
-# read input file
-logging.info("Reading input file")
-fp = MCMCFile(opts.input_file, "r")
-
-# make a subplot for each distribution
-#fig, axs = plt.subplots(len(distributions))
-#axs = [axs] if len(distributions) is 1 else axs
-
-fig, axs = plt.subplots(len(distributions))
-
-# loop over distributions from prior
-for i,dist in enumerate(distributions):
-
-    # if multi-parameter distribution
-    if len(dist.params) > 1:
-
-        
-        continue
-
-    # if single-parameter distribution
-    params = dist.params
-    if params[0] not in variable_args:
-        continue
-    bounds = dist.bounds[params[0]]
-
-    # evaulate PDF between the bounds
-    pdf = []
-    x = []
-    step = float(bounds[1]-bounds[0])/opts.bins
-    for j in numpy.arange(bounds[0], bounds[1], step):
-        pdf.append( dist.pdf(**{params[0]:j}) )
-        x.append(j)
-
-    # plot each distribution as a different line on the subplot
-    axs[i].plot(x, pdf, label="PDF")
-
-    # read samples from file
-    samples = fp.read_samples(params[0], thin_start=opts.thin_start,
-                                    thin_interval=opts.thin_interval)
-    samples = numpy.concatenate(samples)
-
-    # plot histogram of samples
-    weights = numpy.ones(len(samples)) / float(len(samples))
-    axs[i].hist(samples, bins=opts.bins, weights=weights,
-                histtype="stepfilled", fc=(0, 0, 0, 0), label="Samples")
-
-    # y-axis label
-    axs[i].set_ylabel(", ".join([p for p in dist.params]))
-
-    # y-axis limits
-    axs[i].set_ylim(0, 1.1)
-
-    # x-axis limits
-    low = bounds[0] - 5 * step
-    high = bounds[1] + 5 * step
-    axs[i].set_xlim(low, high)
-
-    # legend
-    if i == 0:
-        axs[i].legend(loc="upper right")
-
-# save figure with meta-data
-caption_kwargs = {
-    "parameters" : ", ".join(variable_args),
-}
-caption = """The probability density function (PDF) is drawn in blue. Samples
-drawn from the MCMC are shown as a histogram outlined in black. The histogram
-is normalized to the total number of samples."""
-title = "Prior distribution for {parameters}".format(**caption_kwargs)
-results.save_fig_with_metadata(fig, opts.output_file,
-                               cmd=" ".join(sys.argv),
-                               title=title,
-                               caption=caption)
-plt.close()
-
-# exit
-logging.info("Done")
 
 

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -197,7 +197,6 @@ class Uniform(object):
         special_args = ["name"] + ["min-%s"%param for param in variable_args] \
                                 + ["max-%s"%param for param in variable_args]
 
-
         # get a dict with bounds as value
         dist_args = {}
         for param in variable_args:

--- a/pycbc/io/mcmc.py
+++ b/pycbc/io/mcmc.py
@@ -84,7 +84,7 @@ class MCMCFile(h5py.File):
         numpy.array
             Samples from a specific walker for a parameter.
         """
-        return self[variable_arg]["walker%d"%nwalker][:]
+        return self[variable_arg]["walker%d"%nwalker][thin_start::thin_interval]
 
     def read_label(self, variable_arg):
         """ Returns the label for the parameter.

--- a/setup.py
+++ b/setup.py
@@ -468,6 +468,7 @@ setup (
                'bin/inference/pycbc_mcmc_plot_acceptance_rate',
                'bin/inference/pycbc_mcmc_plot_acf',
                'bin/inference/pycbc_mcmc_plot_corner',
+               'bin/inference/pycbc_mcmc_plot_prior',
                'bin/inference/pycbc_mcmc_plot_samples',
                'bin/inference/pycbc_mcmc_table_summary',
                'bin/plotting/pycbc_plot_waveform',


### PR DESCRIPTION
This PR just adds an executable that plots the PDF of the distributions from the ``pycbc.inference.prior`` module.

Depends on #849 and #862.

Example plot is here: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/prior_test.png