### PR TITLE
Adds a --thin-end option

### DIFF
--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -70,7 +70,7 @@ for i,arg in enumerate(parameters):
     for j in range(fp.nwalkers):
 
         # plot each walker as a different line on the subplot
-        y = fp.read_samples_from_walkers(arg, walkers=i,
+        y = fp.read_samples_from_walkers(arg, walkers=j,
                                  thin_start=opts.thin_start,
                                  thin_interval=opts.thin_interval)
         axs[i].plot(y[arg], alpha=0.25)

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -62,6 +62,9 @@ def add_inference_results_option_group(parser):
         default=None,
         help="Interval to use for thinning samples. If none provided, will "
              "use the auto-correlation length found in the file.")
+    results_reading_group.add_argument("--thin-end", type=int, default=None,
+        help="Sample number to stop collecting samples to plot. If none "
+             "provided, will stop at the last sample from the sampler.")
 
     return results_reading_group
 
@@ -109,7 +112,8 @@ def results_from_cli(opts, load_samples=True, walkers=None):
     if load_samples:
         logging.info("Loading samples")
         samples = fp.read_samples_from_walkers(parameters, walkers=walkers, 
-            thin_start=opts.thin_start, thin_interval=opts.thin_interval)
+            thin_start=opts.thin_start, thin_interval=opts.thin_interval,
+            thin_end=opts.thin_end)
     else:
         samples = None
     return fp, parameters, labels, samples

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -222,7 +222,8 @@ class InferenceFile(h5py.File):
         parameter(s). See read_samples_from_walkers for more details.
         """
         return self.read_samples_from_walkers(parameters, walkers=None,
-            thin_start=thin_start, thin_interval=thin_interval, thin_end=None)
+            thin_start=thin_start, thin_interval=thin_interval,
+            thin_end=thin_end)
 
     def read_acceptance_fraction(self, thin_start=None, thin_interval=None):
         """ Returns a numpy.array of the fraction of samples acceptanced at

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -150,7 +150,8 @@ class InferenceFile(h5py.File):
         return self.attrs["acl"]
 
     def read_samples_from_walkers(self, parameters, walkers=None,
-                                 thin_start=None, thin_interval=None):
+                                 thin_start=None, thin_interval=None,
+                                 thin_end=None):
         """Reads samples from the specified walker(s) for the given
         parameter(s).
 
@@ -172,6 +173,9 @@ class InferenceFile(h5py.File):
             Interval to accept every i-th sample. Default is to use the
             self.acl attribute. If self.acl is not set, then use all samples
             (set thin_interval to 1).
+        thin_end : int
+            Index of the last sample to read. If not given then
+            self.niterations is used.
 
         Returns
         -------
@@ -183,6 +187,7 @@ class InferenceFile(h5py.File):
             walkers = range(self.nwalkers)
         if isinstance(walkers, int):
             walkers = [walkers]
+
         # default is to skip burn in samples
         thin_start = self.attrs["burn_in_iterations"] if thin_start is None \
             else thin_start
@@ -194,9 +199,12 @@ class InferenceFile(h5py.File):
         else:
             thin_interval = 1 if thin_interval is None else thin_interval
 
+        # default is to read only as far as niterations
+        thin_end = self.niterations if thin_end is None else thin_end
+
         # figure out the size of the output array to create
-        n_per_walker = \
-            self[self.variable_args[0]]['walker0'][thin_start::thin_interval].size
+        n_per_walker = self[self.variable_args[0]]['walker0'] \
+                                       [thin_start:thin_end:thin_interval].size
         arrsize = len(walkers) * n_per_walker
 
         # create an array to store the results
@@ -204,16 +212,17 @@ class InferenceFile(h5py.File):
         # populate
         for name in arr.fieldnames:
             for ii,walker in enumerate(walkers):
-                arr[name][ii*n_per_walker:(ii+1)*n_per_walker] = \
-                    self[name]['walker%i' % walker][thin_start::thin_interval]
+                arr[name][ii*n_per_walker:(ii+1)*n_per_walker] = self[name] \
+                         ['walker%i'%walker][thin_start:thin_end:thin_interval]
         return arr
 
-    def read_samples(self, parameters, thin_start=None, thin_interval=None):
+    def read_samples(self, parameters, thin_start=None, thin_interval=None,
+                    thin_end=None):
         """ Reads samples from all of the walkers for the given
         parameter(s). See read_samples_from_walkers for more details.
         """
         return self.read_samples_from_walkers(parameters, walkers=None,
-            thin_start=thin_start, thin_interval=thin_interval)
+            thin_start=thin_start, thin_interval=thin_interval, thin_end=None)
 
     def read_acceptance_fraction(self, thin_start=None, thin_interval=None):
         """ Returns a numpy.array of the fraction of samples acceptanced at


### PR DESCRIPTION
Adds a ``--thin-end`` option which defaults to using ``InferenceFile.nierations``.

This is convenient if you're running a long run and want to plot the results while its running. Without this you would get a large number of samples at position (0,0,0,...).

It includes #951. So once that's merged I imagine this will need to be rebased.

EDIT: Also giving ``--thin-start 0 --thin-interval 1 --thin-end -1`` plots all samples in the file.