### PR TITLE
Function to figure out ACL

### DIFF
--- a/bin/inference/pycbc_mcmc_plot_acf
+++ b/bin/inference/pycbc_mcmc_plot_acf
@@ -93,8 +93,6 @@ for param_name in variable_args:
         # autocorrelate and add to list
         param_acfs.append( calculate_acf(y) )
 
-        print calculate_acl(y)
-
     # add list with parameters ACF to list of all ACFs
     all_acfs.append(param_acfs)
 

--- a/bin/inference/pycbc_mcmc_plot_acf
+++ b/bin/inference/pycbc_mcmc_plot_acf
@@ -24,7 +24,7 @@ import matplotlib.pyplot as plt
 import numpy
 import sys
 from pycbc import results
-from pycbc.filter.autocorrelation import calculate_acf, calculate_acl
+from pycbc.filter import autocorrelation
 from pycbc.io.mcmc import MCMCFile
 
 # command line usage
@@ -91,7 +91,7 @@ for param_name in variable_args:
                                         thin_interval=opts.thin_interval)
 
         # autocorrelate and add to list
-        param_acfs.append( calculate_acf(y) )
+        param_acfs.append( autocorrelation.calculate_acf(y) )
 
     # add list with parameters ACF to list of all ACFs
     all_acfs.append(param_acfs)

--- a/bin/inference/pycbc_mcmc_plot_acf
+++ b/bin/inference/pycbc_mcmc_plot_acf
@@ -24,6 +24,7 @@ import matplotlib.pyplot as plt
 import numpy
 import sys
 from pycbc import results
+from pycbc.filter.autocorrelation import calculate_acf, calculate_acl
 from pycbc.io.mcmc import MCMCFile
 
 # command line usage
@@ -89,20 +90,10 @@ for param_name in variable_args:
                                         thin_start=opts.thin_start,
                                         thin_interval=opts.thin_interval)
 
-        # subtract mean
-        z =  y - y.mean()
+        # autocorrelate and add to list
+        param_acfs.append( calculate_acf(y) )
 
-        # autocorrelate
-        acf = numpy.correlate(z, z, mode="full")
-
-        # take only the second half of the autocorrelation time series
-        acf = acf[acf.size/2:]
-
-        # normalize
-        acf /= y.var() * numpy.arange(y.size, 0, -1)
-
-        # add to list of autocorrelation time series
-        param_acfs.append(acf)
+        print calculate_acl(y)
 
     # add list with parameters ACF to list of all ACFs
     all_acfs.append(param_acfs)

--- a/pycbc/filter/autocorrelation.py
+++ b/pycbc/filter/autocorrelation.py
@@ -1,0 +1,82 @@
+# Copyright (C) 2016  Christopher M. Biwer
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""
+This modules provides functions for calculating the autocorrelation function
+and length of time series.
+"""
+
+import numpy
+
+def calculate_acf(data):
+    """ Calculates the autocorrelation function (ACF) and returns the one-sided
+    ACF.
+    """
+
+    # subtract mean
+    z =  data - data.mean()
+
+    # autocorrelate
+    acf = numpy.correlate(z, z, mode="full")
+
+    # take only the second half of the autocorrelation time series
+    acf = acf[acf.size/2:]
+
+    # normalize
+    acf /= data.var() * numpy.arange(data.size, 0, -1)
+
+    return acf
+
+def calculate_acl(data, m=5, k=2):
+    """ Calculates the autocorrelation length (ACL).
+    """
+
+    # calculate ACF
+    # get number of points in ACF
+    acf = calculate_acf(data)
+    n = len(acf)
+
+    print acf
+
+    # get maximum index in ACF for calculation
+    # will terminate at this index
+    imax = n / k
+
+    # loop over ACF indexes
+    acl = 1.0
+    for i in range(n):
+
+        # see if we have reached terminating condition
+        s = float(i+1) / m
+        if not acl >= s:
+            print acl, s
+            break
+
+        # see if ACL is indeterminate
+        if s > imax:
+            return numpy.inf
+
+        # add term for ACL
+        acl += 2 * acf[i]
+
+    return numpy.ceil(acl)

--- a/pycbc/filter/autocorrelation.py
+++ b/pycbc/filter/autocorrelation.py
@@ -23,7 +23,7 @@
 #
 """
 This modules provides functions for calculating the autocorrelation function
-and length of an numpy.array.
+and length of a data series.
 """
 
 import numpy


### PR DESCRIPTION
This PR:
  * Adds a ``pycbc.filter.autocorrelation`` module that has functions for calculating ACL/ACF.

ACL is the integrated ACL, ie.: 1 + 2 sum ACF(k)

Adds some extra features like in ``LALInferenceComputeMaxAutoCorrLen`` (https://github.com/lscsoft/lalsuite/blob/e79c77830cf04cb4957731654ad3123688636fe8/lalinference/src/LALInferenceProposal.c#L3740):
  * A ``k`` parameter that tells calculation to not go past a certain index, useful for avoiding edge effects of ACF.
  * A ``m`` parameter that sets a stopping condition.

Example is:
```
import matplotlib.pyplot as plt
import numpy
from pycbc.filter.autocorrelation import calculate_acf, calculate_acl

# make some data with line in it
data = numpy.array([numpy.random.uniform() for i in range(10000)])
for i in range(40,70,1):
    data[i] += (i-40)
#for i in range(50,60,1):
#    data[i] += ((10-i)+50)

# sine wave
#s = 2
#fs = 100.0
#f = 2.0
#x = numpy.arange(s*fs)
#data = numpy.array([ numpy.sin(2*numpy.pi*f * (i/fs)) for i in x])

# get ACL
pycbc_acl = calculate_acl(data)

# print statement
print pycbc_acl

# get ACF for plotting
acf = calculate_acf(data)

# plot ACF
plt.scatter(range(len(acf)), acf)
plt.vlines(pycbc_acl, -1, 1, "g")
plt.ylim(-1.1,1.1)
plt.xlim(0)
plt.show()

# plot s/m factor versus the integrated ACL
plt.semilogy(range(len(acf)), [(i+1)/5.0 for i in range(len(acf))], "k")
plt.semilogy(range(len(acf)), 1+2*numpy.cumsum(acf), "m")
plt.vlines(pycbc_acl, -1, 1, "g")
plt.ylim(-1.1)
plt.xlim(0,120)
plt.show()

# plot data
plt.scatter(range(len(data)), data)
plt.ylim(-1)
plt.xlim(0)
plt.show()
```