### PR TITLE
Fix broken workflow module

### DIFF
--- a/pycbc/workflow/__init__.py
+++ b/pycbc/workflow/__init__.py
@@ -44,7 +44,6 @@ try:
     from pycbc.workflow.splittable import *
     from pycbc.workflow.coincidence import *
     from pycbc.workflow.injection import *
-    from pycbc.workflow.timeslides import *
     from pycbc.workflow.postprocessing_cohptf import *
     from pycbc.workflow.plotting import *
     from pycbc.workflow.minifollowups import *


### PR DESCRIPTION
Currently the PyCBC workflow module is broken.

The issue is that the timeslides module is removed but `__init__.py` still tries to import it.

Now this *should* have been caught by sanity checks, but there is currently a hack in the workflow module's init file to allow it to run inference stuff without pegasus present. Can/should the hack be removed?