### PR TITLE
Move geom-bank over to PyCBC workflow

### DIFF
--- a/bin/pycbc_aligned_bank_cat
+++ b/bin/pycbc_aligned_bank_cat
@@ -54,6 +54,8 @@ parser.add_argument("--verbose", action="store_true", default=False,
                     help="verbose output")
 parser.add_argument("-i", "--input-glob",
                     help="file glob the list of paramters")
+parser.add_argument("-I", "--input-files", nargs='+',
+                    help="Explicit list of input files.")
 parser.add_argument("-o", "--output-file",  help="Output file name")
 parser.add_argument("-m", "--metadata-file", metavar="METADATA_FILE",
                   help="XML file containing the process and process_params "
@@ -80,8 +82,6 @@ else:
 logging.basicConfig(format='%(asctime)s %(message)s', level=log_level)
 
 # Sanity check options
-if not options.input_glob:
-    parser.error("Must supply --input-glob.")
 if not options.output_file:
     parser.error("Must supply --output-file.")
 
@@ -131,7 +131,11 @@ metricParams = tmpltbank.determine_eigen_directions(metricParams,
 # Read in template params
 # NOTE: Files must be set out so that the columns are:
 # Mass1, Mass2, Spin1z, Spin2z
-tempBank = loadtxt(fileinput.input(glob.glob(options.input_glob)))
+if options.input_files:
+    input_files = options.input_files
+else:
+    input_files = glob.glob(options.input_glob)
+tempBank = loadtxt(fileinput.input(input_files))
 
 # FIXME: Currently the aligned spin bank will not output the ethinca components.
 # They are not meaningful for an aligned spin bank anyway. If these values are

--- a/bin/pycbc_geom_aligned_2dstack
+++ b/bin/pycbc_geom_aligned_2dstack
@@ -103,6 +103,11 @@ parser.add_argument("--random-seed", action="store", type=int,\
                             translating all points back to physical space.
                             If this is used the code should give the same
                             output if run with the same random seed.""")
+parser.add_argument('--reject-file', default=None,
+            help="If given, store the rejected points into this file.")
+parser.add_argument('--depths-file', default=None,
+            help="If given store the parameter space depth in this file.")
+
 
 pycbc.tmpltbank.insert_base_bank_options(parser)
 
@@ -199,10 +204,11 @@ maxBHspin = opts.max_bh_spin_mag
 
 # Here we start looping over bank
 temp_number = 0
-outFile = opts.output_file
-outPointer = open(outFile,'w')
-outPointer2 = open(outFile+'.reject','w')
-outPointer3 = open(outFile+'.depths','w')
+outPointer = open(opts.output_file, 'w')
+if opts.reject_file is not None:
+    outPointer2 = open(opts.reject_file, 'w')
+if opts.depths_file is not None:
+    outPointer3 = open(opts.depths_file, 'w')
 numtemps = len(tempBank)
 for entry in tempBank:
     temp_number += 1
@@ -229,6 +235,8 @@ for entry in tempBank:
     if dist.min() > 2.:
         logging.info("Template %d rejected as too far away" % temp_number)
         # Print info to the rejected points file
+        if opts.reject_file is None:
+            continue
         if opts.threed_lattice:
             print >> outPointer2, "%e %e %e %e %e %e %e %e" \
                      %(xi1_des, xi2_des, xi3_des, 0, 0, 0, 0, dist.min())
@@ -248,6 +256,8 @@ for entry in tempBank:
     if masses[5] > opts.max_mismatch:
         # Reject point, it is too far away
         logging.info("Template %d rejected as too far away" % temp_number)
+        if opts.reject_file is None:
+            continue
         if opts.threed_lattice:
             print >> outPointer2, "%e %e %e %e %e %e %e %e" \
                      %(xi1_des, xi2_des, xi3_des, masses[0], masses[1],\
@@ -333,12 +343,13 @@ for entry in tempBank:
     else:
         vec5_min = vec5_max = vec5_depth = 0
     # Output depths
-    if opts.threed_lattice:
-        print >> outPointer3, "%e %e %e %e %e"\
-                 %(xi1_des, xi2_des, xi3_des, vec4_depth, vec5_depth)
-    else:
-        print >> outPointer3, "%e %e %e %e %e"\
-                 %(xi1_des, xi2_des, vec3_depth, vec4_depth, vec5_depth)
+    if opts.depths_file is not None:
+        if opts.threed_lattice:
+            print >> outPointer3, "%e %e %e %e %e"\
+                     %(xi1_des, xi2_des, xi3_des, vec4_depth, vec5_depth)
+        else:
+            print >> outPointer3, "%e %e %e %e %e"\
+                     %(xi1_des, xi2_des, vec3_depth, vec4_depth, vec5_depth)
    # Figure out how many templates we need to stack in 3rd direction
     vec3DepthVal = opts.stack_distance
     if opts.threed_lattice:
@@ -396,3 +407,7 @@ for entry in tempBank:
                             masses[5])
 
 outPointer.close()
+if opts.reject_file is not None:
+    outPointer2.close()
+if opts.depths_file is not None:
+    outPointer3.close()

--- a/bin/pycbc_geom_aligned_bank
+++ b/bin/pycbc_geom_aligned_bank
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (C) 2011 Ian W. Harry
+# Copyright (C) 2016 Ian W. Harry
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -17,7 +17,10 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 """
-Aligned spin bank generator.
+Aligned spin bank generator. Initial placement of template points, and
+rejection of "too far away" templates is done in the code, but the final
+translation between points in the chirp parameters parameter space is done
+in a workflow.
 """
 
 from __future__ import division
@@ -41,6 +44,7 @@ import pycbc.psd
 import pycbc.strain
 import pycbc.version
 import pycbc.tmpltbank
+import pycbc.workflow as wf
 from scipy import spatial
 
 __author__  = "Ian Harry <ian.harry@ligo.org>"
@@ -49,7 +53,70 @@ __date__    = pycbc.version.date
 __program__ = "pycbc_geom_aligned_bank"
 
 
-# Define function used below
+# Define Executable functions for workflow generation
+
+class GeomAligned2DStackExecutable(wf.Executable):
+    """ Class for running pycbc_geom_aligned_2dstack.
+    """
+    current_retention_level = wf.Executable.ALL_TRIGGERS
+
+    file_input_options = ['--asd-file', '--psd-file']
+
+    def create_node(self, input_points, cov_evecs_file, metric_evals_file,
+                    metric_evecs_file, analysis_time, extra_tags=None):
+        """ Create a node.
+        """
+        if extra_tags is None:
+            extra_tags = []
+        node = wf.Executable.create_node(self)
+
+        node.add_input_opt('--input-bank-file', input_points)
+        node.add_input_opt('--cov-evecs-file', cov_evecs_file)
+        node.add_input_opt('--metric-evals-file', metric_evals_file)
+        node.add_input_opt('--metric-evecs-file', metric_evecs_file)
+
+        node.new_output_file_opt(analysis_time, '.dat', '--output-file',
+                                 tags=self.tags + extra_tags + ['bank'])
+        node.new_output_file_opt(analysis_time, '.dat', '--reject-file',
+                                 tags=self.tags + extra_tags + ['reject'])
+        node.new_output_file_opt(analysis_time, '.dat', '--depths-file',
+                                 tags=self.tags + extra_tags + ['depths'])
+        return node
+
+class AlignedBankCatExecutable(wf.Executable):
+    """ Class for running pycbc_aligned_bank_cat.
+    """
+    current_retention_level = wf.Executable.FINAL_RESULT
+
+    file_input_options = ['--asd-file', '--psd-file']
+
+    def create_node(self, input_file_list, metadata_file, analysis_time):
+        """ Create a node.
+        """
+        node = wf.Executable.create_node(self)
+
+        node.add_input_list_opt('--input-files', input_file_list)
+        node.add_input_opt('--metadata-file', metadata_file)
+
+        node.new_output_file_opt(analysis_time, '.xml', '--output-file',
+                                 tags=self.tags)
+        return node
+
+class TmpltbankToChiParams(wf.Executable):
+    """ Class for running pycbc_tmpltbank_to_chi_params.
+    """
+    current_retention_level = wf.Executable.FINAL_RESULT
+
+    def create_node(self, input_bank, analysis_time):
+        """ Create a node.
+        """
+        node = wf.Executable.create_node(self)
+
+        node.add_input_opt('--input-bank', input_bank)
+
+        node.new_output_file_opt(analysis_time, '.dat', '--output-file',
+                                 tags=self.tags)
+        return node
 
 def add_commands_to_cp(commands, options, cp, section_name):
     for command in commands:
@@ -100,6 +167,8 @@ parser.add_argument("--print-chi-points", action="store", default=None,
                     "using pycbc_tmpltbank_to_chi_params. This will be "
                     "written to FILENAME. If this argument is not given, no "
                     "chi points file will be written.")
+parser.add_argument("--workflow-name", type=str, default='bank_gen',
+                    help="Name to use for the produced .dax file.")
 
 pycbc.tmpltbank.insert_base_bank_options(parser)
 
@@ -335,113 +404,138 @@ if len(newV1s) % opts.split_bank_num:
     bankFile.close()
 
 # And begin dag generation
-tempfile.tempdir = opts.log_path
-tempfile.template='bank_gen.dag.log.'
-logfile = tempfile.mktemp()
-fh = open( logfile, "w" )
-fh.close()
-dag = pipeline.CondorDAG(logfile, False)
-dag.set_dag_file('bank_generation')
-exe_path = distutils.spawn.find_executable('pycbc_geom_aligned_2dstack')
-job = pipeline.CondorDAGJob('vanilla',exe_path)
-#pipeline.AnalysisJob.__init__(job,cp,False)
-job.set_stdout_file('/dev/null')
-job.set_stderr_file('logs/bank_gen-$(cluster)-$(process).err')
-job.set_sub_file('bank_gen.sub')
-# Add global job options
+# First: Set up the config parser.
 cp = ConfigParser.ConfigParser()
-cp.add_section('bank')
-# Add full set of mass range options
+# Workflow first:
+cp.add_section('workflow')
+cp.set('workflow', 'file-retention-level', 'all_files')
+cp.set('workflow', 'start-time', '900000000')
+cp.set('workflow', 'end-time', '900010000')
+cp.add_section('workflow-ifos')
+cp.set('workflow-ifos', 'h1', '')
+cp.set('workflow-ifos', 'l1', '')
+cp.set('workflow-ifos', 'v1', '')
+
+# Then executables
+cp.add_section('executables')
+cp.set('executables', 'aligned2dstack', '${which:pycbc_geom_aligned_2dstack}')
+cp.set('executables', 'alignedbankcat', '${which:pycbc_aligned_bank_cat}')
+cp.set('executables', 'dumptochis', '${which:pycbc_tmpltbank_to_chi_params}')
+
+# Shared option groups
+cp.add_section('sharedoptions')
+cp.set('sharedoptions', 'massranges', 'aligned2dstack')
+cp.set('sharedoptions', 'metric', 'alignedbankcat')
+cp.set('sharedoptions', 'psd', 'alignedbankcat')
+cp.set('sharedoptions', 'data', 'alignedbankcat')
+cp.set('sharedoptions', 'ethinca', 'alignedbankcat')
+
+cp.add_section('sharedoptions-massranges')
 mass_range_commands = pycbc.tmpltbank.get_options_from_group(mass_range_opts)
-add_commands_to_cp(mass_range_commands, orig_opts, cp, 'bank')
-
-cp.set('bank','pn-order',opts.pn_order)
-cp.set('bank','metric-evals-file','metric_evals_%d.dat' %metricParams.fUpper)
-cp.set('bank','metric-evecs-file','metric_evecs_%d.dat' %metricParams.fUpper)
-cp.set('bank','cov-evecs-file','covariance_evecs_%d.dat' %metricParams.fUpper)
-cp.set('bank','f0',str(opts.f0))
-cp.set('bank','min-match',str(opts.min_match))
-cp.set('bank','stack-distance',str(opts.stack_distance))
-if opts.threed_lattice:
-    cp.set('bank','threed-lattice','')
-if opts.random_seed:
-    cp.set('bank', 'random-seed', str(opts.random_seed))
-job.add_ini_opts(cp, 'bank')
-job.add_condor_cmd('Requirements', 'Memory >= 1390')
-job.add_condor_cmd('request_memory', '1400')
-job.add_condor_cmd('getenv','True')
-# Make the output job
-cat_path = distutils.spawn.find_executable('pycbc_aligned_bank_cat')
-job_cat = pipeline.CondorDAGJob('vanilla', cat_path)
-job_cat.set_stdout_file('/dev/null')
-job_cat.set_stderr_file('logs/bank_cat-$(cluster)-$(process).err')
-job_cat.set_sub_file('bank_cat.sub')
-job_cat.add_condor_cmd('getenv','True')
-cp.add_section('combiner')
+add_commands_to_cp(mass_range_commands, orig_opts, cp,
+                   'sharedoptions-massranges')
+cp.add_section('sharedoptions-metric')
 metric_commands = pycbc.tmpltbank.get_options_from_group(metric_opts)
-add_commands_to_cp(metric_commands, orig_opts, cp, 'combiner')
+add_commands_to_cp(metric_commands, orig_opts, cp, 'sharedoptions-metric')
+cp.add_section('sharedoptions-psd')
 psd_commands = pycbc.tmpltbank.get_options_from_group(psd_opts)
-add_commands_to_cp(psd_commands, orig_opts, cp, 'combiner')
+add_commands_to_cp(psd_commands, orig_opts, cp, 'sharedoptions-psd')
+cp.add_section('sharedoptions-data')
 data_commands = pycbc.tmpltbank.get_options_from_group(data_opts)
-add_commands_to_cp(data_commands, orig_opts, cp, 'combiner')
+add_commands_to_cp(data_commands, orig_opts, cp, 'sharedoptions-data')
+cp.add_section('sharedoptions-ethinca')
 ethinca_commands = pycbc.tmpltbank.get_options_from_group(ethinca_opts)
-add_commands_to_cp(ethinca_commands, orig_opts, cp, 'combiner')
-job_cat.add_ini_opts(cp, 'combiner')
+add_commands_to_cp(ethinca_commands, orig_opts, cp, 'sharedoptions-ethinca')
 
-# Make the output node
-cat_node = pipeline.CondorDAGNode(job_cat)
-cat_node.add_var_opt('metadata-file', cmds_file_name)
-cat_node.add_var_opt('input-glob', 'output_banks/output_bank_*.dat')
-cat_node.add_var_opt('output-file', opts.output_file)
+# 2dstack
+cp.add_section('aligned2dstack')
+cp.set('aligned2dstack', 'pn-order',opts.pn_order)
+cp.set('aligned2dstack', 'f0', str(opts.f0))
+cp.set('aligned2dstack', 'min-match', str(opts.min_match))
+cp.set('aligned2dstack', 'stack-distance', str(opts.stack_distance))
+if opts.threed_lattice:
+    cp.set('aligned2dstack', 'threed-lattice', '')
+if opts.random_seed:
+    cp.set('aligned2dstack', 'random-seed', str(opts.random_seed))
 
-# Make the nodes
-numBanks = int((len(newV1s) - 0.5)//opts.split_bank_num) + 1
-for i in xrange(numBanks):
-    node = pipeline.CondorDAGNode(job)
-    node.add_var_opt('input-bank-file','split_banks/split_bank_%05d.dat'%(i))
-    node.add_var_opt('output-file','output_banks/output_bank_%05d.dat'%(i))
-    cat_node.add_parent(node)
-    dag.add_node(node)
+# alignedcat
+cp.add_section('alignedbankcat')
 
-dag.add_node(cat_node)
+# dumptochis
+cp.add_section('dumptochis')
+# Add options by parsing the options sent to this job. Convert to dict
+print_chis_opts = vars(copy.deepcopy(orig_opts))
+# Remove options we don't want to send on
+remove_opts = ['output_file', 'log_path', 'min_match', 'stack_distance',
+               'threed_lattice', 'split_bank_num', 'filter_points',
+               'print_chi_points', 'verbose']
+for opt in remove_opts:
+    if opt in print_chis_opts.keys():
+        del print_chis_opts[opt]
+# Add the rest
+for opt, val in print_chis_opts.items():
+    if val is None:
+        continue
+    elif val is True or val is False:
+        cp.set('dumptochis', str(opt.replace("_","-")), "")
+    else:
+        cp.set('dumptochis', str(opt.replace("_","-")), str(val))
 
-if opts.print_chi_points:
-    # Make the printer job
-    cat_path = distutils.spawn.find_executable('pycbc_tmpltbank_to_chi_params')
-    job_print = pipeline.CondorDAGJob('vanilla', cat_path)
-    job_print.set_stdout_file('/dev/null')
-    job_print.set_stderr_file('logs/print_chi-$(cluster)-$(process).err')
-    job_print.set_sub_file('print_chi.sub')
-    job_print.add_condor_cmd('getenv','True')
+temp_fp = open('temp.ini', 'w')
+cp.write(temp_fp)
+temp_fp.close()
 
-    # Add options by parsing the options sent to this job. Convert to dict
-    print_chis_opts = vars(copy.deepcopy(orig_opts))
-    # Remove options we don't want to send on
-    remove_opts = ['output_file', 'log_path', 'min_match', 'stack_distance',
-                   'threed_lattice', 'split_bank_num', 'filter_points',
-                   'print_chi_points', 'verbose']
-    for opt in remove_opts:
-        if opt in print_chis_opts.keys():
-            del print_chis_opts[opt]
-    # Add the rest
-    for opt, val in print_chis_opts.items():
-        if val is None:
-            continue
-        elif val is True or val is False:
-            job_print.add_opt(str(opt.replace("_","-")), "")
-        else:
-            job_print.add_opt(str(opt.replace("_","-")), str(val))
+opts.config_files=['temp.ini']
+opts.config_overrides=[]
 
-    print_node = pipeline.CondorDAGNode(job_print)
-    
-    print_node.add_var_opt('input-bank', opts.output_file)
-    print_node.add_var_opt('output-file', opts.print_chi_points)
-    print_node.add_parent(cat_node)
-    dag.add_node(print_node)
+# Now setup the workflow
+workflow = wf.Workflow(opts, opts.workflow_name)
 
-dag.write_sub_files()
-dag.write_dag()
-dag.write_script()
+# Start with 2dstack jobs
+wf.makedir('stack2d')
 
-print "Now submit bank_generation.dag to generate your template bank."
-print "This may take a while, go make a cup of tea!"
+stack_exe = GeomAligned2DStackExecutable(workflow.cp, 'aligned2dstack',
+                                   ifos=workflow.ifos, out_dir='stack2d')
+num_banks = int((len(newV1s) - 0.5)//opts.split_bank_num) + 1
+cov_evecs_files = wf.File.from_path('covariance_evecs_%d.dat' \
+                                     %metricParams.fUpper)
+metric_evals_file = wf.File.from_path('metric_evals_%d.dat' \
+                                       %metricParams.fUpper)
+metric_evecs_file = wf.File.from_path('metric_evecs_%d.dat' \
+                                       %metricParams.fUpper)
+
+all_outs = wf.FileList([])
+
+for idx in xrange(num_banks):
+    stackid = 'file%05d' %(idx)
+    input_points = wf.File.from_path('split_banks/split_bank_%05d.dat'%(idx))
+    stack_node = stack_exe.create_node(input_points, cov_evecs_files,
+                                       metric_evals_file, metric_evecs_file,
+                                       workflow.analysis_time,
+                                       extra_tags=[stackid])
+    workflow += stack_node
+    stack_outs = stack_node.output_files
+    stack_out = stack_outs.find_output_with_tag('bank')
+    assert(len(stack_out) == 1)
+    stack_out = stack_out[0]
+    all_outs.append(stack_out)
+
+# Then combine everything together
+combine_exe = AlignedBankCatExecutable(workflow.cp, 'alignedbankcat',
+                                        ifos=workflow.ifos, out_dir='.')
+metadata_file = wf.File.from_path(cmds_file_name)
+combine_node = combine_exe.create_node(all_outs, metadata_file,
+                                        workflow.analysis_time)
+workflow += combine_node
+assert(len(combine_node.output_files) == 1)
+out_bank = combine_node.output_files[0]
+
+# And do the convert to chis job
+chiparams_exe = TmpltbankToChiParams(workflow.cp, 'dumptochis',
+                                      ifos=workflow.ifos, out_dir='.')
+chiparams_node = chiparams_exe.create_node(out_bank, workflow.analysis_time)
+
+workflow.save()
+
+logging.info("Submit the resulting dax file to generate your template bank.")
+logging.info("See pycbc_submit_dax --help for instructions.")


### PR DESCRIPTION
This patch updates pycbc_geom_aligned_bank to generate a workflow using pycbc.workflow.

Currently this code builds a glue workflow internally given command line argument to pycbc_geom_aligned_bank. I decided to preserve this behaviour in this case, although it's a little weird. This at least means that no changes are needed when running this code. One just submits with pycbc_submit_dax and not condor_submit_dag.

I've also preserved the old code in case anyone cannot figure out pegasus. I'm not sure whether this is the right thing to do and this can be removed if desired.