### PR TITLE
Save number of burn in samples in MCMC file and make default to not plot burn in samples

### DIFF
--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -225,7 +225,7 @@ with ctx:
 
         # burn in
         logging.info("MCMC burn in")
-        p, post, q = sampler.burn_in(p0)
+        sampler.burn_in(p0)
 
         # generate more samples
         logging.info("Generating more MCMC samples")
@@ -255,8 +255,8 @@ labels = [cp.get("labels",param) for param in variable_args]
 
 # save samples to file
 fp = MCMCFile(opts.output_file, "w")
-fp.write(variable_args, opts.instruments, chain, labels=labels,
-         acceptance_fraction=sampler.acceptance_fraction,
+fp.write(variable_args, opts.instruments, sampler, labels=labels,
+         burn_in_length=burn_in_length,
          low_frequency_cutoff=low_frequency_cutoff_dict,
          psds=psd_dyn_dict)
 fp.close()

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -256,7 +256,6 @@ labels = [cp.get("labels",param) for param in variable_args]
 # save samples to file
 fp = MCMCFile(opts.output_file, "w")
 fp.write(variable_args, opts.instruments, sampler, labels=labels,
-         burn_in_length=burn_in_length,
          low_frequency_cutoff=low_frequency_cutoff_dict,
          psds=psd_dyn_dict)
 fp.close()

--- a/bin/inference/pycbc_mcmc_plot_corner
+++ b/bin/inference/pycbc_mcmc_plot_corner
@@ -44,9 +44,9 @@ parser.add_argument("--labels", type=str, nargs="+",
     help="Label for each parameter.")
 
 # add thinning options
-parser.add_argument("--thin-start", type=int, required=True,
+parser.add_argument("--thin-start", type=int, default=None,
     help="Sample number to start collecting samples to plot.")
-parser.add_argument("--thin-interval", type=int, required=True,
+parser.add_argument("--thin-interval", type=int, default=1,
     help="Interval to use for thinning samples.")
 
 # verbose option

--- a/bin/inference/pycbc_mcmc_table_summary
+++ b/bin/inference/pycbc_mcmc_table_summary
@@ -39,7 +39,7 @@ parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
 
 # add thinning options
-parser.add_argument("--thin-start", type=int, default=0,
+parser.add_argument("--thin-start", type=int, default=None,
     help="Sample number to start collecting samples to plot.")
 parser.add_argument("--thin-interval", type=int, default=1,
     help="Interval to use for thinning samples.")

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -53,12 +53,6 @@ class _BaseSampler(object):
         """
         return ValueError("chain function not set.")
 
-    @property
-    def burn_in_iterations(self):
-        """ This function should return the number of samples from burn in.
-        """
-        return ValueError("burn_in_iterations function not set.")
-
     def burn_in(self, initial_values):
         """ This function should burn in the MCMC.
         """
@@ -116,12 +110,6 @@ class KombineSampler(_BaseSampler):
         """ Get all past samples as an niterations x nwalker x ndim array.
         """
         return self.sampler.chain
-
-    @property
-    def burn_in_iterations(self):
-        """ Get number of samples from burn in.
-        """
-        return self.burn_in_iterations
 
     def burn_in(self, initial_values):
         """ Evolve an ensemble until the acceptance rate becomes roughly

--- a/pycbc/io/mcmc.py
+++ b/pycbc/io/mcmc.py
@@ -148,7 +148,7 @@ class MCMCFile(h5py.File):
 
         return label
 
-    def write(self, variable_args, ifo_list, sampler, acceptance_fraction=None,
+    def write(self, variable_args, ifo_list, sampler,
               labels=None, low_frequency_cutoff=None, psds=None):
         """ Writes the output from pycbc.io.sampler to a file.
 
@@ -160,9 +160,6 @@ class MCMCFile(h5py.File):
             A list of the IFOs.
         sampler : pycbc.inference._BaseSampler
             A sampler instance from pycbc.inference.sampler.
-        acceptance_fraction : numpy.Array
-            A 1-dimensional array that contains the number of samples accepted
-            for each iteration.
         labels : list
             A list of str that have formatted names for parameter.
         low_frequency_cutoff : dict
@@ -210,9 +207,8 @@ class MCMCFile(h5py.File):
                 group_dim.create_dataset(dataset_name, data=samples_subset)
 
         # create a dataset for the acceptance fraction
-        if acceptance_fraction is not None:
-            self.create_dataset("acceptance_fraction",
-                                data=acceptance_fraction)
+        self.create_dataset("acceptance_fraction",
+                            data=sampler.acceptance_fraction)
 
         # create datasets for each PSD
         if psds and low_frequency_cutoff:

--- a/pycbc/io/mcmc.py
+++ b/pycbc/io/mcmc.py
@@ -44,7 +44,7 @@ class MCMCFile(h5py.File):
     def __init__(self, path, mode=None, **kwargs):
         super(MCMCFile, self).__init__(path, mode, **kwargs)
 
-    def read_samples(self, variable_arg, thin_start=0, thin_interval=1):
+    def read_samples(self, variable_arg, thin_start=None, thin_interval=1):
         """ Reads independent samples from all walkers for a parameter.
 
         Parameters


### PR DESCRIPTION
This PR:
  * Saves number of burn in samples to MCMC file in attributes.
  * ``MCMCFile.write`` now takes the sampler class and handles get all information from the sampler class.
  * Default for ``thin_start`` set to ``None``. This will automatically choose to start plotting after the number of burn in samples.