### PR TITLE
Add multimode ringdown approximants to ringdown module

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -36,7 +36,10 @@ def select_waveform_generator(approximant):
     elif approximant in waveform.td_approximants():
         return waveform.TDomainCBCGenerator
     elif approximant in waveform.ringdown_fd_approximants:
-        return waveform.FDomainRingdownGenerator
+        if approximant=='FdQNM':
+            return waveform.FDomainRingdownGenerator
+        elif approximant=='FdQNMmultiModes':
+            return waveform.FDomainMultiModeRingdownGenerator
     elif approximant in waveform.ringdown_td_approximants:
         raise ValueError("Time domain ringdowns not supported")
     else:

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -161,6 +161,28 @@ class FDomainRingdownGenerator(BaseGenerator):
         super(FDomainRingdownGenerator, self).__init__(ringdown.get_fd_qnm,
             variable_args=variable_args, **frozen_params)
 
+class FDomainMultiModeRingdownGenerator(BaseGenerator):
+    """Uses ringdown.get_fd_lm_allmodes as a generator function to create 
+    frequency-domain ringdown waveforms with higher modes in the radiation 
+    frame; i.e., with no detector response function applied. 
+    For more details, see BaseGenerator.
+
+    Examples
+    --------
+    Initialize a generator:
+    >>> generator = waveform.FDomainMultiModeRingdownGenerator(
+            variable_args=['Mfinal', 'Sfinal', 'lmns','amp220','amp210','phi220','phi210'],
+            delta_f=1./32, f_lower=30., f_final=500)
+
+    Create a ringdown with the variable arguments:
+    >>> generator.generate(65., 0.7, ['221','211'], 1e-21, 0.1e-21, 0., 0.)
+    (<pycbc.types.frequencyseries.FrequencySeries at 0x51614d0>,
+    <pycbc.types.frequencyseries.FrequencySeries at 0x5161550>)
+    """
+    def __init__(self, variable_args=(), **frozen_params):
+        super(FDomainMultiModeRingdownGenerator, self).__init__(ringdown.get_fd_lm_allmodes,
+            variable_args=variable_args, **frozen_params)
+
 class FDomainDetFrameGenerator(object):
     """Generates a waveform using the given radiation frame generator class,
     and applies the detector response function and appropriate time offset.

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -656,5 +656,5 @@ def get_fd_lm_allmodes(template=None, **kwargs):
     return outplustilde, outcrosstilde
 
 # Approximant names ###########################################################
-ringdown_fd_approximants = {'FdQNM': get_fd_qnm}
-ringdown_td_approximants = {'TdQNM': get_td_qnm}
+ringdown_fd_approximants = {'FdQNM': get_fd_qnm, 'FdQNMmultiModes': get_fd_lm_allmodes}
+ringdown_td_approximants = {'TdQNM': get_td_qnm, 'TdQNMmultiModes': get_td_lm_allmodes}

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -362,9 +362,7 @@ def get_td_waveform(template=None, **kwargs):
                             (input_params['approximant']))
 
     for arg in td_required_args:
-        if arg in input_params:
-            pass
-        else:
+        if arg not in input_params:
             raise ValueError("Please provide " + str(arg) )
 
     return wav_gen[input_params['approximant']](**input_params)
@@ -401,9 +399,7 @@ def get_fd_waveform(template=None, **kwargs):
                             (input_params['approximant']))
 
     for arg in fd_required_args:
-        if arg in input_params:
-            pass
-        else:
+        if arg not in input_params:
             raise ValueError("Please provide " + str(arg) )
 
     return wav_gen[input_params['approximant']](**input_params)
@@ -507,9 +503,7 @@ def get_sgburst_waveform(template=None, **kwargs):
     input_params = props_sgburst(template,**kwargs)
 
     for arg in sgburst_required_args:
-        if arg in input_params:
-            pass
-        else:
+        if arg not in input_params:
             raise ValueError("Please provide " + str(arg))
 
     return _lalsim_sgburst_waveform(**input_params)

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -226,9 +226,8 @@ def filter_approximants(scheme=_scheme.mgr.state):
 
 # Input parameter handling ###################################################
 
-def props(obj, **kwargs):
-    """ Return a dictionary bult from the combination of defaults, kwargs,
-    and the attributes of the given object.
+def get_obj_attrs(obj):
+    """ Return a dictionary built from the attributes of the given object.
     """
     pr = {}
     if obj is not None:
@@ -249,6 +248,14 @@ def props(obj, **kwargs):
                         pr[name] = value
                 except:
                     continue
+
+    return pr
+
+def props(obj, **kwargs):
+    """ Return a dictionary built from the combination of defaults, kwargs,
+    and the attributes of the given object.
+    """
+    pr = get_obj_attrs(obj) 
 
     # Get the parameters to generate the waveform
     # Note that keyword arguments override values in the template object


### PR DESCRIPTION
**Wait for Request #4430 in LALSimulation**

This adds the functions `get_td/fd_lm` to generate one lm ringdown with n overtones, and `get_td/fd_lm_allmodes` to generate a multi-mode ringdown with all the lmn selected, based on the modes available in SEOBNRv2. To compute the higher modes it requires the function `XLALSimIMREOBGenerateQNMFreqV2fromFinal` in LALSimulation, which has been added and is in progress of being reviewed and merged. 
The way of dealing with the input parameters has also been re-organized.

Also, in waveform.py, split the function `props` into two functions: `get_obj_attrs` to read the template object, and `props` to combine that with the rest of arguments. This way, `get_obj_attrs` can be called from the ringdown module without interfering with the default arguments.