### PR TITLE
Add pycbc_submit_dax to the set of bundles

### DIFF
--- a/install_pycbc.sh
+++ b/install_pycbc.sh
@@ -791,6 +791,9 @@ if [[ $IS_BUNDLE_ENV == "yes" ]] ; then
   condor_check_userlogs pyinstaller_build_1.log
   grep "Normal termination (return value 0)" build_static.dag.dagman.log
 
+  # Create the pycbc_submit_dax "bundle" (inline tar with config files)
+  ./bundle_pycbc_submit_dax.sh
+
   #Copy the existing static files into the dist directory
   cp -v ${VIRTUAL_ENV}/bin/lalapps_inspinj dist/
   for prog in lalapps_cbc_sbank_choose_mchirp_boundaries lalapps_cbc_sbank_merge_sims lalapps_cbc_sbank_pipe lalapps_cbc_sbank lalapps_cbc_sbank_sim 


### PR DESCRIPTION
pycbc_submit_dax is a shell script so needs special handling.  The script to this is already available, this patch just adds a call to that script to the installer.