### PR TITLE
Add ringdown support to pycbc_mcmc

### DIFF
--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -35,6 +35,10 @@ def select_waveform_generator(approximant):
         return waveform.FDomainCBCGenerator
     elif approximant in waveform.td_approximants():
         return waveform.TDomainCBCGenerator
+    elif approximant in waveform.ringdown_fd_approximants:
+        return waveform.FDomainRingdownGenerator
+    elif approximant in waveform.ringdown_td_approximants:
+        raise ValueError("Time domain ringdowns not supported")
     else:
         raise ValueError("%s is not a valid approximant."%approximant)
 

--- a/examples/inference/ringdown_example.ini
+++ b/examples/inference/ringdown_example.ini
@@ -1,0 +1,47 @@
+[variable_args]
+; waveform parameters that will vary in MCMC
+tc =
+f_0 =
+tau =
+amp =
+phi_0 =
+
+[static_args]
+; waveform parameters that will not change in MCMC
+approximant = FdQNM
+ra = 2.21535724066
+dec = -1.23649695537
+polarization = 0.
+f_lower = 28.0
+
+[prior-tc]
+; prior for the coalesence time
+; Note: tc is measured in time from the beginning of
+; the segment
+name = uniform
+min-tc = 1126259462.32
+max-tc = 1126259462.52
+
+[prior-f_0]
+; prior for the ringdown frequency
+name = uniform
+min-f_0 = 250.
+max-f_0 = 270.
+
+[prior-tau]
+; prior for damping time
+name = uniform
+min-tau = 0.001
+max-tau = 0.020
+
+[prior-amp]
+; prior for amplitude
+name = uniform
+min-amp = 5e-23
+max-amp = 1e-21
+
+[prior-phi_0]
+; prior for initial phase
+name = uniform
+min-phi_0 = 0
+max-phi_0 = 6.283185307179586

--- a/examples/inference/run_ringdown_example.sh
+++ b/examples/inference/run_ringdown_example.sh
@@ -1,0 +1,84 @@
+#! /bin/bash
+
+#
+# Injection parameters
+#
+INJ_OUTPUT=test_injection.xml.gz
+INJ_APPROX=SEOBNRv2
+TRIGGER_TIME=1126259462.42
+# masses are observed, not source
+MASS1=37.
+MASS2=32.
+RA=2.21535724066
+DEC=-1.23649695537
+INC=0
+DISTANCE=400000 # in kpc
+INJ_F_MIN=28.
+
+#
+# Parameters for MCMC
+#
+# the amount of time simulated; the start,
+# stop times of the segment will be the trigger
+# time +/-SEGLEN, and the df used will = 1/(2*SEGLEN)
+OUTPUT=ringdown_example.hdf
+SEGLEN=2
+IFOS="H1 L1"
+STRAIN="H1:aLIGOZeroDetHighPower L1:aLIGOZeroDetHighPower"
+SAMPLE_RATE=1024
+F_MIN=30.
+N_WALKERS=500
+N_ITERATIONS=1000
+PROCESSING_SCHEME=cpu
+CONFIG_PATH=ringdown_example.ini
+
+
+#
+# Do not edit below this
+#
+TRIGGER_TIME_INT=${TRIGGER_TIME%.*}
+
+GPS_START_TIME=$((${TRIGGER_TIME_INT} - ${SEGLEN}))
+GPS_END_TIME=$((${TRIGGER_TIME_INT} + ${SEGLEN}))
+
+echo "Creating injection file"
+lalapps_inspinj \
+    --output ${INJ_OUTPUT} \
+    --seed 1000 \
+    --f-lower ${INJ_F_MIN} \
+    --waveform ${INJ_APPROX} \
+    --amp-order 7 \
+    --gps-start-time ${TRIGGER_TIME} \
+    --gps-end-time ${TRIGGER_TIME} \
+    --time-step 1 \
+    --t-distr fixed \
+    --l-distr fixed \
+    --longitude ${RA} \
+    --latitude ${DEC} \
+    --d-distr uniform \
+    --min-distance ${DISTANCE} \
+    --max-distance ${DISTANCE} \
+    --i-distr fixed \
+    --fixed-inc ${INC} \
+    --m-distr fixMasses \
+    --fixed-mass1 ${MASS1} \
+    --fixed-mass2 ${MASS2} \
+    --disable-spin
+
+echo "Running MCMC"
+echo "============================"
+pycbc_mcmc --verbose \
+    --instruments ${IFOS} \
+    --gps-start-time ${GPS_START_TIME} \
+    --gps-end-time ${GPS_END_TIME} \
+    --psd-model ${STRAIN} \
+    --fake-strain ${STRAIN} \
+    --sample-rate ${SAMPLE_RATE} \
+    --low-frequency-cutoff ${F_MIN} \
+    --processing-scheme ${PROCESSING_SCHEME} \
+    --sampler kombine \
+    --likelihood-evaluator gaussian \
+    --nwalkers ${N_WALKERS} \
+    --niterations ${N_ITERATIONS} \
+    --config-file ${CONFIG_PATH} \
+    --output-file ${OUTPUT}


### PR DESCRIPTION
This patch adds support to pycbc_mcmc for using frequency-domain QNMs as the waveform model. For this, it just has to know about the ringdown approximants.

This patch also adds an example config file and script to run the mcmc using the frequency domain QNM on a BBH injection in Gaussian noise.