### PR TITLE
Fix tc bug and cache frequencies for applying time shifts

### DIFF
--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -31,10 +31,10 @@ from pycbc.workflow import WorkflowConfigParser
 def select_waveform_generator(approximant):
     """ Returns the generator for the approximant.
     """
-    if approximant in waveform.td_approximants():
-        return waveform.TDomainCBCGenerator
-    elif approximant in waveform.fd_approximants():
+    if approximant in waveform.fd_approximants():
         return waveform.FDomainCBCGenerator
+    elif approximant in waveform.td_approximants():
+        return waveform.TDomainCBCGenerator
     else:
         raise ValueError("%s is not a valid approximant."%approximant)
 
@@ -173,6 +173,7 @@ with ctx:
 
     # construct class that will generate waveforms
     generator = waveform.FDomainDetFrameGenerator(generator_function,
+                        epoch=stilde_dict.values()[0].epoch,
                         variable_args=variable_args,
                         detectors=opts.instruments,
                         delta_f=delta_f_dict.values()[0], **static_args)

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -177,9 +177,17 @@ class FDomainDetFrameGenerator(object):
         must be included in either the variable args or the frozen params. If
         None, the generate function will just return the plus polarization
         returned by the rFrameGeneratorClass shifted by any desired time shift.
+    epoch : {float, lal.LIGOTimeGPS
+        The epoch start time to set the waveform to. A time shift = tc - epoch is
+        applied to waveforms before returning.
     variable_args : {(), list or tuple}
         A list or tuple of strings giving the names and order of parameters
         that will be passed to the generate function.
+    cache_fseries : {True, bool}
+        If True, the frequency series of the first generated waveform will be cached,
+        to speed up subsequent generations. This assumes that all subsequent generations
+        will be equally sampled. The frequency cache can be updated using the
+        set_cached_frequencies method.
     \**frozen_params
         Keyword arguments setting the parameters that will not be changed from
         call-to-call of the generate function.
@@ -207,6 +215,14 @@ class FDomainDetFrameGenerator(object):
     detector_names : list
         The list of detector names. If no detectors were provided, then this
         will be ['RF'] for "radiation frame".
+    epoch : lal.LIGOTimeGPS
+        The GPS start time of the frequency series returned by the generate function.
+        A time shift is applied to the waveform equal to tc-epoch. Update by using
+        ``set_epoch``.
+    cache_fseries : bool
+        Whether or not ``cached_frequencies`` are used for applying time shifts.
+    cached_frequencies : {None, array}
+        The cached frequencies. Update by using ``set_cached_frequencies``.
     current_params : dict
         A dictionary of name, value pairs of the arguments that were last
         used by the generate function.
@@ -223,7 +239,7 @@ class FDomainDetFrameGenerator(object):
     Examples
     --------
     Initialize a generator:
-    >>> generator = waveform.FDomainDetFrameGenerator(waveform.FDomainCBCGenerator, variable_args=['mass1', 'mass2', 'spin1z', 'spin2z', 'tc', 'ra', 'dec', 'polarization'], detectors=['H1', 'L1'], delta_f=1./64, f_lower=20., approximant='SEOBNRv2_ROM_DoubleSpin')
+    >>> generator = waveform.FDomainDetFrameGenerator(waveform.FDomainCBCGenerator, 0., variable_args=['mass1', 'mass2', 'spin1z', 'spin2z', 'tc', 'ra', 'dec', 'polarization'], detectors=['H1', 'L1'], delta_f=1./64, f_lower=20., approximant='SEOBNRv2_ROM_DoubleSpin')
 
     Generate a waveform:
     >>> generator.generate(38.6, 29.3, 0.33, -0.94, 2.43, 1.37, -1.26, 2.76)
@@ -233,8 +249,8 @@ class FDomainDetFrameGenerator(object):
 
     location_args = set(['tc', 'ra', 'dec', 'polarization'])
 
-    def __init__(self, rFrameGeneratorClass, detectors=None,
-            variable_args=(), **frozen_params):
+    def __init__(self, rFrameGeneratorClass, epoch, detectors=None,
+            variable_args=(), cache_fseries=True, **frozen_params):
         # initialize frozen & current parameters:
         self.current_params = frozen_params.copy()
         # we'll separate out frozen location parameters from the frozen
@@ -250,6 +266,9 @@ class FDomainDetFrameGenerator(object):
         # initialize the radiation frame generator
         self.rframe_generator = rFrameGeneratorClass(
             variable_args=rframe_variables, **frozen_params)
+        self.set_epoch(epoch)
+        self.cache_fseries = cache_fseries
+        self._cached_frequencies = None
         # if detectors are provided, convert to detector type; also ensure that
         # location variables are specified
         if detectors is not None:
@@ -267,6 +286,21 @@ class FDomainDetFrameGenerator(object):
             self.detectors = {'RF': None}
         self.detector_names = sorted(self.detectors.keys())
 
+    def set_epoch(self, epoch):
+        """Sets the epoch; epoch should be a float or a LIGOTimeGPS."""
+        self._epoch = _lal.LIGOTimeGPS(epoch)
+
+    @property
+    def epoch(self):
+        return self._epoch
+
+    def set_cached_frequencies(self, fseries):
+        self._cached_frequencies = fseries
+
+    @property
+    def cached_frequencies(self):
+        return self._cached_frequencies
+
     def generate(self, *args):
         """Generates a waveform, applies a time shift and the detector response
         function."""
@@ -277,10 +311,25 @@ class FDomainDetFrameGenerator(object):
         rfparams = dict([(param, self.current_params[param])
             for param in self.rframe_generator.variable_args])
         hp, hc = self.rframe_generator.generate_from_kwargs(**rfparams)
+        hp._epoch = hc._epoch = self._epoch
         h = {}
-        if self.detector_names != ['RF']:
+        if 'tc' in self.current_params:
             # we'll need the frequency points for applying the time shift
-            fseries = hp.sample_frequencies.numpy()
+            if self._cached_frequencies is None or not self.cache_fseries:
+                fseries = hp.sample_frequencies.numpy()
+                if self.cache_fseries:
+                    self.set_cached_frequencies(fseries)
+            else:
+                fseries = self._cached_frequencies
+                # the cahced fseries may not be the right size
+                if len(fseries) < len(hp):
+                    fseries = hp.sample_frequencies.numpy()
+                    # update with the longer frequency series
+                    self.set_cached_frequencies(fseries)
+                elif len(fseries) > len(hp):
+                    fseries = fseries[:len(hp)]
+
+        if self.detector_names != ['RF']:
             for detname, det in self.detectors.items():
                 # apply detector response function
                 fp, fc = det.antenna_pattern(self.current_params['ra'],
@@ -293,14 +342,11 @@ class FDomainDetFrameGenerator(object):
                     det.time_delay_from_earth_center(self.current_params['ra'],
                                                      self.current_params['dec'],
                                                      self.current_params['tc'])
-                h[detname] = apply_fd_time_shift(thish, tc, fseries=fseries,
-                    copy=False)
-        elif 'tc' in self.current_params:
-            # apply the time shift if specified
-            fseries = hp.sample_frequencies.numpy()
-            h['RF'] = apply_fd_time_shift(hp, self.current_params['tc'],
-                        fseries=fseries, copy=False)
+                h[detname] = apply_fd_time_shift(thish, tc, fseries=fseries, copy=False)
         else:
-            # just return the plus polarization
+            # no detector response, just use the + polarization
+            if 'tc' in self.current_params:
+                hp = apply_fd_time_shift(hp, self.current_params['tc'],
+                            fseries=fseries, copy=False)
             h['RF'] = hp
         return h


### PR DESCRIPTION
There is a bug in the way FDomainDetFrameGenerator applies the coalescence time in ``pycbc_mcmc``. Currently, tc is used by apply_fd_timeshift, which takes the difference between it and the start of the FD waveform (the epoch) to figure out what to shift the waveform by. Thus you currently specify tc as an offset from the segment start time in pycbc_mcmc. However, tc is also needed for the detector's response function, as it is used to calculate the sidereal time. This means that with the current setup, the sidereal time will be wrong, as it'll always be with a few 1000 seconds after Jan 6, 1980 00:00UTC.

This patch fixes this by adding an epoch attribute to the waveform generator. This ensures that the appropriate time offset is applied to the waveform by apply_fd_timeshift, and that the correct antenna pattern is set. The likelihood evaluator checks that the epoch is the same as the given data on initialization. This means that tc should not be specified in GPS seconds in the pycbc_mcmc ini file; this does make it easier to not mess up, since the coalescence time will be provide from the search in GPS.

Also, the order in which approximants in pycbc_mcmc are checked is switched, so that frequency domain is checked before time domain. As-is currently, you cannot use any of the IMRPhenom waveforms because they appear in both TD and FD.

This patch also speeds up waveform generation by caching the frequency series after the first generation. In profiling the likelihood evaluator, I found that calling get_sample_frequencies was taking up ~20% of the generation time. Here is a graph of 1000 calls to the likelihood evaluator before this patch:

https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/likelihood_tests/likelihood_profile_nocaching.png

This took ~50s to run. This is a graph after the patch:

https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/likelihood_tests/likelihood_profile.png

get_sample_frequencies no longer appears as a major bottleneck; it took ~35s to run. The script to do the benchmarking can be found here:

https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/likelihood_tests/benchmark_likelihood.sh

Note: apply_fd_time_shift still takes up a large chunk (~25%) of the calculation. I've talked to @ahnitz and we'll have a patch for speeding it up soon.