### PR TITLE
Increase speed of GPU code

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -69,9 +69,9 @@ def init_logging(verbose=False):
 try:
     # This is a crude check to make sure that the driver is installed
     try:
-        err = subprocess.call(["nvidia-smi"], stdout=open(os.devnull, 'wb'), stderr=open(os.devnull, 'wb'))
-        if err != 0:
-            raise ImportError("Cannot access 'nvidia-smi', driver may not be installed correctly")
+        loaded_modules = subprocess.check_output(["lsmod"], stderr=subprocess.STDOUT)
+        if str.find(loaded_modules, "nvidia") == -1:
+            raise ImportError("nvidia driver may not be installed correctly")
     except OSError:
         pass
 

--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -116,7 +116,7 @@ class CUDAScheme(Scheme):
         import pycuda.driver
         pycuda.driver.init()
         self.device = pycuda.driver.Device(device_num)
-        self.context = self.device.make_context(flags=pycuda.driver.ctx_flags.SCHED_YIELD)
+        self.context = self.device.make_context(flags=pycuda.driver.ctx_flags.SCHED_BLOCKING_SYNC)
         import atexit
         atexit.register(clean_cuda,self.context)
 


### PR DESCRIPTION
The PyCBC ``__init__`` module calls ``nvidia-smi`` to see if the CUDA driver is installed. This can take a long time to return on large GPU machines, and so I replaced it with a call to ``lsmod`` to directly check for the driver.

The second patch changes the default mode from ``SCHED_YIELD`` to ``SCHED_BLOCKING_SYNC`` which should decrease CPU load and increase speed on large GPU systems. @soumide1102 is testing this.