### PR TITLE
Minor fixes in prep. for larger tmpltbank changes

### DIFF
--- a/bin/pycbc_make_sngl_workflow
+++ b/bin/pycbc_make_sngl_workflow
@@ -105,7 +105,7 @@ insps = _workflow.setup_matchedfltr_workflow(workflow, scienceSegs, datafinds,
 # setup ligolw_add executable
 llwadds = _workflow.FileList([])
 llwadd_exe = _workflow.LigolwAddExecutable(workflow.cp, 'llwadd',
-                                   ifo=''.join(scienceSegs.keys()),
+                                   ifos=''.join(scienceSegs.keys()),
                                    out_dir=fulldataDir)
 
 # group inspiral files by IFO and loop over IFOs

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1012,11 +1012,12 @@ class LigolwAddExecutable(Executable):
     """ The class used to create nodes for the ligolw_add Executable. """
     
     current_retention_level = Executable.INTERMEDIATE_PRODUCT
-    def __init__(self, cp, exe_name, universe=None, ifo=None, out_dir=None, tags=[]):
-        super(LigolwAddExecutable, self).__init__(cp, exe_name, universe, ifo, out_dir, tags=tags)
+    def __init__(self, *args, **kwargs):
+        super(LigolwAddExecutable, self).__init__(*args, **kwargs)
         self.set_memory(2000)
 
-    def create_node(self, jobSegment, input_files, output=None, tags=[]):
+    def create_node(self, jobSegment, input_files, output=None,
+                    use_tmp_subdirs=True, tags=[]):
         node = Node(self)
 
         # Very few options to ligolw_add, all input files are given as a long
@@ -1036,7 +1037,7 @@ class LigolwAddExecutable(Executable):
         else:
             node.new_output_file_opt(jobSegment, '.xml.gz', '--output',
                                     tags=tags, store_file=self.retain_files,
-                                    use_tmp_subdirs=True)
+                                    use_tmp_subdirs=use_tmp_subdirs)
         return node
 
 class LigolwSSthincaExecutable(Executable):

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -140,7 +140,7 @@ class Node(ProfileShortcuts):
     def add_opt(self, opt, value=None):
         """ Add a option
         """
-        if value:
+        if value is not None:
             if not isinstance(value, File):
                 value = str(value)
             self._options += [opt, value]

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -894,7 +894,7 @@ def get_cumulative_segs(workflow, categories, seg_files_list, out_dir,
     outfile = File(workflow.ifos, name, workflow.analysis_time,
                                             directory=out_dir, extension='xml',
                                             tags=[segment_name] + tags)
-    add_job = LigolwAddExecutable(cp, 'llwadd', ifo=ifo, out_dir=out_dir,
+    add_job = LigolwAddExecutable(cp, 'llwadd', ifos=ifo, out_dir=out_dir,
                                   tags=tags)
     add_node = add_job.create_node(valid_segment, add_inputs, output=outfile)
     if file_needs_generating(add_node.output_files[0].cache_entry.path,


### PR DESCRIPTION
I'm starting to move over the template bank generators over to PyCBC workflow and change Tito's .sh script into one uber-workflow (with some changes to sBank and the geom bank to be discussed).

First step is some prep. work. Firstly the LigolwaddExecutable is old and should not use different options to `__init__` than the standard ones (specifically ifo is now ifos).

Also I found a bug in pegasus_workflow. If one supplies:

```
node.add_opt('--some-integer', 0)
```
it will translate it to

```
--some-integer
```

because 0 will fail the "is true" test. Fix is to test for "is option not None".