### PR TITLE
Fix shebang line in inference excutables

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -17,7 +17,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import argparse
-import kombine
 import logging
 import numpy
 import pycbc.opt

--- a/bin/inference/pycbc_inference_plot_acceptance_rate
+++ b/bin/inference/pycbc_inference_plot_acceptance_rate
@@ -1,4 +1,4 @@
-#! /usr/bin/evn python
+#! /usr/bin/env python
 
 # Copyright (C) 2016 Christopher M. Biwer
 #

--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -1,4 +1,4 @@
-#! /usr/bin/evn python
+#! /usr/bin/env python
 
 # Copyright (C) 2016 Christopher M. Biwer
 #

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -1,4 +1,4 @@
-#! /usr/bin/evn python
+#! /usr/bin/env python
 
 # Copyright (C) 2016 Christopher M. Biwer
 #

--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -1,4 +1,4 @@
-#! /usr/bin/evn python
+#! /usr/bin/env python
 
 # Copyright (C) 2016 Christopher M. Biwer
 #

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -1,4 +1,4 @@
-#! /usr/bin/evn python
+#! /usr/bin/env python
 
 # Copyright (C) 2016 Christopher M. Biwer
 #

--- a/pycbc/frame.py
+++ b/pycbc/frame.py
@@ -386,7 +386,7 @@ def write_frame(location, channels, timeseries):
     lalframe.FrameWrite(frame, location)
 
 class DataBuffer(object):
-    """ A linear buffer that acts a a FILO for reading in frame data
+    """ A linear buffer that acts as a FILO for reading in frame data
     """
     def __init__(self, frame_src, 
                        channel_name,

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -183,9 +183,6 @@ def make_inference_corner_plot(workflow, inference_file, output_dir,
         The file with posterior samples.
     output_dir: str
         The directory to store result plots and files.
-    config_file: str
-        The path to the inference configuration file that has a
-        [variable_args] section.
     variable_args : list
         A list of parameters to use instead of [variable_args].
     name: str

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -51,9 +51,9 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
     dax_output : str
         The name of the output DAX file.
     out_dir: path
-        The directory to store minifollowups result plots and files
+        The directory to store inference result plots and files
     tags: {None, optional}
-        Tags to add to the minifollowups executables
+        Tags to add to the inference executables
     """
 
     logging.info("Entering inference module")
@@ -140,7 +140,7 @@ def make_inference_summary_table(workflow, inference_file, output_dir,
        The segment this job encompasses. If None then use the total analysis
        time from the workflow.
     tags: {None, optional}
-        Tags to add to the minifollowups executables.
+        Tags to add to the inference executables.
 
     Returns
     -------
@@ -195,7 +195,7 @@ def make_inference_corner_plot(workflow, inference_file, output_dir,
        The segment this job encompasses. If None then use the total analysis
        time from the workflow.
     tags: {None, optional}
-        Tags to add to the minifollowups executables.
+        Tags to add to the inference executables.
 
     Returns
     -------
@@ -245,7 +245,7 @@ def make_inference_acceptance_rate_plot(workflow, inference_file, output_dir,
        The segment this job encompasses. If None then use the total analysis
        time from the workflow.
     tags: {None, optional}
-        Tags to add to the minifollowups executables.
+        Tags to add to the inference executables.
 
     Returns
     -------
@@ -302,7 +302,7 @@ def make_inference_single_parameter_plots(workflow, inference_file, output_dir,
        The segment this job encompasses. If None then use the total analysis
        time from the workflow.
     tags: {None, optional}
-        Tags to add to the minifollowups executables.
+        Tags to add to the inference executables.
 
     Returns
     -------


### PR DESCRIPTION
Fixes a copy-paste error in the shebang line.

Also fixes some typos in ``inference_followups`` and ``frame``.

Removes an old unused import in ``pycbc_inference``.