### PR TITLE
making minifollowup jobs precession-proof

### DIFF
--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -129,11 +129,15 @@ for num_event in range(num_events):
     params['mass2'] = bank_data['mass2'][bank_id]
     params['spin1z'] = bank_data['spin1z'][bank_id]
     params['spin2z'] = bank_data['spin2z'][bank_id]
-    params['spin1x'] = bank_data['spin1x'][bank_id]
-    params['spin1y'] = bank_data['spin1y'][bank_id]
-    params['spin2x'] = bank_data['spin2x'][bank_id]
-    params['spin2y'] = bank_data['spin2y'][bank_id]
-    params['inclination'] = bank_data['inclination'][bank_id]
+    # don't require precessing template info if not present
+    try:
+        params['spin1x'] = bank_data['spin1x'][bank_id]
+        params['spin1y'] = bank_data['spin1y'][bank_id]
+        params['spin2x'] = bank_data['spin2x'][bank_id]
+        params['spin2y'] = bank_data['spin2y'][bank_id]
+        params['inclination'] = bank_data['inclination'][bank_id]
+    except KeyError:
+        pass
 
     files += mini.make_single_template_plots(workflow, insp_segs,
                                     args.inspiral_data_read_name,

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -192,11 +192,15 @@ for num_event in range(num_events):
         curr_params['mass2'] = hd_sngl.mass2
         curr_params['spin1z'] = hd_sngl.spin1z
         curr_params['spin2z'] = hd_sngl.spin2z
-        curr_params['spin1x'] = hd_sngl.spin1x
-        curr_params['spin2x'] = hd_sngl.spin2x
-        curr_params['spin1y'] = hd_sngl.spin1y
-        curr_params['spin2y'] = hd_sngl.spin2y
-        curr_params['inclination'] = hd_sngl.inclination
+        # don't require precessing template info if not present
+        try:
+            curr_params['spin1x'] = hd_sngl.spin1x
+            curr_params['spin2x'] = hd_sngl.spin2x
+            curr_params['spin1y'] = hd_sngl.spin1y
+            curr_params['spin2y'] = hd_sngl.spin2y
+            curr_params['inclination'] = hd_sngl.inclination
+        except KeyError:
+            pass
         try:
             # Only present for precessing search
             curr_params['u_vals'] = hd_sngl.u_vals

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -90,7 +90,6 @@ trigs = hdf.SingleDetTriggers(args.single_detector_file, args.bank_file,
                               args.veto_file, args.veto_segment_name,
                               None, args.instrument)
 
-
 trigs.mask_to_n_loudest_clustered_events(n_loudest=num_events,
                                       ranking_statistic=args.ranking_statistic)
 
@@ -122,11 +121,15 @@ for num_event in range(num_events):
     curr_params['spin1z'] = trigs.spin1z[num_event]
     curr_params['spin2z'] = trigs.spin2z[num_event]
     curr_params[args.instrument + '_end_time'] = time
-    curr_params['spin1x'] = trigs.spin1x[num_event]
-    curr_params['spin2x'] = trigs.spin2x[num_event]
-    curr_params['spin1y'] = trigs.spin1y[num_event]
-    curr_params['spin2y'] = trigs.spin2y[num_event]
-    curr_params['inclination'] = trigs.inclination[num_event]
+    # don't require precessing template info if not present
+    try:
+        curr_params['spin1x'] = trigs.spin1x[num_event]
+        curr_params['spin2x'] = trigs.spin2x[num_event]
+        curr_params['spin1y'] = trigs.spin1y[num_event]
+        curr_params['spin2y'] = trigs.spin2y[num_event]
+        curr_params['inclination'] = trigs.inclination[num_event]
+    except KeyError:
+        pass
     try:
         # Only present for precessing search
         curr_params['u_vals'] = trigs.u_vals[num_event]


### PR DESCRIPTION
since non-precessing runs don't need info about extra precessing fields, don't require it