### PR TITLE
Add None to call to SimInspiralTaylorF2AlignedPhasing() for empty testGRparams.

### DIFF
--- a/pycbc/waveform/spa_tmplt.py
+++ b/pycbc/waveform/spa_tmplt.py
@@ -176,7 +176,7 @@ def spa_tmplt(**kwds):
 
     #Calculate the PN terms 
     phasing = lalsimulation.SimInspiralTaylorF2AlignedPhasing(float(mass1), 
-                                        float(mass2), float(s1z), float(s2z), 1, 1, spin_order)
+                                        float(mass2), float(s1z), float(s2z), 1, 1, spin_order, None)
                                            
     pfaN = phasing.v[0]
     pfa2 = phasing.v[2] / pfaN


### PR DESCRIPTION
This fixes the problem reported by Anuradha Gupta
