### PR TITLE
Reformat MCMC corner plot if only 1 parameter is being plotted

### DIFF
--- a/bin/inference/pycbc_mcmc_plot_corner
+++ b/bin/inference/pycbc_mcmc_plot_corner
@@ -134,7 +134,7 @@ if len(opts.variable_args) == 1:
     fig.axes[0].set_xlim(xmin - step, xmax + step)
 
     # make 10 tick marks on the boundaries of bins from the histogram
-    fig.axes[0].set_xticks(numpy.arange(xmin - step, xmax+step, (xmax-xmin)/step/10*step))
+    fig.axes[0].set_xticks(numpy.arange(xmin - step, xmax+2*step, (xmax-xmin)/step/10*step))
 
 # save figure with meta-data
 caption_kwargs = {

--- a/bin/inference/pycbc_mcmc_plot_corner
+++ b/bin/inference/pycbc_mcmc_plot_corner
@@ -148,9 +148,13 @@ vertical lines correspond to the {quantiles} quantiles. The thinning used to
 make this plot took samples beginning at the {thin_start} and then every
 {thin_interval}-th sample after that. Each chain of samples had {niterations}
 iterations.""".format(**caption_kwargs)
+if len(opts.variable_args) == 1:
+    title = "%s posterior"%opts.variable_args[0]
+else:
+    title = "Posterior Distributions"
 results.save_fig_with_metadata(fig, opts.output_file,
                                cmd=" ".join(sys.argv),
-                               title="Posterior distributions",
+                               title=title,
                                caption=caption)
 plt.close()
 

--- a/bin/inference/pycbc_mcmc_plot_corner
+++ b/bin/inference/pycbc_mcmc_plot_corner
@@ -112,6 +112,30 @@ else:
     labels = opts.variable_args
 fig = corner.corner(x, labels=labels, quantiles=quantiles)
 
+# if there is only one histogram then change some formatting
+if len(opts.variable_args) == 1:
+
+    # make plot larger
+    fig.set_size_inches(8, 5)
+
+    # get max and min values in order to expand plot to show all values
+    xmin = x.min()
+    xmax = x.max()
+
+    # determine width of each bin the histogram
+    axs = fig.axes[0]
+    poly_xy = axs.patches[0].get_xy()
+    step = poly_xy[2][0] - poly_xy[0][0]
+
+    # remove whitespace
+    fig.set_tight_layout(True)
+
+    # set new x-axis limits
+    fig.axes[0].set_xlim(xmin - step, xmax + step)
+
+    # make 10 tick marks on the boundaries of bins from the histogram
+    fig.axes[0].set_xticks(numpy.arange(xmin - step, xmax+step, (xmax-xmin)/step/10*step))
+
 # save figure with meta-data
 caption_kwargs = {
     "quantiles" : ", ".join(map(str, [q for q in quantiles])),


### PR DESCRIPTION
This changes the appearance of the corner plot if you only want to plot 1 variable parameter (ie. you only get a histogram instead of 2-D plots plus histograms).

In this PR:
  * The plot is larger
  * More x-axis tick marks
  * Plots all samples

Example plot is: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/post.png