### PR TITLE
Allow MCMC executable to use multi-parameter prior distributions

### DIFF
--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -143,7 +143,8 @@ with ctx:
     # sanity check that each parameter in [variable_args] has a priors section
     variable_args = cp.options("variable_args")
     subsections = cp.get_subsections("prior")
-    if not all(param in subsections for param in variable_args):
+    tags = numpy.concatenate([tag.split("+") for tag in subsections])
+    if not any(param in tags for param in variable_args):
         raise KeyError("You are missing a priors section in the config file.")
 
     # get parameters that do not change in MCMC
@@ -158,8 +159,9 @@ with ctx:
     # get prior distribution for each variable parameter
     logging.info("Setting up priors for each parameter")
     distributions = []
-    for param in variable_args:
-        distributions.append( inference.distribution_from_config(cp, "prior", param) )
+    for subsection in cp.get_subsections("prior"):
+        name = cp.get_opt_tag("prior", "name", subsection)
+        distributions.append( inference.priors[name].from_config(cp, "prior", subsection) )
 
     # construct class that will return the prior
     prior = inference.PriorEvaluator(variable_args, *distributions)
@@ -188,20 +190,27 @@ with ctx:
     # get distribution to draw from for each walker initial position
     logging.info("Setting walkers initial conditions for varying parameters")
 
-    # get distribution to draw from for each walker initial condition
+    # check if user wants to use different distributions than prior for setting
+    # walkers initial positions
     initial_distributions = []
-    for param in variable_args:
-        if cp.has_section("initial-%s"%param):
-            initial_distributions.append( inference.distribution_from_config(cp, "initial", param) )
-        else:
-            initial_distributions.append( inference.distribution_from_config(cp, "prior", param) )
+    if len(cp.get_subsections("initial")):
+        section = "initial"
+    else:
+        section = "prior"
+
+    # get distribution to draw from for each walker initial condition
+    for subsection in cp.get_subsections(section):
+        name = cp.get_opt_tag(section, "name", subsection)
+        initial_distributions.append( inference.priors[name].from_config(cp, section, tag) )
 
     #loop over number of walkers
     # set initial values for variable parameters for this walker
     p0 = numpy.ones(shape=(opts.nwalkers, ndim))
     for i,_ in enumerate(p0):
-        p0[i] = [initial_distributions[j].rvs(size=1, param=variable_args[j])[0][0] \
-                                                          for j in range(ndim)]
+        for j,param in enumerate(variable_args):
+            for idist in initial_distributions:
+                if param in idist.params:
+                    p0[i][j] = idist.rvs(size=1, param=param)[0][0]
 
     # check if user wants to skip the burn in
     if not opts.skip_burn_in:

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -201,16 +201,19 @@ with ctx:
     # get distribution to draw from for each walker initial condition
     for subsection in cp.get_subsections(section):
         name = cp.get_opt_tag(section, "name", subsection)
-        initial_distributions.append( inference.priors[name].from_config(cp, section, tag) )
+        initial_distributions.append( inference.priors[name].from_config(cp, section, subsection) )
 
-    #loop over number of walkers
-    # set initial values for variable parameters for this walker
+    # set initial values for variable parameters for each walker
+    # loop over all walkers and then parameters
+    # find the distribution that has that parameter in it and draw a
+    # random value from the distribution
     p0 = numpy.ones(shape=(opts.nwalkers, ndim))
     for i,_ in enumerate(p0):
         for j,param in enumerate(variable_args):
             for idist in initial_distributions:
                 if param in idist.params:
                     p0[i][j] = idist.rvs(size=1, param=param)[0][0]
+                    break
 
     # check if user wants to skip the burn in
     if not opts.skip_burn_in:

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -186,7 +186,7 @@ class Uniform(object):
 
          Returns
          -------
-         distribution
+         Uniform
              A distribution instance from the pycbc.inference.prior module.
         """
 
@@ -197,7 +197,6 @@ class Uniform(object):
         special_args = ["name"] + ["min-%s"%param for param in variable_args] \
                                 + ["max-%s"%param for param in variable_args]
 
-        print variable_args, tag
 
         # get a dict with bounds as value
         dist_args = {}
@@ -224,7 +223,6 @@ class Uniform(object):
             dist_args.update({key:val})
 
         # construction distribution and add to list
-        print dist_args
         return cls(**dist_args)
 
 priors = {Uniform.name: Uniform}

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -169,57 +169,65 @@ class Uniform(object):
                                         size=size)
         return arr
 
+    @classmethod
+    def from_config(cls, cp, section, tag):
+        """ Returns a distribution based on a configuration file.
+
+        Parameters
+         ----------
+         cp : pycbc.workflow.WorkflowConfigParser
+             A parsed configuration file that contains the distribution
+             options.
+         section : str
+             Name of the section in the configuration file.
+         tag : str
+             Name of the tag in the configuration file to use, eg. the
+             configuration file has a [section-tag] section.
+
+         Returns
+         -------
+         distribution
+             A distribution instance from the pycbc.inference.prior module.
+        """
+
+        # seperate out tags from section tag
+        variable_args = tag.split("+")
+
+        # list of args that are used to construct distribution
+        special_args = ["name"] + ["min-%s"%param for param in variable_args] \
+                                + ["max-%s"%param for param in variable_args]
+
+        print variable_args, tag
+
+        # get a dict with bounds as value
+        dist_args = {}
+        for param in variable_args:
+            low = float(cp.get_opt_tag(section, "min-%s"%param, tag))
+            high = float(cp.get_opt_tag(section, "max-%s"%param, tag))
+            dist_args[param] = (low,high)
+
+        # add any additional options that user put in that section
+        for key in cp.options( "-".join([section,tag]) ):
+
+            # ignore options that are already included
+            if key in special_args:
+                continue
+
+            # check if option can be cast as a float
+            val = cp.get_opt_tag("prior", key, tag)
+            try:
+                val = float(val)
+            except:
+                pass
+
+            # add option
+            dist_args.update({key:val})
+
+        # construction distribution and add to list
+        print dist_args
+        return cls(**dist_args)
+
 priors = {Uniform.name: Uniform}
-
-def distribution_from_config(cp, section, tag):
-    """ Returns a distribution based on a configuration file.
-
-    Parameters
-     ----------
-     cp : pycbc.workflow.WorkflowConfigParser
-         A parsed configuration file that contains the distribution options.
-     section : str
-         Name of the section in the configuration file.
-     tag : str
-         Name of the tag in the configuration file to use, eg. the
-         configuration file has a [section-tag] section.
-
-     Returns
-     -------
-     distribution
-         A distribution instance from the pycbc.inference.prior module.
-    """
-
-    # list of args that are used to construct distribution
-    special_args = ["name", "min", "max"]
-
-    # get name of distribution to use
-    name = cp.get_opt_tag(section, "name", tag)
-
-    # get a dict with bounds as value
-    low = float(cp.get_opt_tag(section, "min", tag))
-    high = float(cp.get_opt_tag(section, "max", tag))
-    dist_args = { tag : (low,high) }
-
-    # add any additional options that user put in that section
-    for key in cp.options( "-".join([section,tag]) ):
-
-        # ignore options that are already included
-        if key in special_args:
-            continue
-
-        # check if option can be cast as a float
-        val = cp.get_opt_tag("prior",key,tag)
-        try:
-            val = float(val)
-        except:
-            pass
-
-        # add option
-        dist_args.update({key:val})
-
-    # construction distribution and add to list
-    return priors[name](**dist_args)
 
 class PriorEvaluator(object):
     """


### PR DESCRIPTION
On hold because it depends on #864.

This PR:
  * Moves the ``from_config`` function for reading distributions from configuration file to a class function of ``Uniform``.
  * Allows multi-parameter prior distributions in MCMC executable.

The way to specify a multi-parameter prior distribution in the inference configuration file is to use a ``+`` symbol in the subsection name, eg.
```
[prior-tc]
name = uniform
min-tc = 5.0
max-tc = 31.0

[prior-mass1+mass2]
name = uniform
min-mass1 = 1.0
max-mass1 = 10.0
min-mass2 = 1.0
max-mass2 = 10.0
```

So in the example above, there are two distribution instances created. One for ``tc``, and one for ``mass1`` and ``mass2``.

Whenever a new distribution gets added, there can be a class function that initializes the distribution from the configuration file.

Is this the idea you had in mind Collin?