### PR TITLE
Create PyCBC sbank workflow generator

### DIFF
--- a/bin/workflows/pycbc_create_sbank_workflow
+++ b/bin/workflows/pycbc_create_sbank_workflow
@@ -1,0 +1,250 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2016 Ian W. Harry, Y Ddraig Goch
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+Workflow generator for the lalapps_cbc_sbank template bank generation.
+This is intended to be standalone, without putting things like the
+SbankExecutable class in the pycbc.workflow module, to give an illustration of
+how a simple workflow is constructed with pycbc.workflow.
+"""
+
+#imports
+from __future__ import division
+import os
+import argparse
+import pycbc
+import pycbc.version
+import pycbc.workflow as wf
+
+# Boiler-plate stuff
+__author__  = "Ian Harry <ian.harry@ligo.org>"
+__version__ = pycbc.version.git_verbose_msg
+__date__    = pycbc.version.date
+__program__ = "pycbc_create_sbank_workflow"
+
+# We define classes for all executables used in the workflow
+
+class SbankExecutable(wf.Executable):
+    """ Class for running lalapps_cbc_sbank
+    """
+    # This can be altered if you don't always want to store output files
+    current_retention_level = wf.Executable.FINAL_RESULT
+
+    # This tells us that reference-psd is a file option
+    file_input_options = ['--reference-psd']
+
+    sbank_job_seed = 0
+
+    def create_node(self, analysis_time, seed_bank=None, trial_bank=None,
+                     mchirp_boundaries_file=None, mchirp_boundary_idx=None,
+                     extra_tags=None):
+        if extra_tags is None:
+            extra_tags = []
+        node = wf.Executable.create_node(self)
+        # Most options are specified in the config file. In some cases though,
+        # for example input/output files, options are specified directly in
+        # the create_node function. *DO NOT* specify these in the config file.
+
+        # The seed must be unique for each job and reproducible
+        node.add_opt('--seed', str(self.sbank_job_seed))
+        SbankExecutable.sbank_job_seed += 1
+
+        # These input files are optional. If given, add them
+        if seed_bank is not None:
+            node.add_input_opt('--bank-seed', seed_bank)
+        if trial_bank is not None:
+            node.add_input_opt('--trial-waveforms', trial_bank)
+        if mchirp_boundaries_file is not None:
+            node.add_input_opt('--mchirp-boundaries-file',
+                               mchirp_boundaries_file)
+            # The boundaries file option also requires the boundary idx
+            assert(mchirp_boundary_idx is not None)
+            node.add_opt('--mchirp-boundaries-index', mchirp_boundary_idx)
+
+        # Here we add the output file, but we are letting pycbc.workflow
+        # handle how to name the file
+        node.new_output_file_opt(analysis_time, '.xml.gz',
+                              '--output-filename', tags=self.tags + extra_tags)
+        return node
+
+class SbankChooseMchirpBinsExecutable(wf.Executable):
+    """ Class for running lalapps_cbc_sbank_choose_mchirp_boundaries
+    """
+    current_retention_level = wf.Executable.FINAL_RESULT
+
+    def create_node(self, input_file, nbanks):
+        node = wf.Executable.create_node(self)
+
+        # Here we add the output file
+        node.new_output_file_opt(workflow.analysis_time, '.txt',
+                                 '--output-file', tags=self.tags)
+
+        # And the input file, which is an argument, not an option
+        node.add_input_arg(input_file)
+
+        # nbanks is just a normal option, but as it affects the workflow
+        # structure, it is supplied here and not directly in the config file
+        node.add_opt('--nbanks', nbanks)
+
+        return node
+
+# There is already a ligolw_add executable (wf.LigolwAddExecutable), so we
+# just use that directly.
+
+##############################################################################
+# Argument parsing and setup of workflow                                     #
+##############################################################################
+
+
+# Use the standard workflow command-line parsing routines. Things like a 
+# configuration file are specified within the "workflow command line group"
+# so run this with --help to see what options are added.
+_desc = __doc__[1:]
+parser = argparse.ArgumentParser(description=_desc)
+parser.add_argument('--version', action='version', version=__version__)
+parser.add_argument("--workflow-name", type=str, default='sbank_workflow',
+                    help="Descriptive name of the analysis.")
+parser.add_argument("-d", "--output-dir", default=None,
+                    help="Path to output directory.")
+wf.add_workflow_command_line_group(parser)
+args = parser.parse_args()
+
+# Create the workflow object
+workflow = wf.Workflow(args, args.workflow_name)
+
+wf.makedir(args.output_dir)
+os.chdir(args.output_dir)
+
+##############################################################################
+# First add the COARSE job to start things off                               #
+##############################################################################
+
+wf.makedir('coarse')
+# Generate Executable class (similar to Job in the old terminology)
+# The tags=coarse option is used to ensure that options in the ['sbank-coarse']
+# section of the ini file are sent to this job, and *only* this job
+coarse_sbank_exe = SbankExecutable(workflow.cp, 'sbank', ifos=workflow.ifos,
+                                   out_dir='coarse', tags=['coarse'])
+# Then make a specific node
+coarse_node = coarse_sbank_exe.create_node(workflow.analysis_time)
+# Add to workflow
+workflow += coarse_node
+# And record output file, as it will be needed later
+assert(len(coarse_node.output_files) == 1)
+coarse_file = coarse_node.output_files[0]
+
+##############################################################################
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX                               #
+##############################################################################
+
+# How many repetitions to try? Get this from config-parser. Special
+# config-parser options like this go in the [workflow] section
+
+num_cycles = int(workflow.cp.get('workflow', 'num-cycles'))
+input_file = coarse_file
+
+for cycle_idx in range(num_cycles):
+    #########
+    # SETUP #
+    #########
+    cycle_tag = 'cycle%d' %(cycle_idx)
+    out_dir = cycle_tag
+    wf.makedir(cycle_tag)
+
+    # How many banks to use? This can vary cycle to cycle, or be the same for
+    # all. Either supply it once in [workflow], or in [workflow-cycleN] for
+    # N in range(num_cycles)
+    nbanks = workflow.cp.get_opt_tags('workflow', 'nbanks', tags=[cycle_tag])
+    nbanks = int(nbanks)
+    
+    #############
+    # MASS BINS #
+    #############
+
+    bins_exe = SbankChooseMchirpBinsExecutable(workflow.cp, 'sbank_mchirp_bins',
+                                    ifos=workflow.ifos, out_dir=out_dir,
+                                    tags=[cycle_tag])
+    bins_node = bins_exe.create_node(input_file, nbanks)
+    workflow += bins_node
+    assert(len(bins_node.output_files) == 1)
+    bins_file = bins_node.output_files[0]
+
+    #######################
+    # PARALELLIZED SBANKS #
+    #######################
+
+    main_sbank_exe = SbankExecutable(workflow.cp, 'sbank', ifos=workflow.ifos,
+                                 out_dir=out_dir, tags=['parallel', cycle_tag])
+    main_sbank_files = wf.FileList([])
+    for nbank_idx in range(nbanks):
+        nbank_tag = 'nbank%d' %(nbank_idx)
+        main_sbank_node = main_sbank_exe.create_node(workflow.analysis_time,
+                                              seed_bank=input_file,
+                                              mchirp_boundaries_file=bins_file,
+                                              mchirp_boundary_idx=nbank_idx,
+                                              extra_tags=[nbank_tag])
+        workflow += main_sbank_node
+        assert(len(main_sbank_node.output_files) == 1)
+        main_sbank_files += main_sbank_node.output_files
+
+    ############
+    # COMBINER #
+    ############
+
+    llwadd_exe = wf.LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
+                                    out_dir=out_dir, tags=[cycle_tag, 'FIRST'])
+    llwadd_node = llwadd_exe.create_node(workflow.analysis_time,
+                                         main_sbank_files,
+                                         use_tmp_subdirs=False)
+    workflow += llwadd_node
+    assert(len(llwadd_node.output_files) == 1)
+    llwadd_out = llwadd_node.output_files[0]
+
+    ###########
+    # READDER #
+    ###########
+
+    readder_sbank_exe = SbankExecutable(workflow.cp, 'sbank',
+                                        ifos=workflow.ifos, out_dir=out_dir,
+                                        tags=[cycle_tag, 'readder'])
+    readder_sbank_node = readder_sbank_exe.create_node(workflow.analysis_time,
+                                              seed_bank=input_file,
+                                              trial_bank=llwadd_out)
+    workflow += readder_sbank_node
+    assert(len(readder_sbank_node.output_files) == 1)
+    readder_out = readder_sbank_node.output_files[0]
+
+    #################
+    # FINAL COMBINE #
+    #################
+
+    # Is this the final output file?
+    if cycle_idx == (num_cycles - 1):
+        out_dir ='.'
+
+    llwadd_exe = wf.LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
+                                    out_dir=out_dir, tags=[cycle_tag, 'FINAL'])
+    llwadd_node = llwadd_exe.create_node(workflow.analysis_time,
+                                         [input_file, readder_out],
+                                         use_tmp_subdirs=False)
+    workflow += llwadd_node
+    assert(len(llwadd_node.output_files) == 1)
+    # This becomes the input file for the next loop if going again
+    input_file = llwadd_node.output_files[0]
+
+workflow.save()

--- a/setup.py
+++ b/setup.py
@@ -473,6 +473,7 @@ setup (
                'bin/inference/pycbc_inference_plot_samples',
                'bin/inference/pycbc_inference_table_summary',
                'bin/plotting/pycbc_plot_waveform',
+               'bin/workflows/pycbc_create_sbank_workflow',
                ],
     packages = [
                'pycbc',


### PR DESCRIPTION
This is the new PyCBC workflow generator code to allow one to generate "sbank" workflows. Note that with recent changes to sbank this workflow is a little different in structure to the existing one. The basic idea of this is to avoid the issue where sbank is run highly parallelized and ends up double covering everywhere, and also to avoid the issue where sbank can get "stuck" if one job starts to take forever. I'm going to try and assign this to Steve P to look over. An example of it running can be found in vulcan under:

/home/spxiwh/aLIGO/O2/template_banks/test_new_gener/sbank_only