### PR TITLE
Plot waveform fixes

### DIFF
--- a/bin/plotting/pycbc_plot_waveform
+++ b/bin/plotting/pycbc_plot_waveform
@@ -18,7 +18,7 @@
 """
 
 # imports
-import sys, argparse, matplotlib, numpy
+import sys, argparse, matplotlib, numpy, math
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1.inset_locator import zoomed_inset_axes
@@ -93,18 +93,37 @@ flen = tlen / 2 + 1
 class WaveformTemplate(object):
     pass
 
+tmp_params = WaveformTemplate()
+tmp_params.mass1 = opt.mass1
+tmp_params.mass2 = opt.mass2
+tmp_params.spin1x = opt.spin1x
+tmp_params.spin1y = opt.spin1y
+tmp_params.spin1z = opt.spin1z
+tmp_params.spin2x = opt.spin2x
+tmp_params.spin2y = opt.spin2y
+tmp_params.spin2z = opt.spin2z
+tmp_params.inclination = opt.inclination
+
+# Deal with parameter-dependent approximant string
+def parse_option(row, arg):
+    safe_dict = {}
+    safe_dict.update(row.__dict__)
+    safe_dict.update(math.__dict__)
+    return eval(arg, {"__builtins__":None}, safe_dict)
+
+if 'params' in opt.approximant:
+    t = type('t', (object,), {'params' : tmp_params})
+    approximant = str(parse_option(t, opt.approximant))
+else:
+    approximant = opt.approximant
+
+
 hp, hc = waveform.get_two_pol_waveform_filter(zeros(flen, dtype=complex64),
                                     zeros(flen, dtype=complex64),
-                                    WaveformTemplate(),
-                                    approximant=opt.approximant,
-                                    mass1=opt.mass1, mass2=opt.mass2,
-                                    spin1z=opt.spin1z, spin2z=opt.spin2z,
-                                    spin1y=opt.spin1y, spin2y=opt.spin2y,
-                                    spin1x=opt.spin1x, spin2x=opt.spin2x,
+                                    tmp_params, approximant=opt.approximant,
                                     taper=opt.taper_template, 
                                     f_lower=opt.low_frequency_cutoff,
-                                    delta_f=delta_f, delta_t=delta_t,
-                                    inclination=opt.inclination)
+                                    delta_f=delta_f, delta_t=delta_t)
 
 # 0.1s (post-merger) added for safety
 tmplt_length = hp.length_in_time + 0.1

--- a/bin/plotting/pycbc_plot_waveform
+++ b/bin/plotting/pycbc_plot_waveform
@@ -117,10 +117,13 @@ if 'params' in opt.approximant:
 else:
     approximant = opt.approximant
 
+# This is a hack. We don't have a two-pol SPATmplt, so use TaylorF2
+if approximant == 'SPAtmplt':
+    approximant = 'TaylorF2'
 
 hp, hc = waveform.get_two_pol_waveform_filter(zeros(flen, dtype=complex64),
                                     zeros(flen, dtype=complex64),
-                                    tmp_params, approximant=opt.approximant,
+                                    tmp_params, approximant=approximant,
                                     taper=opt.taper_template, 
                                     f_lower=opt.low_frequency_cutoff,
                                     delta_f=delta_f, delta_t=delta_t)

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -666,13 +666,6 @@ def seobnrrom_final_frequency(**kwds):
     return get_final_freq("SEOBNRv2", kwds['mass1'], kwds['mass2'],
                    kwds['spin1z'], kwds['spin2z'])
 
-_filter_ends["SPAtmplt"] = _filter_ends["TaylorF2"] = spa_tmplt_end
-_filter_ends["SEOBNRv2_ROM_DoubleSpin"] = _filter_ends["SEOBNRv2_ROM_DoubleSpin_HI"] =  seobnrrom_final_frequency
-
-_template_amplitude_norms["SPAtmplt"] = spa_amplitude_factor
-_filter_time_lengths["SPAtmplt"] = spa_length_in_time
-
-
 def seobnrrom_length_in_time(**kwds):
     """
     This is a stub for holding the calculation for getting length of the ROM
@@ -694,6 +687,7 @@ _filter_norms["SPAtmplt"] = spa_tmplt_norm
 _filter_preconditions["SPAtmplt"] = spa_tmplt_precondition
 
 _filter_ends["SPAtmplt"] = spa_tmplt_end
+_filter_ends["TaylorF2"] = spa_tmplt_end
 _filter_ends["SEOBNRv1_ROM_EffectiveSpin"] = seobnrrom_final_frequency
 _filter_ends["SEOBNRv1_ROM_DoubleSpin"] =  seobnrrom_final_frequency
 _filter_ends["SEOBNRv2_ROM_EffectiveSpin"] = seobnrrom_final_frequency
@@ -704,8 +698,8 @@ _filter_ends["SEOBNRv2_ROM_DoubleSpin_HI"] = seobnrrom_final_frequency
 #_filter_ends["IMRPhenomD"] = seobnrrom_final_frequency
 
 _template_amplitude_norms["SPAtmplt"] = spa_amplitude_factor
-
 _filter_time_lengths["SPAtmplt"] = spa_length_in_time
+_filter_time_lengths["TaylorF2"] = spa_length_in_time
 _filter_time_lengths["SEOBNRv1_ROM_EffectiveSpin"] = seobnrrom_length_in_time
 _filter_time_lengths["SEOBNRv1_ROM_DoubleSpin"] = seobnrrom_length_in_time
 _filter_time_lengths["SEOBNRv2_ROM_EffectiveSpin"] = seobnrrom_length_in_time


### PR DESCRIPTION
Some fixes to plot_waveform. Specifically:

 * Allow the code to handle approximant strings, like in uberbank workflow
 * Allow the code to be able to use SPAtmplt (by falling back on TaylorF2)
 * Make TaylorF2 actually work as a filter waveform (by adding length_in_time)
 * Remove some duplicated end_frequency and time_lengths from waveform.py

Example of this running:

https://galahad.aei.mpg.de/~spxiwh/LVC/aLIGO/O1/analyses/zero_padding/chunk3/smallrun_test4/