### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -995,7 +995,7 @@ class Gaussian(Uniform):
             corresponding to the given parameter. Otherwise, the array will
             have an element for each parameter in self's params.
         """
-        params = [param] if param != None else self._params
+        params = [param] if param is not None else self._params
         vals = numpy.zeros(shape=(size,len(params)))
         for i,param in enumerate(params):
             sigma = numpy.sqrt(self._var[param])

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -254,7 +254,7 @@ class InferenceFile(h5py.File):
                 label = getattr(wfparams, parameter).label
             except AttributeError:
                 label = None
-        if label == None:
+        if label is None:
             if error_on_none:
                 raise ValueError("Cannot find a label for paramter %s" %(
                     parameter))
@@ -362,7 +362,7 @@ class InferenceFile(h5py.File):
                 group_dim = self.create_group(dim_name)
                 if "label" in group_dim.attrs.keys():
                     pass
-                elif labels != None:
+                elif labels is not None:
                     group_dim.attrs["label"] = labels[i]
                 else:
                     group_dim.attrs["label"] = dim_name

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -36,7 +36,7 @@ def render_workflow_html_template(filename, subtemplate, filelists):
     dir = os.path.dirname(filename)
 
     try:
-        filenames = [f.name for filelist in filelists for f in filelist if f != None]
+        filenames = [f.name for filelist in filelists for f in filelist if f is not None]
     except TypeError:
         filenames = []
 

--- a/pycbc/sensitivity.py
+++ b/pycbc/sensitivity.py
@@ -97,7 +97,7 @@ def volume_montecarlo(found_d, missed_d, found_mchirp, missed_mchirp,
     else: raise NotImplementedError("%s is not a recognized parameter" % limits_param)
 
     # if no max distance param given, use maximum physical distance actually injected
-    if max_param == None:
+    if max_param is None:
         max_distance = max(found_d.max(), missed_d.max())
 
     # volume of sphere

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -1377,7 +1377,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         self.strain[len(self.strain) - csize + self.corruption:] = strain[self.corruption:]
         self.strain.start_time += blocksize
 
-        if self.psd == None and self.wait_duration <=0:
+        if self.psd is None and self.wait_duration <=0:
             self.recalculate_psd()
 
         if self.wait_duration > 0:

--- a/pycbc/tmpltbank/option_utils.py
+++ b/pycbc/tmpltbank/option_utils.py
@@ -1198,7 +1198,7 @@ def check_ethinca_against_bank_params(ethincaParams, metricParams):
             raise ValueError("Ethinca metric calculation does not currently "
                              "support a f-low value different from the bank "
                              "metric!")
-        if ethincaParams.pnOrder == None:
+        if ethincaParams.pnOrder is None:
             ethincaParams.pnOrder = metricParams.pnOrder
     else: pass
 

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -49,7 +49,7 @@ class FrequencySeries(Array):
     def __init__(self, initial_array, delta_f=None, epoch="", dtype=None, copy=True):
         if len(initial_array) < 1:
             raise ValueError('initial_array must contain at least one sample.')
-        if delta_f == None:
+        if delta_f is None:
             try:
                 delta_f = initial_array.delta_f
             except AttributeError:

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -56,7 +56,7 @@ class TimeSeries(Array):
     def __init__(self, initial_array, delta_t=None, epoch="", dtype=None, copy=True):
         if len(initial_array) < 1:
             raise ValueError('initial_array must contain at least one sample.')
-        if delta_t == None:
+        if delta_t is None:
             try:
                 delta_t = initial_array.delta_t
             except AttributeError:

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -95,7 +95,7 @@ def setup_datafind_workflow(workflow, scienceSegs, outputDir, seg_file=None,
         The name with which the analysable time is stored in the
         sci_avlble_file.
     """
-    if tags == None:
+    if tags is None:
         tags = []
     logging.info("Entering datafind module")
     make_analysis_dir(outputDir)
@@ -394,7 +394,7 @@ def setup_datafind_runtime_cache_multi_calls_perifo(cp, scienceSegs,
         List of all the datafind output files for use later in the pipeline.
 
     """
-    if tags == None:
+    if tags is None:
         tags = []
 
     # First job is to do setup for the datafind jobs
@@ -475,7 +475,7 @@ def setup_datafind_runtime_cache_single_call_perifo(cp, scienceSegs, outputDir,
         List of all the datafind output files for use later in the pipeline.
 
     """
-    if tags == None:
+    if tags is None:
         tags = []
 
     # First job is to do setup for the datafind jobs
@@ -644,7 +644,7 @@ def setup_datafind_from_pregenerated_lcf_files(cp, ifos, outputDir, tags=None):
     datafindOuts : pycbc.workflow.core.FileList
         List of all the datafind output files for use later in the pipeline.
     """
-    if tags == None:
+    if tags is None:
         tags = []
 
     datafindcaches = []
@@ -790,7 +790,7 @@ def setup_datafind_server_connection(cp, tags=None):
     connection
         The open connection to the datafind server.
     """
-    if tags == None:
+    if tags is None:
         tags = []
 
     if cp.has_option_tags("workflow-datafind",

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -164,7 +164,7 @@ def make_inference_prior_plot(workflow, config_file, output_dir,
     # add command line options
     node.add_input_opt("--config-file", config_file)
     node.new_output_file_opt(analysis_seg, ".png", "--output-file")
-    if sections != None:
+    if sections is not None:
         node.add_opt("--sections", " ".join(sections))
 
     # add node to workflow

--- a/test/test_frequencyseries.py
+++ b/test/test_frequencyseries.py
@@ -104,7 +104,7 @@ class TestFrequencySeriesBase(array_base,unittest.TestCase):
         # These are FrequencySeries that have problems specific to FrequencySeries
         self.bad3 = FrequencySeries([1,1,1], 0.2, epoch=self.epoch, dtype = self.dtype)
         # This next one is actually okay for frequencyseries
-        if self.epoch == None:
+        if self.epoch is None:
             self.bad4 = FrequencySeries([1,1,1], 0.1, epoch = lal.LIGOTimeGPS(1000, 1000), dtype = self.dtype)
         else:
             self.bad4 = FrequencySeries([1,1,1], 0.1, epoch=None, dtype = self.dtype)

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -103,7 +103,7 @@ class TestTimeSeriesBase(array_base,unittest.TestCase):
 
         # These are timeseries that have problems specific to timeseries
         self.bad3 = TimeSeries([1,1,1], 0.2, epoch=self.epoch, dtype = self.dtype)
-        if self.epoch == None:
+        if self.epoch is None:
             self.bad4 = TimeSeries([1,1,1], self.delta_t, epoch = lal.LIGOTimeGPS(1000, 1000), dtype = self.dtype)
         else:
             self.bad4 = TimeSeries([1,1,1], self.delta_t, epoch=None, dtype = self.dtype)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:ligo-cbc:pycbc?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:ligo-cbc:pycbc?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)