### PR TITLE
Inference with WaveformArray

### DIFF
--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -25,37 +25,26 @@ import numpy
 import sys
 from pycbc import results
 from pycbc.filter import autocorrelation
-from pycbc.io.inference_hdf import InferenceFile
+from pycbc.results import str_utils
+from pycbc.inference import option_utils
 
 # command line usage
-parser = argparse.ArgumentParser(usage="pycbc_inference_plot_acf [--options]",
+parser = argparse.ArgumentParser(
     description="Plots autocorrelation function from inference samples.")
 
-# add data options
-parser.add_argument("--input-file", type=str, required=True,
-    help="Path to input HDF file.")
-parser.add_argument("--variable-args", type=str, nargs="+", default=None,
-    help="Name of parameters varied.")
-
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+    help="Print logging info.")
+# output plot options
+parser.add_argument("--output-file", type=str, required=True,
+    help="Path to output plot.")
 # add plotting options
 parser.add_argument("--ymin", type=float,
     help="Minimum value to plot on y-axis.")
 parser.add_argument("--ymax", type=float,
     help="Maximum value to plot on y-axis.")
-
-# output plot options
-parser.add_argument("--output-file", type=str, required=True,
-    help="Path to output plot.")
-
-# add thinning options
-parser.add_argument("--thin-start", type=int, default=None,
-    help="Sample number to start collecting samples to plot.")
-parser.add_argument("--thin-interval", type=int, default=None,
-    help="Interval to use for thinning samples.")
-
-# verbose option
-parser.add_argument("--verbose", action="store_true", default=False,
-    help="")
+# add results group
+option_utils.add_inference_results_option_group(parser)
 
 # parse the command line
 opts = parser.parse_args()
@@ -67,18 +56,14 @@ else:
     log_level = logging.WARN
 logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 
-# read input file
-logging.info("Reading input file")
-fp = InferenceFile(opts.input_file, "r")
-variable_args = fp.variable_args if opts.variable_args is None else opts.variable_args
-
-# get number of dimensions
-ndim = len(variable_args)
+# load the results
+fp, parameters, labels, _ = option_utils.results_from_cli(opts,
+    load_samples=False)
 
 # calculate autocorrelation function for each walker
 logging.info("Calculating autocorrelation functions")
 all_acfs = []
-for param_name in variable_args:
+for param_name in parameters:
 
     # loop over walkers and save an autocorrelation function
     # for each walker
@@ -86,12 +71,12 @@ for param_name in variable_args:
     for i in range(fp.nwalkers):
 
         # get all the past samples for this walker
-        y = fp.read_samples_from_walker(param_name, i,
-                                        thin_start=opts.thin_start,
-                                        thin_interval=opts.thin_interval)
+        y = fp.read_samples_from_walkers(param_name, walkers=i,
+                                 thin_start=opts.thin_start,
+                                 thin_interval=opts.thin_interval)
 
         # autocorrelate and add to list
-        param_acfs.append( autocorrelation.calculate_acf(y) )
+        param_acfs.append( autocorrelation.calculate_acf(y[param_name]) )
 
     # add list with parameters ACF to list of all ACFs
     all_acfs.append(param_acfs)
@@ -103,7 +88,7 @@ for param_acfs in all_acfs:
     for acf in param_acfs:
         plt.plot(range(len(acf)), acf, alpha=0.25)
 plt.xlabel("Iteration")
-plt.ylabel(r'Autocorrelation Function for %s'%', '.join(['%s'%fp.read_label(param) for param in variable_args]))
+plt.ylabel(r'Autocorrelation Function for %s'%', '.join(labels))
 
 # format plot
 if opts.ymin:
@@ -113,7 +98,7 @@ if opts.ymax:
 
 # save figure with meta-data
 caption_kwargs = {
-    "parameters" : ", ".join(["%s"%fp.read_label(param, html=True) for param in variable_args]),
+    "parameters" : ", ".join(map(str_utils.latex_to_html, labels)),
 }
 caption = """Autocorrelation function (ACF) from all the walker chains for the
 parameters. Each line is an ACF for a chain of walker samples."""

--- a/bin/inference/pycbc_inference_plot_acl
+++ b/bin/inference/pycbc_inference_plot_acl
@@ -25,33 +25,24 @@ import numpy
 import sys
 from pycbc import results
 from pycbc.filter import autocorrelation
-from pycbc.io.inference_hdf import InferenceFile
+from pycbc.results import str_utils
+from pycbc.inference import option_utils
 
 # command line usage
-parser = argparse.ArgumentParser(usage="pycbc_inference_plot_acl [--options]",
+parser = argparse.ArgumentParser(
     description="Histograms autocorrelation length from inference samples.")
 
-# add data options
-parser.add_argument("--input-file", type=str, required=True,
-    help="Path to input HDF file.")
-parser.add_argument("--variable-args", type=str, nargs="+", default=None,
-    help="Name of parameters varied.")
-
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+    help="Print logging info.")
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
 parser.add_argument("--bins", type=int, default=10,
     help="Number of bins in histogram.")
 
-# add thinning options
-parser.add_argument("--thin-start", type=int, default=None,
-    help="Sample number to start collecting samples to plot.")
-parser.add_argument("--thin-interval", type=int, default=None,
-    help="Interval to use for thinning samples.")
-
-# verbose option
-parser.add_argument("--verbose", action="store_true", default=False,
-    help="")
+# add results group
+option_utils.add_inference_results_option_group(parser)
 
 # parse the command line
 opts = parser.parse_args()
@@ -63,29 +54,23 @@ else:
     log_level = logging.WARN
 logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 
-# read input file
-logging.info("Reading input file")
-fp = InferenceFile(opts.input_file, "r")
-variable_args = fp.variable_args if opts.variable_args is None else opts.variable_args
-
-# get number of dimensions
-ndim = len(variable_args)
+# load the results
+fp, parameters, labels, _ = option_utils.results_from_cli(opts,
+    load_samples=False)
 
 # calculate autocorrelation length for each walker
 logging.info("Calculating autocorrelation length")
 acls = []
-for param_name in variable_args:
+for param_name in parameters:
 
     # loop over walkers and save an autocorrelation length
     # for each walker
     for i in range(fp.nwalkers):
 
-        # get all the past samples for this walker
-        # calculate autocorrelation length and add to list
-        y = fp.read_samples_from_walker(param_name, i,
-                                        thin_start=opts.thin_start,
-                                        thin_interval=opts.thin_interval)
-        acl = autocorrelation.calculate_acl(y, dtype=int)
+        y = fp.read_samples_from_walkers(param_name, walkers=i,
+                                 thin_start=opts.thin_start,
+                                 thin_interval=opts.thin_interval)
+        acl = autocorrelation.calculate_acl(y[param_name], dtype=int)
         if acl == numpy.inf:
             acl = fp.niterations
         acls.append( acl )
@@ -102,7 +87,7 @@ poly_xy = patches[0].get_xy()
 step = poly_xy[2][0] - poly_xy[0][0]
 
 plt.xlabel("Iteration")
-plt.ylabel(r'Autocorrelation Length for %s'%', '.join(['%s'%fp.read_label(param) for param in variable_args]))
+plt.ylabel(r'Autocorrelation Length for %s'%', '.join(labels))
 plt.ylim(0, int(1.1*y.max()))
 x_min = max(0, x.min()-2*step)
 plt.xlim(x_min, x.max()+2*step)
@@ -112,7 +97,7 @@ plt.vlines(fp.acl, 0, int(1.1*y.max()))
 
 # save figure with meta-data
 caption_kwargs = {
-    "parameters" : ", ".join(["%s"%fp.read_label(param, html=True) for param in variable_args]),
+    "parameters" : ", ".join(map(str_utils.latex_to_html, labels)),
 }
 caption = """ The histogram (blue) is the autocorrelation length (ACL) from all
  the walker chains for the parameters. The vertical black line is the ACL

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -26,7 +26,6 @@ import numpy
 import sys
 from pycbc import pnutils, results
 from pycbc.results import str_utils
-from pycbc.io.inference_hdf import InferenceFile
 from pycbc.inference import option_utils
 
 # command line usage

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -25,6 +25,7 @@ import matplotlib.pyplot as plt
 import numpy
 import sys
 from pycbc import pnutils, results
+from pycbc.results import str_utils
 from pycbc.io.inference_hdf import InferenceFile
 
 # command line usage
@@ -34,14 +35,17 @@ parser = argparse.ArgumentParser(usage="pycbc_inference_plot_corner [--options]"
 # add data options
 parser.add_argument("--input-file", type=str, required=True,
     help="Path to input HDF file.")
-parser.add_argument("--variable-args", type=str, nargs="+", default=None,
-    help="Name of parameters varied.")
+parser.add_argument("--parameters", type=str, nargs="+", default=None,
+    help="Name of parameters to plot.")
+parser.add_argument("--labels", type=str, nargs="+", default=None,
+    help="Labels to use on the plots for each parameter. If None provided, "
+         "will use the labels in the input file for any parameter that is "
+         "the same as the variable-args. If provided, must be the same number "
+         "as --parameters.")
 
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
-parser.add_argument("--labels", type=str, nargs="+",
-    help="Label for each parameter.")
 
 # add thinning options
 parser.add_argument("--thin-start", type=int, default=None,
@@ -66,42 +70,35 @@ logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 # read input file
 logging.info("Reading input file")
 fp = InferenceFile(opts.input_file, "r")
-variable_args = fp.variable_args if opts.variable_args is None else opts.variable_args
+parameters = fp.variable_args if opts.parameters is None \
+             else opts.parameters
 
-# thin samples to get independent samples from each sampler
-logging.info("Thinning samples")
-x = []
+# load the parameters
+logging.info("Loading samples")
+samples = fp.read_samples(parameters, thin_start=opts.thin_start,
+                          thin_interval=opts.thin_interval)
+# load the labels
+if opts.labels is None:
+    labels = []
+    for p in parameters:
+        # try to get a label from the file
+        label = fp.read_label(p)
+        labels.append(label)
+else:
+    labels = opts.labels
 
-# loop over each walkers
-for i in range(fp.nwalkers):
-
-    # loop over each parameter
-    samples = []
-    for param in variable_args:
-
-        # get varied parameters
-        samples.append( fp.read_samples_from_walker(param, i,
-                                        thin_start=opts.thin_start,
-                                        thin_interval=opts.thin_interval) )
-
-    # transpose walker samples to get an ndim x nwalker x niteration array
-    # add iteration to x
-    samples = numpy.array(samples)
-    samples = numpy.transpose(samples)
-    x.append(samples)
-
-# concatenate arrays so that all iterations are in a single array
-logging.info("Concatenating samples together")
-x = numpy.concatenate(x)
+# convert to 2D array
+x = numpy.zeros((samples.size, len(parameters)))
+for ii,p in enumerate(parameters):
+    x[:,ii] = samples[p]
 
 # plot posterior
 logging.info("Plot posteriors")
 quantiles = [0.16, 0.5, 0.84]
-labels = [r'%s'%str(fp.read_label(param)) for param in variable_args]
 fig = corner.corner(x, labels=labels, quantiles=quantiles)
 
 # if there is only one histogram then change some formatting
-if len(variable_args) == 1:
+if len(parameters) == 1:
 
     # make plot larger
     fig.set_size_inches(8, 6)
@@ -138,8 +135,9 @@ vertical lines correspond to the {quantiles} quantiles. The thinning used to
 make this plot took samples beginning at the {thin_start} and then every
 {thin_interval}-th sample after that. Each chain of samples had {niterations}
 iterations.""".format(**caption_kwargs)
-if len(variable_args) == 1:
-    title = "Posterior Distribution for %s"%fp.read_label(variable_args[0], html=True)
+if len(parameters) == 1:
+    title = "Posterior Distribution for %s" %(
+        str_utils.latex_to_html(labels[0]))
 else:
     title = "Posterior Distributions"
 results.save_fig_with_metadata(fig, opts.output_file,

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -27,35 +27,19 @@ import sys
 from pycbc import pnutils, results
 from pycbc.results import str_utils
 from pycbc.io.inference_hdf import InferenceFile
+from pycbc.inference import option_utils
 
 # command line usage
-parser = argparse.ArgumentParser(usage="pycbc_inference_plot_corner [--options]",
+parser = argparse.ArgumentParser(
     description="Plots corner plot of posteriors from inference sampler.")
-
-# add data options
-parser.add_argument("--input-file", type=str, required=True,
-    help="Path to input HDF file.")
-parser.add_argument("--parameters", type=str, nargs="+", default=None,
-    help="Name of parameters to plot.")
-parser.add_argument("--labels", type=str, nargs="+", default=None,
-    help="Labels to use on the plots for each parameter. If None provided, "
-         "will use the labels in the input file for any parameter that is "
-         "the same as the variable-args. If provided, must be the same number "
-         "as --parameters.")
-
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+    help="Print logging info.")
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
-
-# add thinning options
-parser.add_argument("--thin-start", type=int, default=None,
-    help="Sample number to start collecting samples to plot.")
-parser.add_argument("--thin-interval", type=int, default=None,
-    help="Interval to use for thinning samples.")
-
-# verbose option
-parser.add_argument("--verbose", action="store_true", default=False,
-    help="")
+# add results group
+option_utils.add_inference_results_option_group(parser)
 
 # parse the command line
 opts = parser.parse_args()
@@ -67,27 +51,11 @@ else:
     log_level = logging.WARN
 logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 
-# read input file
-logging.info("Reading input file")
-fp = InferenceFile(opts.input_file, "r")
-parameters = fp.variable_args if opts.parameters is None \
-             else opts.parameters
+# load the results
+fp, parameters, labels, samples = option_utils.results_from_cli(opts,
+    load_samples=True, walkers=None)
 
-# load the parameters
-logging.info("Loading samples")
-samples = fp.read_samples(parameters, thin_start=opts.thin_start,
-                          thin_interval=opts.thin_interval)
-# load the labels
-if opts.labels is None:
-    labels = []
-    for p in parameters:
-        # try to get a label from the file
-        label = fp.read_label(p)
-        labels.append(label)
-else:
-    labels = opts.labels
-
-# convert to 2D array
+# convert the samples to a 2D array
 x = numpy.zeros((samples.size, len(parameters)))
 for ii,p in enumerate(parameters):
     x[:,ii] = samples[p]
@@ -95,7 +63,7 @@ for ii,p in enumerate(parameters):
 # plot posterior
 logging.info("Plot posteriors")
 quantiles = [0.16, 0.5, 0.84]
-fig = corner.corner(x, labels=labels, quantiles=quantiles)
+fig = corner.corner(x, labels=labels, quantiles=quantiles, color='navy')
 
 # if there is only one histogram then change some formatting
 if len(parameters) == 1:

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -23,31 +23,21 @@ import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
 import sys
 from pycbc import results
-from pycbc.io.inference_hdf import InferenceFile
+from pycbc.results import str_utils
+from pycbc.inference import option_utils
 
 # command line usage
 parser = argparse.ArgumentParser(usage="pycbc_inference_plot_samples [--options]",
     description="Plots samples from inference sampler.")
 
-# add data options
-parser.add_argument("--input-file", type=str, required=True,
-    help="Path to input HDF file.")
-parser.add_argument("--variable-args", type=str, nargs="+", default=None,
-    help="Name of parameters varied.")
-
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+    help="Print logging info.")
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
-
-# add thinning options
-parser.add_argument("--thin-start", type=int, default=None,
-    help="Sample number to start collecting samples to plot.")
-parser.add_argument("--thin-interval", type=int, default=None,
-    help="Interval to use for thinning samples.")
-
-# verbose option
-parser.add_argument("--verbose", action="store_true", default=False,
-    help="")
+# add results group
+option_utils.add_inference_results_option_group(parser)
 
 # parse the command line
 opts = parser.parse_args()
@@ -59,39 +49,38 @@ else:
     log_level = logging.WARN
 logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 
-# read input file
-logging.info("Reading input file")
-fp = InferenceFile(opts.input_file, "r")
-variable_args = fp.variable_args if opts.variable_args is None else opts.variable_args
+# load the results
+fp, parameters, labels, _ = option_utils.results_from_cli(opts,
+    load_samples=False)
 
 # get number of dimensions
-ndim = len(variable_args)
+ndim = len(parameters)
 
 # plot samples
-# plot each variable arg has a different subplot
+# plot each parameter as a different subplot
 logging.info("Plotting samples")
 fig, axs = plt.subplots(ndim, sharex=True)
 plt.xlabel("Iteration")
 
-# loop over variable args
+# loop over parameters
 axs = [axs] if not hasattr(axs, "__iter__") else axs
-for i,arg in enumerate(variable_args):
+for i,arg in enumerate(parameters):
 
     # loop over walkers
     for j in range(fp.nwalkers):
 
         # plot each walker as a different line on the subplot
-        axs[i].plot(fp.read_samples_from_walker(arg, j,
-                                                thin_start=opts.thin_start,
-                                                thin_interval=opts.thin_interval),
-                    alpha=0.25)
+        y = fp.read_samples_from_walkers(arg, walkers=i,
+                                 thin_start=opts.thin_start,
+                                 thin_interval=opts.thin_interval)
+        axs[i].plot(y[arg], alpha=0.25)
 
         # y-axis label
-        axs[i].set_ylabel(r'%s'%fp.read_label(arg))
+        axs[i].set_ylabel(labels[i])
 
 # save figure with meta-data
 caption_kwargs = {
-    "parameters" : ", ".join([fp.read_label(param, html=True) for param in variable_args]),
+    "parameters" : ", ".join(map(str_utils.latex_to_html, labels)),
 }
 caption = r"""All samples from all the walker chains for the parameters. Each
 line is a different chain of walker samples."""

--- a/bin/inference/pycbc_inference_table_summary
+++ b/bin/inference/pycbc_inference_table_summary
@@ -22,36 +22,24 @@ import logging
 import numpy
 import sys
 from pycbc import results
-from pycbc.io.inference_hdf import InferenceFile
+from pycbc.results import str_utils
+from pycbc.inference import option_utils
 
 # command line usage
-parser = argparse.ArgumentParser(usage="pycbc_inference_table_summary [--options]",
+parser = argparse.ArgumentParser(
     description="Makes a table of posterior results.")
-
-# add data options
-parser.add_argument("--input-file", type=str, required=True,
-    help="Path to input HDF file.")
-parser.add_argument("--variable-args", type=str, nargs="+", default=[],
-    help="Name of parameters varied in sampler.")
-
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+    help="Print logging info.")
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
-
-# add thinning options
-parser.add_argument("--thin-start", type=int, default=None,
-    help="Sample number to start collecting samples to plot.")
-parser.add_argument("--thin-interval", type=int, default=1,
-    help="Interval to use for thinning samples.")
-
 # add quantile options
 parser.add_argument("--quantiles", type=float, nargs="+",
     default=[0.16,0.50,0.84],
     help="Quantiles to calculate.")
-
-# verbose option
-parser.add_argument("--verbose", action="store_true", default=False,
-    help="")
+# add results group
+option_utils.add_inference_results_option_group(parser)
 
 # parse the command line
 opts = parser.parse_args()
@@ -63,30 +51,22 @@ else:
     log_level = logging.WARN
 logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 
-# read input file
-logging.info("Reading input file")
-fp = InferenceFile(opts.input_file, "r")
-
-# check if command line specifies variable parameters
-if opts.variable_args:
-    variable_args = opts.variable_args
-else:
-    variable_args = fp.variable_args
+# load the results
+fp, parameters, labels, samples = option_utils.results_from_cli(opts,
+    load_samples=True, walkers=None)
 
 # get thinned samples for each parameter
 table = []
-for param in variable_args:
-    samples = fp.read_samples(param, thin_start=opts.thin_start,
-                              thin_interval=opts.thin_interval)
+for param, label in zip(parameters, labels):
 
-    # get label and set as first column in table
-    row = [fp.read_label(param, html=True)]
+    # convert label to html
+    row = [str_utils.latex_to_html(label)]
 
     # calculate the score at a given percentile
     # eg. 50 is the median, 16 and 84 correspond to 68 percentile
     quantiles = []
     for q in opts.quantiles:
-        quantiles.append( numpy.percentile(samples, 100*q) )
+        quantiles.append( numpy.percentile(samples[param], 100*q) )
 
     # add qunatiles to row; we'll quote using scientific notation with
     # 3 sig figs

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -1,0 +1,113 @@
+# Copyright (C) 2016 Collin Capano
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Generals
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+This module contains standard options used for inference-related programs.
+"""
+
+import logging
+from pycbc.io import InferenceFile
+
+def add_inference_results_option_group(parser):
+    """
+    Adds the options used to call pycbc.inference.results_from_cli function
+    to an argument parser. These are options releated to loading the results
+    from a run of pycbc_inference, for purposes of plotting and/or creating
+    tables.
+
+    Parameters
+    ----------
+    parser : object
+        ArgumentParser instance.
+    """
+
+    results_reading_group = parser.add_argument_group("arguments for loading "
+        "inference results")
+
+    # required options
+    results_reading_group.add_argument("--input-file", type=str, required=True,
+        help="Path to input HDF file.")
+    results_reading_group.add_argument("--parameters", type=str, nargs="+",
+        required=True, metavar="PARAM[:LABEL]",
+        help="Name of parameters to plot. Can be any of the variable args in "
+             "the input file, derived parameters from them, or any function "
+             "of them. Syntax for functions is python; any math functions in "
+             "the numpy libary may be used. Can optionally also specify a "
+             "label for each parameter. If no label is provided, will try to "
+             "retrieve a label from the input-file. If no label can be found "
+             "in the input-file, will try to get a label from "
+             "pycbc.waveform.parameters. If no label can be found in either "
+             "place, will just use the parameter.")
+
+    # optionals
+    results_reading_group.add_argument("--thin-start", type=int, default=None,
+        help="Sample number to start collecting samples to plot. If none "
+             "provided, will start at the end of the burn-in.")
+    results_reading_group.add_argument("--thin-interval", type=int,
+        default=None,
+        help="Interval to use for thinning samples. If none provided, will "
+             "use the auto-correlation length found in the file.")
+
+    return results_reading_group
+
+def results_from_cli(opts, load_samples=True, walkers=None):
+    """
+    Loads an inference result file along with any labels associated with it
+    from the command line options.
+
+    Parameters
+    ----------
+    opts : ArgumentParser options
+        The options from the command line.
+    load_samples : {True, bool}
+        Load samples from the results file using the parameters, thin_start,
+        and thin_interval specified in the options. The samples are returned
+        as a WaveformArray instance.
+    walkers : {None, (list of) int}
+        If loading samples, the walkers to load from. If None, will load from
+        all walkers.
+
+    Returns
+    -------
+    result_file : pycbc.io.InferenceFile
+        The result file as an InferenceFile.
+    parameters : list
+        List of the parameters to use, parsed from the parameters option.
+    labels : list
+        List of labels to associate with the parameters.
+    samples : {None, WaveformArray}
+        If load_samples, the samples as a WaveformArray; otherwise, None.
+    """
+    logging.info("Reading input file")
+    fp = InferenceFile(opts.input_file, "r")
+    parameters = fp.variable_args if opts.parameters is None \
+                 else opts.parameters
+    # load the labels
+    labels = []
+    for ii,p in enumerate(parameters):
+        if len(p.split(':')) == 2:
+            p, label = p.split(':')
+            parameters[ii] = p
+        else:
+            label = fp.read_label(p)
+        labels.append(label)
+    if load_samples:
+        logging.info("Loading samples")
+        samples = fp.read_samples_from_walkers(parameters, walkers=walkers, 
+            thin_start=opts.thin_start, thin_interval=opts.thin_interval)
+    else:
+        samples = None
+    return fp, parameters, labels, samples

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -41,8 +41,10 @@ def add_inference_results_option_group(parser):
     results_reading_group.add_argument("--input-file", type=str, required=True,
         help="Path to input HDF file.")
     results_reading_group.add_argument("--parameters", type=str, nargs="+",
-        required=True, metavar="PARAM[:LABEL]",
-        help="Name of parameters to plot. Can be any of the variable args in "
+        metavar="PARAM[:LABEL]",
+        help="Name of parameters to plot. If none provided will load all of "
+             "the variable args in the input-file. If provided, the "
+             "parameters can be any of the variable args in "
              "the input file, derived parameters from them, or any function "
              "of them. Syntax for functions is python; any math functions in "
              "the numpy libary may be used. Can optionally also specify a "

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -82,8 +82,10 @@ class InferenceFile(h5py.File):
         # WaveformArray, with the _staticfields set to the variable args
         # that are in the file. We can only do this if there are actual
         # results in the file
-        if self.variable_args[0] in self:
+        try:
             self._arraycls = self._create_arraycls()
+        except KeyError:
+            self._arraycls = None
 
     def _create_arraycls(self):
         """Returns a sub-class of WaveformArray, with the _staticfields
@@ -188,8 +190,6 @@ class InferenceFile(h5py.File):
             thin_interval = 1 if thin_interval is None else thin_interval
 
         # figure out the size of the output array to create
-        #n_per_walker = 1 + \
-        #    int((self.niterations-thin_start)/float(thin_interval))
         n_per_walker = \
             self[self.variable_args[0]]['walker0'][thin_start::thin_interval].size
         arrsize = len(walkers) * n_per_walker

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -29,6 +29,7 @@ import h5py
 import numpy
 from pycbc import pnutils
 from pycbc.results import str_utils
+from pycbc.io.record import WaveformArray
 
 def read_label_from_config(cp, variable_arg, section="labels", html=False):
     """ Returns the label for the variable_arg.
@@ -76,6 +77,24 @@ class InferenceFile(h5py.File):
 
     def __init__(self, path, mode=None, **kwargs):
         super(InferenceFile, self).__init__(path, mode, **kwargs)
+        # create a result class to return values as. This is a sub-class
+        # WaveformArray, with the _staticfields set to the variable args
+        # that are in the file. We can only do this if there are actual
+        # results in the file
+        if self.variable_args[0] in self:
+            self._arraycls = self._create_arraycls()
+
+    def _create_arraycls(self):
+        """Returns a sub-class of WaveformArray, with the _staticfields
+        set to the variable args that are in the file."""
+        # we'll need the name of a walker to get the dtypes
+        refwalker = self[self.variable_args[0]].keys()[0]
+        # get the names, dtypes of the variable args
+        fields = dict([[name, self[name][refwalker].dtype]
+            for name in self.variable_args])
+        class ResultArray(WaveformArray):
+            _staticfields = fields
+        return ResultArray
 
     @property
     def variable_args(self):
@@ -121,37 +140,21 @@ class InferenceFile(h5py.File):
         """
         return self.attrs["acl"]
 
-    def read_samples(self, variable_arg, thin_start=None, thin_interval=1):
-        """ Reads independent samples from all walkers for a parameter.
-
-        Parameters
-        -----------
-        variable_arg : str
-            Name of parameter to get independent samples.
-        thin_start : int
-            Index of the sample to begin returning samples.
-        thin_interval : int
-            Interval to accept every i-th sample.
-
-        Returns
-        -------
-        numpy.array
-            All independent samples from all walkers for a parameter.
-        """
-
-        nwalkers = self.nwalkers
-        return numpy.array([self.read_samples_from_walker(variable_arg, j, thin_start, thin_interval) for j in range(nwalkers)])
-
-    def read_samples_from_walker(self, variable_arg, nwalker,
+    def read_samples_from_walkers(self, parameters, walkers=None,
                                  thin_start=None, thin_interval=None):
-        """ Reads all samples from a specific walker for a parameter.
+        """Reads samples from the specified walker(s) for the given
+        parameter(s).
 
         Parameters
         -----------
-        variable_arg : str
-            Name of parameter to get independent samples.
-        nwalker : int
-            Index of the walker to get samples.
+        parameters : (list of) strings
+            The parameter(s) to retrieve. A parameter can be the name of a
+            variable argument, a virtual field or method of WaveformArray
+            (as long as the file contains the necessary variables to derive
+            the virtual field or method), and/or a function of these.
+        walkers : {None, (list of) int}
+            The walker index (or a list of indices) to retrieve. If None,
+            samples from all walkers will be obtained.
         thin_start : int
             Index of the sample to begin returning samples. Default is to read
             samples after burn in. To start from the beginning set thin_start
@@ -159,46 +162,49 @@ class InferenceFile(h5py.File):
         thin_interval : int
             Interval to accept every i-th sample. Default is to use the
             self.acl attribute. If self.acl is not set, then use all samples
-            set thin_interval to 1.
+            (set thin_interval to 1).
 
         Returns
         -------
-        numpy.array
-            Samples from a specific walker for a parameter.
+        WaveformArray
+            Samples for the given parameters, as an instance of a
+            WaveformArray.
         """
-
+        if walkers is None:
+            walkers = range(self.nwalkers)
+        if isinstance(walkers, int):
+            walkers = [walkers]
         # default is to skip burn in samples
-        thin_start = self.attrs["burn_in_iterations"] if thin_start is None else thin_start
+        thin_start = self.attrs["burn_in_iterations"] if thin_start is None \
+            else thin_start
 
         # default is to use stored ACL and accept every i-th sample
         if "acl" in self.attrs.keys():
-            thin_interval = self.acl if thin_interval is None else thin_interval
+            thin_interval = self.acl if thin_interval is None \
+                else thin_interval
         else:
             thin_interval = 1 if thin_interval is None else thin_interval
 
-        # derived parameter case for mchirp will calculate mchrip
-        # from mass1 and mass2
-        if variable_arg == "mchirp" and "mchirp" not in self.keys():
-            mass1 = self.read_samples_from_walker("mass1", nwalker,
-                                      thin_start=thin_start,
-                                      thin_interval=thin_interval)
-            mass2 = self.read_samples_from_walker("mass2", nwalker,
-                                      thin_start=thin_start,
-                                      thin_interval=thin_interval)
-            return pnutils.mass1_mass2_to_mchirp_eta(mass1, mass2)[0]
+        # figure out the size of the output array to create
+        n_per_walker = 1 + \
+            int((self.niterations-thin_start)/float(thin_interval))
+        arrsize = len(walkers) * n_per_walker
 
-        # derived parameter case for eta will calculate eta
-        # from mass1 and mass2
-        elif variable_arg == "eta" and "eta" not in self.keys():
-            mass1 = self.read_samples_from_walker("mass1", nwalker,
-                                      thin_start=thin_start,
-                                      thin_interval=thin_interval)
-            mass2 = self.read_samples_from_walker("mass2", nwalker,
-                                      thin_start=thin_start,
-                                      thin_interval=thin_interval)
-            return pnutils.mass1_mass2_to_mchirp_eta(mass1, mass2)[1]
+        # create an array to store the results
+        arr = self._arraycls(arrsize, names=parameters)
+        # populate
+        for name in arr.fieldnames:
+            for ii,walker in enumerate(walkers):
+                arr[name][ii*n_per_walker:(ii+1)*n_per_walker] = \
+                    self[name]['walker%i' % walker][thin_start::thin_interval]
+        return arr
 
-        return self[variable_arg]["walker%d"%nwalker][thin_start::thin_interval]
+    def read_samples(self, parameters, thin_start=None, thin_interval=None):
+        """ Reads samples from all of the walkers for the given
+        parameter(s). See read_samples_from_walkers for more details.
+        """
+        return self.read_samples_from_walkers(parameters, walkers=None,
+            thin_start=thin_start, thin_interval=thin_interval)
 
     def read_acceptance_fraction(self, thin_start=None, thin_interval=None):
         """ Returns a numpy.array of the fraction of samples acceptanced at


### PR DESCRIPTION
These patches update `io/inference_hdf.py` so that it loads samples as instances of `WaveformArray`. This makes it easy to plot/summarize functions of the variable args, along with derived parameters of the variable, such as chirp mass. It also makes use of the new parameters module, so automatically get labels of unrecognized parameters. This change to `inference_hdf` necessitates updates to the programs that load the samples. Since these programs make use of some common command line options --- namely, `input-file, `parameters` (which replaces the old `variable-args`), `thin-start`, and `thin-interval` --- I also created an `option_utils` module in inference that stores and loads these options.

As before, you need only provide an input-file and an output-file to plot the basic variable-args in the file. For example,
`pycbc_inference_plot_posterior --input-file cbc_example-n1e4_sr2048.hdf --output-file corner_plot-default.png`
Yields:
https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/wfarray_in_inference/corner_plot-default.png

However, now you can specify derived parameters from WaveformArray, as well as functions of the variable args and these derived paramters. For example, the following plots the primary and secondary masses (defined as m_pr >= m_sc), as well as the coalesence time - a GPS time in miliseconds:
`pycbc_inference_plot_posterior --input-file cbc_example-n1e4_sr2048.hdf --output-file corner_plot-mp_ms_tc.png --parameters '(tc-1126259462)*1000.:$t_c - 1126259462$ (ms)' m_p m_s`
This yields:
https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/wfarray_in_inference/corner_plot-mp_ms_tc.png
Note that custom labels are now specified by placing a colon after a parameter with the label, rather than a separate label option. This way, if you only want to customize one label (as in the above), you do not need to re-write all of the labels on the command line.

Here is an example of plotting chirp mass:
`pycbc_inference_plot_posterior --input-file cbc_example-n1e4_sr2048.hdf --output-file corner_plot-mchirp.png --parameters mchirp`
which yields:
https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/wfarray_in_inference/corner_plot-mchirp.png

An example with `table_summary`:
`pycbc_inference_table_summary --output-file summary_table-tc_mp_ms_mchirp_eta_mtotal_q.html --input-file cbc_example-n1e4_sr2048.hdf --verbose --parameters '(tc-1126259462)*1000.:$t_c - 1126259462$ (ms)' m_p m_s mchirp eta mtotal q`
Yields:
https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/wfarray_in_inference/summary_table-tc_mp_ms_mchirp_eta_mtotal_q.html
There is still an issue with the latex to html conversion, as not all of the symbols are being converted, but that will be addressed in a future pull request.

I've also updated `plot_acf` `plot_acl`, and `plot_samples`.  I left `plot_prior` and `plot_acceptance_rate` alone since they do not use `read_samples(_from_walker)`.