### PR TITLE
comment out seobnr final frequency

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -558,11 +558,11 @@ _filter_preconditions["SPAtmplt"] = spa_tmplt_precondition
 
 _filter_ends["SPAtmplt"] = spa_tmplt_end
 _filter_ends["TaylorF2"] = spa_tmplt_end
-_filter_ends["SEOBNRv1_ROM_EffectiveSpin"] = seobnrrom_final_frequency
-_filter_ends["SEOBNRv1_ROM_DoubleSpin"] =  seobnrrom_final_frequency
-_filter_ends["SEOBNRv2_ROM_EffectiveSpin"] = seobnrrom_final_frequency
-_filter_ends["SEOBNRv2_ROM_DoubleSpin"] =  seobnrrom_final_frequency
-_filter_ends["SEOBNRv2_ROM_DoubleSpin_HI"] = seobnrrom_final_frequency
+#_filter_ends["SEOBNRv1_ROM_EffectiveSpin"] = seobnrrom_final_frequency
+#_filter_ends["SEOBNRv1_ROM_DoubleSpin"] =  seobnrrom_final_frequency
+#_filter_ends["SEOBNRv2_ROM_EffectiveSpin"] = seobnrrom_final_frequency
+#_filter_ends["SEOBNRv2_ROM_DoubleSpin"] =  seobnrrom_final_frequency
+#_filter_ends["SEOBNRv2_ROM_DoubleSpin_HI"] = seobnrrom_final_frequency
 # PhenomD returns higher frequencies than this, so commenting this out for now
 #_filter_ends["IMRPhenomC"] = seobnrrom_final_frequency
 #_filter_ends["IMRPhenomD"] = seobnrrom_final_frequency


### PR DESCRIPTION
The SEOBNR final frequency function doesn't seem to work properly. For some waveforms it seems to end far earlier than the model naturally does, and causes truncation within the ligo band of the waveform. This truncation causes the background to increase significantly. 

(current master)
https://www.atlas.aei.uni-hannover.de/~ahnitz/LSC/ahnitz/projects/dynamic_flow/analysis3/output/local-site-scratch/html/H1L1-PLOT_SNRIFAR_FULL_DATA_FULL_CUMULATIVE_CAT_12H_FULL_DATA_FULL_BIN_2_CLOSED-1128299417-1083600.png

(patch)
https://www.atlas.aei.uni-hannover.de/~ahnitz/LSC/ahnitz/projects/dynamic_flow/revert2/output/local-site-scratch/work/main_ID0000001/H1L1-PLOT_SNRIFAR_FULL_DATA_FULL_CUMULATIVE_CAT_12H_FULL_DATA_FULL_BIN_2_CLOSED-1128299417-1083600.png

For now, the only solution I have is to deactivate this. Functions such as the interpolated waveforms will still work as long as they have a time estimates. 