### PR TITLE
Add --thin-start and --thin-interval to MCMC plotting codes

### DIFF
--- a/bin/inference/pycbc_mcmc_plot_acceptance_rate
+++ b/bin/inference/pycbc_mcmc_plot_acceptance_rate
@@ -36,6 +36,12 @@ parser.add_argument("--input-file", type=str, required=True,
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
 
+# add thinning options
+parser.add_argument("--thin-start", type=int, default=None,
+    help="Sample number to start collecting samples to plot.")
+parser.add_argument("--thin-interval", type=int, default=1,
+    help="Interval to use for thinning samples.")
+
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
     help="")
@@ -56,7 +62,7 @@ fp = h5py.File(opts.input_file, "r")
 
 # plot acceptance rate and drawn values
 logging.info("Plotting acceptance fraction")
-acceptance_fraction = fp["acceptance_fraction"][:]
+acceptance_fraction = fp["acceptance_fraction"][opts.thin_start::opts.thin_interval]
 fig = plt.figure()
 plt.plot(acceptance_fraction, 'k', alpha=.5)
 plt.ylabel("Mean Acceptance Rate")

--- a/bin/inference/pycbc_mcmc_plot_acf
+++ b/bin/inference/pycbc_mcmc_plot_acf
@@ -46,6 +46,12 @@ parser.add_argument("--ymax", type=float,
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
 
+# add thinning options
+parser.add_argument("--thin-start", type=int, default=None,
+    help="Sample number to start collecting samples to plot.")
+parser.add_argument("--thin-interval", type=int, default=1,
+    help="Interval to use for thinning samples.")
+
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
     help="")

--- a/bin/inference/pycbc_mcmc_plot_acf
+++ b/bin/inference/pycbc_mcmc_plot_acf
@@ -78,7 +78,9 @@ for param_name in opts.variable_args:
     for i in range(fp.attrs["nwalkers"]):
 
         # get all the past samples for this walker
-        y = fp.read_samples_from_walker(param_name, i)
+        y = fp.read_samples_from_walker(param_name, i,
+                                        thin_start=opts.thin_start,
+                                        thin_interval=opts.thin_interval)
 
         # subtract mean
         z =  y - y.mean()

--- a/bin/inference/pycbc_mcmc_plot_samples
+++ b/bin/inference/pycbc_mcmc_plot_samples
@@ -39,6 +39,12 @@ parser.add_argument("--variable-args", type=str, nargs="+", required=True,
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
 
+# add thinning options
+parser.add_argument("--thin-start", type=int, default=None,
+    help="Sample number to start collecting samples to plot.")
+parser.add_argument("--thin-interval", type=int, default=1,
+    help="Interval to use for thinning samples.")
+
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
     help="")
@@ -74,7 +80,9 @@ for i,arg in enumerate(opts.variable_args):
     for j in range(fp.attrs["nwalkers"]):
 
         # plot each walker as a different line on the subplot
-        axs[i].plot(fp.read_samples_from_walker(arg, j))
+        axs[i].plot(fp.read_samples_from_walker(arg, j,
+                                                thin_start=opts.thin_start,
+                                                thin_interval=opts.thin_interval))
 
         # y-axis label
         axs[i].set_ylabel(r'%s'%fp.read_label(arg))


### PR DESCRIPTION
This PR:
  * Adds ``--thin-start`` and ``--thin-interval`` to ``pycbc_mcmc_plot_acf``, ``pycbc_mcmc_plot_acceptance_rate``, and ``pycbc_mcmc_plot_samples``.
  * Pass those command line arguments when reading samples from the ``MCMCFile``.

This will make it so these codes skip the burn in samples; the other MCMC plotting codes already have these options. Changing ``--thin-start`` tells the code to start reading samples at that iteration in the MCMC and ``--thin-interval`` says to take every i-th sample from the chain after ``--thin-start``. To read all samples, you use ``--thin-start 0 --thin-interval 1``.