### PR TITLE
Add FieldArrayWithDefaults and WaveformArray to record.py

### DIFF
--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -242,7 +242,11 @@ def get_needed_fieldnames(arr, names):
                 # no fget attribute, assume is an instance method
                 func = getattr(arr, name)
             # evaluate the source code of the function
-            sourcecode = inspect.getsource(func)
+            try:
+                sourcecode = inspect.getsource(func)
+            except TypeError:
+                # not a function, just pass
+                continue
             # evaluate the source code for the fields
             possible_fields = get_instance_fields_from_arg(sourcecode)
             # some of the variables returned by possible fields may themselves
@@ -1323,7 +1327,7 @@ class WaveformArray(_FieldArrayWithDefaults):
     @property
     def q(self):
         """Returns the mass ratio m1/m2, where m1 >= m2."""
-        return self.mP / self.mS
+        return self.m_p / self.m_s
 
     # FIXME: mchirp and eta functions should be added to pnutils as separate
     # functions

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -31,6 +31,7 @@ import os, sys, types, re, copy, numpy, inspect
 import lal
 import lalsimulation as lalsim
 from glue.ligolw import types as ligolw_types
+from pycbc.detector import Detector
 from pycbc.waveform import parameters
 
 #
@@ -1211,9 +1212,8 @@ class _FieldArrayWithDefaults(FieldArray):
 #
 
 # we'll vectorize TimeDelayFromEarthCenter for faster processing of end times
-def _time_delay_from_center(tc, detector, ra, dec):
-    return tc + lal.TimeDelayFromEarthCenter(detector.location,
-        ra, dec, tc)
+def _time_delay_from_center(detector, ra, dec, tc):
+    return tc + detector.time_delay_from_earth_center(ra, dec, tc)
 time_delay_from_center = numpy.vectorize(_time_delay_from_center)
 
 class WaveformArray(_FieldArrayWithDefaults):
@@ -1394,9 +1394,8 @@ class WaveformArray(_FieldArrayWithDefaults):
 
     def det_tc(self, detector):
         """Returns the coalesence time in the given detector."""
-        detector = lalsim.DetectorPrefixToLALDetector(detector)
-        return time_delay_from_center(self.tc, detector, self.ra,
-            self.dec)
+        detector = Detector(detector)
+        return time_delay_from_center(detector, self.ra, self.dec, self.tc)
 
 
 __all__ = ['FieldArray', 'WaveformArray']

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -27,7 +27,9 @@ FieldArrays are wrappers of numpy recarrays with additional functionality useful
 for storing and retrieving data created by a search for gravitational waves.
 """
 
-import os, sys, types, re, copy, numpy
+import os, sys, types, re, copy, numpy, inspect
+import lal
+import lalsimulation as lalsim
 from glue.ligolw import types as ligolw_types
 
 #
@@ -47,6 +49,7 @@ numpy.typeDict.update(ligolw_types.ToNumPyType)
 # we define here an integer to indicate 'id not set'. 
 ID_NOT_SET = -1
 EMPTY_OBJECT = None
+VIRTUALFIELD_DTYPE = 'VIRTUAL'
 
 def set_default_empty(array):
     if array.dtype.names is None:
@@ -176,8 +179,79 @@ def get_fields_from_arg(arg):
     """
     return set(_fieldparser.findall(arg))
 
+# this parser looks for fields inside a class method function. This is done by
+# looking for variables that start with self.{x} or self["{x}"]; e.g.,
+# self.a.b*3 + self.c, self['a.b']*3 + self.c, self.a.b*3 + self["c"], all
+# return set('a.b', 'c').
+_instfieldparser = re.compile(
+    r'''self(?:\.|(?:\[['"]))(?P<identifier>[\w_][.\w\d_]*)''')
+def get_instance_fields_from_arg(arg):
+    """Given a python string definining a method function on an instance of an
+    FieldArray, returns the field names used in it. This differs from
+    get_fields_from_arg in that it looks for variables that start with 'self'.
+    """
+    return set(_instfieldparser.findall(arg))
 
-#
+def get_needed_fieldnames(arr, names):
+    """Given a FieldArray-like array and a list of names, determines what
+    fields are needed from the array so that using the names does not result
+    in an error.
+
+    Parameters
+    ----------
+    arr : instance of a FieldArray or similar
+        The array from which to determine what fields to get.
+    names : (list of) strings
+        A list of the names that are desired. The names may be either a field,
+        a virtualfield, a property, a method of ``arr``, or any function of
+        these. If a virtualfield/property or a method, the source code of that
+        property/method will be analyzed to pull out what fields are used in
+        it.
+
+    Returns
+    -------
+    set
+        The set of the fields needed to evaluate the names.
+    """
+    fieldnames = set([])
+    # we'll need the class that the array is an instance of to evaluate some 
+    # things
+    cls = arr.__class__
+    if isinstance(names, str) or isinstance(names, unicode):
+        names = [names]
+    # parse names for variables, incase some of them are functions of fields
+    parsed_names = set([])
+    for name in names:
+        parsed_names.update(get_fields_from_arg(name))
+    # only include things that are in the array's namespace
+    names = list(parsed_names & (set(dir(arr)) | set(arr.fieldnames)))
+    for name in names:
+        if name in arr.fieldnames:
+            # is a field, just add the name
+            fieldnames.update([name])
+        else:
+            # the name is either a virtualfield, a method, or some other
+            # property; we need to evaluate the source code to figure out what
+            # fields we need
+            try:
+                # the underlying functions of properties need to be retrieved
+                # using their fget attribute
+                func = getattr(cls, name).fget
+            except AttributeError:
+                # no fget attribute, assume is an instance method
+                func = getattr(arr, name)
+            # evaluate the source code of the function
+            sourcecode = inspect.getsource(func)
+            # evaluate the source code for the fields
+            possible_fields = get_instance_fields_from_arg(sourcecode)
+            # some of the variables returned by possible fields may themselves
+            # be methods/properties that depend on other fields. For instance,
+            # mchirp relies on eta and mtotal, which each use mass1 and mass2;
+            # we therefore need to anayze each of the possible fields
+            fieldnames.update(get_needed_fieldnames(arr, possible_fields))
+    return fieldnames
+
+
 def get_dtype_descr(dtype):
     """Numpy's ``dtype.descr`` will return empty void fields if a dtype has
     offsets specified. This function tries to fix that by not including
@@ -967,4 +1041,353 @@ class FieldArray(numpy.recarray):
         self.__copy_attributes__(newself)
         return newself
 
-__all__ = ['FieldArray']
+def aliases_from_fields(fields):
+    """
+    Given a dictionary of fields, will return a dictionary mapping the aliases
+    to the names.
+    """
+    return dict(c for c in fields if isinstance(c, tuple))
+
+
+def fields_from_names(fields, names=None):
+    """
+    Given a dictionary of fields and a list of names, will return a dictionary
+    consisting of the fields specified by names. Names can be either the names
+    of fields, or their aliases.
+    """
+    if names is None:
+        return fields
+    if isinstance(names, str) or isinstance(names, unicode):
+        names = [names]
+    aliases_to_names = aliases_from_fields(fields)
+    names_to_aliases = dict(zip(aliases_to_names.values(),
+        aliases_to_names.keys()))
+    outfields = {}
+    for name in names:
+        try:
+            outfields[name] = fields[name]
+        except KeyError:
+            if name in aliases_to_names:
+                key = (name, aliases_to_names[name])
+            elif name in names_to_aliases:
+                key = (names_to_aliases[name], name)
+            else:
+                raise KeyError('default fields has no field %s' % name)
+            outfields[key] = fields[key]
+    return outfields
+
+
+#
+# =============================================================================
+#
+#                           FieldArrays with default fields
+#
+# =============================================================================
+#
+
+class _FieldArrayWithDefaults(FieldArray):
+    """Subclasses FieldArray, adding class attribute ``_staticfields``, and
+    class method ``default_fields``. The ``_staticfields`` should be a
+    dictionary that defines some field names and corresponding dtype. The
+    ``default_fields`` method returns a dictionary of the static fields
+    and any default virtualfields that were added. A field array can then
+    be initialized in one of 3 ways:
+
+     1. With just a shape. In this case, the returned array will have all
+     of the default fields.
+
+     2. With a shape and a list of names, given by the ``names`` keyword
+     argument. The names may be default fields, virtual fields, a method or
+     property of the class, or any python function of these things. If a
+     virtual field, method, or property is in the names, the needed underlying
+     fields will be included in the return array. For example, if the class
+     has a virtual field called 'mchirp', which is a function of fields called
+     'mass1' and 'mass2', then 'mchirp' or any function of 'mchirp' may be
+     included in the list of names (e.g., names=['mchirp**(5/6)']). If so, the
+     returned array will have fields 'mass1' and 'mass2' even if these were
+     not specified in names, so that 'mchirp' may be used without error.
+     names must be names of either default fields or virtualfields, else a
+     KeyError is raised.
+
+     3. With a shape and a dtype. Any field specified by the dtype will be
+     used. The fields need not be in the list of default fields, and/or the
+     dtype can be different than that specified by the default fields.
+
+    If additional fields are desired beyond the default fields, these can
+    be specified using the ``additional_fields`` keyword argument; these should
+    be provided in the same way as ``dtype``; i.e, as a list of (name, dtype)
+    tuples.
+
+    This class does not define any static fields, and ``default_fields`` just
+    returns an empty dictionary. This class is mostly meant to be subclassed
+    by other classes, so they can add their own defaults.
+    """
+    _staticfields = {}
+    @classmethod
+    def default_fields(cls, include_virtual=True, **kwargs):
+        """The default fields and their dtypes. By default, this returns
+        whatever the class's ``_staticfields`` and ``_virtualfields`` is set
+        to as a dictionary of fieldname, dtype (the dtype of virtualfields is
+        given by VIRTUALFIELD_DTYPE). This function should be overridden by
+        subclasses to add dynamic fields; i.e., fields that require some input
+        parameters at initialization. Keyword arguments can be passed to this
+        to set such dynamic fields.
+        """
+        add_fields = {}
+        if include_virtual:
+            add_fields.update(dict([[name, VIRTUALFIELD_DTYPE]
+                for name in cls._virtualfields]))
+        return dict(cls._staticfields.items() + add_fields.items())
+        
+
+    def __new__(cls, shape, name=None, additional_fields=[], field_kwargs={},
+            **kwargs):
+        """The ``additional_fields`` should be specified in the same way as
+        ``dtype`` is normally given to FieldArray. The ``field_kwargs`` are
+        passed to the class's default_fields method as keyword arguments.
+        """
+        if 'names' in kwargs and 'dtype' in kwargs:
+            raise ValueError("Please provide names or dtype, not both")
+        default_fields = cls.default_fields(include_virtual=False,
+            **field_kwargs)
+        if 'names' in kwargs:
+            names = kwargs.pop('names')
+            if isinstance(names, str) or isinstance(names, unicode):
+                names = [names]
+            # evaluate the names to figure out what base fields are needed
+            # to do this, we'll create a small default instance of self (since
+            # no names are specified in the following initialization, this
+            # block of code is skipped)
+            arr = cls(1, field_kwargs=field_kwargs)
+            names = get_needed_fieldnames(arr, names)
+            # add the fields as the dtype argument for initializing 
+            kwargs['dtype'] = [(name, default_fields[name]) for name in names]
+        if 'dtype' not in kwargs:
+            kwargs['dtype'] = default_fields.items()
+        # add the additional fields
+        kwargs['dtype'] += additional_fields
+        return super(_FieldArrayWithDefaults, cls).__new__(cls, shape,
+            name=None, **kwargs)
+
+    def add_default_fields(self, names, **kwargs):
+        """
+        Adds one or more empty default fields to self.
+
+        Parameters
+        ----------
+        names : (list of) string(s)
+            The names of the fields to add. Must be a field in self's default
+            fields.
+        
+        Other keyword args are any arguments passed to self's default fields.
+
+        Returns
+        -------
+        new array : instance of this array
+            A copy of this array with the field added.
+        """
+        if isinstance(names, str) or isinstance(names, unicode):
+            names = [names]
+        default_fields = cls.default_fields(include_virtual=False, **kwargs)
+        # parse out any virtual fields
+        arr = self.__class__(1, field_kwargs=kwargs)
+        names = get_needed_fieldnames(arr, names)
+        fields = [(name, default_fields[name]) for name in names]
+        arrays = []
+        names = []
+        for name,dt in fields:
+            arrays.append(default_empty(self.size, dtype=[(name, dt)])) 
+            names.append(name)
+        return self.add_fields(arrays, names)
+
+
+#
+# =============================================================================
+#
+#                           WaveformArray
+#
+# =============================================================================
+#
+
+# we'll vectorize TimeDelayFromEarthCenter for faster processing of end times
+def _time_delay_from_center(tc, detector, ra, dec):
+    return tc + lal.TimeDelayFromEarthCenter(detector.location,
+        ra, dec, tc)
+time_delay_from_center = numpy.vectorize(_time_delay_from_center)
+
+class WaveformArray(_FieldArrayWithDefaults):
+    """A FieldArray with some default fields and properties commonly used
+    by CBC waveforms. This may be initialized in one of 3 ways:
+    
+    1. With just the size of the array. In this case, the returned array will
+    have all of the default field names. Example:
+    >>> warr.fieldnames
+    ('polarization',
+     'mass1',
+     'mass2',
+     'spin2x',
+     'spin2y',
+     'spin2z',
+     'spin1y',
+     'spin1x',
+     'spin1z',
+     'inclination',
+     'coa_phase',
+     'dec',
+     'tc',
+     'ra')
+
+    2. With some subset of the default field names. Example:
+    >>> warr = WaveformArray(10, names=['mass1', 'mass2'])
+    >>> warr.fieldnames
+    ('mass1', 'mass2')
+
+    The list of names may include virtual fields, and methods, as well as
+    functions of these. If one or more virtual fields or methods are specified,
+    the source code is analyzed to pull out whatever underlying fields are
+    needed. Example:
+    >>> warr = WaveformArray(10, names=['mchirp**(5/6)', 'chi_eff', 'cos(coa_phase)'])
+    >>> warr.fieldnames
+    ('spin2z', 'mass1', 'mass2', 'coa_phase', 'spin1z')
+
+    3. By specifying a dtype. In this case, only the provided fields will
+    be used, even if they are not in the defaults. Example:
+    >>> warr = WaveformArray(10, dtype=[('foo', float)])
+    >>> warr.fieldnames
+    ('foo',)    
+
+    Additional fields can also be specified using the additional_fields
+    keyword argument. Example:
+    >>> warr = WaveformArray(10, names=['mass1', 'mass2'], additional_fields=[('lambda1', float)])
+    >>> warr.fieldnames
+    ('mass1', 'mass2', 'lambda1')
+    """
+
+    _staticfields = {
+            'mass1': float,
+            'mass2': float,
+            'spin1x': float,
+            'spin1y': float,
+            'spin1z': float,
+            'spin2x': float,
+            'spin2y': float,
+            'spin2z': float,
+            'tc': float,
+            'coa_phase': float,
+            'ra': float,
+            'dec': float,
+            'polarization': float,
+            'inclination': float,
+    }
+
+    _virtualfields = ['mP', 'mS', 'mtotal', 'q', 'eta', 'mchirp']
+
+    @property
+    def mP(self):
+        """Returns the larger of self.mass1 and self.mass2 (P = primary)."""
+        out = numpy.zeros(self.size, dtype=self.mass1.dtype)
+        out[:] = self.mass1
+        mask = self.mass1 < self.mass2
+        out[mask] = self.mass2[mask]
+        return out
+
+    @property
+    def mS(self):
+        """Returns the smaller of self.mass1 and self.mass2 (S = secondary)."""
+        out = numpy.zeros(self.size, dtype=self.mass2.dtype)
+        out[:] = self.mass2
+        mask = self.mass1 < self.mass2
+        out[mask] = self.mass1[mask]
+        return out
+
+    @property
+    def mtotal(self):
+        """Returns the total mass."""
+        return self.mass1 + self.mass2
+
+    @property
+    def q(self):
+        """Returns the mass ratio m1/m2, where m1 >= m2."""
+        return self.mP / self.mS
+
+    # FIXME: mchirp and eta functions should be added to pnutils as separate
+    # functions
+    @property
+    def eta(self):
+        """Returns the symmetric mass ratio."""
+        return self.mass1*self.mass2 / (self.mass1 + self.mass2)**2.
+
+    @property
+    def mchirp(self):
+        """Returns the chirp mass."""
+        return self.eta**(3./5) * self.mtotal
+
+    # FIXME: this should probably be moved to pnutils at some point
+    @property
+    def chi_eff(self):
+        """Returns the effective spin."""
+        return (self.spin1z * self.mass1 + self.spin2z * self.mass2) / \
+                self.mtotal
+
+    @property
+    def spinPx(self):
+        """Returns the x-component of the primary mass."""
+        out = numpy.zeros(self.size, dtype=self.spin1x.dtype)
+        out[:] = self.spin1x
+        mask = self.mass1 < self.mass2
+        out[mask] = self.spin2x[mask]
+        return out
+
+    @property
+    def spinPy(self):
+        """Returns the y-component of the primary mass."""
+        out = numpy.zeros(self.size, dtype=self.spin1y.dtype)
+        out[:] = self.spin1y
+        mask = self.mass1 < self.mass2
+        out[mask] = self.spin2y[mask]
+        return out
+
+    @property
+    def spinPz(self):
+        """Returns the z-component of the secondary mass."""
+        out = numpy.zeros(self.size, dtype=self.spin1z.dtype)
+        out[:] = self.spin1z
+        mask = self.mass1 < self.mass2
+        out[mask] = self.spin2z[mask]
+        return out
+
+    @property
+    def spinSx(self):
+        """Returns the x-component of the secondary mass."""
+        out = numpy.zeros(self.size, dtype=self.spin2x.dtype)
+        out[:] = self.spin2x
+        mask = self.mass1 < self.mass2
+        out[mask] = self.spin1x[mask]
+        return out
+
+    @property
+    def spinSy(self):
+        """Returns the y-component of the secondary mass."""
+        out = numpy.zeros(self.size, dtype=self.spin2y.dtype)
+        out[:] = self.spin2y
+        mask = self.mass1 < self.mass2
+        out[mask] = self.spin1y[mask]
+        return out
+
+    @property
+    def spinSz(self):
+        """Returns the z-component of the secondary mass."""
+        out = numpy.zeros(self.size, dtype=self.spin2z.dtype)
+        out[:] = self.spin2z
+        mask = self.mass1 < self.mass2
+        out[mask] = self.spin1z[mask]
+        return out
+
+    def det_tc(self, detector):
+        """Returns the coalesence time in the given detector."""
+        detector = lalsim.DetectorPrefixToLALDetector(detector)
+        return time_delay_from_center(self.tc, detector, self.ra,
+            self.dec)
+
+
+__all__ = ['FieldArray', 'WaveformArray']

--- a/pycbc/waveform/__init__.py
+++ b/pycbc/waveform/__init__.py
@@ -3,3 +3,4 @@ from pycbc.waveform.utils import *
 from pycbc.waveform.bank import *
 from pycbc.waveform.generator import *
 from pycbc.waveform.ringdown import *
+from pycbc.waveform.parameters import *

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -32,7 +32,7 @@ from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
 from pycbc.filter import sigmasq
 from pycbc import DYN_RANGE_FAC
 from pycbc.pnutils import nearest_larger_binary_number
-from pycbc.io import FieldArray
+import pycbc.io
 from copy import copy
 
 def sigma_cached(self, psd):
@@ -81,7 +81,7 @@ class TemplateBank(object):
                 filename, False, contenthandler=LIGOLWContentHandler)
             self.table = table.get_table(
                 self.indoc, lsctables.SnglInspiralTable.tableName)
-            self.table = FieldArray.from_ligolw_table(self.table)
+            self.table = pycbc.io.FieldArray.from_ligolw_table(self.table)
 
             # inclination stored in xml alpha3 column
             names = list(self.table.dtype.names)
@@ -100,7 +100,7 @@ class TemplateBank(object):
                     pass
 
             num = len(data[data.keys()[0]])
-            self.table = FieldArray(num, dtype=dtype)
+            self.table = pycbc.io.FieldArray(num, dtype=dtype)
             for key in data:
                 self.table[key] = data[key]
         else:

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -209,36 +209,36 @@ q = Parameter("q",
                 dtype=float, label=r"$q$",
                 description="The mass ratio, m1/m2, where m1 >= m2.")
 m_p = Parameter("m_p",
-                dtype=float, label=r"$m_{>}$",
+                dtype=float, label=r"$m_{\mathrm{pr}}$",
                 description="Mass of the primary object (in solar masses).")
 m_s = Parameter("m_s",
-                dtype=float, label=r"$m_{<}$",
+                dtype=float, label=r"$m_{\mathrm{sc}}$",
                 description="Mass of the secondary object (in solar masses).")
 chi_eff = Parameter("chi_eff",
                 dtype=float, label=r"$\chi_\mathrm{eff}$",
                 description="Effective spin of the binary.")
 spin_px = Parameter("spin_px",
-                dtype=float, label=r"$\chi_{>x}$",
+                dtype=float, label=r"$\chi_{\mathrm{pr}\,x}$",
                 description="The x component of the dimensionless spin of the "
                             "primary object.")
 spin_py = Parameter("spin_py",
-                dtype=float, label=r"$\chi_{>y}$",
+                dtype=float, label=r"$\chi_{\mathrm{pr}\,y}$",
                 description="The y component of the dimensionless spin of the "
                             "primary object.")
 spin_pz = Parameter("spin_pz",
-                dtype=float, label=r"$\chi_{>z}$",
+                dtype=float, label=r"$\chi_{\mathrm{pr}\,z}$",
                 description="The z component of the dimensionless spin of the "
                             "primary object.")
 spin_sx = Parameter("spin_sx",
-                dtype=float, label=r"$\chi_{<x}$",
+                dtype=float, label=r"$\chi_{\mathrm{sc}\,x}$",
                 description="The x component of the dimensionless spin of the "
                             "secondary object.")
 spin_sy = Parameter("spin_sy",
-                dtype=float, label=r"$\chi_{<y}$",
+                dtype=float, label=r"$\chi_{\mathrm{sc}\,y}$",
                 description="The y component of the dimensionless spin of the "
                             "secondary object.")
 spin_sz = Parameter("spin_sz",
-                dtype=float, label=r"$\chi_{<z}$",
+                dtype=float, label=r"$\chi_{\mathrm{sc}\,z}$",
                 description="The z component of the dimensionless spin of the "
                             "secondary object.")
 

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -65,7 +65,8 @@ class Parameter(str):
 
 class ParameterList(UserList):
     """A list of parameters. Each element in the list is expected to be a
-    Parameter instance."""
+    Parameter instance.
+    """
 
     @property
     def names(self):
@@ -86,25 +87,29 @@ class ParameterList(UserList):
         """Returns a list of the name and default value of each parameter,
         as tuples. If include_nulls is False, only parameters that do not
         have None as a default are returnted. Otherwise, all parameters
-        are returned."""
+        are returned.
+        """
         return [(x, x.default) for x in self
                     if include_nulls or x.default is not None]
 
     def default_dict(self, include_nulls=False):
         """Returns a dictionary of the name and default value of each
-        parameter."""
+        parameter.
+        """
         return dict(self.defaults(include_nulls=include_nulls))
 
     @property
     def nodefaults(self):
         """Returns a ParameterList of the parameters that have None for
-        defaults."""
+        defaults.
+        """
         return ParameterList([x for x in self if x.default is None])
 
     @property
     def dtypes(self):
         """Returns a list of the name and dtype of each parameter,
-        as tuples."""
+        as tuples.
+        """
         return [(x, x.dtype) for x in self]
 
     @property
@@ -115,7 +120,8 @@ class ParameterList(UserList):
     @property
     def descriptions(self):
         """Returns a list of the name and description of each parameter,
-        as tuples."""
+        as tuples.
+        """
         return [(x, x.description) for x in self]
 
     @property
@@ -126,8 +132,7 @@ class ParameterList(UserList):
 
     @property
     def labels(self):
-        """Returns a list of each parameter and its label, as tuples.
-        """
+        """Returns a list of each parameter and its label, as tuples."""
         return [(x, x.label) for x in self]
 
     @property
@@ -137,8 +142,7 @@ class ParameterList(UserList):
         return dict(self.labels)
 
     def docstr(self, prefix='', include_label=True):
-        """Returns the ``docstr`` of each parameter joined together.
-        """
+        """Returns the ``docstr`` of each parameter joined together."""
         return '\n'.join([x.docstr(prefix, include_label) for x in self])
 
 #

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -1,0 +1,371 @@
+# Copyright (C) 2016 Collin Capano
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""Classes to define common parameters used for waveform generation.
+"""
+
+from UserList import UserList
+
+#
+# =============================================================================
+#
+#                                  Base definitions
+#
+# =============================================================================
+#
+
+class Parameter(str):
+    """A class that stores information about a parameter. This is done by
+    sub-classing string, adding additional attributes.
+    """
+
+    def __new__(cls, name, dtype=None, default=None, label=None,
+                 description="No description."):
+        obj = str.__new__(cls, name)
+        obj.name = name
+        obj.dtype = dtype
+        obj.default = default
+        obj.label = label
+        obj.description = description
+        return obj
+
+    def docstr(self, prefix='', include_label=True):
+        """Returns a string summarizing the parameter. Format is:
+        <prefix>``name`` : {``default``, ``dtype``}
+        <prefix>   ``description`` Label: ``label``.
+        """
+        outstr = "%s%s : {%s, %s}\n" %(prefix, self.name, str(self.default),
+            str(self.dtype).replace("<type '", '').replace("'>", '')) + \
+            "%s    %s" %(prefix, self.description)
+        if include_label:
+            outstr += " Label: %s" %(self.label)
+        return outstr
+
+
+class ParameterList(UserList):
+    """A list of parameters. Each element in the list is expected to be a
+    Parameter instance."""
+
+    @property
+    def names(self):
+        """Returns a list of the names of each parameter."""
+        return [x.name for x in self]
+
+    @property
+    def aslist(self):
+        """Cast to basic list."""
+        return list(self)
+
+    @property
+    def asdict(self):
+        """Returns a dictionary of the parameters keyed by the parameters."""
+        return dict([[x, x] for x in self])
+
+    def defaults(self, include_nulls=False):
+        """Returns a list of the name and default value of each parameter,
+        as tuples. If include_nulls is False, only parameters that do not
+        have None as a default are returnted. Otherwise, all parameters
+        are returned."""
+        return [(x, x.default) for x in self
+                    if include_nulls or x.default is not None]
+
+    def default_dict(self, include_nulls=False):
+        """Returns a dictionary of the name and default value of each
+        parameter."""
+        return dict(self.defaults(include_nulls=include_nulls))
+
+    @property
+    def nodefaults(self):
+        """Returns a ParameterList of the parameters that have None for
+        defaults."""
+        return ParameterList([x for x in self if x.default is None])
+
+    @property
+    def dtypes(self):
+        """Returns a list of the name and dtype of each parameter,
+        as tuples."""
+        return [(x, x.dtype) for x in self]
+
+    @property
+    def dtype_dict(self):
+        """Returns a dictionary of the name and dtype of each parameter."""
+        return dict(self.dtypes)
+
+    @property
+    def descriptions(self):
+        """Returns a list of the name and description of each parameter,
+        as tuples."""
+        return [(x, x.description) for x in self]
+
+    @property
+    def description_dict(self):
+        """Return a dictionary of the name and description of each parameter.
+        """
+        return dict(self.descriptions)
+
+    @property
+    def labels(self):
+        """Returns a list of each parameter and its label, as tuples.
+        """
+        return [(x, x.label) for x in self]
+
+    @property
+    def label_dict(self):
+        """Return a dictionary of the name and label of each parameter.
+        """
+        return dict(self.labels)
+
+    def docstr(self, prefix='', include_label=True):
+        """Returns the ``docstr`` of each parameter joined together.
+        """
+        return '\n'.join([x.docstr(prefix, include_label) for x in self])
+
+#
+# =============================================================================
+#
+#                        Parameter definitions
+#
+# =============================================================================
+#
+
+#
+#   CBC intrinsic parameters
+#
+mass1 = Parameter("mass1",
+                dtype=float, default=None, label=r"$m_1~(\mathrm{M}_\odot)$",
+                description="The mass of the first component object in the "
+                          "binary (in solar masses).")
+mass2 = Parameter("mass2",
+                dtype=float, default=None, label=r"$m_2~(\mathrm{M}_\odot)$",
+                description="The mass of the second component object in the "
+                            "binary (in solar masses).")
+spin1x = Parameter("spin1x",
+                dtype=float, default=0., label=r"$\chi_{1x}$",
+                description="The x component of the first binary component's "
+                            "dimensionless spin.")
+spin1y = Parameter("spin1y",
+                dtype=float, default=0., label=r"$\chi_{1y}$",
+                description="The y component of the first binary component's "
+                            "dimensionless spin.")
+spin1z = Parameter("spin1z",
+                dtype=float, default=0., label=r"$\chi_{1z}$",
+                description="The z component of the first binary component's "
+                            "dimensionless spin.")
+spin2x = Parameter("spin2x",
+                dtype=float, default=0., label=r"$\chi_{2x}$",
+                description="The x component of the second binary component's "
+                            "dimensionless spin.")
+spin2y = Parameter("spin2y",
+                dtype=float, default=0., label=r"$\chi_{2y}$",
+                description="The y component of the second binary component's "
+                            "dimensionless spin.")
+spin2z = Parameter("spin2z",
+                dtype=float, default=0., label=r"$\chi_{2z}$",
+                description="The z component of the second binary component's "
+                            "dimensionless spin.")
+lambda1 = Parameter("lambda1",
+                dtype=float, default=0., label=r"$\lambda_1$",
+                description="The tidal deformability parameter of object 1.")
+lambda2 = Parameter("lambda2",
+                dtype=float, default=0., label=r"$\lambda_2$",
+                description="The tidal deformability parameter of object 2.")
+
+# common derived parameters (these are not used for waveform generation)
+mchirp = Parameter("mchirp",
+                dtype=float, label=r"$\mathcal{M}~(\mathrm{M}_\odot)$",
+                description="The chirp mass of the binary (in solar masses).")
+eta = Parameter("eta",
+                dtype=float, label=r"$\eta$",
+                description="The symmetric mass ratio of the binary.")
+mtotal = Parameter("mtotal",
+                dtype=float, label=r"$M~(\mathrm{M}_\odot)$",
+                description="The total mass of the binary (in solar masses).")
+q = Parameter("q",
+                dtype=float, label=r"$q$",
+                description="The mass ratio, m1/m2, where m1 >= m2.")
+m_p = Parameter("m_p",
+                dtype=float, label=r"$m_{>}$",
+                description="Mass of the primary object (in solar masses).")
+m_s = Parameter("m_s",
+                dtype=float, label=r"$m_{<}$",
+                description="Mass of the secondary object (in solar masses).")
+chi_eff = Parameter("chi_eff",
+                dtype=float, label=r"$\chi_\mathrm{eff}$",
+                description="Effective spin of the binary.")
+spin_px = Parameter("spin_px",
+                dtype=float, label=r"$\chi_{>x}$",
+                description="The x component of the dimensionless spin of the "
+                            "primary object.")
+spin_py = Parameter("spin_py",
+                dtype=float, label=r"$\chi_{>y}$",
+                description="The y component of the dimensionless spin of the "
+                            "primary object.")
+spin_pz = Parameter("spin_pz",
+                dtype=float, label=r"$\chi_{>z}$",
+                description="The z component of the dimensionless spin of the "
+                            "primary object.")
+spin_sx = Parameter("spin_sx",
+                dtype=float, label=r"$\chi_{<x}$",
+                description="The x component of the dimensionless spin of the "
+                            "secondary object.")
+spin_sy = Parameter("spin_sy",
+                dtype=float, label=r"$\chi_{<y}$",
+                description="The y component of the dimensionless spin of the "
+                            "secondary object.")
+spin_sz = Parameter("spin_sz",
+                dtype=float, label=r"$\chi_{<z}$",
+                description="The z component of the dimensionless spin of the "
+                            "secondary object.")
+
+#
+#   Parameters needed for CBC waveform generation
+#
+f_lower = Parameter("f_lower",
+                dtype=float, default=None, label=r"$f_0$ (Hz)",
+                description="The starting frequency of the waveform (in Hz).")
+f_final = Parameter("f_final",
+                dtype=float, default=0, label=r"$f_{\mathrm{final}}$ (Hz)",
+                description="The ending frequency of the waveform. The "
+                            "default (0) indicates that the choice is made by "
+                            "the respective approximant.")
+f_ref = Parameter("f_ref",
+                dtype=float, default=0, label=r"$f_{\mathrm{ref}}$ (Hz)",
+                description="The reference frequency.")
+delta_f = Parameter("delta_f",
+                dtype=float, default=None, label=r"$\Delta f$ (Hz)",
+                description="The frequency step used to generate the waveform "
+                            "(in Hz).")
+delta_t = Parameter("delta_t",
+                dtype=float, default=None, label=r"$\Delta t$ (s)",
+                description="The time step used to generate the waveform "
+                            "(in s).")
+sample_points = Parameter("sample_points",
+                dtype="Array", default=None, label=None,
+                description="An array of the frequencies (in Hz) at which to "
+                            "generate the waveform.")
+approximant = Parameter("approximant",
+                dtype=str, default=None, label=None,
+                description="A string that indicates the chosen approximant.")
+phase_order = Parameter("phase_order",
+                dtype=int, default=-1, label=None,
+                description="The pN order of the orbital phase. The default "
+                            "of -1 indicates that all implemented orders are "
+                            "used.")
+spin_order = Parameter("spin_order",
+                dtype=int, default=-1, label=None,
+                description="The pN order of the spin corrections. The "
+                            "default of -1 indicates that all implemented "
+                            "orders are used.")
+tidal_order = Parameter("tidal_order",
+                dtype=int, default=-1, label=None,
+                description="The pN order of the tidal corrections. The "
+                            "default of -1 indicates that all implemented "
+                            "orders are used.")
+amplitude_order = Parameter("amplitude_order",
+                dtype=int, default=-1, label=None,
+                description="The pN order of the amplitude. The default of -1 "
+                            "indicates that all implemented orders are used.")
+numrel_data = Parameter("numrel_data",
+                dtype=str, default="", label=None,
+                description="Sets the NR flags; only needed for NR waveforms.")
+
+#
+#   General location parameters
+#
+distance = Parameter("distance",
+                dtype=float, default=1., label=r"$d_L$ (Mpc)",
+                description="Luminosity distance to the binary (in Mpc).")
+coa_phase = Parameter("coa_phase",
+                dtype=float, default=0., label=r"$\phi_c$",
+                description="Coalesence phase of the binary (in rad).")
+inclination = Parameter("inclination",
+                dtype=float, default=0., label=r"$\iota$",
+                description="Inclination (rad), defined as the angle between "
+                            "the total angular momentum J and the "
+                            "line-of-sight.")
+tc = Parameter("tc",
+                dtype=float, default=None, label=r"$t_c$ (s)",
+                description="Coalescence time (s).")
+ra = Parameter("ra",
+                dtype=float, default=None, label=r"$\alpha$",
+                description="Right ascension (rad).")
+dec = Parameter("dec",
+                dtype=float, default=None, label=r"$\delta$",
+                description="Declination (rad).")
+polarization = Parameter("polarization",
+                dtype=float, default=None, label=r"$\psi$",
+                description="Polarization (rad).")
+
+#
+# =============================================================================
+#
+#                        Parameter list definitions
+#
+# =============================================================================
+#
+
+# parameters describing the location of a binary w.r.t. the Earth. Note: we
+# do not include distance here. This is because these parameters are not
+# passed to the waveform generators in lalsimulation, but are instead applied
+# after a waveform is generated. Distance, however, is a parameter used by
+# the waveform generators.
+location_params = ParameterList([tc, ra, dec, polarization])
+
+# parameters describing the orientation of a binary w.r.t. the radiation
+# frame. Note: we include distance here, as it is typically used for generating
+# waveforms.
+orientation_params = ParameterList([distance, coa_phase, inclination])
+
+# the extrinsic parameters of a waveform
+extrinsic_params = orientation_params + location_params 
+
+# intrinsic parameters of a CBC waveform
+cbc_intrinsic_params = ParameterList([
+    mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z,
+    lambda1, lambda2])
+
+# the parameters of a cbc in the radiation frame
+cbc_rframe_params = cbc_intrinsic_params + orientation_params
+
+# common generation parameters are parameters needed to generate either
+# a TD, FD, or frequency sequence waveform
+common_generation_params = ParameterList([
+    approximant, f_ref, phase_order, spin_order, tidal_order, amplitude_order])
+
+# the following are parameters needed to generate an FD or TD waveform that
+# is equally sampled
+common_gen_equal_sampled_params = ParameterList([f_lower]) + \
+    common_generation_params
+
+# the following are parameters needed to generate an FD waveform
+fd_waveform_params = cbc_rframe_params + ParameterList([delta_f]) + \
+    common_gen_equal_sampled_params + ParameterList([f_final])
+
+# the following are parameters needed to generate a TD waveform
+td_waveform_params = cbc_rframe_params + ParameterList([delta_t]) + \
+    common_gen_equal_sampled_params + ParameterList([numrel_data])
+
+# the following are parameters needed to generate a frequency series waveform
+fd_waveform_sequence_params = cbc_rframe_params + \
+    ParameterList([sample_points]) + common_generation_params

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -35,20 +35,17 @@ from pycbc.fft import fft
 from pycbc import pnutils
 from pycbc import psd
 from pycbc.waveform import utils as wfutils
+from pycbc.waveform import parameters
 from pycbc.filter import interpolate_complex_frequency
 import pycbc
 
-default_args = {'spin1x':0, 'spin1y':0, 'spin1z':0, 'spin2x':0, 'spin2y':0,
-                'spin2z':0, 'lambda1':0, 'lambda2':0,
-                'inclination':0, 'distance':1, 'f_final':0, 'f_ref':0,
-                'coa_phase':0, 'amplitude_order':-1, 'phase_order':-1,
-                'spin_order':-1, 'tidal_order':-1, 'numrel_data':""}
+default_args = (parameters.fd_waveform_params.default_dict() + \
+    parameters.td_waveform_params).default_dict()
 
 default_sgburst_args = {'eccentricity':0, 'polarization':0}
 
-base_required_args = ['mass1','mass2','f_lower']
-td_required_args = base_required_args + ['delta_t']
-fd_required_args = base_required_args + ['delta_f']
+td_required_args = parameters.td_waveform_params.nodefaults.aslist
+fd_required_args = parameters.fd_waveform_params.nodefaults.aslist
 sgburst_required_args = ['q','frequency','hrss']
 
 # td, fd, filter waveforms generated on the CPU
@@ -284,58 +281,16 @@ def props_sgburst(obj, **kwargs):
 
 # Waveform generation ########################################################
 def get_fd_waveform_sequence(template=None, **kwds):
-    """  Return values of the waveform evaluated at the sequence of frequency 
+    """
+    Return values of the waveform evaluated at the sequence of frequency 
     points.
 
     Parameters
     ----------
     template: object
         An object that has attached properties. This can be used to substitute
-        for keyword arguments. A common example would be a row in an xml table. 
-    approximant : string
-        A string that indicates the chosen approximant. See `fd_approximants` 
-        for available options. 
-    mass1 : float
-        The mass of the first component object in the binary in solar masses.
-    mass2 : float
-        The mass of the second component object in the binary in solar masses.
-    f_ref : {float}, optional
-        The reference frequency.
-    distance : {1, float}, optional
-        The distance from the observer to the source in megaparsecs.
-    inclination : {0, float}, optional
-        The inclination angle of the source. 
-    coa_phase : {0, float}, optional
-        The final phase or phase at the peak of the waveform. See documentation
-        on specific approximants for exact usage. 
-    spin1x : {0, float}, optional
-        The x component of the first binary component's spin vector.
-    spin1y : {0, float}, optional
-        y component of the first binary component's spin.
-    spin1z : {0, float}, optional
-        z component of the first binary component's spin.
-    spin2x : {0, float}, optional
-        The x component of the second binary component's spin vector.
-    spin2y : {0, float}, optional
-        y component of the second binary component's spin.
-    spin2z : {0, float}, optional
-        z component of the second binary component's spin.
-    lambda1: {0, float}, optional
-        The tidal deformability parameter of object 1.
-    lambda2: {0, float}, optional
-        The tidal deformability parameter of object 2.
-    phase_order: {-1, int}, optional
-        The pN order of the orbital phase. The default of -1 indicates that 
-        all implemented orders are used.
-    spin_order: {-1, int}, optional
-        The pN order of the spin corrections. The default of -1 indicates that 
-        all implemented orders are used.
-    tidal_order: {-1, int}, optional
-        The pN order of the tidal corrections. The default of -1 indicates that 
-        all implemented orders are used.
-    amplitude_order: {-1, int}, optional
-        The pN order of the amplitude. The default of -1 indicates that 
-        all implemented orders are used.
+        for keyword arguments. A common example would be a row in an xml table.
+    {params}
 
     Returns
     -------
@@ -346,6 +301,7 @@ def get_fd_waveform_sequence(template=None, **kwds):
         The cross phase of the waveform in frequency domain evaluated at the
     frequency points.
     """
+
     kwds['delta_f'] = -1
     kwds['f_lower'] = -1
     p = props(template, **kwds)
@@ -369,6 +325,10 @@ def get_fd_waveform_sequence(template=None, **kwds):
               
     return Array(hp.data.data), Array(hc.data.data)
 
+get_fd_waveform_sequence.__doc__ = get_fd_waveform_sequence.__doc__.format(
+    params=parameters.fd_waveform_sequence_params.docstr(prefix="    ",
+           include_label=False).lstrip(' '))
+
 def get_td_waveform(template=None, **kwargs):
     """Return the plus and cross polarizations of a time domain waveform. 
 
@@ -376,55 +336,8 @@ def get_td_waveform(template=None, **kwargs):
     ----------
     template: object
         An object that has attached properties. This can be used to subsitute
-        for keyword arguments. A common example would be a row in an xml table. 
-    approximant : string
-        A string that indicates the chosen approximant. See `td_approximants` 
-        for available options. 
-    mass1 : float
-        The mass of the first component object in the binary in solar masses.
-    mass2 : 
-        The mass of the second component object in the binary in solar masses.
-    delta_t :
-        The time step used to generate the waveform. 
-    f_lower :
-        The starting frequency of the waveform.
-    f_ref : {float}, optional
-        The reference frequency
-    distance : {1, float}, optional
-        The distance from the observer to the source in megaparsecs.
-    inclination : {0, float}, optional
-        The inclination angle of the source. 
-    coa_phase : {0, float}, optional
-        The final phase or phase at the peak of the wavform. See documentation
-        on specific approximants for exact usage. 
-    spin1x : {0, float}, optional
-        The x component of the first binary component's spin vector.
-    spin1y : {0, float}, optional
-        y component of the first binary component's spin.
-    spin1z : {0, float}, optional
-        z component of the first binary component's spin.
-    spin2x : {0, float}, optional
-        The x component of the second binary component's spin vector.
-    spin2y : {0, float}, optional
-        y component of the second binary component's spin.
-    spin2z : {0, float}, optional
-        z component of the second binary component's spin.
-    lambda1: {0, float}, optional
-        The tidal deformability parameter of object 1.
-    lambda2: {0, float}, optional
-        The tidal deformability parameter of object 2.
-    phase_order: {-1, int}, optional
-        The pN order of the orbital phase. The default of -1 indicates that 
-        all implemented orders are used.
-    spin_order: {-1, int}, optional
-        The pN order of the spin corrections. The default of -1 indicates that 
-        all implemented orders are used.
-    tidal_order: {-1, int}, optional
-        The pN order of the tidal corrections. The default of -1 indicates that 
-        all implemented orders are used.
-    amplitude_order: {-1, int}, optional
-        The pN order of the amplitude. The default of -1 indicates that 
-        all implemented orders are used.
+        for keyword arguments. A common example would be a row in an xml table.
+    {params}
 
     Returns
     -------
@@ -450,6 +363,10 @@ def get_td_waveform(template=None, **kwargs):
 
     return wav_gen[input_params['approximant']](**input_params)
 
+get_td_waveform.__doc__ = get_td_waveform.__doc__.format(
+    params=parameters.td_waveform_params.docstr(prefix="    ",
+           include_label=False).lstrip(' '))
+
 def get_fd_waveform(template=None, **kwargs):
     """Return a frequency domain gravitational waveform.
 
@@ -457,58 +374,8 @@ def get_fd_waveform(template=None, **kwargs):
     ----------
     template: object
         An object that has attached properties. This can be used to substitute
-        for keyword arguments. A common example would be a row in an xml table. 
-    approximant : string
-        A string that indicates the chosen approximant. See `fd_approximants` 
-        for available options. 
-    mass1 : float
-        The mass of the first component object in the binary in solar masses.
-    mass2 : float
-        The mass of the second component object in the binary in solar masses.
-    delta_f : float
-        The frequency step used to generate the waveform. 
-    f_lower : float
-        The starting frequency of the waveform.
-    f_final : {-1, float}, optional
-        The ending frequency of the waveform. The default indicates that the
-        choice is made by the respective approximant. 
-    f_ref : {float}, optional
-        The reference frequency.
-    distance : {1, float}, optional
-        The distance from the observer to the source in megaparsecs.
-    inclination : {0, float}, optional
-        The inclination angle of the source. 
-    coa_phase : {0, float}, optional
-        The final phase or phase at the peak of the waveform. See documentation
-        on specific approximants for exact usage. 
-    spin1x : {0, float}, optional
-        The x component of the first binary component's spin vector.
-    spin1y : {0, float}, optional
-        y component of the first binary component's spin.
-    spin1z : {0, float}, optional
-        z component of the first binary component's spin.
-    spin2x : {0, float}, optional
-        The x component of the second binary component's spin vector.
-    spin2y : {0, float}, optional
-        y component of the second binary component's spin.
-    spin2z : {0, float}, optional
-        z component of the second binary component's spin.
-    lambda1: {0, float}, optional
-        The tidal deformability parameter of object 1.
-    lambda2: {0, float}, optional
-        The tidal deformability parameter of object 2.
-    phase_order: {-1, int}, optional
-        The pN order of the orbital phase. The default of -1 indicates that 
-        all implemented orders are used.
-    spin_order: {-1, int}, optional
-        The pN order of the spin corrections. The default of -1 indicates that 
-        all implemented orders are used.
-    tidal_order: {-1, int}, optional
-        The pN order of the tidal corrections. The default of -1 indicates that 
-        all implemented orders are used.
-    amplitude_order: {-1, int}, optional
-        The pN order of the amplitude. The default of -1 indicates that 
-        all implemented orders are used.
+        for keyword arguments. A common example would be a row in an xml table.
+    {params}
 
     Returns
     -------
@@ -534,6 +401,10 @@ def get_fd_waveform(template=None, **kwargs):
             raise ValueError("Please provide " + str(arg) )
 
     return wav_gen[input_params['approximant']](**input_params)
+
+get_fd_waveform.__doc__ = get_fd_waveform.__doc__.format(
+    params=parameters.fd_waveform_params.docstr(prefix="    ",
+           include_label=False).lstrip(' '))
 
 def get_interpolated_fd_waveform(dtype=numpy.complex64, return_hc=True,
                                  **params):

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -281,8 +281,7 @@ def props_sgburst(obj, **kwargs):
 
 # Waveform generation ########################################################
 def get_fd_waveform_sequence(template=None, **kwds):
-    """
-    Return values of the waveform evaluated at the sequence of frequency 
+    """Return values of the waveform evaluated at the sequence of frequency 
     points.
 
     Parameters


### PR DESCRIPTION
This adds a base class _FieldArrayWithDefaults and WaveformArray to record.py. WaveformArray is an instance of FieldArray with some common default fields and methods defined. A subset of these fields can be set up on initialization using the names keyword argument. The names can include default fields, virtual fields, methods, and/or functions of these. If a virtual field or method is included in the names, the underlying source code is analyzed so that all the necessary fields are included for the virtual field or method to work. See the doc string for WaveformArray for examples.

I intend to use this in the inference plotting codes, to make plotting different parameters easier. (Pull request to follow this one.)