### PR TITLE
Add quantitles text as option for posterior plot.

### DIFF
--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -37,6 +37,11 @@ parser.add_argument("--verbose", action="store_true", default=False,
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")
+parser.add_argument("--quantiles", type=float, nargs="+",
+    default=[0.16, 0.5, 0.84],
+    help="Quantiles to plot on 1-D histograms.")
+parser.add_argument("--show-titles", action="store_true", default=True,
+    help="Display median and lower and maximal quantiles as error bounds.")
 # add results group
 option_utils.add_inference_results_option_group(parser)
 
@@ -61,8 +66,8 @@ for ii,p in enumerate(parameters):
 
 # plot posterior
 logging.info("Plot posteriors")
-quantiles = [0.16, 0.5, 0.84]
-fig = corner.corner(x, labels=labels, quantiles=quantiles, color='navy')
+fig = corner.corner(x, labels=labels, quantiles=opts.quantiles, color='navy',
+                   show_titles=opts.show_titles)
 
 # if there is only one histogram then change some formatting
 if len(parameters) == 1:
@@ -92,7 +97,7 @@ if len(parameters) == 1:
 
 # save figure with meta-data
 caption_kwargs = {
-    "quantiles" : ", ".join(map(str, [q for q in quantiles])),
+    "quantiles" : ", ".join(map(str, opts.quantiles)),
     "thin_start" : opts.thin_start,
     "thin_interval" : opts.thin_interval,
     "niterations" : len(x[0]),


### PR DESCRIPTION
Adds median and lower+upper quantiles text in posterior plots above 1-D histograms.

Example: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/pr_posterior.png