### PR TITLE
Skip division when calculating tlen in to_frequencyseries and to_timeseries

### DIFF
--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -388,15 +388,15 @@ class FrequencySeries(Array):
         nat_delta_t =  1.0 / ((len(self)-1)*2) / self.delta_f
         if not delta_t:
             delta_t = nat_delta_t
-            tlen = (len(self)-1)*2
-        else:
-            tlen  = int(1.0 / self.delta_f / delta_t)
+
+
+        tlen  = int(1.0 / self.delta_f / delta_t + 0.5)
         flen = tlen / 2 + 1
         
         if flen < len(self):
             raise ValueError("The value of delta_t (%s) would be "
                              "undersampled. Maximum delta_t "
-                             "is %s." % (delta_t, nat_delta_t))         
+                             "is %s." % (delta_t, nat_delta_t))
         if not delta_t:
             tmp = self
         else:

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -388,8 +388,9 @@ class FrequencySeries(Array):
         nat_delta_t =  1.0 / ((len(self)-1)*2) / self.delta_f
         if not delta_t:
             delta_t = nat_delta_t
-            
-        tlen  = int(round(1.0 / self.delta_f / delta_t))
+            tlen = (len(self)-1)*2
+        else:
+            tlen  = int(1.0 / self.delta_f / delta_t)
         flen = tlen / 2 + 1
         
         if flen < len(self):

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -389,7 +389,7 @@ class FrequencySeries(Array):
         if not delta_t:
             delta_t = nat_delta_t
             
-        tlen  = int(1.0 / self.delta_f / delta_t)
+        tlen  = int(round(1.0 / self.delta_f / delta_t))
         flen = tlen / 2 + 1
         
         if flen < len(self):

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -389,7 +389,7 @@ class FrequencySeries(Array):
         if not delta_t:
             delta_t = nat_delta_t
 
-
+        # add 0.5 to round integer
         tlen  = int(1.0 / self.delta_f / delta_t + 0.5)
         flen = tlen / 2 + 1
         

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -437,7 +437,7 @@ class TimeSeries(Array):
         if not delta_f:
             delta_f = 1.0 / self.duration
         
-        tlen  = int(1.0 / delta_f / self.delta_t)
+        tlen  = int(round(1.0 / delta_f / self.delta_t))
         flen = tlen / 2 + 1
         
         if tlen < len(self):

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -436,15 +436,15 @@ class TimeSeries(Array):
         from pycbc.fft import fft
         if not delta_f:
             delta_f = 1.0 / self.duration
-            tlen = int(self.duration / self.delta_t)
-        else:
-            tlen  = int(1.0 / delta_f / self.delta_t)
+
+        # add 0.5 to round integer
+        tlen  = int(1.0 / delta_f / self.delta_t + 0.5)
         flen = tlen / 2 + 1
-        
+
         if tlen < len(self):
             raise ValueError("The value of delta_f (%s) would be "
                              "undersampled. Maximum delta_f "
-                             "is %s." % (delta_f, 1.0 / self.duration))         
+                             "is %s." % (delta_f, 1.0 / self.duration))
         if not delta_f:
             tmp = self
         else:

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -436,8 +436,9 @@ class TimeSeries(Array):
         from pycbc.fft import fft
         if not delta_f:
             delta_f = 1.0 / self.duration
-        
-        tlen  = int(round(1.0 / delta_f / self.delta_t))
+            tlen = int(self.duration / self.delta_t)
+        else:
+            tlen  = int(1.0 / delta_f / self.delta_t)
         flen = tlen / 2 + 1
         
         if tlen < len(self):


### PR DESCRIPTION
So I was using ``TimeSeries.to_frequencyseries`` and ``FrequencySeries.to_timeseries`` and it wasn't working for a time series of length 100000 and ``delta_t`` set to 1, eg.:
```
import numpy
from pycbc.types.timeseries import TimeSeries
ts = TimeSeries(numpy.random.random(100000), delta_t=1.0)
ts.to_frequencyseries()
```

Gives the sort of nonsensical error:
```
ValueError: The value of delta_f (1e-05) would be undersampled. Maximum delta_f is 1e-05.
```

A bit of debugging shows:
```
tlen  = int(1.0 / self.delta_f / delta_t)
```

Is rounding down so ``tlen`` is set incorrectly to 99999 instead of 100000. I imagine this just from the arithmetic. Since:
```
In [1]: 1.0 / (1.0/100000) / 1.0
Out[1]: 99999.999999999985
```

This PR changes setting ``tlen`` so if you don't supply a ``delta_t`` then it skips the unnecessary division, ie. now it does:
```
In [1]: 100000/1.0
Out[1]: 100000.0
```

Which allows you to do the FFT/IFFT in this edge case.

EDIT: It was a bit more general to insert a ``round`` call into the ``tlen`` line but it wasn't obviously clear to me if this would have any unintended effects.