### PR TITLE
Fix how epoch stored so can be used in multithreading

### DIFF
--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -277,11 +277,11 @@ class FDomainDetFrameGenerator(object):
 
     def set_epoch(self, epoch):
         """Sets the epoch; epoch should be a float or a LIGOTimeGPS."""
-        self._epoch = _lal.LIGOTimeGPS(epoch)
+        self._epoch = float(epoch)
 
     @property
     def epoch(self):
-        return self._epoch
+        return _lal.LIGOTimeGPS(self._epoch)
 
     def generate(self, *args):
         """Generates a waveform, applies a time shift and the detector response


### PR DESCRIPTION
The patch that added the epoch to the waveform generator broke multi-threading in pycbc_mcmc, as lal.LIGOTimeGPS appears not to be packaged correctly when sent out to slave nodes. This fixes this by storing the epoch in the waveform generator as a float. I tested this with pycbc_mcmc using 4 processors.