### PR TITLE
Allow pycbc_mcmc to dump MCMC chain to output file after certain number of iterations

### DIFF
--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -273,5 +273,4 @@ with ctx:
                          checkpoint_interval=opts.checkpoint_interval)
 
 # exit
-fp.close()
 logging.info("Done")

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -150,9 +150,9 @@ with ctx:
                                              delta_f=psd_dict[key].delta_f)
 
     # save PSD
-    fp = MCMCFile(opts.output_file, "w")
-    fp.write_psds(psds=psd_dyn_dict,
-                  low_frequency_cutoff=low_frequency_cutoff_dict)
+    with MCMCFile(opts.output_file, "w") as fp:
+        fp.write_psds(psds=psd_dyn_dict,
+                      low_frequency_cutoff=low_frequency_cutoff_dict)
 
     # read configuration file
     logging.info("Reading configuration file")
@@ -239,8 +239,9 @@ with ctx:
 
     # create empty datasets in output file
     logging.info("Writing empty datasets to output file")
-    fp.write_samples(variable_args, nwalkers=opts.nwalkers,
-                     niterations=opts.niterations, labels=labels)
+    with MCMCFile(opts.output_file, "a") as fp:
+        fp.write_samples(variable_args, nwalkers=opts.nwalkers,
+                         niterations=opts.niterations, labels=labels)
 
     # check if user wants to skip the burn in
     if not opts.skip_burn_in:
@@ -250,21 +251,25 @@ with ctx:
         sampler.burn_in(p0)
 
         # write sampler attrs to file
-        fp.write_sampler_attrs(variable_args, opts.instruments, sampler)
+        with MCMCFile(opts.output_file, "a") as fp:
+            fp.write_sampler_attrs(variable_args, opts.instruments, sampler)
 
         # generate more samples
         logging.info("Generating more MCMC samples")
-        sampler.run_mcmc(variable_args, opts.niterations, output_file=fp,
+        sampler.run_mcmc(variable_args, opts.niterations,
+                         output_file=opts.output_file,
                          checkpoint_interval=opts.checkpoint_interval)
 
     else:
 
         # write sampler attrs to file
-        fp.write_sampler_attrs(variable_args, opts.instruments, sampler)
+        with MCMCFile(opts.output_file, "a") as fp:
+            fp.write_sampler_attrs(variable_args, opts.instruments, sampler)
 
         # generate samples
         logging.info("Generating MCMC samples")
-        sampler.run_mcmc(variable_args, opts.niterations, p0=p0, output_file=fp,
+        sampler.run_mcmc(variable_args, opts.niterations, p0=p0,
+                         output_file=opts.output_file,
                          checkpoint_interval=opts.checkpoint_interval)
 
 # exit

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -246,12 +246,12 @@ with ctx:
             fp.write_samples(variable_args, nwalkers=opts.nwalkers,
                              niterations=opts.niterations, labels=labels)
 
-        # determine intervals to run sampler save samples 
-        intervals = [i for i in range(0, opts.niterations, checkpoint_interval)] \
+        # determine intervals to run sampler until we save the new samples 
+        intervals = [i for i in range(0, opts.niterations, opts.checkpoint_interval)] \
                     + [opts.niterations]
 
         # determine if there is a small bit at the end
-        remainder = niterations % opts.checkpoint_interval
+        remainder = opts.niterations % opts.checkpoint_interval
         if remainder:
             intervals += [intervals[-1]+remainder]
 
@@ -267,7 +267,7 @@ with ctx:
         sampler.burn_in(p0)
         p0 = None
 
-    # write sampler attrs to file
+    # write sampler attributes to file
     with MCMCFile(opts.output_file, "a") as fp:
         fp.write_sampler_attrs(sampler)
 

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -281,9 +281,11 @@ with ctx:
             continue
         start = intervals[i-1]
 
-        # run sampler
+        # run sampler and set initial values to None so that sampler
+        # picks up from where it left off next call
         logging.info("Running sampler for %s to %s out of %s iterations"%(start,end,opts.niterations))
         sampler.run_mcmc(end-start, p0=p0)
+        p0 = None
 
         # write new samples
         logging.info("Writing samples for %s to %s out of %s iterations"%(start,end,opts.niterations))

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -256,7 +256,7 @@ with ctx:
 
         # generate more samples
         logging.info("Generating more MCMC samples")
-        sampler.run_mcmc(variable_args, opts.niterations,
+        sampler.run_mcmc(opts.niterations,
                          output_file=opts.output_file,
                          checkpoint_interval=opts.checkpoint_interval)
 
@@ -268,7 +268,7 @@ with ctx:
 
         # generate samples
         logging.info("Generating MCMC samples")
-        sampler.run_mcmc(variable_args, opts.niterations, p0=p0,
+        sampler.run_mcmc(opts.niterations, p0=p0,
                          output_file=opts.output_file,
                          checkpoint_interval=opts.checkpoint_interval)
 

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -237,41 +237,57 @@ with ctx:
     # get labels for each parameter from configuration file
     labels = [cp.get("labels",param) for param in variable_args]
 
-    # create empty datasets in output file
+    # setup checkpointing
     if opts.checkpoint_interval:
+
+        # write empty datasets
         logging.info("Writing empty datasets to output file")
         with MCMCFile(opts.output_file, "a") as fp:
             fp.write_samples(variable_args, nwalkers=opts.nwalkers,
                              niterations=opts.niterations, labels=labels)
 
-    # check if user wants to skip the burn in
-    if not opts.skip_burn_in:
+        # determine intervals to run sampler save samples 
+        intervals = [i for i in range(0, opts.niterations, checkpoint_interval)] \
+                    + [opts.niterations]
 
-        # burn in
+        # determine if there is a small bit at the end
+        remainder = niterations % opts.checkpoint_interval
+        if remainder:
+            intervals += [intervals[-1]+remainder]
+
+    # if not checkpointing then set intervals to run sampler in one call
+    else:
+        intervals = [0, opts.niterations]
+
+    # check if user wants to skip the burn in
+    # if burn in then switch p0 to None and sampler should pick up from last
+    # position after burn in
+    if not opts.skip_burn_in:
         logging.info("MCMC burn in")
         sampler.burn_in(p0)
+        p0 = None
 
-        # write sampler attrs to file
+    # write sampler attrs to file
+    with MCMCFile(opts.output_file, "a") as fp:
+        fp.write_sampler_attrs(sampler)
+
+    # loop over number of checkpoints
+    for i,end in enumerate(intervals):
+
+        # if its the first sample then skip
+        # otherwise start from the last time chain was checkpointed
+        if i == 0:
+            continue
+        start = intervals[i-1]
+
+        # run sampler
+        logging.info("Running sampler for %s to %s out of %s iterations"%(start,end,opts.niterations))
+        sampler.run_mcmc(end-start, p0=p0)
+
+        # write new samples
+        logging.info("Writing samples for %s to %s out of %s iterations"%(start,end,opts.niterations))
         with MCMCFile(opts.output_file, "a") as fp:
-            fp.write_sampler_attrs(sampler)
-
-        # generate more samples
-        logging.info("Generating more MCMC samples")
-        sampler.run_mcmc(opts.niterations,
-                         output_file=opts.output_file,
-                         checkpoint_interval=opts.checkpoint_interval)
-
-    else:
-
-        # write sampler attrs to file
-        with MCMCFile(opts.output_file, "a") as fp:
-            fp.write_sampler_attrs(sampler)
-
-        # generate samples
-        logging.info("Generating MCMC samples")
-        sampler.run_mcmc(opts.niterations, p0=p0,
-                         output_file=opts.output_file,
-                         checkpoint_interval=opts.checkpoint_interval)
+            fp.write_samples_from_sampler(sampler, start=start, end=end)
 
 # exit
 logging.info("Done")

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -238,10 +238,11 @@ with ctx:
     labels = [cp.get("labels",param) for param in variable_args]
 
     # create empty datasets in output file
-    logging.info("Writing empty datasets to output file")
-    with MCMCFile(opts.output_file, "a") as fp:
-        fp.write_samples(variable_args, nwalkers=opts.nwalkers,
-                         niterations=opts.niterations, labels=labels)
+    if opts.checkpoint_interval:
+        logging.info("Writing empty datasets to output file")
+        with MCMCFile(opts.output_file, "a") as fp:
+            fp.write_samples(variable_args, nwalkers=opts.nwalkers,
+                             niterations=opts.niterations, labels=labels)
 
     # check if user wants to skip the burn in
     if not opts.skip_burn_in:
@@ -252,7 +253,7 @@ with ctx:
 
         # write sampler attrs to file
         with MCMCFile(opts.output_file, "a") as fp:
-            fp.write_sampler_attrs(variable_args, opts.instruments, sampler)
+            fp.write_sampler_attrs(sampler)
 
         # generate more samples
         logging.info("Generating more MCMC samples")
@@ -264,7 +265,7 @@ with ctx:
 
         # write sampler attrs to file
         with MCMCFile(opts.output_file, "a") as fp:
-            fp.write_sampler_attrs(variable_args, opts.instruments, sampler)
+            fp.write_sampler_attrs(sampler)
 
         # generate samples
         logging.info("Generating MCMC samples")

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -78,6 +78,8 @@ parser.add_argument("--config-files", type=str, nargs="+", required=True,
 # output options
 parser.add_argument("--output-file", type=str, required=True,
     help="Output file path.")
+parser.add_argument("--checkpoint-interval", type=int, default=None,
+    help="Number of iterations to take before saving new samples to file.")
 
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
@@ -139,6 +141,18 @@ with ctx:
     psd_dict = psd.from_cli_multi_ifos(opts, length_dict, delta_f_dict,
                                    low_frequency_cutoff_dict, opts.instruments,
                                    strain_dict=strain_dict, precision="double")
+
+    # apply dynamic range factor for saving PSDs since plotting code expects it
+    logging.info("Saving PSDs")
+    psd_dyn_dict = {}
+    for key,val in psd_dict.iteritems():
+         psd_dyn_dict[key] = FrequencySeries(psd_dict[key]*DYN_RANGE_FAC**2,
+                                             delta_f=psd_dict[key].delta_f)
+
+    # save PSD
+    fp = MCMCFile(opts.output_file, "w")
+    fp.write_psds(psds=psd_dyn_dict,
+                  low_frequency_cutoff=low_frequency_cutoff_dict)
 
     # read configuration file
     logging.info("Reading configuration file")
@@ -220,6 +234,14 @@ with ctx:
                     p0[i][j] = idist.rvs(size=1, param=param)[0][0]
                     break
 
+    # get labels for each parameter from configuration file
+    labels = [cp.get("labels",param) for param in variable_args]
+
+    # create empty datasets in output file
+    logging.info("Writing empty datasets to output file")
+    fp.write_samples(variable_args, nwalkers=opts.nwalkers,
+                     niterations=opts.niterations, labels=labels)
+
     # check if user wants to skip the burn in
     if not opts.skip_burn_in:
 
@@ -227,38 +249,24 @@ with ctx:
         logging.info("MCMC burn in")
         sampler.burn_in(p0)
 
+        # write sampler attrs to file
+        fp.write_sampler_attrs(variable_args, opts.instruments, sampler)
+
         # generate more samples
         logging.info("Generating more MCMC samples")
-        sampler.run_mcmc(opts.niterations)
+        sampler.run_mcmc(variable_args, opts.niterations, output_file=fp,
+                         checkpoint_interval=opts.checkpoint_interval)
 
     else:
 
+        # write sampler attrs to file
+        fp.write_sampler_attrs(variable_args, opts.instruments, sampler)
+
         # generate samples
         logging.info("Generating MCMC samples")
-        sampler.run_mcmc(opts.niterations, p0=p0)
-
-# get all past samples as an niterations x nwalker x ndim array
-logging.info("Writing output file")
-chain = sampler.chain
-
-# transpose past samples to get an ndim x nwalker x niteration array
-chain = numpy.transpose(chain)
-
-# apply dynamic range factor to PSDs since plotting code expects it
-psd_dyn_dict = {}
-for key,val in psd_dict.iteritems():
-     psd_dyn_dict[key] = FrequencySeries(psd_dict[key]*DYN_RANGE_FAC**2,
-                                         delta_f=psd_dict[key].delta_f)
-
-# get labels for each parameter from configuration file
-labels = [cp.get("labels",param) for param in variable_args]
-
-# save samples to file
-fp = MCMCFile(opts.output_file, "w")
-fp.write(variable_args, opts.instruments, sampler, labels=labels,
-         low_frequency_cutoff=low_frequency_cutoff_dict,
-         psds=psd_dyn_dict)
-fp.close()
+        sampler.run_mcmc(variable_args, opts.niterations, p0=p0, output_file=fp,
+                         checkpoint_interval=opts.checkpoint_interval)
 
 # exit
+fp.close()
 logging.info("Done")

--- a/bin/inference/pycbc_mcmc
+++ b/bin/inference/pycbc_mcmc
@@ -245,6 +245,7 @@ with ctx:
         with MCMCFile(opts.output_file, "a") as fp:
             fp.write_samples(variable_args, nwalkers=opts.nwalkers,
                              niterations=opts.niterations, labels=labels)
+            fp.write_acceptance_fraction(niterations=opts.niterations)
 
         # determine intervals to run sampler until we save the new samples 
         intervals = [i for i in range(0, opts.niterations, opts.checkpoint_interval)] \
@@ -288,6 +289,8 @@ with ctx:
         logging.info("Writing samples for %s to %s out of %s iterations"%(start,end,opts.niterations))
         with MCMCFile(opts.output_file, "a") as fp:
             fp.write_samples_from_sampler(sampler, start=start, end=end)
+            fp.write_acceptance_fraction(data=sampler.acceptance_fraction,
+                                         start=start, end=end)
 
 # exit
 logging.info("Done")

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -26,6 +26,8 @@ This modules provides classes and functions for using different sampler
 packages for parameter estimation.
 """
 
+from pycbc.io.mcmc import MCMCFile
+
 class _BaseSampler(object):
     """ Base container class for running the MCMC sampler.
 
@@ -171,14 +173,13 @@ class KombineSampler(_BaseSampler):
             # and add to list
             remainder = niterations % checkpoint_interval
             if remainder:
-                print "intb", intervals
                 intervals += [intervals[-1]+remainder]
-                print "inta", intervals
 
             # loop over number of checkpoints
             for i,end in enumerate(intervals):
 
                 # if its the first checkpoint then start from 0
+                # otherwise start from the last time chain was checkpointed
                 if i == 0:
                     start = 0
                 else:
@@ -187,11 +188,10 @@ class KombineSampler(_BaseSampler):
                 # run sampler
                 self.sampler.run_mcmc(checkpoint_interval, **kwargs)
 
-                print start, end, "dsad"
-
                 # write new samples
-                output_file.write_samples(variable_args, self.sampler,
-                                          start=start, end=end)
+                with MCMCFile(output_file, "a") as fp:
+                    fp.write_samples(variable_args, self.sampler,
+                                     start=start, end=end)
 
         # sanity check that user did not forget an option in the case above
         elif output_file or checkpoint_interval:

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -37,8 +37,8 @@ class _BaseSampler(object):
         An instance of the sampler class from its package.
     """
 
-    def __init__(self, sampler):
-        self.sampler = sampler
+    def __init__(self, likelihood_evaluator):
+        self.likelihood_evaluator = likelihood_evaluator
         self.burn_in_iterations = 0
 
     @property
@@ -96,22 +96,24 @@ class KombineSampler(_BaseSampler):
         except ImportError:
             raise ImportError("kombine is not installed.")
 
-        # construct sampler 
-        sampler = kombine.Sampler(nwalkers, ndim, likelihood_evaluator,
+        # construct sampler for use in KombineSampler
+        self._sampler = kombine.Sampler(nwalkers, ndim, likelihood_evaluator,
                                           transd=transd, processes=processes)
-        super(KombineSampler, self).__init__(sampler)
+
+        # initialize
+        super(KombineSampler, self).__init__(likelihood_evaluator)
 
     @property
     def acceptance_fraction(self):
         """ Get the fraction of walkers that accepted each step as an arary.
         """
-        return self.sampler.acceptance_fraction
+        return self._sampler.acceptance_fraction
 
     @property
     def chain(self):
         """ Get all past samples as an niterations x nwalker x ndim array.
         """
-        return self.sampler.chain
+        return self._sampler.chain
 
     def burn_in(self, initial_values):
         """ Evolve an ensemble until the acceptance rate becomes roughly
@@ -136,13 +138,13 @@ class KombineSampler(_BaseSampler):
             with shape (nwalkers, ndim).
         """
         if self.burn_in_iterations == 0:
-            p, post, q = self.sampler.burnin(initial_values)
+            p, post, q = self._sampler.burnin(initial_values)
             self.burn_in_iterations = self.chain.shape[0]
         else:
             raise ValueError("Burn in has already been performed")
         return p, post, q
 
-    def run_mcmc(self, variable_args, niterations, output_file=None,
+    def run_mcmc(self, niterations, output_file=None,
                  checkpoint_interval=None, **kwargs):
         """ Advance the MCMC for a number of samples.
 
@@ -162,6 +164,9 @@ class KombineSampler(_BaseSampler):
             The list of log proposal densities for the walkers at positions p,
             with shape (nwalkers, ndim).
         """
+
+        # get variable_args from waveform generator
+        variable_args = self.likelihood_evaluator.waveform_generator.variable_args
 
         # check if user wants to checkpoint
         if output_file and checkpoint_interval:
@@ -185,11 +190,11 @@ class KombineSampler(_BaseSampler):
                 start = intervals[i-1]
 
                 # run sampler
-                self.sampler.run_mcmc(end-start, **kwargs)
+                self._sampler.run_mcmc(end-start, **kwargs)
 
                 # write new samples
                 with MCMCFile(output_file, "a") as fp:
-                    fp.write_samples(variable_args, self.sampler,
+                    fp.write_samples(variable_args, self,
                                      start=start, end=end)
 
         # sanity check that user did not forget an option in the case above
@@ -198,7 +203,7 @@ class KombineSampler(_BaseSampler):
 
         # else run without checkpointing
         else:
-            return self.sampler.run_mcmc(niterations, **kwargs)
+            return self._sampler.run_mcmc(niterations, **kwargs)
 
 samplers = {
     "kombine" : KombineSampler,

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -144,8 +144,7 @@ class KombineSampler(_BaseSampler):
             raise ValueError("Burn in has already been performed")
         return p, post, q
 
-    def run_mcmc(self, niterations, output_file=None,
-                 checkpoint_interval=None, **kwargs):
+    def run_mcmc(self, niterations, **kwargs):
         """ Advance the MCMC for a number of samples.
 
         Parameters
@@ -164,45 +163,7 @@ class KombineSampler(_BaseSampler):
             The list of log proposal densities for the walkers at positions p,
             with shape (nwalkers, ndim).
         """
-
-        # get variable_args from waveform generator
-        variable_args = self.likelihood_evaluator.waveform_generator.variable_args
-
-        # check if user wants to checkpoint
-        if output_file and checkpoint_interval:
-
-            # figure out samples to perform each checkpoint
-            intervals = [i for i in range(0, niterations, checkpoint_interval)]
-
-            # determine if there is a small bin at the end
-            # and add to list
-            remainder = niterations % checkpoint_interval
-            if remainder:
-                intervals += [intervals[-1]+remainder]
-
-            # loop over number of checkpoints
-            for i,end in enumerate(intervals):
-
-                # if its the first sample then skip
-                # otherwise start from the last time chain was checkpointed
-                if i == 0:
-                    continue
-                start = intervals[i-1]
-
-                # run sampler
-                self._sampler.run_mcmc(end-start, **kwargs)
-
-                # write new samples
-                with MCMCFile(output_file, "a") as fp:
-                    fp.write_samples_from_sampler(self, start=start, end=end)
-
-        # sanity check that user did not forget an option in the case above
-        elif output_file or checkpoint_interval:
-            raise ValueError("Must specify both output_file and checkpoint_interval")
-
-        # else run without checkpointing
-        else:
-            return self._sampler.run_mcmc(niterations, **kwargs)
+        return self._sampler.run_mcmc(niterations, **kwargs)
 
 samplers = {
     "kombine" : KombineSampler,

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -194,8 +194,7 @@ class KombineSampler(_BaseSampler):
 
                 # write new samples
                 with MCMCFile(output_file, "a") as fp:
-                    fp.write_samples(variable_args, self,
-                                     start=start, end=end)
+                    fp.write_samples_from_sampler(self, start=start, end=end)
 
         # sanity check that user did not forget an option in the case above
         elif output_file or checkpoint_interval:

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -26,8 +26,6 @@ This modules provides classes and functions for using different sampler
 packages for parameter estimation.
 """
 
-from pycbc.io.mcmc import MCMCFile
-
 class _BaseSampler(object):
     """ Base container class for running the MCMC sampler.
 

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -178,15 +178,14 @@ class KombineSampler(_BaseSampler):
             # loop over number of checkpoints
             for i,end in enumerate(intervals):
 
-                # if its the first checkpoint then start from 0
+                # if its the first sample then skip
                 # otherwise start from the last time chain was checkpointed
                 if i == 0:
-                    start = 0
-                else:
-                     start = end - intervals[i-1]
+                    continue
+                start = intervals[i-1]
 
                 # run sampler
-                self.sampler.run_mcmc(checkpoint_interval, **kwargs)
+                self.sampler.run_mcmc(end-start, **kwargs)
 
                 # write new samples
                 with MCMCFile(output_file, "a") as fp:

--- a/pycbc/io/mcmc.py
+++ b/pycbc/io/mcmc.py
@@ -223,7 +223,7 @@ class MCMCFile(h5py.File):
                 dataset_name = "walker%d"%j
                 if dataset_name not in self[dim_name].keys():
                     samples_subset = numpy.empty(niterations)
-                    if data:
+                    if data is not None:
                         samples_subset[start:end] = samples[i,j,start:end]
                     group_dim.create_dataset(dataset_name,
                                              data=samples_subset)

--- a/pycbc/io/mcmc.py
+++ b/pycbc/io/mcmc.py
@@ -205,10 +205,10 @@ class MCMCFile(h5py.File):
             # create a group in the output file for this dimension
             if dim_name not in self.keys():
                 group_dim = self.create_group(dim_name)
-            if labels:
-                group_dim.attrs["label"] = labels[i]
-            else:
-                group_dim.attrs["label"] = dim_name
+                if labels:
+                    group_dim.attrs["label"] = labels[i]
+                else:
+                    group_dim.attrs["label"] = dim_name
 
             # loop over number of walkers
             for j in range(nwalkers):
@@ -216,14 +216,16 @@ class MCMCFile(h5py.File):
                 # create dataset with shape (ndim,nwalkers,niterations)
                 dataset_name = "walker%d"%j
                 if dataset_name not in self[dim_name].keys():
+                    samples_subset = numpy.empty(niterations)
                     if sampler:
-                        samples_subset = numpy.empty(niterations)
                         samples_subset[start:end] = samples[i,j,start:end]
                     group_dim.create_dataset(dataset_name,
                                              data=samples_subset)
 
                 # write all samples in range from walker for this dimension
                 else:
+                    if end > len(samples[i,j,:]):
+                        end = None
                     samples_subset = samples[i,j,start:end]
                     self[dim_name+"/"+dataset_name][start:end] = samples_subset
 

--- a/pycbc/io/mcmc.py
+++ b/pycbc/io/mcmc.py
@@ -235,31 +235,32 @@ class MCMCFile(h5py.File):
                     samples_subset = samples[i,j,start:end]
                     self[dim_name+"/"+dataset_name][start:end] = samples_subset
 
+    def write_acceptance_fraction(self, data=None, niterations=None, start=None, end=None):
+        """
+        """
+
+        # sanity check options and if data is not given then make empty array
+        if data is None and niterations is None:
+            raise ValueError("Must specify either data or niterations")
+        elif data is None:
+            data = numpy.empty(niterations)
+
+        # write data
+        if "acceptance_fraction" not in self.keys():
+            self.create_dataset("acceptance_fraction",
+                                data=data)
+        else:
+            self["acceptance_fraction"][start:end] = data[start:end]
+            print self["acceptance_fraction"][start:end], start, end, data[start:end]
+
     def write_samples_from_sampler(self, sampler, start=None, end=None,
                       nwalkers=0, niterations=0, labels=None):
         """
         """
-
-        # write samples
         variable_args = sampler.likelihood_evaluator.waveform_generator.variable_args
         self.write_samples(variable_args, data=sampler.chain,
                            start=start, end=end,
                            nwalkers=nwalkers, niterations=niterations,
                            labels=labels)
 
-        # create a dataset for the acceptance fraction
-        if "acceptance_fraction" not in self.keys():
-            self.create_dataset("acceptance_fraction",
-                                data=numpy.empty(niterations))
-        else:
-            self["acceptance_fraction"][start:end] = sampler.acceptance_fraction[start:end]
 
-    def write(self, variable_args, ifo_list, sampler, labels=None,
-              psds=None, low_frequency_cutoff=None):
-        """
-        """
-
-        self.write_sampler_attrs(variable_args, ifo_list, sampler)
-        self.write_samples(variable_args, sampler=sampler, labels=labels)
-        if psds:
-            self.write_psds(psds, low_frequency_cutoff)

--- a/pycbc/io/mcmc.py
+++ b/pycbc/io/mcmc.py
@@ -149,7 +149,15 @@ class MCMCFile(h5py.File):
         return label
 
     def write_psds(self, psds, low_frequency_cutoff):
-        """
+        """ Writes PSD for each IFO to file.
+
+        Parameters
+        -----------
+        psds : {dict, FrequencySeries}
+            A dict of FrequencySeries where the key is the IFO.
+        low_frequency_cutoff : {dict, float}
+            A dict of the low-frequency cutoff where the key is the IFO. The
+            minimum value will be stored as an attr in the File.
         """
         self.attrs["low_frequency_cutoff"] = min(low_frequency_cutoff.values())
         for key in psds.keys():
@@ -158,7 +166,12 @@ class MCMCFile(h5py.File):
             psd_dim.attrs["delta_f"] = psds[key].delta_f
 
     def write_sampler_attrs(self, sampler):
-        """
+        """ Write information about the sampler to the file attrs.
+
+        Parameters
+        -----------
+        sampler : pycbc.inference._BaseSampler
+            An instance of a sampler class from pycbc.inference.sampler.
         """
 
         # get attributes from waveform generator
@@ -180,7 +193,28 @@ class MCMCFile(h5py.File):
 
     def write_samples(self, variable_args, data=None, start=None, end=None,
                       nwalkers=0, niterations=0, labels=None):
-        """
+        """ Writes samples to the file. To write to a subsample of the array
+        use start and end. To initialize an empty array of length niterations
+        for each walker use nwalkers and niterations.
+
+        Parameters
+        -----------
+        variable_args : {list, str}
+            List of names of parameters.
+        data : numpy.array
+            Data to be saved with shape (niterations,nwalkers,ndim). if data is
+            None then create an array fo zeros for each walker with
+            length niterations.
+        start : int
+            If given then begin inserting this data at this index.
+        end : int
+            If given then stop inserting data at this index.
+        nwalkers : int
+            Number of walkers should be given if data is None.
+        niterations : int
+            Number of iterations should be given if data is None.
+        labels : {list, str}
+            A list of str to use as dislay by downsteam executables.
         """
 
         # transpose past samples to get an (ndim,nwalkers,niteration) array
@@ -235,8 +269,24 @@ class MCMCFile(h5py.File):
                     samples_subset = samples[i,j,start:end]
                     self[dim_name+"/"+dataset_name][start:end] = samples_subset
 
-    def write_acceptance_fraction(self, data=None, niterations=None, start=None, end=None):
-        """
+    def write_acceptance_fraction(self, data=None, start=None, end=None,
+                                  niterations=None):
+        """ Write acceptance_fraction data to file. To write to a subsample
+        of the array use start and end. To initialize an array of zeros, set
+        data to None and specify niterations.
+
+        Parameters
+        -----------
+        data : numpy.array
+            Data to be saved with shape (niterations,nwalkers,ndim). if data is
+            None then create an array fo zeros for each walker with
+            length niterations.
+        start : int
+            If given then begin inserting this data at this index.
+        end : int
+            If given then stop inserting data at this index.
+        niterations : int
+            Number of iterations should be given if data is None.
         """
 
         # sanity check options and if data is not given then make empty array
@@ -254,7 +304,22 @@ class MCMCFile(h5py.File):
 
     def write_samples_from_sampler(self, sampler, start=None, end=None,
                       nwalkers=0, niterations=0, labels=None):
-        """
+        """ Wtite data from sampler to file.
+
+        Parameters
+        -----------
+        sampler : pycbc.inference._BaseSampler
+            An instance of a sampler class from pycbc.inference.sampler.
+        start : int
+            If given then begin inserting this data at this index.
+        end : int
+            If given then stop inserting data at this index.
+        nwalkers : int
+            Number of walkers should be given if data is None.
+        niterations : int
+            Number of iterations should be given if data is None.
+        labels : {list, str}
+            A list of str to use as dislay by downsteam executables.
         """
         variable_args = sampler.likelihood_evaluator.waveform_generator.variable_args
         self.write_samples(variable_args, data=sampler.chain,

--- a/pycbc/io/mcmc.py
+++ b/pycbc/io/mcmc.py
@@ -197,7 +197,7 @@ class MCMCFile(h5py.File):
         else:
             ndim = len(variable_args)
             shape = (ndim, nwalkers, niterations)
-            samples = numpy.empty(shape)
+            samples = numpy.zeros(shape)
 
         # save number of iterations so far
         if "niterations" in self.attrs.keys():
@@ -222,7 +222,7 @@ class MCMCFile(h5py.File):
                 # create dataset with shape (ndim,nwalkers,niterations)
                 dataset_name = "walker%d"%j
                 if dataset_name not in self[dim_name].keys():
-                    samples_subset = numpy.empty(niterations)
+                    samples_subset = numpy.zeros(niterations)
                     if data is not None:
                         samples_subset[start:end] = samples[i,j,start:end]
                     group_dim.create_dataset(dataset_name,
@@ -243,7 +243,7 @@ class MCMCFile(h5py.File):
         if data is None and niterations is None:
             raise ValueError("Must specify either data or niterations")
         elif data is None:
-            data = numpy.empty(niterations)
+            data = numpy.zeros(niterations)
 
         # write data
         if "acceptance_fraction" not in self.keys():
@@ -251,7 +251,6 @@ class MCMCFile(h5py.File):
                                 data=data)
         else:
             self["acceptance_fraction"][start:end] = data[start:end]
-            print self["acceptance_fraction"][start:end], start, end, data[start:end]
 
     def write_samples_from_sampler(self, sampler, start=None, end=None,
                       nwalkers=0, niterations=0, labels=None):

--- a/pycbc/io/mcmc.py
+++ b/pycbc/io/mcmc.py
@@ -166,7 +166,9 @@ class MCMCFile(h5py.File):
             psd_dim.attrs["delta_f"] = psds[key].delta_f
 
     def write_sampler_attrs(self, sampler):
-        """ Write information about the sampler to the file attrs.
+        """ Write information about the sampler to the file attrs. If sampler
+        will run burn in, this should be called after sampler has already
+        run burn in.
 
         Parameters
         -----------


### PR DESCRIPTION
This PR:
  * ``pycbc_mcmc`` dumps the MCMC chain to the output file after a certain number of iterations. Number of iterations is given on the command line with ``--checkpoint-interval``. If ``--checkpoint-interval`` is not given, then it will write samples to file once its finished.
  * Seperate out ``MCMCFile.write`` out into smaller functions that get called at different points in ``pycbc_mcmc``, eg. ``MCMCFile.write_psds``, ``MCMCFile.write_samples``, ``MCMC_write_sampler_attrs``, etc. Instead of one write function that handled all of these.

At line 243 of ``pycbc_mcmc`` it writes zeros of length ``--niterations`` to the output file as placeholder. Then as ``pycbc_mcmc`` runs, it fills in the chunks. In the ``MCMCFile.attrs`` it saves a ``niterations`` that is the number of iterations done so far.