### PR TITLE
Calculate ACL at end of pycbc_inference and store it in InferenceFile

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -309,7 +309,12 @@ with InferenceFile(opts.output_file, "r") as fp:
     for i in range(opts.nwalkers):
         for param in fp.read_variable_args():
             acls.append( autocorrelation.calculate_acl(fp.read_samples_from_walker(param, i), dtype=int) )
+
+# get max ACL to save to file
+# if ACL is infinity then set it to the length of the chain of samples
 max_acl = numpy.array(acls).max()
+if max_acl == numpy.inf:
+    max_acl = len(fp.attrs["niterations"])
 
 # write ACL
 logging.info("Writing ACL of %f samples to file"%max_acl)

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -307,7 +307,7 @@ logging.info("Calculating maximum ACL")
 acls = []
 with InferenceFile(opts.output_file, "r") as fp:
     for i in range(opts.nwalkers):
-        for param in fp.read_variable_args():
+        for param in fp.variable_args:
             acls.append( autocorrelation.calculate_acl(fp.read_samples_from_walker(param, i), dtype=int) )
 
 # get max ACL to save to file

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -314,7 +314,7 @@ with InferenceFile(opts.output_file, "r") as fp:
 # if ACL is infinity then set it to the length of the chain of samples
 max_acl = numpy.array(acls).max()
 if max_acl == numpy.inf:
-    max_acl = len(fp.attrs["niterations"])
+    max_acl = len(fp.niterations)
 
 # write ACL
 logging.info("Writing ACL of %f samples to file"%max_acl)

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -308,7 +308,7 @@ acls = []
 with InferenceFile(opts.output_file, "r") as fp:
     for i in range(opts.nwalkers):
         for param in fp.variable_args:
-            acls.append( autocorrelation.calculate_acl(fp.read_samples_from_walker(param, i), dtype=int) )
+            acls.append( autocorrelation.calculate_acl(fp.read_samples_from_walker(param, i), dtype=float) )
 
 # get max ACL to save to file
 # if ACL is infinity then set it to the length of the chain of samples
@@ -319,6 +319,7 @@ if max_acl == numpy.inf:
 # write ACL
 logging.info("Writing ACL of %f samples to file"%max_acl)
 with InferenceFile(opts.output_file, "a") as fp:
+    max_acl = int(numpy.ceil(max_acl))
     fp.write_acl(max_acl)
 
 # exit

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -23,6 +23,7 @@ import pycbc.opt
 import pycbc.weave
 import random
 from pycbc import DYN_RANGE_FAC, fft, inference, psd, scheme, strain, waveform
+from pycbc.filter import autocorrelation
 from pycbc.io.inference_hdf import InferenceFile
 from pycbc.types import FrequencySeries, MultiDetOptionAction
 from pycbc.workflow import WorkflowConfigParser
@@ -300,6 +301,20 @@ with ctx:
                                           labels=labels)
             fp.write_acceptance_fraction(data=sampler.acceptance_fraction,
                                          start=start, end=end)
+
+# calculate ACL for each series of samples for each parameter for each walker
+logging.info("Calculating maximum ACL")
+acls = []
+with InferenceFile(opts.output_file, "r") as fp:
+    for i in range(opts.nwalkers):
+        for param in fp.read_variable_args():
+            acls.append( autocorrelation.calculate_acl(fp.read_samples_from_walker(param, i), dtype=int) )
+max_acl = numpy.array(acls).max()
+
+# write ACL
+logging.info("Writing ACL of %f samples to file"%max_acl)
+with InferenceFile(opts.output_file, "a") as fp:
+    fp.write_acl(max_acl)
 
 # exit
 logging.info("Done")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -308,18 +308,17 @@ acls = []
 with InferenceFile(opts.output_file, "r") as fp:
     for i in range(opts.nwalkers):
         for param in fp.variable_args:
-            acls.append( autocorrelation.calculate_acl(fp.read_samples_from_walker(param, i), dtype=float) )
+            acls.append( autocorrelation.calculate_acl(fp.read_samples_from_walker(param, i), dtype=int) )
 
 # get max ACL to save to file
 # if ACL is infinity then set it to the length of the chain of samples
 max_acl = numpy.array(acls).max()
 if max_acl == numpy.inf:
-    max_acl = len(fp.niterations)
+    max_acl = opts.niterations
 
-# write ACL
+# write ACL as an int rounding up
 logging.info("Writing ACL of %f samples to file"%max_acl)
 with InferenceFile(opts.output_file, "a") as fp:
-    max_acl = int(numpy.ceil(max_acl))
     fp.write_acl(max_acl)
 
 # exit

--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -70,7 +70,7 @@ logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 # read input file
 logging.info("Reading input file")
 fp = InferenceFile(opts.input_file, "r")
-variable_args = fp.read_variable_args() if opts.variable_args is None else opts.variable_args
+variable_args = fp.variable_args if opts.variable_args is None else opts.variable_args
 
 # get number of dimensions
 ndim = len(variable_args)

--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -83,7 +83,7 @@ for param_name in variable_args:
     # loop over walkers and save an autocorrelation function
     # for each walker
     param_acfs = []
-    for i in range(fp.attrs["nwalkers"]):
+    for i in range(fp.nwalkers):
 
         # get all the past samples for this walker
         y = fp.read_samples_from_walker(param_name, i,

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -66,7 +66,7 @@ logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 # read input file
 logging.info("Reading input file")
 fp = InferenceFile(opts.input_file, "r")
-variable_args = fp.read_variable_args() if opts.variable_args is None else opts.variable_args
+variable_args = fp.variable_args if opts.variable_args is None else opts.variable_args
 
 # thin samples to get independent samples from each sampler
 logging.info("Thinning samples")

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -73,7 +73,7 @@ logging.info("Thinning samples")
 x = []
 
 # loop over each walkers
-for i in range(fp.attrs["nwalkers"]):
+for i in range(fp.nwalkers):
 
     # loop over each parameter
     samples = []

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -62,7 +62,7 @@ logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 # read input file
 logging.info("Reading input file")
 fp = InferenceFile(opts.input_file, "r")
-variable_args = fp.read_variable_args() if opts.variable_args is None else opts.variable_args
+variable_args = fp.variable_args if opts.variable_args is None else opts.variable_args
 
 # get number of dimensions
 ndim = len(variable_args)

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -78,7 +78,7 @@ axs = [axs] if not hasattr(axs, "__iter__") else axs
 for i,arg in enumerate(variable_args):
 
     # loop over walkers
-    for j in range(fp.attrs["nwalkers"]):
+    for j in range(fp.nwalkers):
 
         # plot each walker as a different line on the subplot
         axs[i].plot(fp.read_samples_from_walker(arg, j,

--- a/bin/inference/pycbc_inference_table_summary
+++ b/bin/inference/pycbc_inference_table_summary
@@ -71,7 +71,7 @@ fp = InferenceFile(opts.input_file, "r")
 if opts.variable_args:
     variable_args = opts.variable_args
 else:
-    variable_args = fp.read_variable_args()
+    variable_args = fp.variable_args
 
 # get thinned samples for each parameter
 table = []

--- a/pycbc/filter/autocorrelation.py
+++ b/pycbc/filter/autocorrelation.py
@@ -27,6 +27,7 @@ and length of a data series.
 """
 
 import numpy
+from math import isnan
 from pycbc.types import TimeSeries
 
 def calculate_acf(data):
@@ -126,7 +127,7 @@ def calculate_acl(data, m=5, k=2, dtype=int):
             break
 
         # see if ACL is indeterminate
-        if i > imax:
+        if i > imax or isnan(acf[i]):
             return numpy.inf
 
         # add term for ACL

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -44,6 +44,39 @@ class InferenceFile(h5py.File):
     def __init__(self, path, mode=None, **kwargs):
         super(InferenceFile, self).__init__(path, mode, **kwargs)
 
+    @property
+    def variable_args(self):
+        """ Returns list of variable_args.
+
+        Returns
+        -------
+        variable_args : {list, str}
+            List of str that contain variable_args keys.
+        """
+        return self.attrs["variable_args"]
+
+    @property
+    def niterations(self):
+        """ Returns number of iterations performed.
+
+        Returns
+        -------
+        niterations : int
+            Number of iterations performed.
+        """
+        return self.attrs["niterations"]
+
+    @property
+    def acl(self):
+        """ Returns the saved autocorelation length (ACL).
+
+        Returns
+        -------
+        acl : {int, float}
+            The ACL.
+        """
+        return self.attrs["acl"]
+
     def read_samples(self, variable_arg, thin_start=None, thin_interval=1):
         """ Reads independent samples from all walkers for a parameter.
 
@@ -130,16 +163,6 @@ class InferenceFile(h5py.File):
             The acceptance fraction.
         """
         return self["acceptance_fraction"][thin_start::thin_interval]
-
-    def read_variable_args(self):
-        """ Returns list of variable_args.
-
-        Returns
-        -------
-        variable_args : {list, str}
-            List of str that contain variable_args keys.
-        """
-        return self.attrs["variable_args"]
 
     def read_label(self, variable_arg, html=False):
         """ Returns the label for the parameter.

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -56,6 +56,17 @@ class InferenceFile(h5py.File):
         return self.attrs["variable_args"]
 
     @property
+    def nwalkers(self):
+        """ Returns number of walkers used.
+
+        Returns
+        -------
+        nwalkesr : int
+            Number of walkers used.
+        """
+        return self.attrs["niterations"]
+
+    @property
     def niterations(self):
         """ Returns number of iterations performed.
 

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -64,7 +64,7 @@ class InferenceFile(h5py.File):
         nwalkesr : int
             Number of walkers used.
         """
-        return self.attrs["niterations"]
+        return self.attrs["nwalkers"]
 
     @property
     def niterations(self):
@@ -106,7 +106,7 @@ class InferenceFile(h5py.File):
             All independent samples from all walkers for a parameter.
         """
 
-        nwalkers = self.attrs["nwalkers"]
+        nwalkers = self.nwalkers
         return numpy.array([self.read_samples_from_walker(variable_arg, j, thin_start, thin_interval) for j in range(nwalkers)])
 
     def read_samples_from_walker(self, variable_arg, nwalker,

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -125,7 +125,8 @@ class InferenceFile(h5py.File):
             to 0.
         thin_interval : int
             Interval to accept every i-th sample. Default is to use the
-            self.acl attribute. To use all samples set thin_interval to 1.
+            self.acl attribute. If self.acl is not set, then use all samples
+            set thin_interval to 1.
 
         Returns
         -------
@@ -137,7 +138,10 @@ class InferenceFile(h5py.File):
         thin_start = self.attrs["burn_in_iterations"] if thin_start is None else thin_start
 
         # default is to use stored ACL and accept every i-th sample
-        thin_interval = self.acl if thin_interval is None else thin_interval
+        if "acl" in self.attrs.keys():
+            thin_interval = self.acl if thin_interval is None else thin_interval
+        else:
+            thin_interval = 1 if thin_interval is None else thin_interval
 
         # derived parameter case for mchirp will calculate mchrip
         # from mass1 and mass2

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -110,7 +110,7 @@ class InferenceFile(h5py.File):
         return numpy.array([self.read_samples_from_walker(variable_arg, j, thin_start, thin_interval) for j in range(nwalkers)])
 
     def read_samples_from_walker(self, variable_arg, nwalker,
-                                 thin_start=None, thin_interval=1):
+                                 thin_start=None, thin_interval=None):
         """ Reads all samples from a specific walker for a parameter.
 
         Parameters
@@ -120,9 +120,12 @@ class InferenceFile(h5py.File):
         nwalker : int
             Index of the walker to get samples.
         thin_start : int
-            Index of the sample to begin returning samples.
+            Index of the sample to begin returning samples. Default is to read
+            samples after burn in. To start from the beginning set thin_start
+            to 0.
         thin_interval : int
-            Interval to accept every i-th sample.
+            Interval to accept every i-th sample. Default is to use the
+            self.acl attribute. To use all samples set thin_interval to 1.
 
         Returns
         -------
@@ -132,6 +135,9 @@ class InferenceFile(h5py.File):
 
         # default is to skip burn in samples
         thin_start = self.attrs["burn_in_iterations"] if thin_start is None else thin_start
+
+        # default is to use stored ACL and accept every i-th sample
+        thin_interval = self.acl
 
         # derived parameter case for mchirp will calculate mchrip
         # from mass1 and mass2

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -336,7 +336,7 @@ class InferenceFile(h5py.File):
 
     def write_samples_from_sampler(self, sampler, start=None, end=None,
                       nwalkers=0, niterations=0, labels=None):
-        """ Wtite data from sampler to file.
+        """ Write data from sampler to file.
 
         Parameters
         -----------
@@ -359,4 +359,12 @@ class InferenceFile(h5py.File):
                            nwalkers=nwalkers, niterations=niterations,
                            labels=labels)
 
+    def write_acl(self, acl):
+        """ Writes the autocorrelation length (ACL) to file.
 
+        Parameters
+        ----------
+        acl : float
+            The ACL.
+        """
+        self.attrs["acl"] = acl

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -137,7 +137,7 @@ class InferenceFile(h5py.File):
         thin_start = self.attrs["burn_in_iterations"] if thin_start is None else thin_start
 
         # default is to use stored ACL and accept every i-th sample
-        thin_interval = self.acl
+        thin_interval = self.acl if thin_interval is None else thin_interval
 
         # derived parameter case for mchirp will calculate mchrip
         # from mass1 and mass2


### PR DESCRIPTION
This PR:
  * Calculates the maximum ACL at the end of ``pycbc_inference`` and stores it as ``InferenceFile.acl``.
  * Changes ``InferenceFile.read_samples_from_walker`` so that default interval to use for thinning is the ACL. This means all plotting code will default to using the ACL. Can use ``--thin-interval 1`` on plotting executables to plot all samples.
  * If the input data to ``calculate_acl`` has a variance of 0, it will return ``numpy.inf``.
  * Makes class attributes for things in ``InferenceFile.attrs``.