### PR TITLE
Update location of xrootd server

### DIFF
--- a/pycbc/workflow/pegasus_files/pegasus-properties.conf
+++ b/pycbc/workflow/pegasus_files/pegasus-properties.conf
@@ -8,7 +8,7 @@ pegasus.dir.storage.mapper.replica.file=output.map
 # XrootD for OSG, then gridftp, then anything else
 pegasus.selector.replica=Regex
 pegasus.selector.replica.regex.rank.1=file://scratch.*
-pegasus.selector.replica.regex.rank.2=root://srm.unl.edu.*
+pegasus.selector.replica.regex.rank.2=root://xrootd-local.unl.edu.*
 pegasus.selector.replica.regex.rank.3=gridftp://.*
 pegasus.selector.replica.regex.rank.4=.\*
 


### PR DESCRIPTION
This updates the location of the xrootd server at UNL from `srm.unl.edu` to `xrootd-local.unl.edu`.  The corresponding changes to the cache file in the pycbc-config repo have already been made.