### PR TITLE
Fix error in SingleDetTriggers clustering

### DIFF
--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -411,7 +411,12 @@ class SingleDetTriggers(object):
                 break
         index = np.array(new_index)
         self.stat = stat[index]
-        self.mask = self.mask[index]
+        if self.mask.dtype == 'bool':
+            orig_indices = self.mask.nonzero()[0][index]
+            self.mask = np.in1d(np.arange(len(self.mask)), orig_indices,
+                                assume_unique=True)
+        else:
+            self.mask = self.mask[index]
 
     @property
     def template_id(self):


### PR DESCRIPTION
mask_to_n_loudest_clustered_events() does not work correctly if the mask
is a bool array, such as when a filter function has been used before.
This patch makes it work in both cases.