### PR TITLE
Zero noise

### DIFF
--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -308,7 +308,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
                                                 seed=opt.fake_strain_seed)
         else:
             logging.info("Making zero-noise time series")
-            strain = TimeSeries(numpy.zeros(tlen), delta_t=1.0/opt.sample_rate)
+            strain = TimeSeries(pycbc.types.zeros(tlen),
+                                delta_t=1.0/opt.sample_rate)
         strain._epoch = lal.LIGOTimeGPS(opt.gps_start_time)
 
         if opt.injection_file:


### PR DESCRIPTION
In some cases it is useful to produce "fake-strain" with no noise at all. For example testing pycbc_inspiral, or for generating zero-noise frame files of injections to be used in lalinference.

This patch is being used to generate frame files for this purpose, so it would be good to get this on master soon.