### PR TITLE
Geom_bank updates

### DIFF
--- a/bin/pycbc_aligned_bank_cat
+++ b/bin/pycbc_aligned_bank_cat
@@ -27,6 +27,7 @@ import glob
 import argparse
 import numpy
 import pycbc.version
+import h5py
 from glue.ligolw import ligolw
 from glue.ligolw import lsctables
 from glue.ligolw import utils
@@ -135,7 +136,23 @@ if options.input_files:
     input_files = options.input_files
 else:
     input_files = glob.glob(options.input_glob)
-tempBank = loadtxt(fileinput.input(input_files))
+
+mass1 = []
+mass2 = []
+spin1z = []
+spin2z = []
+for inp_file in input_files:
+    inp_fp = h5py.File(inp_file, 'r')
+    data = inp_fp['accepted_templates'][:]
+    if len(data) == 0:
+        continue
+    mass1.extend(data[:,0])
+    mass2.extend(data[:,1])
+    spin1z.extend(data[:,2])
+    spin2z.extend(data[:,3])
+    inp_fp.close()
+
+temp_bank = numpy.array([mass1,mass2,spin1z,spin2z]).T
 
 # FIXME: Currently the aligned spin bank will not output the ethinca components.
 # They are not meaningful for an aligned spin bank anyway. If these values are
@@ -150,7 +167,7 @@ if options.metadata_file:
                                      contenthandler=LIGOLWContentHandler)
 else:
     outdoc = None
-tmpltbank.output_sngl_inspiral_table(options.output_file, tempBank,
+tmpltbank.output_sngl_inspiral_table(options.output_file, temp_bank,
     metricParams, ethincaParams, programName=__program__,
     optDict=options.__dict__,
     outdoc=outdoc, comment="", version=pycbc.version.git_hash,

--- a/bin/pycbc_geom_aligned_2dstack
+++ b/bin/pycbc_geom_aligned_2dstack
@@ -31,6 +31,7 @@ import argparse
 import copy
 import numpy
 import logging
+import h5py
 import pycbc.tmpltbank
 import pycbc.version
 from pycbc.tmpltbank.lambda_mapping import pycbcValidOrdersHelpDescriptions
@@ -67,22 +68,14 @@ parser.add_argument("--f0", action="store", type=float,\
                        "applications. OPTIONAL"+\
                        "WARNING: If using ethinca calculation this must be "+\
                        "equal to f-low. UNITS=Hz")
-parser.add_argument("-I", "--input-bank-file", action="store", type=str,\
-                   default=None,\
-                   help="ASCII file containing the input bank. "+\
+parser.add_argument("-I", "--input-file", action="store", type=str,
+                   required=True,
+                   help="HDF file containing the input bank and the "
+                        "various metric information. "
                         "REQUIRED ARGUMENT.")
-parser.add_argument("--metric-evals-file", action="store", type=str,\
-                   default=None,\
-                   help="ASCII file containing the metric eigenvalues. "+\
-                        "REQUIRED ARGUMENT.")
-parser.add_argument("--metric-evecs-file", action="store", type=str,\
-                   default=None,\
-                   help="ASCII file containing the metric eigenvectors ."+\
-                        "REQUIRED ARGUMENT.")
-parser.add_argument("--cov-evecs-file", action="store", type=str,\
-                   default=None,\
-                   help="ASCII file containing the covariance eigenvectors. "+\
-                        "REQUIRED ARGUMENT.")
+parser.add_argument("--split-bank-num", action="store", type=int,
+                    required=True,
+                    help="Which splitbank do I read out of the HDF file?.")
 parser.add_argument("--stack-distance", action="store", type=float,\
                   default=0.2, help="Minimum metric spacing before we stack"+\
                                     "OPTIONAL")
@@ -103,11 +96,6 @@ parser.add_argument("--random-seed", action="store", type=int,\
                             translating all points back to physical space.
                             If this is used the code should give the same
                             output if run with the same random seed.""")
-parser.add_argument('--reject-file', default=None,
-            help="If given, store the rejected points into this file.")
-parser.add_argument('--depths-file', default=None,
-            help="If given store the parameter space depth in this file.")
-
 
 pycbc.tmpltbank.insert_base_bank_options(parser)
 
@@ -127,15 +115,7 @@ logging.basicConfig(format='%(asctime)s %(message)s', level=log_level)
 # Sanity check options
 if not opts.pn_order:
     parser.error("Must supply --pn-order")
-if not opts.input_bank_file:
-    parser.error("Must supply --input-bank-file")
 opts.max_mismatch = 1 - opts.min_match
-if not opts.metric_evals_file:
-    parser.error("Must supply --metric-evals-file")
-if not opts.metric_evecs_file:
-    parser.error("Must supply --metric-evecs-file")
-if not opts.cov_evecs_file:
-    parser.error("Must supply --cov-evecs-file")
 pycbc.tmpltbank.verify_mass_range_options(opts, parser)
 massRangeParams=pycbc.tmpltbank.massRangeParameters.from_argparse(opts)
 # Set random seed if needed
@@ -151,18 +131,20 @@ metricParams = pycbc.tmpltbank.metricParameters(opts.pn_order, 0, opts.f0, \
                                                 0, f0=opts.f0)
 
 # Load the list of points from file
-tempBank = numpy.loadtxt(opts.input_bank_file)
-# If only one template numpy only outputs a 1D array: make 2D
-try:
-    len(tempBank[0])
-except TypeError:
-    tempBank = [tempBank]
+h5file = h5py.File(opts.input_file, 'r')
+v1s = h5file['split_banks/split_bank_%05d/v1s' % opts.split_bank_num][:]
+v2s = h5file['split_banks/split_bank_%05d/v2s' % opts.split_bank_num][:]
+if 'v3s' in h5file['split_banks/split_bank_%05d' % opts.split_bank_num].keys():
+    v3s = h5file['split_banks/split_bank_%05d/v3s' % opts.split_bank_num][:]
+    temp_bank = numpy.array([v1s,v2s,v3s]).T
+else:
+    temp_bank = numpy.array([v1s,v2s]).T
 
 # Load the files giving the information needed to define the xi_i
 # parameter space
-evals = numpy.loadtxt(opts.metric_evals_file)
-evecs = numpy.matrix(numpy.loadtxt(opts.metric_evecs_file))
-evecsCV = numpy.matrix(numpy.loadtxt(opts.cov_evecs_file))
+evals = h5file['metric_evals']
+evecs = h5file['metric_evecs']
+evecsCV = h5file['cov_evecs']
 
 metricParams.evals = {}
 metricParams.evecs = {}
@@ -204,13 +186,11 @@ maxBHspin = opts.max_bh_spin_mag
 
 # Here we start looping over bank
 temp_number = 0
-outPointer = open(opts.output_file, 'w')
-if opts.reject_file is not None:
-    outPointer2 = open(opts.reject_file, 'w')
-if opts.depths_file is not None:
-    outPointer3 = open(opts.depths_file, 'w')
-numtemps = len(tempBank)
-for entry in tempBank:
+reject_info = []
+depths_info = []
+points_info = []
+numtemps = len(temp_bank)
+for entry in temp_bank:
     temp_number += 1
     logging.info("Analysing template %d" % temp_number)
     # First find the closest point in our set of 2000000 defined above 
@@ -235,14 +215,11 @@ for entry in tempBank:
     if dist.min() > 2.:
         logging.info("Template %d rejected as too far away" % temp_number)
         # Print info to the rejected points file
-        if opts.reject_file is None:
-            continue
         if opts.threed_lattice:
-            print >> outPointer2, "%e %e %e %e %e %e %e %e" \
-                     %(xi1_des, xi2_des, xi3_des, 0, 0, 0, 0, dist.min())
+            reject_info.append([xi1_des, xi2_des, xi3_des, 0, 0,
+                                0, 0, dist.min()])
         else:
-            print >> outPointer2, "%e %e %e %e %e %e %e" \
-                     %(xi1_des, xi2_des, 0, 0, 0, 0, dist.min())
+            reject_info.append([xi1_des, xi2_des, 0, 0, 0, 0, dist.min()])
         continue
     # This function will use the starting point and iteratively find a
     # physical point has a mismatch < 0.0001 with the desired one
@@ -256,16 +233,12 @@ for entry in tempBank:
     if masses[5] > opts.max_mismatch:
         # Reject point, it is too far away
         logging.info("Template %d rejected as too far away" % temp_number)
-        if opts.reject_file is None:
-            continue
         if opts.threed_lattice:
-            print >> outPointer2, "%e %e %e %e %e %e %e %e" \
-                     %(xi1_des, xi2_des, xi3_des, masses[0], masses[1],\
-                       masses[2], masses[3], masses[5])
+            reject_info.append([xi1_des, xi2_des, xi3_des, masses[0],
+                                masses[1], masses[2], masses[3], masses[5]])
         else:
-            print >> outPointer2, "%e %e %e %e %e %e %e" \
-                     %(xi1_des, xi2_des, masses[0], masses[1], masses[2],\
-                       masses[3], masses[5])
+            reject_info.append([xi1_des, xi2_des, masses[0], masses[1],
+                                masses[2], masses[3], masses[5]])
         continue
     # If we got this far the point will be accepted.
     # Now we figure out if the depth of the *other* directions are wide enough
@@ -343,13 +316,11 @@ for entry in tempBank:
     else:
         vec5_min = vec5_max = vec5_depth = 0
     # Output depths
-    if opts.depths_file is not None:
-        if opts.threed_lattice:
-            print >> outPointer3, "%e %e %e %e %e"\
-                     %(xi1_des, xi2_des, xi3_des, vec4_depth, vec5_depth)
-        else:
-            print >> outPointer3, "%e %e %e %e %e"\
-                     %(xi1_des, xi2_des, vec3_depth, vec4_depth, vec5_depth)
+    if opts.threed_lattice:
+        depths_info.append([xi1_des, xi2_des, xi3_des, vec4_depth, vec5_depth])
+    else:
+        depths_info.append([xi1_des, xi2_des, vec3_depth, vec4_depth,
+                            vec5_depth])
    # Figure out how many templates we need to stack in 3rd direction
     vec3DepthVal = opts.stack_distance
     if opts.threed_lattice:
@@ -373,8 +344,8 @@ for entry in tempBank:
         if vec4_depth < vec3DepthVal or masses[5] > opts.max_mismatch:
             if masses[5]:
                 # Write point to file
-                print >> outPointer, "%e %e %e %e %e" \
-                      %(masses[0], masses[1], masses[2], masses[3], masses[5])
+                points_info.append([masses[0], masses[1], masses[2], masses[3],
+                                    masses[5]])
         else:
             # OR we need to estimate the depth in the 4th direction at this
             # 3d point
@@ -401,13 +372,11 @@ for entry in tempBank:
                            copy.deepcopy(bestMasses), copy.deepcopy(bestXis), \
                            req_match, massRangeParams, metricParams, opts.f0)
                 if masses[5]:
-                    # Write point to file
-                    print >> outPointer, "%e %e %e %e %e"\
-                          %(masses[0], masses[1], masses[2], masses[3],\
-                            masses[5])
+                    points_info.append([masses[0], masses[1], masses[2],
+                                        masses[3], masses[5]])
 
-outPointer.close()
-if opts.reject_file is not None:
-    outPointer2.close()
-if opts.depths_file is not None:
-    outPointer3.close()
+h5outfile = h5py.File(opts.output_file, 'w')
+h5outfile['reject_points'] = numpy.array(reject_info)
+h5outfile['point_depths'] = numpy.array(depths_info)
+h5outfile['accepted_templates'] = numpy.array(points_info)
+h5outfile.close()

--- a/bin/pycbc_geom_aligned_bank
+++ b/bin/pycbc_geom_aligned_bank
@@ -32,7 +32,7 @@ import ConfigParser
 import numpy
 import logging
 import distutils.spawn
-from glue import pipeline
+import h5py
 from glue.ligolw import ligolw
 from glue.ligolw import table
 from glue.ligolw import lsctables
@@ -62,25 +62,19 @@ class GeomAligned2DStackExecutable(wf.Executable):
 
     file_input_options = ['--asd-file', '--psd-file']
 
-    def create_node(self, input_points, cov_evecs_file, metric_evals_file,
-                    metric_evecs_file, analysis_time, extra_tags=None):
+    def create_node(self, input_file, split_bank_num,
+                    analysis_time, extra_tags=None):
         """ Create a node.
         """
         if extra_tags is None:
             extra_tags = []
         node = wf.Executable.create_node(self)
 
-        node.add_input_opt('--input-bank-file', input_points)
-        node.add_input_opt('--cov-evecs-file', cov_evecs_file)
-        node.add_input_opt('--metric-evals-file', metric_evals_file)
-        node.add_input_opt('--metric-evecs-file', metric_evecs_file)
+        node.add_input_opt('--input-file', input_file)
+        node.add_opt('--split-bank-num', split_bank_num)
 
-        node.new_output_file_opt(analysis_time, '.dat', '--output-file',
+        node.new_output_file_opt(analysis_time, '.hdf', '--output-file',
                                  tags=self.tags + extra_tags + ['bank'])
-        node.new_output_file_opt(analysis_time, '.dat', '--reject-file',
-                                 tags=self.tags + extra_tags + ['reject'])
-        node.new_output_file_opt(analysis_time, '.dat', '--depths-file',
-                                 tags=self.tags + extra_tags + ['depths'])
         return node
 
 class AlignedBankCatExecutable(wf.Executable):
@@ -90,7 +84,8 @@ class AlignedBankCatExecutable(wf.Executable):
 
     file_input_options = ['--asd-file', '--psd-file']
 
-    def create_node(self, input_file_list, metadata_file, analysis_time):
+    def create_node(self, input_file_list, metadata_file, analysis_time,
+                    output_file_path=None):
         """ Create a node.
         """
         node = wf.Executable.create_node(self)
@@ -98,8 +93,15 @@ class AlignedBankCatExecutable(wf.Executable):
         node.add_input_list_opt('--input-files', input_file_list)
         node.add_input_opt('--metadata-file', metadata_file)
 
-        node.new_output_file_opt(analysis_time, '.xml', '--output-file',
-                                 tags=self.tags)
+        if output_file_path is None:
+            node.new_output_file_opt(analysis_time, '.xml', '--output-file',
+                                     tags=self.tags)
+        else:
+            # Convert path to file
+            out_file = wf.File.from_path(output_file_path)
+            if self.retain_files:
+                out_file.storage_path = output_file_path
+            node.add_output_opt('--output-file', out_file)
         return node
 
 class TmpltbankToChiParams(wf.Executable):
@@ -137,9 +139,6 @@ parser = argparse.ArgumentParser(description=_desc,
 parser.add_argument('--version', action='version', version=__version__)
 parser.add_argument("-V", "--verbose", action="store_true", default=False,
                     help="verbose output")
-parser.add_argument("-L", "--log-path", action="store", required=True, type=str,
-                    default=None,
-                    help="Directory to store condor logs. REQUIRED ARGUMENT")
 parser.add_argument("-s", "--stack-distance", action="store", type=float,\
                   default=0.2, help="Minimum metric spacing before we "+\
                                "stack.")
@@ -169,6 +168,21 @@ parser.add_argument("--print-chi-points", action="store", default=None,
                     "chi points file will be written.")
 parser.add_argument("--workflow-name", type=str, default='bank_gen',
                     help="Name to use for the produced .dax file.")
+parser.add_argument("--dax-filename", type=str, default=None,
+                    help="This can be used if running this job in a "
+                         "sub-workflow to specify the dax filename.")
+parser.add_argument("--map-filename", type=str, default=None,
+                    help="This can be used if running this job in a "
+                         "sub-workflow to specify the output map filename. "
+                         "WARNING: Giving this if not running as a "
+                         "sub-workflow will cause pycbc_submit_dax to not "
+                         "work.")
+parser.add_argument("--intermediate-data-file", type=str, required=True,
+                    help="The HDF file to be used to store data to pass down "
+                    "to the various worker jobs.")
+parser.add_argument("--metadata-file", type=str, required=True,
+                    help="Location of the output file containing the metadata "
+                    "that will be added to the final XML file.")
 
 pycbc.tmpltbank.insert_base_bank_options(parser)
 
@@ -192,7 +206,7 @@ opts = parser.parse_args()
 orig_opts = copy.deepcopy(opts)
 
 # Set up the process/process_params table and output xml document
-cmds_file_name = "aligned_bank_commands.xml"
+cmds_file_name = opts.metadata_file
 outdoc = ligolw.Document()
 outdoc.appendChild(ligolw.LIGO_LW())
 ligolw_process.register_to_xmldoc(outdoc, __program__, vars(opts), comment="",
@@ -367,42 +381,53 @@ else:
     if opts.threed_lattice:
         newV3s = v3s
 
-# Dump the full bank in \xi_i coordinates
-with open('bank_chis.dat', 'w') as bankFile:
-    if opts.threed_lattice:
-        for i in xrange(len(newV1s)):
-            print >> bankFile, "%e %e %e" %(newV1s[i],newV2s[i],newV3s[i])
-    else:
-        for i in xrange(len(newV1s)):
-            print >> bankFile, "%e %e" %(newV1s[i],newV2s[i])
-
 # Now begin to generate the dag
-# First split the bank
-if not os.path.isdir('split_banks'):
-    os.makedirs('split_banks')
-if not os.path.isdir('output_banks'):
-    os.makedirs('output_banks')
-if not os.path.isdir('logs'):
-    os.makedirs('logs')
+h5file = h5py.File(opts.intermediate_data_file, 'w')
+# Dump the full bank in \xi_i coordinates
+h5file['full_bank/v1s'] = newV1s
+h5file['full_bank/v2s'] = newV2s
+if opts.threed_lattice:
+    h5file['full_bank/v3s'] = newV3s
 
-bankNum = 0
+# Now store split banks
+bank_num = 0
 
-logging.info("Printing split banks")
-bankFile = open('split_banks/split_bank_%05d.dat' % bankNum, 'w')
+logging.info("Printing split banks to HDF file.")
+v1s = []
+v2s = []
+v3s = []
 for i in xrange(len(newV1s)):
+    v1s.append(newV1s[i])
+    v2s.append(newV2s[i])
     if opts.threed_lattice:
-        print >> bankFile, "%e %e %e" %(newV1s[i],newV2s[i],newV3s[i])
-    else:
-        print >> bankFile, "%e %e" %(newV1s[i],newV2s[i])
+        v3s.append(newV3s[i])
     if not (i+1) % opts.split_bank_num:
-        bankFile.close()
-        bankNum = bankNum + 1
-        if not i == (len(newV1s)-1):
-            bankFile = open('split_banks/split_bank_%05d.dat' % bankNum, 'w')
-  
-if len(newV1s) % opts.split_bank_num:
-    bankFile.close()
+        h5file['split_banks/split_bank_%05d/v1s' % bank_num] = v1s
+        h5file['split_banks/split_bank_%05d/v2s' % bank_num] = v2s
+        v1s = []
+        v2s = []
+        if opts.threed_lattice:
+            h5file['split_banks/split_bank_%05d/v3s' % bank_num] = v3s
+            v3s = []
+        bank_num = bank_num + 1
 
+if len(v1s):
+    # There are still templates to dump
+    h5file['split_banks/split_bank_%05d/v1s' % bank_num] = v1s
+    h5file['split_banks/split_bank_%05d/v2s' % bank_num] = v2s
+    if opts.threed_lattice:
+        h5file['split_banks/split_bank_%05d/v3s' % bank_num] = v3s
+
+logging.info('Adding metric information to HDF file.')
+cov_evecs = numpy.loadtxt('covariance_evecs_%d.dat' % metricParams.fUpper)
+metric_evals = numpy.loadtxt('metric_evals_%d.dat' % metricParams.fUpper)
+metric_evecs = numpy.loadtxt('metric_evecs_%d.dat' % metricParams.fUpper)
+h5file['cov_evecs'] = cov_evecs
+h5file['metric_evals'] = metric_evals
+h5file['metric_evecs'] = metric_evecs
+
+h5file.close()
+  
 # And begin dag generation
 # First: Set up the config parser.
 cp = ConfigParser.ConfigParser()
@@ -466,7 +491,7 @@ cp.add_section('dumptochis')
 # Add options by parsing the options sent to this job. Convert to dict
 print_chis_opts = vars(copy.deepcopy(orig_opts))
 # Remove options we don't want to send on
-remove_opts = ['output_file', 'log_path', 'min_match', 'stack_distance',
+remove_opts = ['output_file', 'min_match', 'stack_distance',
                'threed_lattice', 'split_bank_num', 'filter_points',
                'print_chi_points', 'verbose']
 for opt in remove_opts:
@@ -497,35 +522,27 @@ wf.makedir('stack2d')
 stack_exe = GeomAligned2DStackExecutable(workflow.cp, 'aligned2dstack',
                                    ifos=workflow.ifos, out_dir='stack2d')
 num_banks = int((len(newV1s) - 0.5)//opts.split_bank_num) + 1
-cov_evecs_files = wf.File.from_path('covariance_evecs_%d.dat' \
-                                     %metricParams.fUpper)
-metric_evals_file = wf.File.from_path('metric_evals_%d.dat' \
-                                       %metricParams.fUpper)
-metric_evecs_file = wf.File.from_path('metric_evecs_%d.dat' \
-                                       %metricParams.fUpper)
+input_h5file = wf.File.from_path(opts.intermediate_data_file)
 
 all_outs = wf.FileList([])
 
 for idx in xrange(num_banks):
-    stackid = 'file%05d' %(idx)
-    input_points = wf.File.from_path('split_banks/split_bank_%05d.dat'%(idx))
-    stack_node = stack_exe.create_node(input_points, cov_evecs_files,
-                                       metric_evals_file, metric_evecs_file,
+    stackid = 'job%05d' %(idx)
+    stack_node = stack_exe.create_node(input_h5file, idx,
                                        workflow.analysis_time,
                                        extra_tags=[stackid])
     workflow += stack_node
     stack_outs = stack_node.output_files
-    stack_out = stack_outs.find_output_with_tag('bank')
-    assert(len(stack_out) == 1)
-    stack_out = stack_out[0]
-    all_outs.append(stack_out)
+    assert(len(stack_outs) == 1)
+    all_outs.append(stack_outs[0])
 
 # Then combine everything together
 combine_exe = AlignedBankCatExecutable(workflow.cp, 'alignedbankcat',
                                         ifos=workflow.ifos, out_dir='.')
 metadata_file = wf.File.from_path(cmds_file_name)
 combine_node = combine_exe.create_node(all_outs, metadata_file,
-                                        workflow.analysis_time)
+                                       workflow.analysis_time,
+                                       output_file_path=opts.output_file)
 workflow += combine_node
 assert(len(combine_node.output_files) == 1)
 out_bank = combine_node.output_files[0]
@@ -535,7 +552,8 @@ chiparams_exe = TmpltbankToChiParams(workflow.cp, 'dumptochis',
                                       ifos=workflow.ifos, out_dir='.')
 chiparams_node = chiparams_exe.create_node(out_bank, workflow.analysis_time)
 
-workflow.save()
+workflow.save(filename=opts.dax_filename, output_map=opts.map_filename)
 
+logging.info("GENERATION SUCCESSFUL.")
 logging.info("Submit the resulting dax file to generate your template bank.")
 logging.info("See pycbc_submit_dax --help for instructions.")

--- a/pycbc/tmpltbank/coord_utils.py
+++ b/pycbc/tmpltbank/coord_utils.py
@@ -375,7 +375,6 @@ def get_cov_params(totmass, eta, beta, sigma, gamma, chis, metricParams, \
     mus = get_conv_params(totmass, eta, beta, sigma, gamma, chis, \
                           metricParams, fUpper)
     # and then mus -> xis
-    mus = numpy.array(mus, copy=False)
     xis = get_covaried_params(mus, metricParams.evecsCV[fUpper])
     return xis
 
@@ -418,7 +417,6 @@ def get_conv_params(totmass, eta, beta, sigma, gamma, chis, metricParams, \
     # Do this by masses -> lambdas
     lambdas = get_chirp_params(totmass, eta, beta, sigma, gamma, chis, \
                                metricParams.f0, metricParams.pnOrder)
-    lambdas = numpy.array(lambdas, copy=False)
     # and lambdas -> mus
     mus = get_mu_params(lambdas, metricParams, fUpper)
     return mus
@@ -447,6 +445,11 @@ def get_mu_params(lambdas, metricParams, fUpper):
     mus : list of floats or numpy.arrays
         Position of the system(s) in the mu coordinate system
     """
+    lambdas = numpy.array(lambdas, copy=False)
+    # If original inputs were floats we need to make this a 2D array
+    if len(lambdas.shape) == 1:
+        lambdas = lambdas[:,None]
+
     evecs = metricParams.evecs[fUpper]
     evals = metricParams.evals[fUpper]
 
@@ -475,6 +478,11 @@ def get_covaried_params(mus, evecsCV):
     xis : list of floats or numpy.arrays
         Position of the system(s) in the xi coordinate system
     """
+    mus = numpy.array(mus, copy=False)
+    # If original inputs were floats we need to make this a 2D array
+    if len(mus.shape) == 1:
+        mus = mus[:,None]
+
     return ((mus.T).dot(evecsCV)).T
 
 def rotate_vector(evecs, old_vector, rescale_factor, index):


### PR DESCRIPTION
This change is in preparation for forthcoming changes to add a make_uberbank_workflow. There are two parts of this:

 * We move all the temporary text files produced by geom_bank to a single HDF file. This greatly simplifies file management and makes it easier to extract information from the output.
 * A number of operations in coord_utils are now done using numpy.dot instead of for loops. Originally these were not a problem because long numpy arrays would be used and the for loop was not a slow down. However, we then moved to using smaller arrays in some parts and I didn't check that this had become a problem. This produces close to an order of magnitude speed up for the 2dstack jobs in the example I am testing on.