### PR TITLE
Allow pycbc_inference_plot_prior to work for more dimensions

### DIFF
--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -18,55 +18,38 @@
 
 import argparse
 import corner
-import logging
 import itertools
-import math
+import logging
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy
-import scipy
 import sys
-from pycbc import inference, pnutils, results
+from pycbc import inference, results
+from pycbc.io.inference_hdf import read_label_from_config
 from pycbc.workflow import WorkflowConfigParser
-
-def binomial_coeff(x, y):
-    """ Returns the binomial coefficient: x! / (y! * (x - y)!)
-    """
-    return  math.factorial(x) // math.factorial(y) // math.factorial(x - y)
 
 def cartesian(arrays):
     """ Returns a cartesian product from a list of iterables.
     """
     return numpy.array([numpy.array(element) for element in itertools.product(*arrays)])
 
-
 # command line usage
 parser = argparse.ArgumentParser(usage="pycbc_inference_plot_prior [--options]",
-    description="Plots priors from inference configuration file.")
+    description="Plots prior distributions.")
 
 # add input options
-parser.add_argument("--config-file", type=str, required=True,
+parser.add_argument("--config-files", type=str, nargs="+", required=True,
     help="A file parsable by pycbc.workflow.WorkflowConfigParser.")
-parser.add_argument("--subsection", type=str, required=True,
-    help="")
+parser.add_argument("--section", type=str, default="prior",
+    help="Name of section that contains subsections with distribution configurations.")
 
 # add prior options
-parser.add_argument("--variable-args", type=str, nargs="+",  default=[],
-    help="Name of parameters varied.")
 parser.add_argument("--bins", type=int, required=True,
-    help="Number of points to evaluator parameter distributions.")
+    help="Number of points to grid a parameter.")
 
-# output plot options
+# add output options
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
-parser.add_argument("--plot-test-points",
-    action="store_true", default=False,
-    help="If true then use a small number of test points instead of prior values.")
-parser.add_argument("--plot-interpolation-points",
-    action="store_true", default=False,
-    help="If true then plot points used to interpolate greyscale.")
-parser.add_argument("--levels", type=int, default=5,
-    help="Number of levels to use in contour plot.")
 
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
@@ -75,10 +58,6 @@ parser.add_argument("--verbose", action="store_true", default=False,
 # parse the command line
 opts = parser.parse_args()
 
-# sanity check number of parameters to plot
-if len(opts.variable_args) > 2:
-    raise ValueError("You cannot plot more than two parameters.")
-
 # setup log
 if opts.verbose:
     log_level = logging.DEBUG
@@ -86,87 +65,63 @@ else:
     log_level = logging.WARN
 logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 
-# read configuration file
-logging.info("Reading configuration file")
-cp = WorkflowConfigParser([opts.config_file])
+# get variable_args from the configuration file
+logging.info("Reading configuration files")
+cp = WorkflowConfigParser(opts.config_files)
+variable_args = sorted(cp.options("variable_args"))
+ndim = len(variable_args)
 
-# get distribution from inference configuration file
-name = cp.get_opt_tag("prior", "name", opts.subsection)
-dist = inference.priors[name].from_config(cp, "prior", opts.subsection)
+# get prior distribution for each variable parameter
+logging.info("Constructing prior")
+distributions = []
+for subsection in cp.get_subsections("prior"):
+    name = cp.get_opt_tag("prior", "name", subsection)
+    distributions.append( inference.priors[name].from_config(cp, "prior", subsection) )
 
-# scale number of subplots with dimensions of the distribution
-fig, axs = plt.subplots( binomial_coeff(len(dist.params),2) )
-axs = [axs] if binomial_coeff(len(dist.params),2) is 1 else axs
+# construct class that will return draws from the prior
+prior = inference.PriorEvaluator(variable_args, *distributions)
 
 # get all points in space to calculate PDF
 logging.info("Getting grid of points")
-vals = []
-for param in dist.params:
-    step = float(dist.bounds[param][1]-dist.bounds[param][0]) / opts.bins
-    vals.append( numpy.arange(dist.bounds[param][0],dist.bounds[param][1],step) )
+vals = numpy.zeros(shape=(ndim,opts.bins))
+bounds = [{}] * ndim
+for dist in distributions:
+    for param in dist.params:
+        idx = variable_args.index(param)
+        step = float(dist.bounds[param][1]-dist.bounds[param][0]) / opts.bins
+        vals[idx,:] = numpy.arange(dist.bounds[param][0],dist.bounds[param][1],step)
+        bounds[idx] = dist.bounds
 pts = cartesian(vals)
 
 # evaulate PDF between the bounds
 logging.info("Calculating PDF")
 pdf = []
 for pt in pts:
-    pt_dict = dict([(param,pt[j]) for j,param in enumerate(dist.params)])
-    pdf.append( dist.pdf(**pt_dict) )
+    pt_dict = dict([(param,pt[j]) for j,param in enumerate(variable_args)])
+    pdf.append( sum([dist.pdf(**pt_dict) for dist in distributions]) )
 pdf = numpy.array(pdf)
 
-# map data to (x,y,z) values
-# since we only have a uniform distribution
-# allow user to plot a set of test points
+# get label for each variable parameter
+labels = [read_label_from_config(cp, param) for param in variable_args]
+
+# plot
 logging.info("Plotting")
-if opts.plot_test_points:
-    x, y, z = 10 * numpy.random.random((3,10))
-else:
-    i = dist.params.index(opts.variable_args[0])
-    j = dist.params.index(opts.variable_args[1])
-    x = pts[:,i]
-    y = pts[:,j]
-    z = pdf
+fig = corner.corner(pts, weights=pdf, labels=labels, plot_contours=False,
+                    plot_datapoints=False)
 
-# create grid of interpolation points
-xi = numpy.linspace(x.min(), x.max(), opts.bins)
-yi = numpy.linspace(y.min(), y.max(), opts.bins)
-xi, yi = numpy.meshgrid(xi, yi)
+# remove the 1-D histograms
+delaxs = fig.axes[::ndim+1]
+[fig.delaxes(ax) for ax in delaxs]
 
-# interpolate
-rbf = scipy.interpolate.Rbf(x, y, z, function='linear')
-zi = rbf(xi, yi)
-
-# plot interpolation points
-if opts.plot_interpolation_points:
-    plt.scatter(x, y)
-
-# plot contours
-extent = [x.min(), x.max(), y.min(), y.max()]
-low = 0.9*min(z)
-high = 1.1*max(z)
-levels = numpy.arange(low, high, (high-low)/opts.levels)
-c = plt.contour(zi, levels, hold='on', colors='w',
-        origin='lower', extent=extent)
-plt.clabel(c, inline=1, fontsize=10)
-
-# plot greyscale
-cmap = plt.get_cmap("Greys")
-plt.imshow(zi, vmin=z.min(), vmax=z.max(), origin='lower', aspect="auto",
-           extent=extent, cmap=cmap)
-
-# format plot
-if opts.plot_test_points:
-    plt.colorbar(label="random test variable")
-    plt.xlabel("random test variable")
-    plt.ylabel("random test variable")
-else:
-    plt.colorbar(label="Probability Density Function")
-    plt.xlabel(opts.variable_args[0])
-    plt.ylabel(opts.variable_args[1])
-
-# save
-plt.savefig(opts.output_file)
+# save figure with meta-data
+caption = """This plot shows the probability density function (PDF) from the 
+prior distributions."""
+title = "Prior Probability Density Functions"
+results.save_fig_with_metadata(fig, opts.output_file,
+                               cmd=" ".join(sys.argv),
+                               title=title,
+                               caption=caption)
 plt.close()
 
 # exit
-logging.info("Finished")
+logging.info("Done")

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -28,6 +28,39 @@ inference samplers generate.
 import h5py
 import numpy
 from pycbc import pnutils
+from pycbc.results import str_utils
+
+def read_label_from_config(cp, variable_arg, section="labels", html=False):
+    """ Returns the label for the variable_arg.
+
+    Parameters
+    ----------
+    cp : WorkflowConfigParser
+        A WorkflowConfigParser instance with [labels] section
+    variable_arg : str
+        The parameter to get label.
+    section : str
+        Name of section in configuration file to get label.
+    html : bool
+        If True then replace LaTeX substrings with HTML substrings.
+
+    Returns
+    -------
+    label : str
+        The label for the parameter.
+    """
+
+    # get label from configuration file if it exists
+    if cp.has_option(section, variable_arg):
+        label = cp.get(section, variable_arg)
+    else:
+        label = variable_arg
+
+    # replace LaTeX with HTML
+    if html:
+        label = str_utils.latex_to_html(label)
+
+    return label
 
 class InferenceFile(h5py.File):
     """ A subclass of the h5py.File object that has extra functions for
@@ -165,14 +198,9 @@ class InferenceFile(h5py.File):
         else:
             label = self[variable_arg].attrs["label"]
 
-        # escape LaTeX subscripts in a simple but not robust method
-        # will change LaTeX subscript to HTML subscript
-        # will change LaTeX eta to HTML eta symbol
+        # replace LaTeX with HTML
         if html:
-            label = label.replace("$", "")
-            label = label.replace("_{", "<sub>").replace("_", "<sub>")
-            label = label.replace("}", "</sub>")
-            label = label.replace("\eta", "&#951;")
+            label = str_utils.latex_to_html(label)
 
         return label
 

--- a/pycbc/results/str_utils.py
+++ b/pycbc/results/str_utils.py
@@ -219,3 +219,22 @@ def format_value(value, error, plus_error=None, use_scientific_notation=3,
     else:
         txt = r'%s%s' %(valtxt, powfactor)
     return txt 
+
+def latex_to_html(text):
+    """ Replaces LaTeX substrings with HTML replacements.
+
+    Parameters
+    ----------
+    text : str
+        Text to be replaced.
+
+    Returns
+    -------
+    text : str
+        Replaced text.
+    """
+    text = text.replace("$", "")
+    text = text.replace("_{", "<sub>")
+    text = text.replace("}", "</sub>")
+    text = text.replace("\eta", "&#951;")
+    return text


### PR DESCRIPTION
This PR:
  * Changes ``pycbc_inference_plot_prior``. Now it can plot more dimensions by using the ``corner.corner`` module. Each point is weight by the PDF.
  * Moves LaTeX HTML function to ``str_utils``.

Example plot: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/tmp.png

Shows coalescence time and mass 2 as gaussian distributions. Mass 1 is a uniform distribution.