### PR TITLE
Use different normalization when calculating ACL

### DIFF
--- a/bin/inference/pycbc_inference_plot_acl
+++ b/bin/inference/pycbc_inference_plot_acl
@@ -62,9 +62,6 @@ logging.info("Calculating autocorrelation length")
 acls = []
 for param_name in parameters:
 
-    j = numpy.where(parameters == param_name)
-    k = len(parameters)
-
     # loop over walkers and save an autocorrelation length
     # for each walker
     for i in range(fp.nwalkers):

--- a/bin/inference/pycbc_inference_plot_acl
+++ b/bin/inference/pycbc_inference_plot_acl
@@ -62,9 +62,14 @@ logging.info("Calculating autocorrelation length")
 acls = []
 for param_name in parameters:
 
+    j = numpy.where(parameters == param_name)
+    k = len(parameters)
+
     # loop over walkers and save an autocorrelation length
     # for each walker
     for i in range(fp.nwalkers):
+
+        print j, "of", k , i, "of", fp.nwalkers
 
         y = fp.read_samples(param_name, walkers=i, thin_start=opts.thin_start,
                            thin_interval=opts.thin_interval)

--- a/bin/inference/pycbc_inference_plot_acl
+++ b/bin/inference/pycbc_inference_plot_acl
@@ -68,9 +68,6 @@ for param_name in parameters:
     # loop over walkers and save an autocorrelation length
     # for each walker
     for i in range(fp.nwalkers):
-
-        print j, "of", k , i, "of", fp.nwalkers
-
         y = fp.read_samples(param_name, walkers=i, thin_start=opts.thin_start,
                            thin_interval=opts.thin_interval)
         acl = autocorrelation.calculate_acl(y[param_name], dtype=int)

--- a/pycbc/filter/autocorrelation.py
+++ b/pycbc/filter/autocorrelation.py
@@ -117,36 +117,20 @@ def calculate_acl(data, m=5, k=2, dtype=int):
 
     # calculate ACF
     acf = calculate_acf(data)
+    acf[1:] *= 2.0
 
-    # get maximum index in ACF for calculation
-    # will terminate at this index
-    n = len(data)
-    imax = n / k
+    # the maximum index
+    imax = int(len(acf)/k)
 
-    # loop over ACF indexes
-    acl = 1.0
-    for i in range(n):
+    cum_acl = 1.0
+    for i,val in enumerate(acf[1:imax]):
 
-        # see if we have reached terminating condition
-        s = float(i+1) / m
-        if not acl >= s:
-            break
+        # check 
+        if cum_acl+val < float(i+1)/m:
+            return numpy.ceil(cum_acl)
 
-        # see if ACL is indeterminate
-        if i > imax or isnan(acf[i]):
-            return numpy.inf
+        cum_acl += val
 
-        # add term for ACL
-        acl += 2 * acf[i]
+    return numpy.inf
 
-    # if input was a TimeSeries then multiply ACL by the delta_t attribute
-    if isinstance(data, TimeSeries):
-        acl *= data.delta_t
 
-    # typecast and return
-    if dtype == int:
-        return int(numpy.ceil(acl))
-    elif dtype == float:
-        return acl
-    else:
-        raise ValueError("Invalid value for dtype")

--- a/pycbc/filter/autocorrelation.py
+++ b/pycbc/filter/autocorrelation.py
@@ -49,8 +49,8 @@ def calculate_acf(data, delta_t=1.0, norm=True):
     delta_t : float
         The time step of the data series if it is not a TimeSeries instance.
     norm : bool
-        If true normalize by the variance. If False normalize by the first
-        element.
+        Default is true to normalize by the variance. If False normalize by the
+        zero-lag element, ie. the first value of the unnormalized ACF.
 
     Returns
     -------
@@ -121,24 +121,25 @@ def calculate_acl(data, m=5, k=2, dtype=int):
         delta_t attribute.
     """
 
-    # calculate ACF
+    # calculate ACF that is normalized by the zero-lag value
     acf = calculate_acf(data, norm=False)
+
+    # multiply all values beyond the zero-lag value by 2
     acf[1:] *= 2.0
 
-    # the maximum index
+    # the maximum index to calculate ACF up until
     imax = int(len(acf)/k)
 
+    # sanity check ACF
     if isnan(acf[0]):
         return numpy.inf
-
     assert acf[0] == 1.0
+
+    # calculate cumlative ACL
     cum_acl = acf[0]
     for i,val in enumerate(acf[1:imax]):
-
-        # check 
         if cum_acl+val < float(i+1)/m:
             return numpy.ceil(cum_acl)
-
         cum_acl += val
 
     return numpy.inf


### PR DESCRIPTION
On hold because it depends on #966. It will most likely need to be rebased when #966 is merged.

So this PR:
  * Moves ``*=2`` multiplication out of loop in ``calculate_acl`` and only have one logical statement in the loop.
  * Adds ``unbiased`` option so that you can choose either ``n-k`` or ``n`` normalization for the autocovariance function. Default is to normalize by ``n`` which doesn't need to compute the variance, this makes ``calculate_acf`` significantly faster (maybe this was the point of confusion before?).

Tested it out here: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/tmp_acl.png

On a single parameter with 100000 iterations and 500 walkers, it calculated the ACLs in about 55 seconds:
```
2016-07-07 16:30:05,442 : Calculating autocorrelation length
2016-07-07 16:31:00,908 : Plotting autocorrelation lengths
```

And tested it out against what is in lalsuite (https://github.com/lscsoft/lalsuite/blob/e79c77830cf04cb4957731654ad3123688636fe8/pylal/pylal/bayespputils.py#L5412).

Note the very high ACLs are not a bug. It looks like this is just because the walkers are not moving. This points to the issue being with the sampler. I see 6 walkers that never moved in the parameter space: https://sugar-jobs.phy.syr.edu/~cbiwer/tmp/tmp_samples_sngl.png