### PR TITLE
Add ACL histogram to inference workflow

### DIFF
--- a/bin/inference/pycbc_inference_plot_acl
+++ b/bin/inference/pycbc_inference_plot_acl
@@ -93,7 +93,9 @@ for param_name in variable_args:
 # plot autocorrelation length
 logging.info("Plotting autocorrelation lengths")
 fig = plt.figure()
-y,x,patches = plt.hist(acls, opts.bins, align="left", histtype="step")
+range_max = max(fp.acl, max(acls))
+y,x,patches = plt.hist(acls, opts.bins, range=(0,range_max),
+                                        histtype="step")
 
 # get histogram bin width
 poly_xy = patches[0].get_xy()
@@ -102,7 +104,8 @@ step = poly_xy[2][0] - poly_xy[0][0]
 plt.xlabel("Iteration")
 plt.ylabel(r'Autocorrelation Length for %s'%', '.join(['%s'%fp.read_label(param) for param in variable_args]))
 plt.ylim(0, int(1.1*y.max()))
-plt.xlim(x.min()-2*step, x.max()+2*step)
+x_min = max(0, x.min()-2*step)
+plt.xlim(x_min, x.max()+2*step)
 
 # plot autocorrelation length saved in InferenceFile
 plt.vlines(fp.acl, 0, int(1.1*y.max()))

--- a/bin/inference/pycbc_inference_plot_acl
+++ b/bin/inference/pycbc_inference_plot_acl
@@ -114,8 +114,9 @@ plt.vlines(fp.acl, 0, int(1.1*y.max()))
 caption_kwargs = {
     "parameters" : ", ".join(["%s"%fp.read_label(param, html=True) for param in variable_args]),
 }
-caption = """Autocorrelation length (ACL) from all the walker chains for the
-parameters. Each line is an ACL for a chain of walker samples."""
+caption = """ The histogram (blue) is the autocorrelation length (ACL) from all
+ the walker chains for the parameters. The vertical black line is the ACL
+read from the input file."""
 title = "Autocorrelation Length for {parameters}".format(**caption_kwargs)
 results.save_fig_with_metadata(fig, opts.output_file,
                                cmd=" ".join(sys.argv),

--- a/bin/inference/pycbc_inference_plot_acl
+++ b/bin/inference/pycbc_inference_plot_acl
@@ -115,8 +115,8 @@ caption_kwargs = {
     "parameters" : ", ".join(["%s"%fp.read_label(param, html=True) for param in variable_args]),
 }
 caption = """Autocorrelation length (ACL) from all the walker chains for the
-parameters. Each line is an ACF for a chain of walker samples."""
-title = "Autocorrelation Function for {parameters}".format(**caption_kwargs)
+parameters. Each line is an ACL for a chain of walker samples."""
+title = "Autocorrelation Length for {parameters}".format(**caption_kwargs)
 results.save_fig_with_metadata(fig, opts.output_file,
                                cmd=" ".join(sys.argv),
                                title=title,

--- a/bin/inference/pycbc_inference_plot_acl
+++ b/bin/inference/pycbc_inference_plot_acl
@@ -1,0 +1,125 @@
+#! /usr/bin/env python
+
+# Copyright (C) 2016 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import argparse
+import h5py
+import logging
+import matplotlib as mpl; mpl.use("Agg")
+import matplotlib.pyplot as plt
+import numpy
+import sys
+from pycbc import results
+from pycbc.filter import autocorrelation
+from pycbc.io.inference_hdf import InferenceFile
+
+# command line usage
+parser = argparse.ArgumentParser(usage="pycbc_inference_plot_acl [--options]",
+    description="Histograms autocorrelation length from inference samples.")
+
+# add data options
+parser.add_argument("--input-file", type=str, required=True,
+    help="Path to input HDF file.")
+parser.add_argument("--variable-args", type=str, nargs="+", default=None,
+    help="Name of parameters varied.")
+
+# output plot options
+parser.add_argument("--output-file", type=str, required=True,
+    help="Path to output plot.")
+parser.add_argument("--bins", type=int, default=10,
+    help="Number of bins in histogram.")
+
+# add thinning options
+parser.add_argument("--thin-start", type=int, default=None,
+    help="Sample number to start collecting samples to plot.")
+parser.add_argument("--thin-interval", type=int, default=None,
+    help="Interval to use for thinning samples.")
+
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+    help="")
+
+# parse the command line
+opts = parser.parse_args()
+
+# setup log
+if opts.verbose:
+    log_level = logging.DEBUG
+else:
+    log_level = logging.WARN
+logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
+
+# read input file
+logging.info("Reading input file")
+fp = InferenceFile(opts.input_file, "r")
+variable_args = fp.variable_args if opts.variable_args is None else opts.variable_args
+
+# get number of dimensions
+ndim = len(variable_args)
+
+# calculate autocorrelation length for each walker
+logging.info("Calculating autocorrelation length")
+acls = []
+for param_name in variable_args:
+
+    # loop over walkers and save an autocorrelation length
+    # for each walker
+    for i in range(fp.nwalkers):
+
+        # get all the past samples for this walker
+        # calculate autocorrelation length and add to list
+        y = fp.read_samples_from_walker(param_name, i,
+                                        thin_start=opts.thin_start,
+                                        thin_interval=opts.thin_interval)
+        acl = autocorrelation.calculate_acl(y, dtype=int)
+        if acl == numpy.inf:
+            acl = fp.niterations
+        acls.append( acl )
+
+# plot autocorrelation length
+logging.info("Plotting autocorrelation lengths")
+fig = plt.figure()
+y,x,patches = plt.hist(acls, opts.bins, align="left", histtype="step")
+
+# get histogram bin width
+poly_xy = patches[0].get_xy()
+step = poly_xy[2][0] - poly_xy[0][0]
+
+plt.xlabel("Iteration")
+plt.ylabel(r'Autocorrelation Length for %s'%', '.join(['%s'%fp.read_label(param) for param in variable_args]))
+plt.ylim(0, int(1.1*y.max()))
+plt.xlim(x.min()-2*step, x.max()+2*step)
+
+# plot autocorrelation length saved in InferenceFile
+plt.vlines(fp.acl, 0, int(1.1*y.max()))
+
+# save figure with meta-data
+caption_kwargs = {
+    "parameters" : ", ".join(["%s"%fp.read_label(param, html=True) for param in variable_args]),
+}
+caption = """Autocorrelation length (ACL) from all the walker chains for the
+parameters. Each line is an ACF for a chain of walker samples."""
+title = "Autocorrelation Function for {parameters}".format(**caption_kwargs)
+results.save_fig_with_metadata(fig, opts.output_file,
+                               cmd=" ".join(sys.argv),
+                               title=title,
+                               caption=caption)
+plt.close()
+
+# exit
+fp.close()
+logging.info("Done")

--- a/setup.py
+++ b/setup.py
@@ -467,6 +467,7 @@ setup (
                'bin/inference/pycbc_inference',
                'bin/inference/pycbc_inference_plot_acceptance_rate',
                'bin/inference/pycbc_inference_plot_acf',
+               'bin/inference/pycbc_inference_plot_acl',
                'bin/inference/pycbc_inference_plot_posterior',
                'bin/inference/pycbc_inference_plot_prior',
                'bin/inference/pycbc_inference_plot_samples',


### PR DESCRIPTION
Adds a histogram of the autocorrelation lengths to the workflow.

Example page is here: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/tmp_workflow_11/

From the caption:
 > The histogram (blue) is the autocorrelation length (ACL) from all the walker chains for the parameters. The vertical black line is the ACL read from the input file.