### PR TITLE
Do not overwrite labels if calling ``InferenceFile.write_samples`` multiple times

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -236,7 +236,12 @@ with ctx:
                     break
 
     # get labels for each parameter from configuration file
-    labels = [cp.get("labels",param) for param in variable_args]
+    labels = []
+    for param in variable_args:
+        if cp.has_option("labels", param):
+            labels.append( cp.get("labels", param) )
+        else:
+            labels.append( param )
 
     # setup checkpointing
     if opts.checkpoint_interval:
@@ -247,6 +252,7 @@ with ctx:
             fp.write_samples(variable_args, nwalkers=opts.nwalkers,
                              niterations=opts.niterations, labels=labels)
             fp.write_acceptance_fraction(niterations=opts.niterations)
+            labels = None
 
         # determine intervals to run sampler until we save the new samples 
         intervals = [i for i in range(0, opts.niterations, opts.checkpoint_interval)] \
@@ -291,7 +297,8 @@ with ctx:
         # write new samples
         logging.info("Writing samples for %s to %s out of %s iterations"%(start,end,opts.niterations))
         with InferenceFile(opts.output_file, "a") as fp:
-            fp.write_samples_from_sampler(sampler, start=start, end=end)
+            fp.write_samples_from_sampler(sampler, start=start, end=end,
+                                          labels=labels)
             fp.write_acceptance_fraction(data=sampler.acceptance_fraction,
                                          start=start, end=end)
 

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -197,8 +197,9 @@ with ctx:
                         delta_f=delta_f_dict.values()[0], **static_args)
 
     # construct class that will return the natural logarithm of likelihood
-    likelihood = inference.GaussianLikelihood(generator, stilde_dict,
-                        opts.low_frequency_cutoff, psds=psd_dict, prior=prior)
+    likelihood = inference.likelihood_evaluators[opts.likelihood_evaluator](generator,
+                        stilde_dict, opts.low_frequency_cutoff,
+                        psds=psd_dict, prior=prior)
 
     # create sampler that will run
     ndim = len(variable_args)

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -275,7 +275,9 @@ class InferenceFile(h5py.File):
             # create a group in the output file for this dimension
             if dim_name not in self.keys():
                 group_dim = self.create_group(dim_name)
-                if labels:
+                if "label" in group_dim.attrs.keys():
+                    pass
+                elif labels != None:
                     group_dim.attrs["label"] = labels[i]
                 else:
                     group_dim.attrs["label"] = dim_name


### PR DESCRIPTION
Does as title says.

Also adds a commit to use the ``likelihood_evaluators`` dict in the module.