### PR TITLE
Allow inference workflow generator to use command line to find analysis times

### DIFF
--- a/bin/inference/pycbc_make_inference_workflow
+++ b/bin/inference/pycbc_make_inference_workflow
@@ -1,4 +1,5 @@
 #!/bin/env python
+
 # Copyright (C) 2016 Christopher M. Biwer, Alexander Harvey Nitz
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -58,14 +59,23 @@ parser.add_argument("--output-map", required=True,
 parser.add_argument("--output-file", required=True,
     help="Path to DAX file.")
 
-# input file options
-parser.add_argument("--bank-file", required=True,
+# input workflow file options
+parser.add_argument("--bank-file", default=None,
     help="HDF format template bank file.")
-parser.add_argument("--statmap-file", required=True,
+parser.add_argument("--statmap-file", default=None,
     help="HDF format clustered coincident trigger result file.")
-parser.add_argument("--single-detector-triggers", nargs="+", required=True,
+parser.add_argument("--single-detector-triggers", nargs="+", default=None,
     action=MultiDetOptionAction,
-    help="HDF format merged single detector trigger files")
+    help="HDF format merged single detector trigger files.")
+
+# analysis time option
+# only required if not using input workflow file options
+parser.add_argument("--ifos", nargs="+", default=None,
+    help="List of IFOs to analyze. Only required if using --gps-end-time.")
+parser.add_argument("--gps-end-time", type=float, nargs="+", default=None,
+    help="Times to analyze. If given workflow files then this option is ignored.")
+
+# input configuration file options
 parser.add_argument("--inference-config-file", type=str, required=True,
     help="workflow.WorkflowConfigParser parsable file with proir information.")
 
@@ -79,6 +89,13 @@ opts = parser.parse_args()
 logging.basicConfig(format="%(asctime)s:%(levelname)s : %(message)s", 
                     level=logging.INFO)
 
+# sanity check that user is either using workflow or command line
+workflow_options = opts.bank_file != None \
+                   and opts.statmap_file != None \
+                   and opts.single_detector_triggers != None
+if not workflow_options and not (opts.gps_end_time != None and opts.ifos != None):
+    raise ValueError("Must use either workflow options or --ifos and --gps-end-time")
+
 # create workflow
 workflow = wf.Workflow(opts, opts.workflow_name)
 
@@ -89,45 +106,42 @@ wf.makedir(opts.output_dir)
 layouts = []
 
 # typecast str from command line to File instances
-tmpltbank_file = to_file(opts.bank_file)
-coinc_file = to_file(opts.statmap_file)
-single_triggers = []
-for ifo in opts.single_detector_triggers:
-    fname = opts.single_detector_triggers[ifo]
-    single_triggers.append( to_file(fname, ifo=ifo) )
 config_file = to_file(opts.inference_config_file)
 
-# get number of events to analyze
-num_events = int(workflow.cp.get_opt_tags("workflow-inference", "num-events", ""))
+# if using workflow files to find analysis times
+if workflow_options:
 
-# get detection statistic from statmap file
-f = h5py.File(opts.statmap_file, "r")
-stat = f["foreground/stat"][:]
+    # typecast str from command line to File instances
+    tmpltbank_file = to_file(opts.bank_file)
+    coinc_file = to_file(opts.statmap_file)
+    single_triggers = []
+    for ifo in opts.single_detector_triggers:
+        fname = opts.single_detector_triggers[ifo]
+        single_triggers.append( to_file(fname, ifo=ifo) )
 
-# get index for sorted detection statistic
-sorting = stat.argsort()[::-1]
+    # get number of events to analyze
+    num_events = int(workflow.cp.get_opt_tags("workflow-inference", "num-events", ""))
 
-# if less events that requested to analyze in config file then analyze
-# all events
-if len(stat) < num_events:
-    num_events = len(stat)
+    # get detection statistic from statmap file
+    # if less events that requested to analyze in config file then analyze all events
+    f = h5py.File(opts.statmap_file, "r")
+    stat = f["foreground/stat"][:]
+    if len(stat) < num_events:
+        num_events = len(stat)
 
-# get ranking statistic in order of highest (index=0) to lowest
-# and grab the loudest events we will analyze
-stat = stat[sorting][0:num_events]
+    # get index for sorted detection statistic
+    sorting = stat.argsort()[::-1]
 
-# get times for loudest events
-times = {f.attrs["detector_1"]: f["foreground/time1"][:][sorting][0:num_events],
-         f.attrs["detector_2"]: f["foreground/time2"][:][sorting][0:num_events],
-        }
+    # get times for loudest events
+    times = {
+        f.attrs["detector_1"]: f["foreground/time1"][:][sorting][0:num_events],
+        f.attrs["detector_2"]: f["foreground/time2"][:][sorting][0:num_events],
+    }
 
-# get trigger_id for the loudest events
-tids = {f.attrs["detector_1"]: f["foreground/trigger_id1"][:][sorting][0:num_events],
-         f.attrs["detector_2"]: f["foreground/trigger_id2"][:][sorting][0:num_events],
-        }
-
-# read template bank file
-bank_data = h5py.File(opts.bank_file, "r")
+# else get analysis times from command line
+else:
+    times = dict([(ifo,opts.gps_end_time) for ifo in opts.ifos])
+    num_events = len(opts.gps_end_time)
 
 # get frame type and channel name as a dict with IFO as keys
 frame_types = {}
@@ -156,18 +170,6 @@ variable_args.sort()
 # loop over number of loudest events to be analyzed
 for num_event in range(num_events):
 
-    # get template_id
-    bank_id = f['foreground/template_id'][:][sorting][num_event]
-
-    # get a dict that holds event parameters
-    params = {}
-    for ifo in times:
-        params["%s_end_time" % ifo] = times[ifo][num_event]
-    params["mass1"] = bank_data["mass1"][bank_id]
-    params["mass2"] = bank_data["mass2"][bank_id]
-    params["spin1z"] = bank_data["spin1z"][bank_id]
-    params["spin2z"] = bank_data["spin2z"][bank_id]
-
     # set GPS times for reading in data around the event
     avg_end_time = sum([end_times[num_event] \
                           for end_times in times.values()]) / len(times.keys())
@@ -193,10 +195,11 @@ for num_event in range(num_events):
     # add node to workflow
     workflow += node
 
-    # add file that prints information about the event
-    layouts += [mini.make_coinc_info(workflow, single_triggers, tmpltbank_file,
-                          coinc_file, num_event, 
-                          opts.output_dir, tags=opts.tags + [str(num_event)])]
+    # add file that prints information about the search event
+    if workflow_options:
+        layouts += [mini.make_coinc_info(workflow, single_triggers, tmpltbank_file,
+                              coinc_file, num_event, 
+                              opts.output_dir, tags=opts.tags + [str(num_event)])]
 
     # add files from summart table for this event
     layouts += [inffu.make_inference_summary_table(workflow, inference_file,

--- a/bin/inference/pycbc_make_inference_workflow
+++ b/bin/inference/pycbc_make_inference_workflow
@@ -70,8 +70,6 @@ parser.add_argument("--single-detector-triggers", nargs="+", default=None,
 
 # analysis time option
 # only required if not using input workflow file options
-parser.add_argument("--ifos", nargs="+", default=None,
-    help="List of IFOs to analyze. Only required if using --gps-end-time.")
 parser.add_argument("--gps-end-time", type=float, nargs="+", default=None,
     help="Times to analyze. If given workflow files then this option is ignored.")
 
@@ -93,8 +91,8 @@ logging.basicConfig(format="%(asctime)s:%(levelname)s : %(message)s",
 workflow_options = opts.bank_file != None \
                    and opts.statmap_file != None \
                    and opts.single_detector_triggers != None
-if not workflow_options and not (opts.gps_end_time != None and opts.ifos != None):
-    raise ValueError("Must use either workflow options or --ifos and --gps-end-time")
+if not workflow_options and not (opts.gps_end_time != None):
+    raise ValueError("Must use either workflow options or --gps-end-time")
 
 # create workflow
 workflow = wf.Workflow(opts, opts.workflow_name)
@@ -140,7 +138,7 @@ if workflow_options:
 
 # else get analysis times from command line
 else:
-    times = dict([(ifo,opts.gps_end_time) for ifo in opts.ifos])
+    times = dict([(ifo,opts.gps_end_time) for ifo in workflow.ifos])
     num_events = len(opts.gps_end_time)
 
 # get frame type and channel name as a dict with IFO as keys


### PR DESCRIPTION
This PR:
  * Makes it so the user can specify ``--statmap-file``, ``--single-detector-files``, and ``--bank-file`` or ``--ifos`` and ``--gps-end-time``.
  * If the user doesn't give the workflow input file options,  then the coinc table is not added to the output HTML page.

Tested both possible command lines with scripts on sugar in: ``/home/cbiwer/projects/pycbc_mcmc_workflow_test/test8/run_pycbc_make_inference_workflow*.sh``

EDIT: Realized shortly afterwards that ``--ifos`` is completely unnecessary so I removed it. Please take a look now.