### PR TITLE
Fix couple of bugs in inference

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -246,14 +246,6 @@ with ctx:
     # setup checkpointing
     if opts.checkpoint_interval:
 
-        # write empty datasets
-        logging.info("Writing empty datasets to output file")
-        with InferenceFile(opts.output_file, "a") as fp:
-            fp.write_samples(variable_args, nwalkers=opts.nwalkers,
-                             niterations=opts.niterations, labels=labels)
-            fp.write_acceptance_fraction(niterations=opts.niterations)
-            labels = None
-
         # determine intervals to run sampler until we save the new samples 
         intervals = [i for i in range(0, opts.niterations, opts.checkpoint_interval)] \
                     + [opts.niterations]
@@ -267,6 +259,8 @@ with ctx:
     else:
         intervals = [0, opts.niterations]
 
+    intervals = numpy.array(intervals)
+
     # check if user wants to skip the burn in
     # if burn in then switch p0 to None and sampler should pick up from last
     # position after burn in
@@ -274,36 +268,45 @@ with ctx:
         logging.info("Burn in")
         sampler.burn_in(p0)
         p0 = None
-        with InferenceFile(opts.output_file, "a") as fp:
-            fp.write_samples_from_sampler(sampler, start=None, end=None,
-                                          labels=labels)
+        n_burnin = sampler.burn_in_iterations
+        logging.info("Used %i burn in samples" % n_burnin)
+    else:
+        n_burnin = 0
+
+    with InferenceFile(opts.output_file, "a") as fp:
+        # create arrays in the file for the burnin + samples
+        fp.write_samples(variable_args, nwalkers=opts.nwalkers,
+                         niterations=opts.niterations+n_burnin,
+                         labels=labels)
+        fp.write_acceptance_fraction(niterations=opts.niterations+n_burnin)
+        # write the burn in
+        if not opts.skip_burn_in:
+            fp.write_samples_from_sampler(sampler, start=0, end=n_burnin)
             fp.write_acceptance_fraction(data=sampler.acceptance_fraction,
-                                         start=None, end=None)
+                                         start=0, end=n_burnin)
 
     # write sampler attributes to file
     with InferenceFile(opts.output_file, "a") as fp:
         fp.write_sampler_attrs(sampler)
 
-    # loop over number of checkpoints
-    for i,end in enumerate(intervals):
+    # increase the intervals to account for the burn in
+    intervals += n_burnin
 
-        # if its the first sample then skip
-        # otherwise start from the last time chain was checkpointed
-        if i == 0:
-            continue
-        start = intervals[i-1]
+    # loop over number of checkpoints
+    for i,start in enumerate(intervals[:-1]):
+
+        end = intervals[i+1]
 
         # run sampler and set initial values to None so that sampler
         # picks up from where it left off next call
-        logging.info("Running sampler for %s to %s out of %s iterations"%(start,end,opts.niterations))
+        logging.info("Running sampler for %i to %i out of %i iterations"%(
+            start-n_burnin,end-n_burnin,opts.niterations))
         sampler.run(end-start, p0=p0)
         p0 = None
 
         # write new samples
-        logging.info("Writing samples for %s to %s out of %s iterations"%(start,end,opts.niterations))
         with InferenceFile(opts.output_file, "a") as fp:
-            fp.write_samples_from_sampler(sampler, start=start, end=end,
-                                          labels=labels)
+            fp.write_samples_from_sampler(sampler, start=start, end=end)
             fp.write_acceptance_fraction(data=sampler.acceptance_fraction,
                                          start=start, end=end)
 
@@ -313,7 +316,9 @@ acls = []
 with InferenceFile(opts.output_file, "r") as fp:
     for i in range(opts.nwalkers):
         for param in fp.variable_args:
-            acls.append( autocorrelation.calculate_acl(fp.read_samples_from_walker(param, i), dtype=int) )
+            acls.append(autocorrelation.calculate_acl(
+                fp.read_samples_from_walkers(param,
+                    walkers=i)[param], dtype=int))
 
 # get max ACL to save to file
 # if ACL is infinity then set it to the length of the chain of samples

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -24,6 +24,7 @@ import pycbc.weave
 import random
 from pycbc import DYN_RANGE_FAC, fft, inference, psd, scheme, strain, waveform
 from pycbc.filter import autocorrelation
+from pycbc.waveform import parameters as wfparams
 from pycbc.io.inference_hdf import InferenceFile
 from pycbc.types import FrequencySeries, MultiDetOptionAction
 from pycbc.workflow import WorkflowConfigParser
@@ -239,9 +240,15 @@ with ctx:
     labels = []
     for param in variable_args:
         if cp.has_option("labels", param):
-            labels.append( cp.get("labels", param) )
+            label = cp.get("labels", param)
         else:
-            labels.append( param )
+            # try looking in pycbc.waveform.parameters
+            try:
+                label = getattr(wfparams, param).label
+            except AttributeError:
+                # just use the parameter name
+                label = param
+        labels.append(label)
 
     # setup checkpointing
     if opts.checkpoint_interval:


### PR DESCRIPTION
In PR #938 I thought the burn-in points were not being included in the sample points, because the length of the sample chains in the output file was the same as the number of iterations (instead of niterations + number of burn in). However, it turns out the burn-in points were included; it was the last points of the chain that was not being included. That patch also introduced a bug that causes inference to fail when using checkpointing.

This patch fixes this by writing an empty array equal to the size of the niterations + burn in right after the burnin, along with the burn-in points.

This patch also fixes a bug introduced in #940. Currently the code crashes when trying to write the acl at the end.

Finally, this adds a patch that will cause the code to try to find a label in waveform.parameters if no labels were provided in the ini file, only falling back to the variable-arg name if it can't find anything there.