### PR TITLE
Do not require H1 or L1 as IFO name in frame insertion script.

### DIFF
--- a/bin/hwinj/pycbc_insert_frame_hwinj
+++ b/bin/hwinj/pycbc_insert_frame_hwinj
@@ -22,8 +22,6 @@ import numpy
 from pycbc.frame import write_frame
 from pycbc import strain as _strain
 
-ifo_list = ['H1', 'L1']
-
 # command line usage
 parser = argparse.ArgumentParser(usage='pycbc_insert_frame_hwinj [--options]',
              description="Inserts a single-column ASCII file into frame data.")
@@ -36,7 +34,6 @@ parser.add_argument('--hwinj-start-time', type=int, required=True,
 
 # frame options
 parser.add_argument('--ifo', type=str, required=True,
-             choices=ifo_list,
              help='IFO.')
 parser.add_argument('--output-file', type=str, required=True,
              help='Path to output frame file.')


### PR DESCRIPTION
Makes it so that any IFO name can be used. The IFO name is only used for naming the frame channel so there's no reason to restrict it to H1 and L1 only.