### PR TITLE
Add burn in points back to output files

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -274,6 +274,11 @@ with ctx:
         logging.info("Burn in")
         sampler.burn_in(p0)
         p0 = None
+        with InferenceFile(opts.output_file, "a") as fp:
+            fp.write_samples_from_sampler(sampler, start=None, end=None,
+                                          labels=labels)
+            fp.write_acceptance_fraction(data=sampler.acceptance_fraction,
+                                         start=None, end=None)
 
     # write sampler attributes to file
     with InferenceFile(opts.output_file, "a") as fp:


### PR DESCRIPTION
The checkpoint addition to pycbc_inference caused it to not write the burn-in points to the output hdf files. This means that when plots/summary are created, valid points are being skipped since by default, thin_start is set to skip the number of burn in iterations. This patch fixes this by adding the burn-in back to the output.