### PR TITLE
Fix typo in sngl_inspiral process_id column

### DIFF
--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -35,7 +35,7 @@ def return_empty_sngl():
         elif cols[entry] == 'lstring':
             setattr(sngl,entry,'')
         elif entry == 'process_id':
-            sngl.process_id = ilwd.ilwdchar("sngl_inspiral:process_id:0")
+            sngl.process_id = ilwd.ilwdchar("process:process_id:0")
         elif entry == 'event_id':
             sngl.event_id = ilwd.ilwdchar("sngl_inspiral:event_id:0")
         else:


### PR DESCRIPTION
The values should be of the form `process:process_id:0`, not `sngl_inspiral:process_id:0`. Perhaps a copy-paste error?

I noticed that pycbc coinc files that I have lying around had `sngl_inspiral` tables whose `process_id` columns have values like `sngl_inspiral:process_id:0`. All other coinc files that I have seen use the form `process:process_id:0` (so that they work as keys to the `process` table).

I'm not familiar enough with pycbc data flow to know where this gets set, but I found this likely typo by grepping through the source tree.