### PR TITLE
Update bundle install and instructions

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -24,15 +24,34 @@ To create a new PyCBC release:
 #. Set ``release = False`` in PyCBC's setup.py file.
 #. Commit these changes and push them to the repository.
 
-To decide what will be in each new  release.
+.. note::
+
+    Releases of PyCBC should be made from the master. Do not make a branch
+    unless you are back-porting a bug fix from a new release series to an
+    old production release series.
+
+------------------------------------------------
+Backporting Bug Fixes to Previous Release Series
+------------------------------------------------
+
+Branches should only be created when bug fixes from master need to be back
+ported to an old release series (e.g. adding a bug fix from the 1.4 series to
+the 1.3 series. 
+
+To create a branch for the bug fix, make a new branch from the last release
+tag and cherry pick the changes to that branch. For example, to create a
+``1.3.8`` branch to add bug fixes to the ``1.3.7`` release, you should
 
 .. code:: bash
 
-  git checkout v1.3
+  git checkout -b b1.3.8 v1.3.7
   git cherry-pick [hash of first change]
   git cherry-pick [hash of second change]
   [continue using git cherry-pick for all new changes]
   git commit
+  git push
+
+Then go to the `PyCBC release page <https://github.com/ligo-cbc/pycbc/releases>`_ and click on ``Draft a new release`` following the instructions above.
 
 =====================================
 Uploading to the Python Package Index

--- a/install_pycbc.sh
+++ b/install_pycbc.sh
@@ -784,6 +784,13 @@ if [[ $IS_BUNDLE_ENV == "yes" ]] ; then
   #Run the dag that makes the bundles
   condor_submit_dag build_static.dag
 
+  #Build the ligolw tools
+  pushd ${VIRTUAL_ENV}/bin
+  for prog in ligolw_add ligolw_combine_segments ligolw_segments_from_cats_dqsegdb ligolw_segment_query_dqsegdb
+  do pyinstaller ${prog} --strip --onefile
+  done
+  popd
+
   # Wait for the dag to finish
   condor_wait -status -echo build_static.dag.dagman.log
 
@@ -796,7 +803,7 @@ if [[ $IS_BUNDLE_ENV == "yes" ]] ; then
 
   #Copy the existing static files into the dist directory
   cp -v ${VIRTUAL_ENV}/bin/lalapps_inspinj dist/
-  for prog in lalapps_cbc_sbank_choose_mchirp_boundaries lalapps_cbc_sbank_merge_sims lalapps_cbc_sbank_pipe lalapps_cbc_sbank lalapps_cbc_sbank_sim 
+  for prog in lalapps_cbc_sbank_choose_mchirp_boundaries lalapps_cbc_sbank_merge_sims lalapps_cbc_sbank_pipe lalapps_cbc_sbank lalapps_cbc_sbank_sim ligolw_add ligolw_combine_segments ligolw_segments_from_cats_dqsegdb ligolw_segment_query_dqsegdb
     do cp -v ${VIRTUAL_ENV}/bin/$prog dist/
   done
 

--- a/install_pycbc.sh
+++ b/install_pycbc.sh
@@ -785,11 +785,14 @@ if [[ $IS_BUNDLE_ENV == "yes" ]] ; then
   condor_submit_dag build_static.dag
 
   #Build the ligolw tools
+  export PYINSTALLER_CONFIG_DIR=`mktemp --tmpdir -d -t pyinstaller-XXXXXXXXXX`
   pushd ${VIRTUAL_ENV}/bin
   for prog in ligolw_add ligolw_combine_segments ligolw_segments_from_cats_dqsegdb ligolw_segment_query_dqsegdb
   do pyinstaller ${prog} --strip --onefile
   done
   popd
+  rm -rf ${PYINSTALLER_CONFIG_DIR}
+  unset PYINSTALLER_CONFIG_DIR
 
   # Wait for the dag to finish
   condor_wait -status -echo build_static.dag.dagman.log


### PR DESCRIPTION
This fixes a problem with the build instructions https://github.com/ligo-cbc/pycbc/issues/876 and also includes the necessary ``ligolw`` tools as bundles.