### PR TITLE
Remove latex_to_html function

### DIFF
--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -25,7 +25,6 @@ import numpy
 import sys
 from pycbc import results
 from pycbc.filter import autocorrelation
-from pycbc.results import str_utils
 from pycbc.inference import option_utils
 
 # command line usage
@@ -97,7 +96,7 @@ if opts.ymax:
 
 # save figure with meta-data
 caption_kwargs = {
-    "parameters" : ", ".join(map(str_utils.latex_to_html, labels)),
+    "parameters" : ", ".join(labels),
 }
 caption = """Autocorrelation function (ACF) from all the walker chains for the
 parameters. Each line is an ACF for a chain of walker samples."""

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -25,7 +25,6 @@ import matplotlib.pyplot as plt
 import numpy
 import sys
 from pycbc import pnutils, results
-from pycbc.results import str_utils
 from pycbc.inference import option_utils
 
 # command line usage
@@ -108,8 +107,7 @@ make this plot took samples beginning at the {thin_start} and then every
 {thin_interval}-th sample after that. Each chain of samples had {niterations}
 iterations.""".format(**caption_kwargs)
 if len(parameters) == 1:
-    title = "Posterior Distribution for %s" %(
-        str_utils.latex_to_html(labels[0]))
+    title = "Posterior Distribution for %s" % labels[0]
 else:
     title = "Posterior Distributions"
 results.save_fig_with_metadata(fig, opts.output_file,

--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -149,7 +149,8 @@ else:
 
 # save figure with meta-data
 caption_kwargs = {
-    "parameters" : ", ".join([read_label_from_config(cp, param, html=True) for param in variable_args])
+    "parameters" : ", ".join([read_label_from_config(cp, param)
+        for param in variable_args])
 }
 caption = """This plot shows the probability density function (PDF) from the 
 prior distributions."""

--- a/bin/inference/pycbc_inference_plot_samples
+++ b/bin/inference/pycbc_inference_plot_samples
@@ -23,7 +23,6 @@ import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
 import sys
 from pycbc import results
-from pycbc.results import str_utils
 from pycbc.inference import option_utils
 
 # command line usage
@@ -79,7 +78,7 @@ for i,arg in enumerate(parameters):
 
 # save figure with meta-data
 caption_kwargs = {
-    "parameters" : ", ".join(map(str_utils.latex_to_html, labels)),
+    "parameters" : ", ".join(labels),
 }
 caption = r"""All samples from all the walker chains for the parameters. Each
 line is a different chain of walker samples."""

--- a/bin/inference/pycbc_inference_table_summary
+++ b/bin/inference/pycbc_inference_table_summary
@@ -58,7 +58,6 @@ fp, parameters, labels, samples = option_utils.results_from_cli(opts,
 table = []
 for param, label in zip(parameters, labels):
 
-    # convert label to html
     row = [label]
 
     # calculate the score at a given percentile
@@ -76,7 +75,7 @@ for param, label in zip(parameters, labels):
     else:
         err = quantiles[0]/100.
     row += ['$%s$' %(results.format_value(val, err, include_error=False,
-        use_scientific_notation=10 if numpy.log10(val) > 0 else 3))
+        use_scientific_notation=10 if numpy.log10(abs(val)) > 0 else 3))
         for val in quantiles]
 
     # add row to table

--- a/bin/inference/pycbc_inference_table_summary
+++ b/bin/inference/pycbc_inference_table_summary
@@ -22,7 +22,6 @@ import logging
 import numpy
 import sys
 from pycbc import results
-from pycbc.results import str_utils
 from pycbc.inference import option_utils
 
 # command line usage
@@ -60,7 +59,7 @@ table = []
 for param, label in zip(parameters, labels):
 
     # convert label to html
-    row = [str_utils.latex_to_html(label)]
+    row = [label]
 
     # calculate the score at a given percentile
     # eg. 50 is the median, 16 and 84 correspond to 68 percentile

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -28,11 +28,10 @@ inference samplers generate.
 import h5py
 import numpy
 from pycbc import pnutils
-from pycbc.results import str_utils
 from pycbc.io.record import WaveformArray
 from pycbc.waveform import parameters as wfparams
 
-def read_label_from_config(cp, variable_arg, section="labels", html=False):
+def read_label_from_config(cp, variable_arg, section="labels"):
     """ Returns the label for the variable_arg.
 
     Parameters
@@ -43,8 +42,6 @@ def read_label_from_config(cp, variable_arg, section="labels", html=False):
         The parameter to get label.
     section : str
         Name of section in configuration file to get label.
-    html : bool
-        If True then replace LaTeX substrings with HTML substrings.
 
     Returns
     -------
@@ -62,11 +59,6 @@ def read_label_from_config(cp, variable_arg, section="labels", html=False):
         except AttributeError:
             # just use the parameter name
             label = variable_arg
-
-    # replace LaTeX with HTML
-    if html:
-        label = str_utils.latex_to_html(label)
-
     return label
 
 class InferenceFile(h5py.File):
@@ -233,7 +225,7 @@ class InferenceFile(h5py.File):
         """
         return self["acceptance_fraction"][thin_start::thin_interval]
 
-    def read_label(self, parameter, html=False, error_on_none=False):
+    def read_label(self, parameter, error_on_none=False):
         """Returns the label for the parameter.
 
         Parameters
@@ -243,8 +235,6 @@ class InferenceFile(h5py.File):
             a label from this file's "label" attributes. If the parameter
             is not found there, will look for a label from
             pycbc.waveform.parameters.
-        html : bool
-            If true then escape LaTeX formatting for HTML rendering.
         error_on_none : {False, bool}
             If True, will raise a ValueError if a label cannot be found, or if
             the label is None. Otherwise, the parameter will just be returned
@@ -270,10 +260,6 @@ class InferenceFile(h5py.File):
                     parameter))
             else:
                 return parameter
-        # replace LaTeX with HTML
-        if html:
-            label = str_utils.latex_to_html(label)
-
         return label
 
     def write_psds(self, psds, low_frequency_cutoff):

--- a/pycbc/results/str_utils.py
+++ b/pycbc/results/str_utils.py
@@ -219,28 +219,3 @@ def format_value(value, error, plus_error=None, use_scientific_notation=3,
     else:
         txt = r'%s%s' %(valtxt, powfactor)
     return txt 
-
-def latex_to_html(text):
-    """ Replaces LaTeX substrings with HTML replacements.
-
-    Parameters
-    ----------
-    text : str
-        Text to be replaced.
-
-    Returns
-    -------
-    text : str
-        Replaced text.
-    """
-    html_mappings = {
-        "\eta" : "&#951;",
-        "\phi" : "&#966;",
-        "\iota" : "&#953;",
-    }
-    text = text.replace("$", "")
-    text = text.replace("_{", "<sub>")
-    text = text.replace("}", "</sub>")
-    for latex_str,html_str in html_mappings.iteritems():
-        text = text.replace(latex_str, html_str)
-    return text

--- a/pycbc/results/str_utils.py
+++ b/pycbc/results/str_utils.py
@@ -165,6 +165,8 @@ def format_value(value, error, plus_error=None, use_scientific_notation=3,
     >>> format_value(val, err, plus_error=err_plus, use_relative_error=True)
     '3.93\\times 10^{-22}\\,^{+2\\%}_{-6\\%}'
     """
+    minus_sign = '-' if value < 0. else ''
+    value = abs(value)
     minus_err = abs(error)
     if plus_error is None:
         plus_err = minus_err 
@@ -217,5 +219,5 @@ def format_value(value, error, plus_error=None, use_scientific_notation=3,
                 txt = r'%s^{+%s}_{-%s}%s' %(valtxt, plus_err_txt,
                     minus_err_txt, powfactor)
     else:
-        txt = r'%s%s' %(valtxt, powfactor)
+        txt = r'%s%s%s' %(minus_sign, valtxt, powfactor)
     return txt 


### PR DESCRIPTION
This patch removes the `latex_to_html` function in the inference plotting programs. The intent is to just use the MathJax CDN. This patch also fixes a bug in format_value that prevented it from printing negative values. Example output of a test run is here:

https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/pycbc_inference/cbc/variable_angles/summary-all_ti800.html