### PR TITLE
Add prior plots to workflow

### DIFF
--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -91,8 +91,6 @@ for sec in opts.sections:
 variable_args = sorted(variable_args)
 ndim = len(variable_args)
 
-print distributions
-
 # construct class that will return draws from the prior
 prior = inference.PriorEvaluator(variable_args, *distributions)
 
@@ -151,7 +149,7 @@ else:
 
 # save figure with meta-data
 caption_kwargs = {
-    "parameters" : ", ".join(labels)
+    "parameters" : ", ".join([read_label_from_config(cp, param, html=True) for param in variable_args])
 }
 caption = """This plot shows the probability density function (PDF) from the 
 prior distributions."""

--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -44,8 +44,8 @@ parser.add_argument("--section", type=str, default="prior",
     help="Name of section that contains subsections with distribution configurations.")
 
 # add prior options
-parser.add_argument("--bins", type=int, required=True,
-    help="Number of points to grid a parameter.")
+parser.add_argument("--bins", type=int, default=20,
+    help="Number of points to grid a parameter. Need at least 20 bins to fill in the plot.")
 
 # add output options
 parser.add_argument("--output-file", type=str, required=True,
@@ -113,10 +113,17 @@ fig = corner.corner(pts, weights=pdf, labels=labels, plot_contours=False,
 delaxs = fig.axes[::ndim+1]
 [fig.delaxes(ax) for ax in delaxs]
 
+# adjust size of remaining plots to cover entire canvas
+fig.subplots_adjust(top=1+1.0/(ndim))
+fig.subplots_adjust(right=1+1.0/(ndim))
+for ax in fig.axes:
+    ax.yaxis.get_label().set_position((-0.2,0.5))
+    ax.xaxis.get_label().set_position((0.5,-0.2))
+
 # save figure with meta-data
 caption = """This plot shows the probability density function (PDF) from the 
 prior distributions."""
-title = "Prior Probability Density Functions"
+title = "Prior Distributions"
 results.save_fig_with_metadata(fig, opts.output_file,
                                cmd=" ".join(sys.argv),
                                title=title,

--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -40,8 +40,8 @@ parser = argparse.ArgumentParser(usage="pycbc_inference_plot_prior [--options]",
 # add input options
 parser.add_argument("--config-files", type=str, nargs="+", required=True,
     help="A file parsable by pycbc.workflow.WorkflowConfigParser.")
-parser.add_argument("--section", type=str, default="prior",
-    help="Name of section that contains subsections with distribution configurations.")
+parser.add_argument("--sections", type=str, nargs="+", default=["prior"],
+    help="Name of section plus subsection with distribution configurations, eg. prior-mass1.")
 
 # add prior options
 parser.add_argument("--bins", type=int, default=20,
@@ -65,18 +65,33 @@ else:
     log_level = logging.WARN
 logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 
-# get variable_args from the configuration file
+# read configuration file
 logging.info("Reading configuration files")
 cp = WorkflowConfigParser(opts.config_files)
-variable_args = sorted(cp.options("variable_args"))
-ndim = len(variable_args)
 
 # get prior distribution for each variable parameter
+# parse command line values for section and subsection
+# if only section then look for subsections
+# and add distributions to list
 logging.info("Constructing prior")
+variable_args = []
 distributions = []
-for subsection in cp.get_subsections("prior"):
-    name = cp.get_opt_tag("prior", "name", subsection)
-    distributions.append( inference.priors[name].from_config(cp, "prior", subsection) )
+for sec in opts.sections:
+    section = sec.split("-")[0]
+    subsec = sec.split("-")[1:]
+    if len(subsec):
+        subsections = ["-".join(subsec)]
+    else:
+        subsections = cp.get_subsections(section)
+    for subsection in subsections:
+        name = cp.get_opt_tag(section, "name", subsection)
+        dist = inference.priors[name].from_config(cp, section, subsection)
+        variable_args += dist.params
+        distributions.append( dist )
+variable_args = sorted(variable_args)
+ndim = len(variable_args)
+
+print distributions
 
 # construct class that will return draws from the prior
 prior = inference.PriorEvaluator(variable_args, *distributions)
@@ -104,26 +119,43 @@ pdf = numpy.array(pdf)
 # get label for each variable parameter
 labels = [read_label_from_config(cp, param) for param in variable_args]
 
-# plot
-logging.info("Plotting")
-fig = corner.corner(pts, weights=pdf, labels=labels, plot_contours=False,
-                    plot_datapoints=False)
+# check if only one parameter to plot PDF
+logging.info("Plotting") 
+if len(variable_args) == 1:
+    x = vals[0,:]
+    xmax = x.max()
+    xmin = x.min()
+    pad = 0.1*(xmax-xmin)
+    fig = plt.figure()
+    plt.plot(x, pdf, "k", label="Prior")
+    plt.xlim(xmin-pad, xmax+pad)
+    plt.ylabel("Probability Density Function")
+    plt.xlabel(labels[0])
+    plt.legend()
 
-# remove the 1-D histograms
-delaxs = fig.axes[::ndim+1]
-[fig.delaxes(ax) for ax in delaxs]
+# else make corner plot of all PDF
+else:
+    fig = corner.corner(pts, weights=pdf, labels=labels, plot_contours=False,
+                        plot_datapoints=False)
 
-# adjust size of remaining plots to cover entire canvas
-fig.subplots_adjust(top=1+1.0/(ndim))
-fig.subplots_adjust(right=1+1.0/(ndim))
-for ax in fig.axes:
-    ax.yaxis.get_label().set_position((-0.2,0.5))
-    ax.xaxis.get_label().set_position((0.5,-0.2))
+    # remove the 1-D histograms
+    delaxs = fig.axes[::ndim+1]
+    [fig.delaxes(ax) for ax in delaxs]
+
+    # adjust size of remaining plots to cover entire canvas
+    fig.subplots_adjust(top=1+1.0/(ndim))
+    fig.subplots_adjust(right=1+1.0/(ndim))
+    for ax in fig.axes:
+        ax.yaxis.get_label().set_position((-0.2,0.5))
+        ax.xaxis.get_label().set_position((0.5,-0.2))
 
 # save figure with meta-data
+caption_kwargs = {
+    "parameters" : ", ".join(labels)
+}
 caption = """This plot shows the probability density function (PDF) from the 
 prior distributions."""
-title = "Prior Distributions"
+title = """Prior Distributions for {parameters}""".format(**caption_kwargs)
 results.save_fig_with_metadata(fig, opts.output_file,
                                cmd=" ".join(sys.argv),
                                title=title,

--- a/bin/inference/pycbc_make_inference_workflow
+++ b/bin/inference/pycbc_make_inference_workflow
@@ -100,9 +100,6 @@ workflow = wf.Workflow(opts, opts.workflow_name)
 # create output directory
 wf.makedir(opts.output_dir)
 
-# create a list that will contain all output files
-layouts = []
-
 # typecast str from command line to File instances
 config_file = to_file(opts.inference_config_file)
 
@@ -165,6 +162,9 @@ if "mass1" in variable_args and "mass2" in variable_args:
     variable_args += ["mchirp", "eta"]
 variable_args.sort()
 
+# create a list that will contain all output files
+layouts = []
+
 # loop over number of loudest events to be analyzed
 for num_event in range(num_events):
 
@@ -199,14 +199,14 @@ for num_event in range(num_events):
                               coinc_file, num_event, 
                               opts.output_dir, tags=opts.tags + [str(num_event)])]
 
-    # add files from summart table for this event
+    # add files from posterior summary table for this event
     layouts += [inffu.make_inference_summary_table(workflow, inference_file,
                           opts.output_dir, variable_args=variable_args,
                           analysis_seg=analysis_time,
                           tags=opts.tags + [str(num_event)])]
 
-    # add files from corner plot for this event
-    layouts += [inffu.make_inference_corner_plot(workflow, inference_file,
+    # add files from posterior corner plot for this event
+    layouts += [inffu.make_inference_posterior_plot(workflow, inference_file,
                           opts.output_dir, variable_args=variable_args,
                           analysis_seg=analysis_time,
                           tags=opts.tags + [str(num_event)])]
@@ -232,6 +232,15 @@ for num_event in range(num_events):
                           analysis_seg=analysis_time,
                           tags=opts.tags + [str(num_event)]) 
     layouts += list(layout.grouper(files, 2))
+
+# add files from prior plots for this event
+# do not add them to layouts so that they appear in the
+# additional files section
+section = "prior"
+for subsection in cp.get_subsections(section):
+    inffu.make_inference_prior_plot(workflow, config_file, opts.output_dir,
+                          analysis_seg=workflow.analysis_time,
+                          sections=[section+"-"+subsection], tags=opts.tags)
 
 # write dax
 workflow.save(filename=opts.output_file, output_map=opts.output_map)

--- a/bin/inference/pycbc_make_inference_workflow
+++ b/bin/inference/pycbc_make_inference_workflow
@@ -240,7 +240,8 @@ section = "prior"
 for subsection in cp.get_subsections(section):
     inffu.make_inference_prior_plot(workflow, config_file, opts.output_dir,
                           analysis_seg=workflow.analysis_time,
-                          sections=[section+"-"+subsection], tags=opts.tags)
+                          sections=[section + "-" + subsection],
+                          tags=opts.tags + [subsection])
 
 # write dax
 workflow.save(filename=opts.output_file, output_map=opts.output_map)

--- a/bin/inference/pycbc_make_inference_workflow
+++ b/bin/inference/pycbc_make_inference_workflow
@@ -76,6 +76,8 @@ parser.add_argument("--gps-end-time", type=float, nargs="+", default=None,
 # input configuration file options
 parser.add_argument("--inference-config-file", type=str, required=True,
     help="workflow.WorkflowConfigParser parsable file with proir information.")
+parser.add_argument("--prior-section", type=str, default="prior",
+    help="Name of the section in inference configuration file that contains priors.")
 
 # add option groups
 wf.add_workflow_command_line_group(parser)
@@ -236,11 +238,10 @@ for num_event in range(num_events):
 # add files from prior plots for this event
 # do not add them to layouts so that they appear in the
 # additional files section
-section = "prior"
-for subsection in cp.get_subsections(section):
+for subsection in cp.get_subsections(opts.prior_section):
     inffu.make_inference_prior_plot(workflow, config_file, opts.output_dir,
                           analysis_seg=workflow.analysis_time,
-                          sections=[section + "-" + subsection],
+                          sections=[opts.prior_section + "-" + subsection],
                           tags=opts.tags + [subsection])
 
 # write dax

--- a/pycbc/results/str_utils.py
+++ b/pycbc/results/str_utils.py
@@ -233,8 +233,14 @@ def latex_to_html(text):
     text : str
         Replaced text.
     """
+    html_mappings = {
+        "\eta" : "&#951;",
+        "\phi" : "&#934;",
+        "\iota" : "&#953;",
+    }
     text = text.replace("$", "")
     text = text.replace("_{", "<sub>")
     text = text.replace("}", "</sub>")
-    text = text.replace("\eta", "&#951;")
+    for latex_str,html_str in html_mappings.iteritems():
+        text = text.replace(latex_str, html_str)
     return text

--- a/pycbc/results/str_utils.py
+++ b/pycbc/results/str_utils.py
@@ -235,7 +235,7 @@ def latex_to_html(text):
     """
     html_mappings = {
         "\eta" : "&#951;",
-        "\phi" : "&#934;",
+        "\phi" : "&#966;",
         "\iota" : "&#953;",
     }
     text = text.replace("$", "")


### PR DESCRIPTION
This PR:
  * Adds ``pycbc_inference_plot_prior`` to inference workflow.
  * Rename posterior workflow helper function in ``pycbc.workflow.inference_followups`` since now there's more than one executables that makes a corner plot.
  * Can specify a list of sections to plot with ``pycbc_inference_plot_prior`` using ``--sections`` now.

Prior files appear in the "Additional Files" section of the HTML by design. I don't think that we need to put them in the well. They'll be one plot for each seperate distribution listed in the configuration file.

An example page is here: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/tmp_workflow_9/