### PR TITLE
Add features to PyCBC's workflow module

### DIFF
--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -25,11 +25,14 @@ Workflow module documentation
 
 The following contains a list of the sub-modules in pycbc's workflow module, a bried description of what each does, and a link to documentation on how to use each module. Collectively these pages should provide complete details on how to set up a workflow from scratch.
 
---------------------
-Initialization
---------------------
+---------------------
+Basics and overview
+---------------------
 
-Take in command line input and the configuration file.
+The following page gives a description of how the workflow module expects
+configuration files to be layed out and how the basic command-line interface
+functions. If writing a workflow for the first time we recommend you read
+through this page!
 
 .. toctree::
    :maxdepth: 1

--- a/docs/workflow/initialization.rst
+++ b/docs/workflow/initialization.rst
@@ -32,7 +32,7 @@ To attempt to solve this the workflow module has a number of features
 
 * Multiple configuration files: You can now supply multiple configuration files to, for e.g. identify a file containing only injection generation parameters, which a user may want to change often. It is even possible to have sections split across files, so one could have a configuration file of key options, ones that might be changed, and another file of "leave alone" options.
 * Direct command line options: In the workflow module command line options are not drawn from obscure sections, they correspond one-to-one with the executables. Options in the [inspiral] section will be sent to the inspiral executable and *only* to the inspiral executable.
-* Combined sections: To avoid the issue of specifiying common options repeatedly we have allowed the ability of combined sections. So if you have two executables with a large set of shared options you can specify a [exe1&exe2] section to provide the shared options and [exe1] and [exe2] sections to supply the individual options.
+* Combined sections: To avoid the issue of specifiying common options repeatedly we have allowed the ability of combined sections. So if you have two executables with a large set of shared options you can specify a [exe1&exe2] section to provide the shared options and [exe1] and [exe2] sections to supply the individual options. One can also use the [sharedoptions-NAME] sections to acheive the same thing.
 * Interpolation: As in configparser 3.0+ we have the ability to specify an option in one place and use an interpolation string to also provide it in other places, this is described below.
 * Tags/subsections: In some cases options may only need to be sent to certain jobs, or you may want to call individual modules multiple times and do different things. To accomodate this the workflow module includes a tagging (or subsections) system to provide options to only a subset of jobs, or to a specific call to a module. For example, options in [inspiral] are sent to all inspiral jobs, options in [inspiral-h1] would be sent to inspiral jobs running only on h1 data.
 * Executable expanding: The workflow module includes macros to enable the user to more easily specify executable paths. For example $(which:exe1} will be expanded to the location of exe1 in the users path automatically.
@@ -96,6 +96,12 @@ The [workflow] section must contain two entries
 * end-time=END
 
 which are used to tell the workflow that is only to consider times in [START,END) for analysis. These will often be supplied as override options directly on the command line.
+
+Another optional entry in the [workflow] section, that we recommend be used is the:
+
+* file-retention-level = all_files
+
+entry. This can take one of 4 values: "all_files", "all_triggers", "merged_triggers" or "results". These specify how many files produced during the workflow should be stored after the workflow finishes. With "all_files", which is the default value, everything produced in the workflow will be stored. With "results" only the critical result files are stored. "all_triggers" and "merged_triggers" store some subset of the full set of files. Defining whether a file should be stored under each of these levels is the job of the Executable class, which carries a current_retention_level attribute (one of executable.INTERMEDIATE_PRODUCT, executable.ALL_TRIGGERS, executable.MERGED_TRIGGERS or executable.FINAL_RESULT). When building workflows one can set this atrribute when creating executable instances to set under what conditions a file should be stored.
 
 It is okay to store other *important and widely used* values in here. You might often see cases where channel names are given here as these are sent to a number of codes on the command line, and it is easier to refer to them here, at the very top of the .ini file, so that the user can more easily see and change such values.
 
@@ -249,7 +255,39 @@ Similar macros can be added as needed, but these should be limited to avoid name
 Example complete workflow .ini file
 ------------------------------------
 
-Please see the examples on the main workflow module page for some examples of complete .ini files and example workflows.
+Please see individual workflow documentation pages for some examples of complete .ini files and example workflows.
+
+========================
+[sharedoptions] section
+========================
+
+An alternative to the [exe1&exe2] section, especially when options are split
+well into groups of options, is to use the [sharedoptions] section. An example of this follows::
+
+  [sharedoptions]
+  massranges = exe1,exe2,exe3-mass
+  metric = exe1,exe2-range,exe3-metric, exe5
+
+  [sharedoptions-massranges]
+  min-mass1 = 2.0
+  max-mass1 = 48.0
+  min-mass2 = 2.0
+  max-mass2 = 48.0
+  max-total-mass = 4.2
+  min-total-mass = 4.0
+  max-eta = 0.25
+  max-ns-spin-mag = 0.9899
+  max-bh-spin-mag = 0.9899
+
+  [sharedoptions-metric]
+  pn-order = threePointFivePN
+  f0 = 70.0
+  f-low = 30.0
+  f-upper = 1100.0
+  delta-f = 0.01
+
+This will ensure that all options in [sharedoptions-massranges] are added to the [exe1], [exe2] and [exe3-mass] sections. All options in [sharedoptions-metric] are added to [exe1], [exe2-range], [exe-metric] and [exe5].
+
 
 =====================
 Code documentation

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -495,8 +495,8 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         This will result in all options in [sharedoptions-massparams] being
         copied into the [inspiral] and [tmpltbank] sections and the options
         in [sharedoptions-dataparams] being copited into [tmpltbank].
-        In the case of duplicates an error will be raised."""
-
+        In the case of duplicates an error will be raised.
+        """
         if not self.has_section('sharedoptions'):
             # No sharedoptions, exit
             return

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -34,6 +34,7 @@ import urllib2
 import time
 import distutils.spawn
 import ConfigParser
+import itertools
 import glue.pipeline
 
 def resolve_url(url, directory=None, permissions=None):
@@ -175,10 +176,12 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         # Split sections like [inspiral&tmplt] into [inspiral] and [tmplt]
         self.split_multi_sections() 
 
+        # Populate shared options from the [sharedoptions] section
+        self.populate_shared_sections()
+
         # Do overrides from command line
         for override in overrideTuples:
             if len(override) not in [2,3]:
-                print override
                 errMsg = "Overrides must be tuples of length 2 or 3."
                 errMsg = "Got %s." %(str(override))
                 raise ValueError(errMsg)
@@ -481,6 +484,34 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
                 self.add_options_to_section(newSec, self.items(section))
             self.remove_section(section)
 
+    def populate_shared_sections(self):
+        """ Parse the [sharedoptions] section of the ini file. That section
+        should contain entries according to:
+
+          * massparams = inspiral, tmpltbank
+          * dataparams = tmpltbank
+
+        This will result in all options in [sharedoptions-massparams] being
+        copied into the [inspiral] and [tmpltbank] sections and the options
+        in [sharedoptions-dataparams] being copited into [tmpltbank].
+        In the case of duplicates an error will be raised.
+        """
+        if not self.has_section('sharedoptions'):
+            # No sharedoptions, exit
+            return
+        for key, value in self.items('sharedoptions'):
+            assert(self.has_section('sharedoptions-%s' %(key)))
+            # Comma separated
+            values = value.split(',')
+            common_options = self.items('sharedoptions-%s' %(key))
+            for section in values:
+                for arg, val in common_options:
+                    if arg in self.options(section):
+                        raise ValueError('Option exists in both original ' + \
+                               'ConfigParser section [%s] and ' %(section,) + \
+                               'sharedoptions section: %s %s' \
+                               %(option,'sharedoptions-%s' %(key)))
+                    self.set(section, arg, val)
 
     def add_options_to_section(self ,section, items, overwrite_options=False):
         """
@@ -638,18 +669,28 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
             if not tags:
                 raise ConfigParser.Error(errString + ".")
             returnVals = []
-            sectionList = ["%s-%s" %(section, tag) for tag in tags]
-            for tag in tags:
-                if self.has_section('%s-%s' %(section, tag)):
-                    if self.has_option('%s-%s' %(section, tag), option):
-                        returnVals.append(self.get('%s-%s' %(section, tag),
+            subSectionList = []
+            for secLen in range(1, len(tags)+1):
+                for tagPermutation in itertools.permutations(tags, secLen):
+                    joinedName = '-'.join(tagPermutation)
+                    subSectionList.append(joinedName)
+            sectionList = ["%s-%s" %(section, sub) for sub in subSectionList]
+            errSectionList = []
+            for sub in subSectionList:
+                if self.has_section('%s-%s' %(section, sub)):
+                    if self.has_option('%s-%s' %(section, sub), option):
+                        errSectionList.append("%s-%s" %(section, sub))
+                        returnVals.append(self.get('%s-%s' %(section, sub),
                                                     option))
+
+            # We also want to recursively go into sections
+
             if not returnVals:
                 errString += "or in sections [%s]." %("] [".join(sectionList))
                 raise ConfigParser.Error(errString)
             if len(returnVals) > 1:
                 errString += "and multiple entries found in sections [%s]."\
-                              %("] [".join(sectionList))
+                              %("] [".join(errSectionList))
                 raise ConfigParser.Error(errString)
             return returnVals[0]
 

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -666,7 +666,7 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         try:
             return self.get(section, option)
         except ConfigParser.Error:
-            errString = "No option '%s' in section [%s] " %(option,section)
+            err_string = "No option '%s' in section [%s] " %(option,section)
             if not tags:
                 raise ConfigParser.Error(errString + ".")
             return_vals = []

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -668,7 +668,7 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         except ConfigParser.Error:
             err_string = "No option '%s' in section [%s] " %(option,section)
             if not tags:
-                raise ConfigParser.Error(errString + ".")
+                raise ConfigParser.Error(err_string + ".")
             return_vals = []
             sub_section_list = []
             for sec_len in range(1, len(tags)+1):

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -485,8 +485,9 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
             self.remove_section(section)
 
     def populate_shared_sections(self):
-        """ Parse the [sharedoptions] section of the ini file. That section
-        should contain entries according to:
+        """Parse the [sharedoptions] section of the ini file.
+
+        That section should contain entries according to:
 
           * massparams = inspiral, tmpltbank
           * dataparams = tmpltbank
@@ -494,8 +495,8 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         This will result in all options in [sharedoptions-massparams] being
         copied into the [inspiral] and [tmpltbank] sections and the options
         in [sharedoptions-dataparams] being copited into [tmpltbank].
-        In the case of duplicates an error will be raised.
-        """
+        In the case of duplicates an error will be raised."""
+
         if not self.has_section('sharedoptions'):
             # No sharedoptions, exit
             return
@@ -510,7 +511,7 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
                         raise ValueError('Option exists in both original ' + \
                                'ConfigParser section [%s] and ' %(section,) + \
                                'sharedoptions section: %s %s' \
-                               %(option,'sharedoptions-%s' %(key)))
+                               %(arg,'sharedoptions-%s' %(key)))
                     self.set(section, arg, val)
 
     def add_options_to_section(self ,section, items, overwrite_options=False):
@@ -668,31 +669,32 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
             errString = "No option '%s' in section [%s] " %(option,section)
             if not tags:
                 raise ConfigParser.Error(errString + ".")
-            returnVals = []
-            subSectionList = []
-            for secLen in range(1, len(tags)+1):
-                for tagPermutation in itertools.permutations(tags, secLen):
-                    joinedName = '-'.join(tagPermutation)
-                    subSectionList.append(joinedName)
-            sectionList = ["%s-%s" %(section, sub) for sub in subSectionList]
-            errSectionList = []
-            for sub in subSectionList:
+            return_vals = []
+            sub_section_list = []
+            for sec_len in range(1, len(tags)+1):
+                for tag_permutation in itertools.permutations(tags, sec_len):
+                    joined_name = '-'.join(tag_permutation)
+                    sub_section_list.append(joined_name)
+            section_list = ["%s-%s" %(section, sb) for sb in sub_section_list]
+            err_section_list = []
+            for sub in sub_section_list:
                 if self.has_section('%s-%s' %(section, sub)):
                     if self.has_option('%s-%s' %(section, sub), option):
-                        errSectionList.append("%s-%s" %(section, sub))
-                        returnVals.append(self.get('%s-%s' %(section, sub),
+                        err_section_list.append("%s-%s" %(section, sub))
+                        return_vals.append(self.get('%s-%s' %(section, sub),
                                                     option))
 
             # We also want to recursively go into sections
 
-            if not returnVals:
-                errString += "or in sections [%s]." %("] [".join(sectionList))
-                raise ConfigParser.Error(errString)
-            if len(returnVals) > 1:
-                errString += "and multiple entries found in sections [%s]."\
-                              %("] [".join(errSectionList))
-                raise ConfigParser.Error(errString)
-            return returnVals[0]
+            if not return_vals:
+                err_string += "or in sections [%s]." \
+                               %("] [".join(section_list))
+                raise ConfigParser.Error(err_string)
+            if len(return_vals) > 1:
+                err_string += "and multiple entries found in sections [%s]."\
+                              %("] [".join(err_section_list))
+                raise ConfigParser.Error(err_string)
+            return return_vals[0]
 
 
     def has_option_tag(self, section, option, tag):

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -368,7 +368,7 @@ class Executable(pegasus_workflow.Executable):
                     tuple_val = (curr_pfn, curr_file)
                     file_input_from_config_dict[curr_lfn] = tuple_val
                 self.common_input_files.append(curr_file)
-                value = curr_file.dax_repr()
+                value = curr_file.dax_repr
             self.common_options += [opt, value]
             
     def add_opt(self, opt, value=None):

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -368,7 +368,7 @@ class Executable(pegasus_workflow.Executable):
                     tuple_val = (curr_pfn, curr_file)
                     file_input_from_config_dict[curr_lfn] = tuple_val
                 self.common_input_files.append(curr_file)
-                value = curr_file._dax_repr()
+                value = curr_file.dax_repr()
             self.common_options += [opt, value]
             
     def add_opt(self, opt, value=None):

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -242,10 +242,10 @@ class Executable(pegasus_workflow.Executable):
                 sec_tags = tags + self.ifo_list
         else:
             sec_tags = tags
-        for secLen in range(1, len(sec_tags)+1):
-            for tagPermutation in permutations(sec_tags, secLen):
-                joinedName = '-'.join(tagPermutation)
-                section = '%s-%s' %(name, joinedName.lower())
+        for sec_len in range(1, len(sec_tags)+1):
+            for tag_permutation in permutations(sec_tags, sec_len):
+                joined_name = '-'.join(tag_permutation)
+                section = '%s-%s' %(name, joined_name.lower())
                 if cp.has_section(section):
                     sections.append(section)
 

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -427,8 +427,7 @@ class File(DataStorage, dax.File):
 
     @classmethod
     def from_path(cls, path):
-        """ Takes a path and returns a File object with the path as the PFN.
-        """
+        """Takes a path and returns a File object with the path as the PFN."""
         path = os.path.abspath(path)
         fil = File(os.path.basename(path))
         fil.PFN(path, "local")

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -401,7 +401,7 @@ class File(DataStorage, dax.File):
 
     @property
     def dax_repr(self):
-    """Return the dax representation of a File."""
+        """Return the dax representation of a File."""
         return self._dax_repr()
         
     def _set_as_input_of(self, node):

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -401,6 +401,7 @@ class File(DataStorage, dax.File):
 
     @property
     def dax_repr(self):
+    """Return the dax representation of a File."""
         return self._dax_repr()
         
     def _set_as_input_of(self, node):

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -424,6 +424,15 @@ class File(DataStorage, dax.File):
         
     def insert_into_dax(self, dax):
         dax.addFile(self)
+
+    @classmethod
+    def from_path(cls, path):
+        """ Takes a path and returns a File object with the path as the PFN.
+        """
+        path = os.path.abspath(path)
+        fil = File(os.path.basename(path))
+        fil.PFN(path, "local")
+        return fil
     
 class Database(DataStorage):
     pass

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -398,6 +398,10 @@ class File(DataStorage, dax.File):
 
     def _dax_repr(self):
         return self
+
+    @property
+    def dax_repr(self):
+        return self._dax_repr()
         
     def _set_as_input_of(self, node):
         node._dax_node.uses(self, link=dax.Link.INPUT, register=False, 


### PR DESCRIPTION
In preparation for moving the template bank generation codes to using pycbc.workflow I want to add some features to the workflow module. Some of these are things we've discussed previously, but some things are new. I think I can summarize the changes into 3 points:

 * Support for tag-subsections. Ie. you can now supply `[inspiral-h1-bnsinj]` (or `[inspiral-bnsinj-h1]`) to give options only to jobs with the bnsinj *and* h1 tags. This should work for any number of tags, but duplication is still forbidden (so a value in `[inspiral-h1-bnsinj]` does *not* override a value in `[inspiral]`. If an option is present in both--or if an option is present twice in *any* set of subsections a code reads from--the code will fail. Therefore it is better not to nest these too deep!).

 * Support for options that are always given as files. The main example is the option in pycbc.psd `--psd-file` and the sbank equivalent. Currently this would be specified in the ini file with a path to the file but pegasus would not know it is a file, so on certain file-systems this will cause problems. Now executable classes can declare "special" options that are known to take a file input and will correctly identify this to pegasus (while not causing issues if the *same* file is given to multiple jobs). The only issue here is it currently only supports, and expects, local paths. @duncan-brown and @lppekows can probably use tricks they used in other cases to make this support (for e.g.) https:// addresses, but I leave this for them to address in a future patch. From the user's perspective they continue to specify the psd-file as a path in the ini file; the code handles the rest.

 * Addition of a [sharedoptions] section (which of course is optional). This basically repeats the functionality of [exe1&exe2] sections, but maybe makes it easier to specify options that naturally group together (e.g. if a set of executables use the PSD option group, maybe they want to read the PSD group of options). A basic example of this

```
  [sharedoptions]
  massranges = exe1,exe2,exe3-mass
  metric = exe1,exe2-range,exe3-metric, exe5

  [sharedoptions-massranges]
  min-mass1 = 2.0
  max-mass1 = 48.0
  min-mass2 = 2.0
  max-mass2 = 48.0
  max-total-mass = 4.2
  min-total-mass = 4.0
  max-eta = 0.25
  max-ns-spin-mag = 0.9899
  max-bh-spin-mag = 0.9899

  [sharedoptions-metric]
  pn-order = threePointFivePN
  f0 = 70.0
  f-low = 30.0
  f-upper = 1100.0
  delta-f = 0.01
```

As I said, this could be replaced by [exe1&exe2&...] sections, but maybe this is clearer? If there is opposition to this I can remove this part.

There's also a bug-fix in here to try to ensure the case sensitivity of tags does not cause problems.

And finally some documentation updates are included.

I'm running the example workflow at the moment (which uses none of these features), and have also successfully run the newly created sbank and geom_bank pycbc.workflow generators to check that these features work. Patches to push these to master will follow this one.