### PR TITLE
Add ringdown approximant names and fix some bugs

### DIFF
--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -31,10 +31,14 @@ from pycbc.workflow import WorkflowConfigParser
 def select_waveform_generator(approximant):
     """ Returns the generator for the approximant.
     """
-    if approximant in waveform.td_approximants():
-        return waveform.TDomainCBCGenerator
-    elif approximant in waveform.fd_approximants():
+    if approximant in waveform.fd_approximants():
         return waveform.FDomainCBCGenerator
+    elif approximant in waveform.td_approximants():
+        return waveform.TDomainCBCGenerator
+    elif approximant in waveform.ringdown_fd_approximants:
+        return waveform.FDomainRingdownGenerator
+    elif approximant in waveform.ringdown_td_approximants:
+        raise ValueError("Time domain ringdowns not supported")
     else:
         raise ValueError("%s is not a valid approximant."%approximant)
 
@@ -220,7 +224,11 @@ with ctx:
 
         # burn in
         logging.info("MCMC burn in")
-        p, post, q = sampler.burn_in(p0)
+        res = sampler.burn_in(p0)
+        if len(res) == 4:
+            p, post, q, _ = res
+        else:
+            p, post, q = res
 
         # generate more samples
         logging.info("Generating more MCMC samples")

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -31,14 +31,10 @@ from pycbc.workflow import WorkflowConfigParser
 def select_waveform_generator(approximant):
     """ Returns the generator for the approximant.
     """
-    if approximant in waveform.fd_approximants():
-        return waveform.FDomainCBCGenerator
-    elif approximant in waveform.td_approximants():
+    if approximant in waveform.td_approximants():
         return waveform.TDomainCBCGenerator
-    elif approximant in waveform.ringdown_fd_approximants:
-        return waveform.FDomainRingdownGenerator
-    elif approximant in waveform.ringdown_td_approximants:
-        raise ValueError("Time domain ringdowns not supported")
+    elif approximant in waveform.fd_approximants():
+        return waveform.FDomainCBCGenerator
     else:
         raise ValueError("%s is not a valid approximant."%approximant)
 
@@ -224,11 +220,7 @@ with ctx:
 
         # burn in
         logging.info("MCMC burn in")
-        res = sampler.burn_in(p0)
-        if len(res) == 4:
-            p, post, q, _ = res
-        else:
-            p, post, q = res
+        p, post, q = sampler.burn_in(p0)
 
         # generate more samples
         logging.info("Generating more MCMC samples")

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -119,8 +119,6 @@ def get_td_qnm(template=None, **kwargs):
         The ringdown-frequency.
     tau : float
         The damping time of the sinusoid.
-    t_0 :  {0, float}, optional
-        The starting time of the ringdown.
     phi_0 : {0, float}, optional
         The initial phase of the ringdown.
     amp : {1, float}, optional
@@ -155,7 +153,6 @@ def get_td_qnm(template=None, **kwargs):
         raise ValueError('tau is required')
     # get optional args
     # the following have defaults, and so will be populated
-    t_0 = input_params.pop('t_0')
     phi_0 = input_params.pop('phi_0')
     amp = input_params.pop('amp')
     # the following may not be in input_params


### PR DESCRIPTION
This adds approximant names for the two ringdown generation functions currently in waveform.ringdown. They are "FdQNM" and "TdQNM". It also fixes a bug when allocating the array size for the output waveforms; the output was saving an extra sample at the end. Finally, I changed "Amp" to "amp", to be consistent with other waveform parameter names, which are all lower case.