### PR TITLE
Add ringdown support to pycbc_mcmc

### DIFF
--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -224,11 +224,7 @@ with ctx:
 
         # burn in
         logging.info("MCMC burn in")
-        res = sampler.burn_in(p0)
-        if len(res) == 4:
-            p, post, q, _ = res
-        else:
-            p, post, q = res
+        p, post, q = sampler.burn_in(p0)
 
         # generate more samples
         logging.info("Generating more MCMC samples")

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -31,10 +31,14 @@ from pycbc.workflow import WorkflowConfigParser
 def select_waveform_generator(approximant):
     """ Returns the generator for the approximant.
     """
-    if approximant in waveform.td_approximants():
-        return waveform.TDomainCBCGenerator
-    elif approximant in waveform.fd_approximants():
+    if approximant in waveform.fd_approximants():
         return waveform.FDomainCBCGenerator
+    elif approximant in waveform.td_approximants():
+        return waveform.TDomainCBCGenerator
+    elif approximant in waveform.ringdown_fd_approximants:
+        return waveform.FDomainRingdownGenerator
+    elif approximant in waveform.ringdown_td_approximants:
+        raise ValueError("Time domain ringdowns not supported")
     else:
         raise ValueError("%s is not a valid approximant."%approximant)
 
@@ -220,7 +224,11 @@ with ctx:
 
         # burn in
         logging.info("MCMC burn in")
-        p, post, q = sampler.burn_in(p0)
+        res = sampler.burn_in(p0)
+        if len(res) == 4:
+            p, post, q, _ = res
+        else:
+            p, post, q = res
 
         # generate more samples
         logging.info("Generating more MCMC samples")


### PR DESCRIPTION
This patch adds support for ringdown approximants to pycbc_mcmc. This depends on pull request #886.