### PR TITLE
Change --thin-interval defaults to None in inference plotting executables

### DIFF
--- a/bin/inference/pycbc_inference_plot_acceptance_rate
+++ b/bin/inference/pycbc_inference_plot_acceptance_rate
@@ -40,7 +40,7 @@ parser.add_argument("--output-file", type=str, required=True,
 # add thinning options
 parser.add_argument("--thin-start", type=int, default=None,
     help="Sample number to start collecting samples to plot.")
-parser.add_argument("--thin-interval", type=int, default=1,
+parser.add_argument("--thin-interval", type=int, default=None,
     help="Interval to use for thinning samples.")
 
 # verbose option

--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -50,7 +50,7 @@ parser.add_argument("--output-file", type=str, required=True,
 # add thinning options
 parser.add_argument("--thin-start", type=int, default=None,
     help="Sample number to start collecting samples to plot.")
-parser.add_argument("--thin-interval", type=int, default=1,
+parser.add_argument("--thin-interval", type=int, default=None,
     help="Interval to use for thinning samples.")
 
 # verbose option

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -46,7 +46,7 @@ parser.add_argument("--labels", type=str, nargs="+",
 # add thinning options
 parser.add_argument("--thin-start", type=int, default=None,
     help="Sample number to start collecting samples to plot.")
-parser.add_argument("--thin-interval", type=int, default=1,
+parser.add_argument("--thin-interval", type=int, default=None,
     help="Interval to use for thinning samples.")
 
 # verbose option

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -42,7 +42,7 @@ parser.add_argument("--output-file", type=str, required=True,
 # add thinning options
 parser.add_argument("--thin-start", type=int, default=None,
     help="Sample number to start collecting samples to plot.")
-parser.add_argument("--thin-interval", type=int, default=1,
+parser.add_argument("--thin-interval", type=int, default=None,
     help="Interval to use for thinning samples.")
 
 # verbose option


### PR DESCRIPTION
Sets the inference plotting executables ``--thin-interval`` default to ``None`` so that changes from #926 to use ``InferenceFile.acl`` as default will be used. Right now its set the default is set to 1 which means plot every sample.