### PR TITLE
Specify min/max as comma separated values in config file

### DIFF
--- a/docs/workflow/pycbc_make_inference_workflow.rst
+++ b/docs/workflow/pycbc_make_inference_workflow.rst
@@ -116,6 +116,9 @@ You will also need a configuration file with sections that tells ``pycbc_inferen
     distance =
     coa_phase =
     inclination =
+    ra =
+    dec =
+    polarization =
 
     [labels]
     ; LaTeX expressions to use in HTML and plotting executables
@@ -125,50 +128,53 @@ You will also need a configuration file with sections that tells ``pycbc_inferen
     distance = $d$
     coa_phase = $\phi_{c}$
     inclination = $\iota$
+    ra = $\alpha$
+    dec = $\delta$
 
     [static_args]
     ; parameters that do not vary in inference sampler
     approximant = TaylorF2
-    ra = 0.0247836709
-    dec = 0.00715585006
-    polarization = 2.56616092
     f_lower = 40.0
 
     [prior-tc]
     ; how to construct prior distribution
     name = uniform
-    min-tc = 1137215767.92
-    max-tc = 1137215768.04
+    tc = 1137215767.92, 1137215768.04
 
     [prior-mass1]
     ; how to construct prior distribution
     name = uniform
-    min-mass1 = 1.3
-    max-mass1 = 10.0
+    mass1 = 1.3, 10.0
 
     [prior-mass2]
     ; how to construct prior distribution
     name = uniform
-    min-mass2 = 1.3
-    max-mass2 = 10.0
+    mass2 = 1.3, 10.0
 
     [prior-distance]
     ; how to construct prior distribution
     name = uniform
-    min-distance = 30.0
-    max-distance = 100.0
+    distance = 30.0, 100.0
 
     [prior-coa_phase]
     ; how to construct prior distribution
-    name = uniform
-    min-coa_phase = 0.0
-    max-coa_phase = 6.28
+    name = uniform_angle
+    ; uniform_angle defaults to [0,2pi), so we
+    ; don't need to specify anything here
 
     [prior-inclination]
     ; how to construct prior distribution
-    name = uniform
-    min-inclination = 0.0
-    max-inclination = 1.57
+    name = uniform_angle
+    ; inclination between 0 and pi
+    inclination = 0,1
+
+    [prior-ra+dec]
+    ; how to construct prior distribution
+    name = uniform_sky
+
+    [prior-polarization]
+    ; how to construct prior distribution
+    name = uniform_angle
 
 If you want to use another variable parameter in the inference sampler then add its name to ``[variable_args]`` and add a prior section like shown above.
 

--- a/docs/workflow/pycbc_make_inference_workflow.rst
+++ b/docs/workflow/pycbc_make_inference_workflow.rst
@@ -139,22 +139,26 @@ You will also need a configuration file with sections that tells ``pycbc_inferen
     [prior-tc]
     ; how to construct prior distribution
     name = uniform
-    tc = 1137215767.92, 1137215768.04
+    min-tc = 1137215767.92
+    max-tc = 1137215768.04
 
     [prior-mass1]
     ; how to construct prior distribution
     name = uniform
-    mass1 = 1.3, 10.0
+    min-mass1 = 1.3
+    max-mass1 = 10.0
 
     [prior-mass2]
     ; how to construct prior distribution
     name = uniform
-    mass2 = 1.3, 10.0
+    min-mass2 = 1.3
+    max-mass2 = 10.0
 
     [prior-distance]
     ; how to construct prior distribution
     name = uniform
-    distance = 30.0, 100.0
+    min-distance = 30.0
+    max-distance = 100.0
 
     [prior-coa_phase]
     ; how to construct prior distribution
@@ -166,7 +170,8 @@ You will also need a configuration file with sections that tells ``pycbc_inferen
     ; how to construct prior distribution
     name = uniform_angle
     ; inclination between 0 and pi
-    inclination = 0,1
+    min-inclination = 0
+    max-inclination = 1
 
     [prior-ra+dec]
     ; how to construct prior distribution


### PR DESCRIPTION
This patch changes how bounds are specified in config files for distributions that inherit from `_BoundedDist` (namely, `Uniform` and `UniformAngle`). Instead of specifying separate `min-{param}` and `max-{param}` lines, the parameter is just set equal to a comma separated value. For example,
```
[prior-mass1]
name = uniform
min-mass1 = 10.
max-mass1 = 80.
```
becomes:
```
[prior-mass1]
name = uniform
mass1 = 10., 80.
```
The `tag` argument in `from_config` is renamed to `variable_args`, to make it explicit that this needs to list the variable args.

The doc file is also updated. The variables `ra`, `dec`, and `polarization` are also changed to variable args in the documentation to show how to specify uniform sky locations and how to use `uniform_angle`.

Note: for the Gaussian prior, bounds are still specified as `min-{param}` and `max-{param}` since mean and variance also need to be specified.