### PR TITLE
Use read_label_from_config in pycbc_inference

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -25,7 +25,7 @@ import random
 from pycbc import DYN_RANGE_FAC, fft, inference, psd, scheme, strain, waveform
 from pycbc.filter import autocorrelation
 from pycbc.waveform import parameters as wfparams
-from pycbc.io.inference_hdf import InferenceFile
+from pycbc.io.inference_hdf import InferenceFile, read_label_from_config
 from pycbc.types import FrequencySeries, MultiDetOptionAction
 from pycbc.workflow import WorkflowConfigParser
 
@@ -55,6 +55,8 @@ parser.add_argument("--frame-type", type=str, nargs="+",
     help="Frame type for each IFO.")
 parser.add_argument("--low-frequency-cutoff", type=float, required=True,
     help="Low frequency cutoff for each IFO.")
+parser.add_argument("--input-file", type=str, default=None,
+    help="InferenceFile to set proposal distribution and initial positions.")
 
 # add inference options
 parser.add_argument("--sampler", required=True,
@@ -175,6 +177,11 @@ with ctx:
         except:
             pass
 
+    # get labels for each parameter from configuration file
+    labels = []
+    for param in variable_args:
+        labels.append( read_label_from_config(cp, param) )
+
     # get prior distribution for each variable parameter
     logging.info("Setting up priors for each parameter")
     distributions = []
@@ -235,20 +242,6 @@ with ctx:
                 if param in idist.params:
                     p0[i][j] = idist.rvs(size=1, param=param)[0][0]
                     break
-
-    # get labels for each parameter from configuration file
-    labels = []
-    for param in variable_args:
-        if cp.has_option("labels", param):
-            label = cp.get("labels", param)
-        else:
-            # try looking in pycbc.waveform.parameters
-            try:
-                label = getattr(wfparams, param).label
-            except AttributeError:
-                # just use the parameter name
-                label = param
-        labels.append(label)
 
     # setup checkpointing
     if opts.checkpoint_interval:

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -55,8 +55,6 @@ parser.add_argument("--frame-type", type=str, nargs="+",
     help="Frame type for each IFO.")
 parser.add_argument("--low-frequency-cutoff", type=float, required=True,
     help="Low frequency cutoff for each IFO.")
-parser.add_argument("--input-file", type=str, default=None,
-    help="InferenceFile to set proposal distribution and initial positions.")
 
 # add inference options
 parser.add_argument("--sampler", required=True,

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -176,9 +176,7 @@ with ctx:
             pass
 
     # get labels for each parameter from configuration file
-    labels = []
-    for param in variable_args:
-        labels.append( read_label_from_config(cp, param) )
+    labels = [read_label_from_config(cp, param) for param in variable_args]
 
     # get prior distribution for each variable parameter
     logging.info("Setting up priors for each parameter")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -24,7 +24,6 @@ import pycbc.weave
 import random
 from pycbc import DYN_RANGE_FAC, fft, inference, psd, scheme, strain, waveform
 from pycbc.filter import autocorrelation
-from pycbc.waveform import parameters as wfparams
 from pycbc.io.inference_hdf import InferenceFile, read_label_from_config
 from pycbc.types import FrequencySeries, MultiDetOptionAction
 from pycbc.workflow import WorkflowConfigParser

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -56,7 +56,12 @@ def read_label_from_config(cp, variable_arg, section="labels", html=False):
     if cp.has_option(section, variable_arg):
         label = cp.get(section, variable_arg)
     else:
-        label = variable_arg
+        # try looking in pycbc.waveform.parameters
+        try:
+            label = getattr(wfparams, param).label
+        except AttributeError:
+            # just use the parameter name
+            label = param
 
     # replace LaTeX with HTML
     if html:

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -58,10 +58,10 @@ def read_label_from_config(cp, variable_arg, section="labels", html=False):
     else:
         # try looking in pycbc.waveform.parameters
         try:
-            label = getattr(wfparams, param).label
+            label = getattr(wfparams, varable_arg).label
         except AttributeError:
             # just use the parameter name
-            label = param
+            label = variable_arg
 
     # replace LaTeX with HTML
     if html:

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -58,7 +58,7 @@ def read_label_from_config(cp, variable_arg, section="labels", html=False):
     else:
         # try looking in pycbc.waveform.parameters
         try:
-            label = getattr(wfparams, varable_arg).label
+            label = getattr(wfparams, variable_arg).label
         except AttributeError:
             # just use the parameter name
             label = variable_arg


### PR DESCRIPTION
As title says. Moves the bit added to ``pycbc_inference`` to ``read_label_from_config`` which means ``wfparams`` will also be picked up for the prior plotting executables.