### PR TITLE
Fix fancybox overflow

### DIFF
--- a/pycbc/results/static/css/fancybox/2.1.5/jquery.fancybox.css
+++ b/pycbc/results/static/css/fancybox/2.1.5/jquery.fancybox.css
@@ -165,7 +165,7 @@
 /* Overlay helper */
 
 .fancybox-lock {
-    overflow: hidden !important;
+    /* overflow: hidden !important; */
     width: auto;
 }
 

--- a/pycbc/results/static/js/fancybox/2.1.5/fancybox-orange.js
+++ b/pycbc/results/static/js/fancybox/2.1.5/fancybox-orange.js
@@ -172,3 +172,15 @@
 
 
 		});
+
+// prevents fancybox from moving to the top of the page again
+$(".fancybox").fancybox({
+    openEffect : 'fade',
+    closeEffect : 'fade',
+    padding: 0,
+    helpers: {
+        overlay: {
+            locked: false
+        }
+    }
+});

--- a/pycbc/results/static/js/fancybox/2.1.5/fancybox-orange.js
+++ b/pycbc/results/static/js/fancybox/2.1.5/fancybox-orange.js
@@ -173,14 +173,3 @@
 
 		});
 
-// prevents fancybox from moving to the top of the page again
-$(".fancybox").fancybox({
-    openEffect : 'fade',
-    closeEffect : 'fade',
-    padding: 0,
-    helpers: {
-        overlay: {
-            locked: false
-        }
-    }
-});


### PR DESCRIPTION
Somewhere along the line it looks like a nuisance was introduced to the HTML pages. Whenever an image is clicked the HTML page would reset at the top, most likely from some conflicting css. This PR fixes that so that the page remains in place.

Example page: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/tmp_workflow_5e/