### PR TITLE
Add priors for anglular parameters

### DIFF
--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -408,12 +408,19 @@ class UniformAngle(Uniform):
             bounds_required=False)
 
 
-class CosAngle(BoundedDist):
+class SinAngle(BoundedDist):
     """
-    A cosine distribution between the given bounds, which must be within
+    A sine distribution between the given bounds, which must be within
     [0,pi). If no bounds are provided, will default to [0, pi). The
     parameter bounds are initialized as multiples of pi, while the stored
     bounds are in radians.
+
+    The pdf of each parameter `\theta` is given by:
+    ..math::
+        p(\theta) = \frac{\sin \theta}{\cos\theta_0 - \cos\theta_1}, \theta_0 \leq \theta < \theta_1,
+
+    and 0 otherwise. Here, :math:`\theta_0, \theta_1` are the bounds of the
+    parameter.
 
     Parameters
     ----------
@@ -426,7 +433,7 @@ class CosAngle(BoundedDist):
 
     Class Attributes
     ----------------
-    name : 'cos_angle'
+    name : 'sin_angle'
         The name of this distribution.
 
     Attributes
@@ -439,7 +446,7 @@ class CosAngle(BoundedDist):
         then the bounds will be:
         `{'psi': (0, 3.141592653589793), 'theta': (0, 3.141592653589793)}`
     """
-    name = 'cos_angle'
+    name = 'sin_angle'
     _func = numpy.cos
     _dfunc = numpy.sin
     _arcfunc = numpy.arccos
@@ -457,7 +464,7 @@ class CosAngle(BoundedDist):
                     "for param %s" %(p))
             params[p] = (bnds[0]*numpy.pi, bnds[1]*numpy.pi)
         # set the params, bounds
-        super(CosAngle, self).__init__(**params)
+        super(SinAngle, self).__init__(**params)
         # compute the norms
         self._lognorm = -sum([numpy.log(
             abs(self._func(bnd[1]) - self._func(bnd[0]))) \
@@ -528,12 +535,19 @@ class CosAngle(BoundedDist):
         return arr
 
 
-class SinAngle(CosAngle):
+class CosAngle(SinAngle):
     """
     A sine distribution between the given bounds, which must be within
     [-pi/2,pi/2). If no bounds are provided, will default to [-pi/2, pi/2). The
     parameter bounds are initialized as multiples of pi, while the stored
     bounds are in radians.
+
+    The pdf of each parameter `\theta` is given by:
+    ..math::
+        p(\theta) = \frac{\cos \theta}{\sin\theta_0 - \sin\theta_1}, \theta_0 \leq \theta < \theta_1,
+
+    and 0 otherwise. Here, :math:`\theta_0, \theta_1` are the bounds of the
+    parameter.
 
     Parameters
     ----------
@@ -546,7 +560,7 @@ class SinAngle(CosAngle):
 
     Class Attributes
     ----------------
-    name : 'sin_angle'
+    name : 'cos_angle'
         The name of this distribution.
 
     Attributes
@@ -559,7 +573,7 @@ class SinAngle(CosAngle):
         then the bounds will be:
         `{'psi': (-1.57[...], 1.57[...]), 'theta': (-0.314[...], 0.314[...])}`
     """
-    name = 'sin_angle'
+    name = 'cos_angle'
     _func = numpy.sin
     _dfunc = numpy.cos
     _arcfunc = numpy.arcsin
@@ -610,7 +624,7 @@ class UniformSolidAngle(BoundedDist):
         The name of the azimuthal angle.
     """
     name = 'uniform_solidangle'
-    _polardistcls = CosAngle
+    _polardistcls = SinAngle
     _azimuthaldistcls = UniformAngle
     _default_polar_angle = 'theta'
     _default_azimuthal_angle = 'phi'
@@ -800,7 +814,7 @@ class UniformSky(UniformSolidAngle):
     ascension) for the azimuthal angle, instead of "theta" and "phi".
     """
     name = 'uniform_sky'
-    _polardistcls = SinAngle
+    _polardistcls = CosAngle
     _default_polar_angle = 'dec'
     _default_azimuthal_angle = 'ra'
 

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -479,7 +479,6 @@ class SinAngle(BoundedDist):
     def lognorm(self):
         return self._lognorm
 
-
     def pdf(self, **kwargs):
         """
         Returns the pdf at the given values. The keyword arguments must contain
@@ -650,45 +649,43 @@ class UniformSolidAngle(BoundedDist):
     def azimuthal_angle(self):
         return self._azimuthal_angle
 
-    def pdf(self, polar_val, azimuthal_val):
+    def pdf(self, **kwargs):
         """
         Returns the pdf at the given angles.
 
         Parameters
         ----------
-        polar_val : float
-            The value (in rad) of the polar angle.
-
-        azimuthal_val : float
-            The value (in rad) of the azimuthal angle.
+        \**kwargs:
+            The keyword arguments should specify the value for each angle,
+            using the names of the polar and azimuthal angles as the keywords.
+            Unrecognized arguments are ignored.
 
         Returns
         -------
         float
             The value of the pdf at the given values.
         """
-        return self._polardist.pdf(**{self._polar_angle: polar_val}) *\
-            self._azimuthaldist.pdf(**{self._azimuthal_angle: azimuthal_val})
+        return self._polardist.pdf(**kwargs) * \
+            self._azimuthaldist.pdf(**kwargs)
         
-    def logpdf(self, polar_val, azimuthal_val):
+    def logpdf(self, **kwargs):
         """
         Returns the logpdf at the given angles.
 
         Parameters
         ----------
-        polar_val : float
-            The value (in rad) of the polar angle.
-
-        azimuthal_val : float
-            The value (in rad) of the azimuthal angle.
+        \**kwargs:
+            The keyword arguments should specify the value for each angle,
+            using the names of the polar and azimuthal angles as the keywords.
+            Unrecognized arguments are ignored.
 
         Returns
         -------
         float
             The value of the pdf at the given values.
         """
-        return self._polardist.logpdf(**{self._polar_angle: polar_val}) +\
-           self._azimuthaldist.logpdf(**{self._azimuthal_angle: azimuthal_val})
+        return self._polardist.logpdf(**kwargs) +\
+            self._azimuthaldist.logpdf(**kwargs)
 
     __call__ = logpdf
 

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -35,7 +35,7 @@ from ConfigParser import Error
 #
 
 # helper function for getting bounds from config file
-def get_param_bounds_fromcp(cp, section, tag, param):
+def get_param_bounds_from_config(cp, section, tag, param):
     """
     Gets bounds for the given parameter from a section in a config file.
     Bounds are specified by setting the parameter name equal to a comma-
@@ -75,7 +75,7 @@ def get_param_bounds_fromcp(cp, section, tag, param):
     return bnds
 
 
-class BoundedDist(object):
+class _BoundedDist(object):
     """
     A generic class for storing common properties of distributions in which
     each parameter has a minimum and maximum value.
@@ -137,7 +137,7 @@ class BoundedDist(object):
 
          Returns
          -------
-         BoundedDist
+         _BoundedDist
              A distribution instance from the pycbc.inference.prior module.
         """
 
@@ -189,7 +189,7 @@ class BoundedDist(object):
         return cls(**dist_args)
 
 
-class Uniform(BoundedDist):
+class Uniform(_BoundedDist):
     """
     A uniform distribution on the given parameters. The parameters are
     independent of each other. Instances of this class can be called like
@@ -408,7 +408,7 @@ class UniformAngle(Uniform):
             bounds_required=False)
 
 
-class SinAngle(BoundedDist):
+class SinAngle(_BoundedDist):
     """
     A sine distribution between the given bounds, which must be within
     [0,pi). If no bounds are provided, will default to [0, pi). The
@@ -579,7 +579,7 @@ class CosAngle(SinAngle):
     _defaultbnds = (-0.5, 0.5)
 
 
-class UniformSolidAngle(BoundedDist):
+class UniformSolidAngle(_BoundedDist):
     """
     A distribution that is uniform in the solid angle of a sphere. The names
     of the two angluar parameters can be specified on initalization.
@@ -794,8 +794,9 @@ class UniformSolidAngle(BoundedDist):
                 azimuthal_angle) + "(%s)"%(', '.join(variable_args)))
 
         # get the bounds, if provided
-        polar_bounds = get_param_bounds_fromcp(cp, section, tag, polar_angle)
-        azimuthal_bounds = get_param_bounds_fromcp(cp, section, tag,
+        polar_bounds = get_param_bounds_from_config(cp, section, tag,
+            polar_angle)
+        azimuthal_bounds = get_param_bounds_from_config(cp, section, tag,
             azimuthal_angle)
 
         return cls(polar_angle=polar_angle, azimuthal_angle=azimuthal_angle,


### PR DESCRIPTION
This adds priors `UniformAngle`, `SinAngle`, `CosAngle`, `UniformSolidAngle`, and `UniformSky` to `inference/prior`. These allow for appropriate sky-loctation priors, and also make it easier to specify angular priors in config files. The priors are:

- `UniformAngle`: same as `Uniform`, but bounds are limited to `[0,2*pi)`. When initializing, you specify the bounds as factors of pi, rather than radians. If no bounds are specified will default to `[0,2*pi)`.
- `SinAngle`: similar to UniformAngle, but points are sine distributed between 0 and pi; see the doc string for math.
- `CosAngle`: same as `SinAngle`, but points are sine distributed between `-pi/2` and `pi/2` (which is equivalent to being cosine distributed between `[0,pi)`).
- `UniformSolidAngle`: creates a prior that is uniform in the solid angle of a sphere. This is a 2-parameter prior. It uses `UniformAngle` for the distribution of the azimuthal angle and `SinAngle` as the distribution of the polar angle.
- `UniformSky`: same as `UniformSolidAngle`, except that the polar angle (which has default name 'dec') uses the `CosAngle` distribution, so that it is = pi/2 at the north pole and -pi/2 at the south pole, consistent with standard ra/dec and latitude/longitude coordinate systems.

I tested these by creating a uniform sky prior, drawing 10000 points from its rvs function, and plotting a histogram of the distribution of each angle with its pdf (red line) and exp(logpdf) (black line). Here is ra:
https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/pycbc_inference/cbc/variable_angles/ra_check.png
Here is dec:
https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/pycbc_inference/cbc/variable_angles/dec_check.png
To make sure this is the correct distribution to use for a uniform sky distribution, I made the same plots from an injection file created by inspinj. Here is the declination:
https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/pycbc_inference/cbc/variable_angles/inspinj-dec.png

I also checked the polar coordinate of a uniform solid angle distribution (here called inclination):
https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/pycbc_inference/cbc/variable_angles/inc_check.png
For comparison, what inspinj gives for inclination when you request uniform orientation:
https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/pycbc_inference/cbc/variable_angles/inspinj-inc.png

This patch also separates some of the machinery for parsing bounds in `Uniform` into another class called `BoundedDist`, which `Uniform` inherits from. I did this because I wanted to be able to inherit these methods in some of the other classes, without all of the stuff that is in `Uniform`.