### PR TITLE
Allow WorkflowConfigParser to be used without Pegasus

### DIFF
--- a/pycbc/workflow/__init__.py
+++ b/pycbc/workflow/__init__.py
@@ -29,24 +29,27 @@ interferometer data
 import os.path
 
 from pycbc.workflow.configuration import *
-from pycbc.workflow.core import *
-from pycbc.workflow.legacy_ihope import *
-from pycbc.workflow.grb_utils import *
-from pycbc.workflow.jobsetup import *
-from pycbc.workflow.psd import *
-from pycbc.workflow.matched_filter import *
-from pycbc.workflow.datafind import *
-from pycbc.workflow.segment import *
-from pycbc.workflow.tmpltbank import *
-from pycbc.workflow.gatefiles import *
-from pycbc.workflow.psdfiles import *
-from pycbc.workflow.splittable import *
-from pycbc.workflow.coincidence import *
-from pycbc.workflow.injection import *
-from pycbc.workflow.timeslides import *
-from pycbc.workflow.postprocessing_cohptf import *
-from pycbc.workflow.plotting import *
-from pycbc.workflow.minifollowups import *
+try:
+    from pycbc.workflow.core import *
+    from pycbc.workflow.legacy_ihope import *
+    from pycbc.workflow.grb_utils import *
+    from pycbc.workflow.jobsetup import *
+    from pycbc.workflow.psd import *
+    from pycbc.workflow.matched_filter import *
+    from pycbc.workflow.datafind import *
+    from pycbc.workflow.segment import *
+    from pycbc.workflow.tmpltbank import *
+    from pycbc.workflow.gatefiles import *
+    from pycbc.workflow.psdfiles import *
+    from pycbc.workflow.splittable import *
+    from pycbc.workflow.coincidence import *
+    from pycbc.workflow.injection import *
+    from pycbc.workflow.timeslides import *
+    from pycbc.workflow.postprocessing_cohptf import *
+    from pycbc.workflow.plotting import *
+    from pycbc.workflow.minifollowups import *
+except ImportError:
+    pass
 
 # Set the configuration file base directory
 INI_FILE_DIRECTORY = os.path.join(os.path.dirname(__file__), 'ini_files')

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -30,6 +30,7 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/initialization_inifile.
 import os
 import re
 import logging
+import urllib2
 import time
 import distutils.spawn
 import ConfigParser

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -29,6 +29,8 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/initialization_inifile.
 
 import os
 import re
+import logging
+import time
 import distutils.spawn
 import ConfigParser
 import glue.pipeline


### PR DESCRIPTION
This patch makes it possible to use WorkflowConfigParser without needing Pegasus installed (issue #883). To do this, ``resolve_url`` is moved from ``worklfow.core`` to ``workflow.configuration``, and all imports except for ``workflow.configuration`` in ``workflow.__init__.py`` are encased in a try/except block. I setup a test workflow on atlas to make sure this doesn't break anything else. The dax is running now; dashboard will be here:
https://atlas8.atlas.local/pegasus/u/cdcapano/r/31/w?wf_uuid=ecf7a6b7-8d8b-4110-950c-878b817ecee0