### PR TITLE
Set default in MCMC plotting codes to plot all parameters

### DIFF
--- a/bin/inference/pycbc_mcmc_plot_acf
+++ b/bin/inference/pycbc_mcmc_plot_acf
@@ -33,7 +33,7 @@ parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_acf [--options]",
 # add data options
 parser.add_argument("--input-file", type=str, required=True,
     help="Path to input HDF file.")
-parser.add_argument("--variable-args", type=str, nargs="+", required=True,
+parser.add_argument("--variable-args", type=str, nargs="+", default=None,
     help="Name of parameters varied in MCMC.")
 
 # add plotting options
@@ -66,17 +66,18 @@ else:
     log_level = logging.WARN
 logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 
-# get number of dimensions
-ndim = len(opts.variable_args)
-
 # read input file
 logging.info("Reading input file")
 fp = MCMCFile(opts.input_file, "r")
+variable_args = fp.read_variable_args() if opts.variable_args is None else opts.variable_args
+
+# get number of dimensions
+ndim = len(variable_args)
 
 # calculate autocorrelation function for each walker
 logging.info("Calculating autocorrelation functions")
 all_acfs = []
-for param_name in opts.variable_args:
+for param_name in variable_args:
 
     # loop over walkers and save an autocorrelation function
     # for each walker
@@ -111,9 +112,9 @@ logging.info("Plotting autocorrelation functions")
 fig = plt.figure()
 for param_acfs in all_acfs:
     for acf in param_acfs:
-        plt.plot(range(len(acf)), acf, alpha=0.5)
+        plt.plot(range(len(acf)), acf, alpha=0.25)
 plt.xlabel("Iteration")
-plt.ylabel(r'Autocorrelation Function for %s'%', '.join(['%s'%fp.read_label(param) for param in opts.variable_args]))
+plt.ylabel(r'Autocorrelation Function for %s'%', '.join(['%s'%fp.read_label(param) for param in variable_args]))
 
 # format plot
 if opts.ymin:
@@ -123,7 +124,7 @@ if opts.ymax:
 
 # save figure with meta-data
 caption_kwargs = {
-    "parameters" : ", ".join(["%s"%fp.read_label(param, html=True) for param in opts.variable_args]),
+    "parameters" : ", ".join(["%s"%fp.read_label(param, html=True) for param in variable_args]),
 }
 caption = """Autocorrelation function (ACF) from all the walker chains for the
 parameters. Each line is an ACF for a chain of walker samples."""

--- a/bin/inference/pycbc_mcmc_plot_corner
+++ b/bin/inference/pycbc_mcmc_plot_corner
@@ -34,7 +34,7 @@ parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_corner [--options]",
 # add data options
 parser.add_argument("--input-file", type=str, required=True,
     help="Path to input HDF file.")
-parser.add_argument("--variable-args", type=str, nargs="+", required=True,
+parser.add_argument("--variable-args", type=str, nargs="+", default=None,
     help="Name of parameters varied in MCMC.")
 
 # output plot options
@@ -66,6 +66,7 @@ logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 # read input file
 logging.info("Reading input file")
 fp = MCMCFile(opts.input_file, "r")
+variable_args = fp.read_variable_args() if opts.variable_args is None else opts.variable_args
 
 # thin samples to get independent samples from each sampler
 logging.info("Thinning samples")
@@ -76,7 +77,7 @@ for i in range(fp.attrs["nwalkers"]):
 
     # loop over each parameter
     samples = []
-    for param in opts.variable_args:
+    for param in variable_args:
 
         # get MCMC parameters
         samples.append( fp.read_samples_from_walker(param, i,
@@ -96,11 +97,11 @@ x = numpy.concatenate(x)
 # plot posterior
 logging.info("Plot posteriors")
 quantiles = [0.16, 0.5, 0.84]
-labels = [r'%s'%str(fp.read_label(param)) for param in opts.variable_args]
+labels = [r'%s'%str(fp.read_label(param)) for param in variable_args]
 fig = corner.corner(x, labels=labels, quantiles=quantiles)
 
 # if there is only one histogram then change some formatting
-if len(opts.variable_args) == 1:
+if len(variable_args) == 1:
 
     # make plot larger
     fig.set_size_inches(8, 6)
@@ -137,8 +138,8 @@ vertical lines correspond to the {quantiles} quantiles. The thinning used to
 make this plot took samples beginning at the {thin_start} and then every
 {thin_interval}-th sample after that. Each chain of samples had {niterations}
 iterations.""".format(**caption_kwargs)
-if len(opts.variable_args) == 1:
-    title = "Posterior Distribution for %s"%fp.read_label(opts.variable_args[0], html=True)
+if len(variable_args) == 1:
+    title = "Posterior Distribution for %s"%fp.read_label(variable_args[0], html=True)
 else:
     title = "Posterior Distributions"
 results.save_fig_with_metadata(fig, opts.output_file,

--- a/bin/inference/pycbc_mcmc_plot_samples
+++ b/bin/inference/pycbc_mcmc_plot_samples
@@ -32,7 +32,7 @@ parser = argparse.ArgumentParser(usage="pycbc_mcmc_plot_samples [--options]",
 # add data options
 parser.add_argument("--input-file", type=str, required=True,
     help="Path to input HDF file.")
-parser.add_argument("--variable-args", type=str, nargs="+", required=True,
+parser.add_argument("--variable-args", type=str, nargs="+", default=None,
     help="Name of parameters varied in MCMC.")
 
 # output plot options
@@ -59,12 +59,13 @@ else:
     log_level = logging.WARN
 logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 
-# get number of dimensions
-ndim = len(opts.variable_args)
-
 # read input file
 logging.info("Reading input file")
 fp = MCMCFile(opts.input_file, "r")
+variable_args = fp.read_variable_args() if opts.variable_args is None else opts.variable_args
+
+# get number of dimensions
+ndim = len(variable_args)
 
 # plot samples
 # plot each variable arg has a different subplot
@@ -73,8 +74,8 @@ fig, axs = plt.subplots(ndim, sharex=True)
 plt.xlabel("Iteration")
 
 # loop over variable args
-axs = [axs] if type(axs) is not list else axs
-for i,arg in enumerate(opts.variable_args):
+axs = [axs] if not hasattr(axs, "__iter__") else axs
+for i,arg in enumerate(variable_args):
 
     # loop over walkers
     for j in range(fp.attrs["nwalkers"]):
@@ -82,14 +83,15 @@ for i,arg in enumerate(opts.variable_args):
         # plot each walker as a different line on the subplot
         axs[i].plot(fp.read_samples_from_walker(arg, j,
                                                 thin_start=opts.thin_start,
-                                                thin_interval=opts.thin_interval))
+                                                thin_interval=opts.thin_interval),
+                    alpha=0.25)
 
         # y-axis label
         axs[i].set_ylabel(r'%s'%fp.read_label(arg))
 
 # save figure with meta-data
 caption_kwargs = {
-    "parameters" : ", ".join([fp.read_label(param, html=True) for param in opts.variable_args]),
+    "parameters" : ", ".join([fp.read_label(param, html=True) for param in variable_args]),
 }
 caption = r"""All samples from all the walker chains for the parameters. Each
 line is a different chain of walker samples."""

--- a/bin/inference/pycbc_mcmc_table_summary
+++ b/bin/inference/pycbc_mcmc_table_summary
@@ -71,7 +71,7 @@ fp = MCMCFile(opts.input_file, "r")
 if opts.variable_args:
     variable_args = opts.variable_args
 else:
-    variable_args = fp.attrs["variable_args"]
+    variable_args = fp.read_variable_args()
 
 # get thinned samples for each parameter
 table = []

--- a/pycbc/io/mcmc.py
+++ b/pycbc/io/mcmc.py
@@ -113,6 +113,16 @@ class MCMCFile(h5py.File):
 
         return self[variable_arg]["walker%d"%nwalker][thin_start::thin_interval]
 
+    def read_variable_args(self):
+        """ Returns list of variable_args.
+
+        Returns
+        -------
+        variable_args : {list, str}
+            List of str that contain variable_args keys.
+        """
+        return self.attrs["variable_args"]
+
     def read_label(self, variable_arg, html=False):
         """ Returns the label for the parameter.
 


### PR DESCRIPTION
Sets the default in MCMC plotting codes to plot all ``variables_args`` stored in the HDF input file.

Adds a function ``MCMCFile.read_variable_args`` to do this.

Now ``pycbc_mcmc_plot_samples``, ``pycbc_mcmc_plot_acf``, ``pycbc_mcmc_plot_corner``, and ``pycbc_mcmc_table_summary`` minimally need ``--input-file`` and ``--output-file`` to run.

Note that the other plotting executable ``pycbc_mcmc_plot_acceptance_rate`` does not use the ``variable_args`` attribute.