### PR TITLE
Uberbank workflow

### DIFF
--- a/bin/pycbc_geom_aligned_bank
+++ b/bin/pycbc_geom_aligned_bank
@@ -33,6 +33,7 @@ import numpy
 import logging
 import distutils.spawn
 import h5py
+from scipy import spatial
 from glue.ligolw import ligolw
 from glue.ligolw import table
 from glue.ligolw import lsctables
@@ -45,8 +46,7 @@ import pycbc.strain
 import pycbc.version
 import pycbc.tmpltbank
 import pycbc.workflow as wf
-import pycbc.workflow import pegasus_workflow as pwf
-from scipy import spatial
+import pycbc.workflow.pegasus_workflow as pwf
 
 __author__  = "Ian Harry <ian.harry@ligo.org>"
 __version__ = pycbc.version.git_verbose_msg
@@ -101,7 +101,11 @@ class AlignedBankCatExecutable(wf.Executable):
             # Convert path to file
             out_file = wf.File.from_path(output_file_path)
             if self.retain_files:
-                out_file.storage_path = output_file_path
+                if not os.path.isabs(output_file_path):
+                    out_file.storage_path = os.path.join(self.out_dir,
+                                                         output_file_path)
+                else:
+                    out_file.storage_path = output_file_path
             node.add_output_opt('--output-file', out_file)
         return node
 
@@ -188,6 +192,9 @@ parser.add_argument("--is-sub-workflow", default=False, action="store_true",
                     help="Only give this option if this code is being run "
                     "as a sub-workflow within pegasus. If this means nothing "
                     "to you, do not give this option.")
+parser.add_argument("--storage-path-base", default=None,
+                    help="If running this code as a sub-workflow then this "
+                    "path is pretended to all storage directories.")
 
 pycbc.tmpltbank.insert_base_bank_options(parser)
 
@@ -228,13 +235,6 @@ log_format='%(asctime)s %(message)s'
 logging.basicConfig(format=log_format, level=log_level)
 
 opts.max_mismatch = 1 - opts.min_match
-if not opts.write_metric:
-    warn_message = "--write-metric is required by this code. Enabling it."
-    logging.warn(warn_message)
-    opts.write_metric = True
-if orig_opts.write_metric:
-    # Do not want the combiner job to write these files again
-    orig_opts.write_metric = False
 
 pycbc.tmpltbank.verify_metric_calculation_options(opts, parser)
 metricParams=pycbc.tmpltbank.metricParameters.from_argparse(opts)
@@ -424,12 +424,9 @@ if len(v1s):
         h5file['split_banks/split_bank_%05d/v3s' % bank_num] = v3s
 
 logging.info('Adding metric information to HDF file.')
-cov_evecs = numpy.loadtxt('covariance_evecs_%d.dat' % metricParams.fUpper)
-metric_evals = numpy.loadtxt('metric_evals_%d.dat' % metricParams.fUpper)
-metric_evecs = numpy.loadtxt('metric_evecs_%d.dat' % metricParams.fUpper)
-h5file['cov_evecs'] = cov_evecs
-h5file['metric_evals'] = metric_evals
-h5file['metric_evecs'] = metric_evecs
+h5file['cov_evecs'] = metricParams.evecsCV[metricParams.fUpper]
+h5file['metric_evals'] = metricParams.evals[metricParams.fUpper]
+h5file['metric_evecs'] = metricParams.evecs[metricParams.fUpper]
 
 h5file.close()
   
@@ -522,10 +519,14 @@ opts.config_overrides=[]
 workflow = wf.Workflow(opts, opts.workflow_name)
 
 # Start with 2dstack jobs
-wf.makedir('stack2d')
+if opts.storage_path_base:
+    curr_dir = os.path.join(opts.storage_path_base, 'stack2d')
+else:
+    curr_dir = 'stack2d'
+#wf.makedir(curr_dir)
 
 stack_exe = GeomAligned2DStackExecutable(workflow.cp, 'aligned2dstack',
-                                   ifos=workflow.ifos, out_dir='stack2d')
+                                   ifos=workflow.ifos, out_dir=curr_dir)
 num_banks = int((len(newV1s) - 0.5)//opts.split_bank_num) + 1
 if not opts.is_sub_workflow:
     input_h5file = wf.File.from_path(opts.intermediate_data_file)
@@ -550,12 +551,17 @@ for idx in xrange(num_banks):
     all_outs.append(stack_outs[0])
 
 # Then combine everything together
-combine_exe = AlignedBankCatExecutable(workflow.cp, 'alignedbankcat',
-                                        ifos=workflow.ifos, out_dir='.')
-if not opts.is_sub_workflow:
-    input_h5file = wf.File.from_path(cmds_file_name)
+if opts.storage_path_base:
+    curr_dir = opts.storage_path_base
 else:
-    input_h5file = pwf.File(os.path.basename(cmds_file_name))
+    curr_dir = '.'
+
+combine_exe = AlignedBankCatExecutable(workflow.cp, 'alignedbankcat',
+                                        ifos=workflow.ifos, out_dir=curr_dir)
+if not opts.is_sub_workflow:
+    metadata_file = wf.File.from_path(cmds_file_name)
+else:
+    metadata_file = pwf.File(os.path.basename(cmds_file_name))
 
 combine_node = combine_exe.create_node(all_outs, metadata_file,
                                        workflow.analysis_time,
@@ -566,7 +572,7 @@ out_bank = combine_node.output_files[0]
 
 # And do the convert to chis job
 chiparams_exe = TmpltbankToChiParams(workflow.cp, 'dumptochis',
-                                      ifos=workflow.ifos, out_dir='.')
+                                      ifos=workflow.ifos, out_dir=curr_dir)
 chiparams_node = chiparams_exe.create_node(out_bank, workflow.analysis_time)
 
 workflow.save(filename=opts.dax_filename, output_map=opts.map_filename)

--- a/bin/pycbc_geom_aligned_bank
+++ b/bin/pycbc_geom_aligned_bank
@@ -45,6 +45,7 @@ import pycbc.strain
 import pycbc.version
 import pycbc.tmpltbank
 import pycbc.workflow as wf
+import pycbc.workflow import pegasus_workflow as pwf
 from scipy import spatial
 
 __author__  = "Ian Harry <ian.harry@ligo.org>"
@@ -183,6 +184,10 @@ parser.add_argument("--intermediate-data-file", type=str, required=True,
 parser.add_argument("--metadata-file", type=str, required=True,
                     help="Location of the output file containing the metadata "
                     "that will be added to the final XML file.")
+parser.add_argument("--is-sub-workflow", default=False, action="store_true",
+                    help="Only give this option if this code is being run "
+                    "as a sub-workflow within pegasus. If this means nothing "
+                    "to you, do not give this option.")
 
 pycbc.tmpltbank.insert_base_bank_options(parser)
 
@@ -522,7 +527,15 @@ wf.makedir('stack2d')
 stack_exe = GeomAligned2DStackExecutable(workflow.cp, 'aligned2dstack',
                                    ifos=workflow.ifos, out_dir='stack2d')
 num_banks = int((len(newV1s) - 0.5)//opts.split_bank_num) + 1
-input_h5file = wf.File.from_path(opts.intermediate_data_file)
+if not opts.is_sub_workflow:
+    input_h5file = wf.File.from_path(opts.intermediate_data_file)
+else:
+    # Basically, if this is a sub-workflow do not store a PFN, as it will be
+    # some meaningless temporary path, but instead tell the uber-workflow
+    # that these files are outputs and used within the sub-dax and let it
+    # handle the rest.
+    input_h5file = pwf.File(os.path.basename(opts.intermediate_data_file))
+
 
 all_outs = wf.FileList([])
 
@@ -539,7 +552,11 @@ for idx in xrange(num_banks):
 # Then combine everything together
 combine_exe = AlignedBankCatExecutable(workflow.cp, 'alignedbankcat',
                                         ifos=workflow.ifos, out_dir='.')
-metadata_file = wf.File.from_path(cmds_file_name)
+if not opts.is_sub_workflow:
+    input_h5file = wf.File.from_path(cmds_file_name)
+else:
+    input_h5file = pwf.File(os.path.basename(cmds_file_name))
+
 combine_node = combine_exe.create_node(all_outs, metadata_file,
                                        workflow.analysis_time,
                                        output_file_path=opts.output_file)

--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -388,7 +388,9 @@ fi
 
 # ugly shell to extract the sub-dax names from the uberdax xml
 for dax in `egrep '<[[:blank:]]*dax' ${DAX_FILE} | tr ' ' \\\n | grep file | awk -F= '{print $2}' | tr -d '">'` ; do 
-  cp ${dax} workflow/dax
+  if [ -e ${dax} ] ; then
+    cp ${dax} workflow/dax
+  fi
   map=`basename ${dax} .dax`.map
   if [ -e ${map} ] ; then
     cp ${map} workflow/output_map

--- a/bin/workflows/pycbc_create_sbank_workflow
+++ b/bin/workflows/pycbc_create_sbank_workflow
@@ -161,7 +161,7 @@ parser.add_argument("--is-sub-workflow", default=False, action="store_true",
                     help="Only give this option if this code is being run "
                     "as a sub-workflow within pegasus. If this means nothing "
                     "to you, do not give this option.")
-parser.add_argument("--tags", default=None, nargs="*", action="store",
+parser.add_argument("--tags", default=[], nargs="*", action="store",
                     help="If this option is given all jobs, and all workflow "
                           "configuration options, will use the tags given "
                           "here. This can be used if running this as a "

--- a/bin/workflows/pycbc_create_sbank_workflow
+++ b/bin/workflows/pycbc_create_sbank_workflow
@@ -104,8 +104,29 @@ class SbankChooseMchirpBinsExecutable(wf.Executable):
 
         return node
 
-# There is already a ligolw_add executable (wf.LigolwAddExecutable), so we
-# just use that directly.
+# There is already a ligolw_add executable (wf.LigolwAddExecutable), this needs
+# a minor change because we are potentially dealing with sub-daxes here.
+class LigolwAddExecutable(wf.LigolwAddExecutable):
+
+    def create_node(self, jobSegment, input_files, output=None,
+                    use_tmp_subdirs=True, tags=None):
+        if output is not None:
+            # Convert path to file
+            out_file = wf.File.from_path(output)
+            if self.retain_files:
+                if not os.path.isabs(output):
+                    out_file.storage_path = os.path.join(self.out_dir,
+                                                         output)
+                else:
+                    out_file.storage_path = output
+        else:
+            out_file = output
+
+        return super(LigolwAddExecutable, self).create_node\
+                        (jobSegment, input_files, output=out_file,
+                         use_tmp_subdirs=use_tmp_subdirs, tags=tags)
+
+
 
 ##############################################################################
 # Argument parsing and setup of workflow                                     #
@@ -122,6 +143,11 @@ parser.add_argument("--workflow-name", type=str, default='sbank_workflow',
                     help="Descriptive name of the analysis.")
 parser.add_argument("-d", "--output-dir", default=None,
                     help="Path to output directory.")
+parser.add_argument("--output-file", type=str, default=None,
+                    help="Specify the output file name. Either a name can be "
+                         "provided or a full path to file. Is this is not "
+                         "given a filename and location is chosen "
+                         "automatically.")
 parser.add_argument("--dax-filename", type=str, default=None,
                     help="This can be used if running this job in a "
                          "sub-workflow to specify the dax filename.")
@@ -135,6 +161,12 @@ parser.add_argument("--is-sub-workflow", default=False, action="store_true",
                     help="Only give this option if this code is being run "
                     "as a sub-workflow within pegasus. If this means nothing "
                     "to you, do not give this option.")
+parser.add_argument("--tags", default=None, nargs="*", action="store",
+                    help="If this option is given all jobs, and all workflow "
+                          "configuration options, will use the tags given "
+                          "here. This can be used if running this as a "
+                          "sub-workflow to give two sets of options to two "
+                          "different invocations of the sbank workflow.")
 
 
 wf.add_workflow_command_line_group(parser)
@@ -154,21 +186,41 @@ if not args.is_sub_workflow:
 
 seed_file = None
 bins_inp_file = None
-if workflow.cp.has_option_tags('workflow', 'seed-bank', []):
+if workflow.cp.has_option_tags('workflow', 'seed-bank', args.tags):
     # If a seed bank is provided register it as a File object 
-    if not args.is_sub_workflow:
-        seed_file = wf.File.from_path(workflow.cp.get_opt_tags\
-                                      ('workflow', 'seed-bank', []))
+    seed_banks = workflow.cp.get_opt_tags('workflow', 'seed-bank', args.tags)
+    seed_banks = seed_banks.split(' ')
+    if len(seed_banks) == 0:
+        raise ValueError("No seed bank actually provided!")
+    seed_files = []
+    for seed_bank in seed_banks:
+        if not args.is_sub_workflow:
+            seed_file = wf.File.from_path(seed_bank)
+        else:
+            seed_file = pwf.File(os.path.basename(seed_bank))
+        seed_files.append(seed_file)
+    if len(seed_files) == 1:
+        seed_file = seed_files[0]
     else:
-        seed_file = pwf.File(os.path.basename\
-                             (workflow.cp.get_opt_tags('workflow', 'seed-bank',
-                                              [])))
+        # Combine with llwadd
+        out_dir = os.path.join(args.output_dir, 'input_combine')
+        llwadd_exe = LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
+                                         out_dir=out_dir,
+                                         tags=['INPUT'] + args.tags)
+        llwadd_exe.current_retention_level = wf.Executable.ALL_TRIGGERS
+        llwadd_node = llwadd_exe.create_node(workflow.analysis_time,
+                                             seed_files,
+                                             use_tmp_subdirs=False)
+        workflow += llwadd_node
+        assert(len(llwadd_node.output_files) == 1)
+        seed_file = llwadd_node.output_files[0]
+
     # bins_inp_file will go to the mchirp_bins generator. seed file will go to
     # the first set of sbank jobs if not None.
     bins_inp_file = seed_file
 
 if not workflow.cp.has_option_tags('workflow', 'use-seed-bank-for-chirp-bins',
-                                   []):
+                                   args.tags):
     out_dir = os.path.join(args.output_dir, 'coarse')
     # Generate Executable class (similar to Job in the old terminology)
     # The tags=coarse option is used to ensure that options in the
@@ -176,7 +228,8 @@ if not workflow.cp.has_option_tags('workflow', 'use-seed-bank-for-chirp-bins',
     # this job
     coarse_sbank_exe = SbankExecutable(workflow.cp, 'sbank',
                                        ifos=workflow.ifos,
-                                       out_dir=out_dir, tags=['coarse'])
+                                       out_dir=out_dir,
+                                       tags=['coarse']+args.tags)
     coarse_sbank_exe.current_retention_level=wf.Executable.MERGED_TRIGGERS
     # Then make a specific node
     coarse_node = coarse_sbank_exe.create_node(workflow.analysis_time)
@@ -188,8 +241,8 @@ if not workflow.cp.has_option_tags('workflow', 'use-seed-bank-for-chirp-bins',
     if seed_file is None:
         if not workflow.cp.has_option_tags('workflow',
                                            'do-not-use-coarse-job-as-seed',
-                                           tags):
-            seed_file = seed_file
+                                           args.tags):
+            seed_file = bins_inp_file
 
 if bins_inp_file is None:
     # Only get here if weird options are given
@@ -204,7 +257,7 @@ if bins_inp_file is None:
 # How many repetitions to try? Get this from config-parser. Special
 # config-parser options like this go in the [workflow] section
 
-num_cycles = int(workflow.cp.get('workflow', 'num-cycles'))
+num_cycles = int(workflow.cp.get_opt_tags('workflow', 'num-cycles', args.tags))
 
 for cycle_idx in range(num_cycles):
     #########
@@ -216,7 +269,8 @@ for cycle_idx in range(num_cycles):
     # How many banks to use? This can vary cycle to cycle, or be the same for
     # all. Either supply it once in [workflow], or in [workflow-cycleN] for
     # N in range(num_cycles)
-    nbanks = workflow.cp.get_opt_tags('workflow', 'nbanks', tags=[cycle_tag])
+    nbanks = workflow.cp.get_opt_tags('workflow', 'nbanks',
+                                      tags=[cycle_tag]+args.tags)
     nbanks = int(nbanks)
     
     #############
@@ -225,7 +279,7 @@ for cycle_idx in range(num_cycles):
 
     bins_exe = SbankChooseMchirpBinsExecutable(workflow.cp, 'sbank_mchirp_bins',
                                     ifos=workflow.ifos, out_dir=out_dir,
-                                    tags=[cycle_tag])
+                                    tags=[cycle_tag] + args.tags)
     bins_node = bins_exe.create_node(workflow.analysis_time,
                                      bins_inp_file, nbanks)
     workflow += bins_node
@@ -237,7 +291,8 @@ for cycle_idx in range(num_cycles):
     #######################
 
     main_sbank_exe = SbankExecutable(workflow.cp, 'sbank', ifos=workflow.ifos,
-                                 out_dir=out_dir, tags=['parallel', cycle_tag])
+                                     out_dir=out_dir,
+                                     tags=['parallel', cycle_tag] + args.tags)
     # These jobs we don't always want to store
     main_sbank_exe.current_retention_level=wf.Executable.INTERMEDIATE_PRODUCT
 
@@ -257,8 +312,9 @@ for cycle_idx in range(num_cycles):
     # COMBINER #
     ############
 
-    llwadd_exe = wf.LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
-                                    out_dir=out_dir, tags=[cycle_tag, 'FIRST'])
+    llwadd_exe = LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
+                                     out_dir=out_dir,
+                                     tags=[cycle_tag, 'FIRST'] + args.tags)
     llwadd_exe.current_retention_level = wf.Executable.ALL_TRIGGERS
     llwadd_node = llwadd_exe.create_node(workflow.analysis_time,
                                          main_sbank_files,
@@ -273,7 +329,7 @@ for cycle_idx in range(num_cycles):
 
     readder_sbank_exe = SbankExecutable(workflow.cp, 'sbank',
                                         ifos=workflow.ifos, out_dir=out_dir,
-                                        tags=[cycle_tag, 'readder'])
+                                        tags=[cycle_tag, 'readder'] + args.tags)
     readder_sbank_execurrent_retention_level = wf.Executable.ALL_TRIGGERS
     readder_sbank_node = readder_sbank_exe.create_node(workflow.analysis_time,
                                                        trial_bank=llwadd_out)
@@ -289,20 +345,23 @@ for cycle_idx in range(num_cycles):
     if cycle_idx == (num_cycles - 1):
         out_dir = args.output_dir
         crl = wf.Executable.FINAL_RESULT
+        output_path = args.output_file
     else:
         crl = wf.Executable.MERGED_TRIGGERS
+        output_path = None
 
-    llwadd_exe = wf.LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
-                                    out_dir=out_dir, tags=[cycle_tag, 'FINAL'])
+    llwadd_exe = LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
+                                     out_dir=out_dir,
+                                     tags=[cycle_tag, 'FINAL'] + args.tags)
     llwadd_exe.current_retention_level = crl
 
     if seed_file is None:
-        inputs = [seed_file]
+        inputs = [readder_out]
     else:
         inputs = [seed_file, readder_out]
 
     llwadd_node = llwadd_exe.create_node(workflow.analysis_time,
-                                         [seed_file, readder_out],
+                                         inputs, output=output_path,
                                          use_tmp_subdirs=False)
     workflow += llwadd_node
     assert(len(llwadd_node.output_files) == 1)

--- a/bin/workflows/pycbc_create_sbank_workflow
+++ b/bin/workflows/pycbc_create_sbank_workflow
@@ -207,7 +207,7 @@ if workflow.cp.has_option_tags('workflow', 'seed-bank', args.tags):
         llwadd_exe = LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
                                          out_dir=out_dir,
                                          tags=['INPUT'] + args.tags)
-        llwadd_exe.current_retention_level = wf.Executable.ALL_TRIGGERS
+        llwadd_exe.update_current_retention_level(wf.Executable.ALL_TRIGGERS)
         llwadd_node = llwadd_exe.create_node(workflow.analysis_time,
                                              seed_files,
                                              use_tmp_subdirs=False)
@@ -230,7 +230,8 @@ if not workflow.cp.has_option_tags('workflow', 'use-seed-bank-for-chirp-bins',
                                        ifos=workflow.ifos,
                                        out_dir=out_dir,
                                        tags=['coarse']+args.tags)
-    coarse_sbank_exe.current_retention_level=wf.Executable.MERGED_TRIGGERS
+    coarse_sbank_exe.update_current_retention_level\
+           (wf.Executable.MERGED_TRIGGERS)
     # Then make a specific node
     coarse_node = coarse_sbank_exe.create_node(workflow.analysis_time)
     # Add to workflow
@@ -294,7 +295,8 @@ for cycle_idx in range(num_cycles):
                                      out_dir=out_dir,
                                      tags=['parallel', cycle_tag] + args.tags)
     # These jobs we don't always want to store
-    main_sbank_exe.current_retention_level=wf.Executable.INTERMEDIATE_PRODUCT
+    main_sbank_exe.update_current_retention_level\
+            (wf.Executable.INTERMEDIATE_PRODUCT)
 
     main_sbank_files = wf.FileList([])
     for nbank_idx in range(nbanks):
@@ -315,7 +317,7 @@ for cycle_idx in range(num_cycles):
     llwadd_exe = LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
                                      out_dir=out_dir,
                                      tags=[cycle_tag, 'FIRST'] + args.tags)
-    llwadd_exe.current_retention_level = wf.Executable.ALL_TRIGGERS
+    llwadd_exe.update_current_retention_level(wf.Executable.ALL_TRIGGERS)
     llwadd_node = llwadd_exe.create_node(workflow.analysis_time,
                                          main_sbank_files,
                                          use_tmp_subdirs=False)
@@ -330,7 +332,8 @@ for cycle_idx in range(num_cycles):
     readder_sbank_exe = SbankExecutable(workflow.cp, 'sbank',
                                         ifos=workflow.ifos, out_dir=out_dir,
                                         tags=[cycle_tag, 'readder'] + args.tags)
-    readder_sbank_execurrent_retention_level = wf.Executable.ALL_TRIGGERS
+    readder_sbank_exe.update_current_retention_level\
+            (wf.Executable.ALL_TRIGGERS)
     readder_sbank_node = readder_sbank_exe.create_node(workflow.analysis_time,
                                                        trial_bank=llwadd_out)
     workflow += readder_sbank_node
@@ -353,7 +356,7 @@ for cycle_idx in range(num_cycles):
     llwadd_exe = LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
                                      out_dir=out_dir,
                                      tags=[cycle_tag, 'FINAL'] + args.tags)
-    llwadd_exe.current_retention_level = crl
+    llwadd_exe.update_current_retention_level(crl)
 
     if seed_file is None:
         inputs = [readder_out]

--- a/bin/workflows/pycbc_create_sbank_workflow
+++ b/bin/workflows/pycbc_create_sbank_workflow
@@ -30,6 +30,7 @@ import argparse
 import pycbc
 import pycbc.version
 import pycbc.workflow as wf
+import pycbc.workflow.pegasus_workflow as pwf
 
 # Boiler-plate stuff
 __author__  = "Ian Harry <ian.harry@ligo.org>"
@@ -121,51 +122,96 @@ parser.add_argument("--workflow-name", type=str, default='sbank_workflow',
                     help="Descriptive name of the analysis.")
 parser.add_argument("-d", "--output-dir", default=None,
                     help="Path to output directory.")
+parser.add_argument("--dax-filename", type=str, default=None,
+                    help="This can be used if running this job in a "
+                         "sub-workflow to specify the dax filename.")
+parser.add_argument("--map-filename", type=str, default=None,
+                    help="This can be used if running this job in a "
+                         "sub-workflow to specify the output map filename. "
+                         "WARNING: Giving this if not running as a "
+                         "sub-workflow will cause pycbc_submit_dax to not "
+                         "work.")
+parser.add_argument("--is-sub-workflow", default=False, action="store_true",
+                    help="Only give this option if this code is being run "
+                    "as a sub-workflow within pegasus. If this means nothing "
+                    "to you, do not give this option.")
+
+
 wf.add_workflow_command_line_group(parser)
 args = parser.parse_args()
 
 # Create the workflow object
 workflow = wf.Workflow(args, args.workflow_name)
 
-wf.makedir(args.output_dir)
-os.chdir(args.output_dir)
+if not args.is_sub_workflow:
+    wf.makedir(args.output_dir)
+    os.chdir(args.output_dir)
 
 ##############################################################################
-# First add the COARSE job to start things off                               #
+# Do I have a seed bank provided and will this be used for chirp mass        #
+# boundaries? If not then add the COARSE job.                                #
 ##############################################################################
 
-wf.makedir('coarse')
-# Generate Executable class (similar to Job in the old terminology)
-# The tags=coarse option is used to ensure that options in the ['sbank-coarse']
-# section of the ini file are sent to this job, and *only* this job
-coarse_sbank_exe = SbankExecutable(workflow.cp, 'sbank', ifos=workflow.ifos,
-                                   out_dir='coarse', tags=['coarse'])
-coarse_sbank_exe.current_retention_level=wf.Executable.MERGED_TRIGGERS
-# Then make a specific node
-coarse_node = coarse_sbank_exe.create_node(workflow.analysis_time)
-# Add to workflow
-workflow += coarse_node
-# And record output file, as it will be needed later
-assert(len(coarse_node.output_files) == 1)
-coarse_file = coarse_node.output_files[0]
+seed_file = None
+bins_inp_file = None
+if workflow.cp.has_option_tags('workflow', 'seed-bank', []):
+    # If a seed bank is provided register it as a File object 
+    if not args.is_sub_workflow:
+        seed_file = wf.File.from_path(workflow.cp.get_opt_tags\
+                                      ('workflow', 'seed-bank', []))
+    else:
+        seed_file = pwf.File(os.path.basename\
+                             (workflow.cp.get_opt_tags('workflow', 'seed-bank',
+                                              [])))
+    # bins_inp_file will go to the mchirp_bins generator. seed file will go to
+    # the first set of sbank jobs if not None.
+    bins_inp_file = seed_file
+
+if not workflow.cp.has_option_tags('workflow', 'use-seed-bank-for-chirp-bins',
+                                   []):
+    out_dir = os.path.join(args.output_dir, 'coarse')
+    # Generate Executable class (similar to Job in the old terminology)
+    # The tags=coarse option is used to ensure that options in the
+    # ['sbank-coarse']section of the ini file are sent to this job, and *only*
+    # this job
+    coarse_sbank_exe = SbankExecutable(workflow.cp, 'sbank',
+                                       ifos=workflow.ifos,
+                                       out_dir=out_dir, tags=['coarse'])
+    coarse_sbank_exe.current_retention_level=wf.Executable.MERGED_TRIGGERS
+    # Then make a specific node
+    coarse_node = coarse_sbank_exe.create_node(workflow.analysis_time)
+    # Add to workflow
+    workflow += coarse_node
+    # And record output file, as it will be needed later
+    assert(len(coarse_node.output_files) == 1)
+    bins_inp_file = coarse_node.output_files[0]
+    if seed_file is None:
+        if not workflow.cp.has_option_tags('workflow',
+                                           'do-not-use-coarse-job-as-seed',
+                                           tags):
+            seed_file = seed_file
+
+if bins_inp_file is None:
+    # Only get here if weird options are given
+    err_msg = 'You have not given a seed bank but have asked to use the seed '
+    err_msg += 'bank for generating the chirp mass bins. This is not possible.'
+    raise ValueError(err_msg)
 
 ##############################################################################
-# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX                               #
+# Begin the parallelization loops                                            #
 ##############################################################################
 
 # How many repetitions to try? Get this from config-parser. Special
 # config-parser options like this go in the [workflow] section
 
 num_cycles = int(workflow.cp.get('workflow', 'num-cycles'))
-input_file = coarse_file
 
 for cycle_idx in range(num_cycles):
     #########
     # SETUP #
     #########
     cycle_tag = 'cycle%d' %(cycle_idx)
-    out_dir = cycle_tag
-    wf.makedir(cycle_tag)
+    out_dir = os.path.join(args.output_dir, cycle_tag)
 
     # How many banks to use? This can vary cycle to cycle, or be the same for
     # all. Either supply it once in [workflow], or in [workflow-cycleN] for
@@ -181,10 +227,10 @@ for cycle_idx in range(num_cycles):
                                     ifos=workflow.ifos, out_dir=out_dir,
                                     tags=[cycle_tag])
     bins_node = bins_exe.create_node(workflow.analysis_time,
-                                     input_file, nbanks)
+                                     bins_inp_file, nbanks)
     workflow += bins_node
     assert(len(bins_node.output_files) == 1)
-    bins_file = bins_node.output_files[0]
+    bins_out_file = bins_node.output_files[0]
 
     #######################
     # PARALELLIZED SBANKS #
@@ -198,11 +244,11 @@ for cycle_idx in range(num_cycles):
     main_sbank_files = wf.FileList([])
     for nbank_idx in range(nbanks):
         nbank_tag = 'nbank%d' %(nbank_idx)
-        main_sbank_node = main_sbank_exe.create_node(workflow.analysis_time,
-                                              seed_bank=input_file,
-                                              mchirp_boundaries_file=bins_file,
-                                              mchirp_boundary_idx=nbank_idx,
-                                              extra_tags=[nbank_tag])
+        main_sbank_node = (main_sbank_exe.create_node\
+                           (workflow.analysis_time, seed_bank=seed_file,
+                            mchirp_boundaries_file=bins_out_file,
+                            mchirp_boundary_idx=nbank_idx,
+                            extra_tags=[nbank_tag]))
         workflow += main_sbank_node
         assert(len(main_sbank_node.output_files) == 1)
         main_sbank_files += main_sbank_node.output_files
@@ -241,7 +287,7 @@ for cycle_idx in range(num_cycles):
 
     # Is this the final output file?
     if cycle_idx == (num_cycles - 1):
-        out_dir ='.'
+        out_dir = args.output_dir
         crl = wf.Executable.FINAL_RESULT
     else:
         crl = wf.Executable.MERGED_TRIGGERS
@@ -250,12 +296,18 @@ for cycle_idx in range(num_cycles):
                                     out_dir=out_dir, tags=[cycle_tag, 'FINAL'])
     llwadd_exe.current_retention_level = crl
 
+    if seed_file is None:
+        inputs = [seed_file]
+    else:
+        inputs = [seed_file, readder_out]
+
     llwadd_node = llwadd_exe.create_node(workflow.analysis_time,
-                                         [input_file, readder_out],
+                                         [seed_file, readder_out],
                                          use_tmp_subdirs=False)
     workflow += llwadd_node
     assert(len(llwadd_node.output_files) == 1)
     # This becomes the input file for the next loop if going again
-    input_file = llwadd_node.output_files[0]
+    seed_file = llwadd_node.output_files[0]
+    bins_inp_file = seed_file
 
-workflow.save()
+workflow.save(filename=args.dax_filename, output_map=args.map_filename)

--- a/bin/workflows/pycbc_create_sbank_workflow
+++ b/bin/workflows/pycbc_create_sbank_workflow
@@ -178,6 +178,7 @@ workflow = wf.Workflow(args, args.workflow_name)
 if not args.is_sub_workflow:
     wf.makedir(args.output_dir)
     os.chdir(args.output_dir)
+    args.output_dir = '.'
 
 ##############################################################################
 # Do I have a seed bank provided and will this be used for chirp mass        #

--- a/bin/workflows/pycbc_create_sbank_workflow
+++ b/bin/workflows/pycbc_create_sbank_workflow
@@ -85,13 +85,13 @@ class SbankExecutable(wf.Executable):
 class SbankChooseMchirpBinsExecutable(wf.Executable):
     """ Class for running lalapps_cbc_sbank_choose_mchirp_boundaries
     """
-    current_retention_level = wf.Executable.FINAL_RESULT
+    current_retention_level = wf.Executable.ALL_TRIGGERS
 
-    def create_node(self, input_file, nbanks):
+    def create_node(self, analysis_time, input_file, nbanks):
         node = wf.Executable.create_node(self)
 
         # Here we add the output file
-        node.new_output_file_opt(workflow.analysis_time, '.txt',
+        node.new_output_file_opt(analysis_time, '.txt',
                                  '--output-file', tags=self.tags)
 
         # And the input file, which is an argument, not an option
@@ -140,6 +140,7 @@ wf.makedir('coarse')
 # section of the ini file are sent to this job, and *only* this job
 coarse_sbank_exe = SbankExecutable(workflow.cp, 'sbank', ifos=workflow.ifos,
                                    out_dir='coarse', tags=['coarse'])
+coarse_sbank_exe.current_retention_level=wf.Executable.MERGED_TRIGGERS
 # Then make a specific node
 coarse_node = coarse_sbank_exe.create_node(workflow.analysis_time)
 # Add to workflow
@@ -179,7 +180,8 @@ for cycle_idx in range(num_cycles):
     bins_exe = SbankChooseMchirpBinsExecutable(workflow.cp, 'sbank_mchirp_bins',
                                     ifos=workflow.ifos, out_dir=out_dir,
                                     tags=[cycle_tag])
-    bins_node = bins_exe.create_node(input_file, nbanks)
+    bins_node = bins_exe.create_node(workflow.analysis_time,
+                                     input_file, nbanks)
     workflow += bins_node
     assert(len(bins_node.output_files) == 1)
     bins_file = bins_node.output_files[0]
@@ -190,6 +192,9 @@ for cycle_idx in range(num_cycles):
 
     main_sbank_exe = SbankExecutable(workflow.cp, 'sbank', ifos=workflow.ifos,
                                  out_dir=out_dir, tags=['parallel', cycle_tag])
+    # These jobs we don't always want to store
+    main_sbank_exe.current_retention_level=wf.Executable.INTERMEDIATE_PRODUCT
+
     main_sbank_files = wf.FileList([])
     for nbank_idx in range(nbanks):
         nbank_tag = 'nbank%d' %(nbank_idx)
@@ -208,6 +213,7 @@ for cycle_idx in range(num_cycles):
 
     llwadd_exe = wf.LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
                                     out_dir=out_dir, tags=[cycle_tag, 'FIRST'])
+    llwadd_exe.current_retention_level = wf.Executable.ALL_TRIGGERS
     llwadd_node = llwadd_exe.create_node(workflow.analysis_time,
                                          main_sbank_files,
                                          use_tmp_subdirs=False)
@@ -222,9 +228,9 @@ for cycle_idx in range(num_cycles):
     readder_sbank_exe = SbankExecutable(workflow.cp, 'sbank',
                                         ifos=workflow.ifos, out_dir=out_dir,
                                         tags=[cycle_tag, 'readder'])
+    readder_sbank_execurrent_retention_level = wf.Executable.ALL_TRIGGERS
     readder_sbank_node = readder_sbank_exe.create_node(workflow.analysis_time,
-                                              seed_bank=input_file,
-                                              trial_bank=llwadd_out)
+                                                       trial_bank=llwadd_out)
     workflow += readder_sbank_node
     assert(len(readder_sbank_node.output_files) == 1)
     readder_out = readder_sbank_node.output_files[0]
@@ -236,9 +242,14 @@ for cycle_idx in range(num_cycles):
     # Is this the final output file?
     if cycle_idx == (num_cycles - 1):
         out_dir ='.'
+        crl = wf.Executable.FINAL_RESULT
+    else:
+        crl = wf.Executable.MERGED_TRIGGERS
 
     llwadd_exe = wf.LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
                                     out_dir=out_dir, tags=[cycle_tag, 'FINAL'])
+    llwadd_exe.current_retention_level = crl
+
     llwadd_node = llwadd_exe.create_node(workflow.analysis_time,
                                          [input_file, readder_out],
                                          use_tmp_subdirs=False)

--- a/bin/workflows/pycbc_create_uberbank_workflow
+++ b/bin/workflows/pycbc_create_uberbank_workflow
@@ -55,13 +55,17 @@ class GeomBankExecutable(wf.Executable):
                           '--fake-strain-from-file', '--injection-file',
                           '--sgburst-injection-file', '--gating-file']
 
-    def create_node(self, analysis_time, geom_out_file,
+    def create_node(self, analysis_time, geom_out_file, out_storage_path,
                     workflow_name='geom_bank'):
         node = wf.Executable.create_node(self)
         
         # Output file: This one is done weirdly because this job doesn't
         # actually produce this file, the resulting dax will do that.
         node.add_opt('--output-file', geom_out_file.name)
+      
+
+        node.add_opt('--storage-path-base', out_storage_path)      
+        node.add_opt('--is-sub-workflow','')
 
         # Intermediate outputs and dax files
         node.new_output_file_opt(analysis_time, '.hdf',
@@ -70,16 +74,16 @@ class GeomBankExecutable(wf.Executable):
         node.new_output_file_opt(analysis_time, '.xml',
                                  '--metadata-file', 
                                  tags=self.tags + ['METADATA'])
-        node.new_output_file_opt(analysis_time, '.map',
-                                 '--map-filename',
-                                 tags=self.tags + ['MAP'])
         node.new_output_file_opt(analysis_time, '.dax',
                                  '--dax-filename',
                                  tags=self.tags + ['DAX'])
+        node.new_output_file_opt(analysis_time, '.map',
+                                 '--map-filename',
+                                 tags=self.tags + ['MAP'])
         return node
 
 class SbankDaxGenerator(wf.Executable):
-    """ Class for running pycbc_geom_aligned_bank.
+    """ Class for running pycbc_create_sbank_workflow.
     """
     # This outputs a dax file.
     current_retention_level = wf.Executable.FINAL_RESULT
@@ -87,33 +91,38 @@ class SbankDaxGenerator(wf.Executable):
     # This tells us about input file options
     file_input_options = []
  
-    def create_node(self, analysis_time, config_file, workflow_name='sbank'):
+    def create_node(self, analysis_time, config_file, out_storage_path,
+                    seed_file=None, use_seed_file_for_chirp_bins=True,
+                    workflow_name='sbank_workflow'):
         """ Create a sbank dax generator node.
         """
         node = wf.Executable.create_node(self)
 
-        dax_lfn = '%s.dax' % workflow_name
-        dax_path = os.path.join(geom_exe.out_dir, dax_lfn)
-        dax_url = urlparse.urlunparse(['file', 'localhost', dax_path,
-                                       None, None, None])
-        dax_file = wf.File(self.ifo_list, geom_exe.name,
-                           analysis_time, file_url=dax_url,
-                           store_file=True)
-        map_lfn = '%s.map' % workflow_name
-        map_path = os.path.join(geom_exe.out_dir, map_lfn)
-        map_url = urlparse.urlunparse(['file', 'localhost', map_path,
-                                       None, None, None])
-        map_file = wf.File(self.ifo_list, geom_exe.name,
-                           analysis_time, file_url=map_url,
-                           store_file=True)
-
         node.add_opt('--workflow-name', workflow_name)
-        node.add_opt('--output-dir', '.')
+        node.add_opt('--output-dir', out_storage_path)
+        node.add_opt('--is-sub-workflow','')
 
         node.add_input_opt('--config-files', config_file)
 
-        node._add_output(dax_file)
-        node._add_output(map_file)
+        config_overrides = []
+
+        if seed_file is not None:
+            seed_file = os.path.basename(seed_file)
+            config_overrides.append('workflow:seed-bank:%s' % seed_file)
+            if use_seed_file_for_chirp_bins:
+                config_overrides.append\
+                    ('workflow:use-seed-bank-for-chirp-bins:')
+
+        if len(config_overrides):
+            node.add_opt('--config-overrides', ' '.join(config_overrides))
+                                       
+
+        node.new_output_file_opt(analysis_time, '.dax',
+                                 '--dax-filename',
+                                 tags=self.tags + ['DAX'])
+        node.new_output_file_opt(analysis_time, '.map',
+                                 '--map-filename',
+                                 tags=self.tags + ['MAP'])
 
         return node
 
@@ -150,19 +159,29 @@ geom_exe = GeomBankExecutable(workflow.cp, 'geom_aligned_bank',
                               ifos=workflow.ifos, out_dir='daxes')
 # This one's a bit weird as the dag generator names the final output file,
 # but that job doesn't *generate* it, so we create this file first.
+# However, this file must *not* appear in the output mapper, as then the 
+# sub-workflow will think that it already exists. So for now we are setting
+# store_file=False and relying on the sub-workflow to specify the PFN for this
+# file. Hopefully this will work if we need to add this file as a dependancy
+# for a later sub-workflow.
 geom_out_file = wf.File(geom_exe.ifo_list, geom_exe.name,
                         workflow.analysis_time, extension='.xml',
                         store_file=True, directory=geom_exe.out_dir,
                         tags=[], use_tmp_subdirs=False)
-geom_node = geom_exe.create_node(workflow.analysis_time,
-                                 workflow_name='initial_geom_bank',
-                                 geom_out_file=geom_out_file)
+geom_node = geom_exe.create_node(workflow.analysis_time, geom_out_file,
+                                 os.path.abspath('initial_geom_bank'),
+                                 workflow_name='initial_geom_bank')
 workflow += geom_node
 
+# Verify files are the correct ones, they have unique extensions
 intermediate_file = geom_node.output_files[0]
+assert(intermediate_file.name.endswith('hdf'))
 metadata_file = geom_node.output_files[1]
+assert(metadata_file.name.endswith('xml'))
 dax_file = geom_node.output_files[2]
+assert(dax_file.name.endswith('.dax'))
 map_file = geom_node.output_files[3]
+assert(map_file.name.endswith('.map'))
 
 # NOTE: One can use workflow += dax_job, but this seems to miss a bunch of
 #       the stuff done below, and does not consider file management
@@ -177,13 +196,16 @@ dax_job.uses(metadata_file, link=dax.Link.INPUT, register=False, transfer=True)
 dax_job.uses(intermediate_file, link=dax.Link.INPUT, register=False,
              transfer=True)
 dax_job.uses(map_file, link=dax.Link.INPUT, register=False, transfer=True)
-dax_job.uses(geom_out_file, link=dax.Link.OUTPUT, register=False,
-             transfer=True)
+# NOTE: Telling the dax that it uses the output file causes the sub-workflow
+#       to fail as the output file is then passed in the input map, and the
+#       sub-workflow believes it already exists and doesn't produce it!
+#dax_job.uses(geom_out_file, link=dax.Link.OUTPUT, register=False,
+#             transfer=True)
 
 workflow._adag.addJob(dax_job)
 dep = dax.Dependency(parent=geom_node._dax_node, child=dax_job)
 workflow._adag.addDependency(dep)
-geom_out_file.node = dax_job
+geom_dax_job = dax_job
 
 workflow._outputs += [geom_out_file]
 
@@ -191,8 +213,8 @@ workflow._outputs += [geom_out_file]
 # Run the sbank workflow for the first time  #
 ##############################################
 
-sbank_exe = SbankDaxGenerator(workflow.cp, 'sbank', ifos=workflow.ifos,
-                              out_dir='daxes')
+sbank_exe = SbankDaxGenerator(workflow.cp, 'sbank_workflow',
+                              ifos=workflow.ifos, out_dir='daxes')
 
 config_path = os.path.abspath('daxes' + '/' + 'sbank_workflow.ini')
 workflow.cp.write(open(config_path, 'w'))
@@ -200,6 +222,9 @@ workflow.cp.write(open(config_path, 'w'))
 config_file = wf.File.from_path(config_path)
 
 sbank_node = sbank_exe.create_node(workflow.analysis_time, config_file,
+                                   os.path.abspath('sbank_first'),
+                                   seed_file=geom_out_file.name,
+                                   use_seed_file_for_chirp_bins=False,
                                    workflow_name='sbank_first')
 
 workflow += sbank_node
@@ -210,8 +235,18 @@ dax_job = dax.DAX(dax_file)
 dax_job.addArguments('--basename %s' % \
                      os.path.splitext(os.path.basename(dax_file.name))[0])
 wf.Workflow.set_job_properties(dax_job, map_file.name)
+
+# Cannot tell the dax job it uses the geom_file because it doesn't understand
+# where this will come from until the sub-workflow gets planned.
+# dax_job.uses(geom_out_file, link=dax.Link.INPUT, register=False,
+#              transfer=True)
+
 workflow._adag.addJob(dax_job)
-# dep = dax.Dependency(parent=geom_node._dax_node, child=dax_job)
-# workflow._adag.addDependency(dep)
+dep = dax.Dependency(parent=sbank_node._dax_node, child=dax_job)
+workflow._adag.addDependency(dep)
+# We must explicitly connect the daxes to allow file dependancies across
+# sub-workflows
+dep = dax.Dependency(parent=geom_dax_job, child=dax_job)
+workflow._adag.addDependency(dep)
 
 workflow.save()

--- a/bin/workflows/pycbc_create_uberbank_workflow
+++ b/bin/workflows/pycbc_create_uberbank_workflow
@@ -1,0 +1,217 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2016 Ian W. Harry
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+Workflow generator for the 'uberbank' template bank construction. The script
+as written runs one configurable example of sbank, and one of
+pycbc_geom_aligned_bank independently. It then combines these two banks
+together and runs a second example of sbank and the resulting output. It is
+foreseen that this script would be altered to generate workflows in slightly
+different configurations to the one described, so hopefully the script is
+clear enough to allow someone to do that.
+"""
+
+#imports
+from __future__ import division
+import os
+import argparse
+import urlparse
+from Pegasus import DAX3 as dax
+import pycbc
+import pycbc.version
+import pycbc.workflow as wf
+
+# Boiler-plate stuff
+__author__  = "Ian Harry <ian.harry@ligo.org>"
+__version__ = pycbc.version.git_verbose_msg
+__date__    = pycbc.version.date
+__program__ = "pycbc_create_sbank_workflow"
+
+# Define classes for executables
+
+class GeomBankExecutable(wf.Executable):
+    """ Class for running pycbc_geom_aligned_bank.
+    """
+    # This outputs a dax file.
+    current_retention_level = wf.Executable.FINAL_RESULT
+
+    # This tells us about input file options
+    file_input_options = ['--psd-file', '--asd-file',
+                          '--fake-strain-from-file', '--injection-file',
+                          '--sgburst-injection-file', '--gating-file']
+
+    def create_node(self, analysis_time, geom_out_file,
+                    workflow_name='geom_bank'):
+        node = wf.Executable.create_node(self)
+        
+        # Output file: This one is done weirdly because this job doesn't
+        # actually produce this file, the resulting dax will do that.
+        node.add_opt('--output-file', geom_out_file.name)
+
+        # Intermediate outputs and dax files
+        node.new_output_file_opt(analysis_time, '.hdf',
+                                 '--intermediate-data-file',
+                                 tags=self.tags + ['INTERMEDIATE'])
+        node.new_output_file_opt(analysis_time, '.xml',
+                                 '--metadata-file', 
+                                 tags=self.tags + ['METADATA'])
+        node.new_output_file_opt(analysis_time, '.map',
+                                 '--map-filename',
+                                 tags=self.tags + ['MAP'])
+        node.new_output_file_opt(analysis_time, '.dax',
+                                 '--dax-filename',
+                                 tags=self.tags + ['DAX'])
+        return node
+
+class SbankDaxGenerator(wf.Executable):
+    """ Class for running pycbc_geom_aligned_bank.
+    """
+    # This outputs a dax file.
+    current_retention_level = wf.Executable.FINAL_RESULT
+
+    # This tells us about input file options
+    file_input_options = []
+ 
+    def create_node(self, analysis_time, config_file, workflow_name='sbank'):
+        """ Create a sbank dax generator node.
+        """
+        node = wf.Executable.create_node(self)
+
+        dax_lfn = '%s.dax' % workflow_name
+        dax_path = os.path.join(geom_exe.out_dir, dax_lfn)
+        dax_url = urlparse.urlunparse(['file', 'localhost', dax_path,
+                                       None, None, None])
+        dax_file = wf.File(self.ifo_list, geom_exe.name,
+                           analysis_time, file_url=dax_url,
+                           store_file=True)
+        map_lfn = '%s.map' % workflow_name
+        map_path = os.path.join(geom_exe.out_dir, map_lfn)
+        map_url = urlparse.urlunparse(['file', 'localhost', map_path,
+                                       None, None, None])
+        map_file = wf.File(self.ifo_list, geom_exe.name,
+                           analysis_time, file_url=map_url,
+                           store_file=True)
+
+        node.add_opt('--workflow-name', workflow_name)
+        node.add_opt('--output-dir', '.')
+
+        node.add_input_opt('--config-files', config_file)
+
+        node._add_output(dax_file)
+        node._add_output(map_file)
+
+        return node
+
+##############################################################################
+# Argument parsing and setup of workflow                                     #
+##############################################################################
+
+
+# Use the standard workflow command-line parsing routines. Things like a 
+# configuration file are specified within the "workflow command line group"
+# so run this with --help to see what options are added.
+_desc = __doc__[1:]
+parser = argparse.ArgumentParser(description=_desc)
+parser.add_argument('--version', action='version', version=__version__)
+parser.add_argument("--workflow-name", type=str, default='sbank_workflow',
+                    help="Descriptive name of the analysis.")
+parser.add_argument("-d", "--output-dir", default=None,
+                    help="Path to output directory.")
+wf.add_workflow_command_line_group(parser)
+args = parser.parse_args()
+
+# Create the workflow object
+workflow = wf.Workflow(args, args.workflow_name)
+
+wf.makedir(args.output_dir)
+os.chdir(args.output_dir)
+wf.makedir('daxes')
+
+##############################################
+# Run the geom_bank workflow the first time  #
+##############################################
+
+geom_exe = GeomBankExecutable(workflow.cp, 'geom_aligned_bank',
+                              ifos=workflow.ifos, out_dir='daxes')
+# This one's a bit weird as the dag generator names the final output file,
+# but that job doesn't *generate* it, so we create this file first.
+geom_out_file = wf.File(geom_exe.ifo_list, geom_exe.name,
+                        workflow.analysis_time, extension='.xml',
+                        store_file=True, directory=geom_exe.out_dir,
+                        tags=[], use_tmp_subdirs=False)
+geom_node = geom_exe.create_node(workflow.analysis_time,
+                                 workflow_name='initial_geom_bank',
+                                 geom_out_file=geom_out_file)
+workflow += geom_node
+
+intermediate_file = geom_node.output_files[0]
+metadata_file = geom_node.output_files[1]
+dax_file = geom_node.output_files[2]
+map_file = geom_node.output_files[3]
+
+# NOTE: One can use workflow += dax_job, but this seems to miss a bunch of
+#       the stuff done below, and does not consider file management
+dax_job = dax.DAX(dax_file)
+dax_job.addArguments('--basename %s' % \
+                     os.path.splitext(os.path.basename(dax_file.name))[0])
+wf.Workflow.set_job_properties(dax_job, map_file.name)
+
+# Tell the dax job that it needs some input files
+# FIXME: I think we need to add some more functionality to our sub-dax classes
+dax_job.uses(metadata_file, link=dax.Link.INPUT, register=False, transfer=True)
+dax_job.uses(intermediate_file, link=dax.Link.INPUT, register=False,
+             transfer=True)
+dax_job.uses(map_file, link=dax.Link.INPUT, register=False, transfer=True)
+dax_job.uses(geom_out_file, link=dax.Link.OUTPUT, register=False,
+             transfer=True)
+
+workflow._adag.addJob(dax_job)
+dep = dax.Dependency(parent=geom_node._dax_node, child=dax_job)
+workflow._adag.addDependency(dep)
+geom_out_file.node = dax_job
+
+workflow._outputs += [geom_out_file]
+
+##############################################
+# Run the sbank workflow for the first time  #
+##############################################
+
+sbank_exe = SbankDaxGenerator(workflow.cp, 'sbank', ifos=workflow.ifos,
+                              out_dir='daxes')
+
+config_path = os.path.abspath('daxes' + '/' + 'sbank_workflow.ini')
+workflow.cp.write(open(config_path, 'w'))
+
+config_file = wf.File.from_path(config_path)
+
+sbank_node = sbank_exe.create_node(workflow.analysis_time, config_file,
+                                   workflow_name='sbank_first')
+
+workflow += sbank_node
+
+dax_file = sbank_node.output_files[0]
+map_file = sbank_node.output_files[1]
+dax_job = dax.DAX(dax_file)
+dax_job.addArguments('--basename %s' % \
+                     os.path.splitext(os.path.basename(dax_file.name))[0])
+wf.Workflow.set_job_properties(dax_job, map_file.name)
+workflow._adag.addJob(dax_job)
+# dep = dax.Dependency(parent=geom_node._dax_node, child=dax_job)
+# workflow._adag.addDependency(dep)
+
+workflow.save()

--- a/bin/workflows/pycbc_create_uberbank_workflow
+++ b/bin/workflows/pycbc_create_uberbank_workflow
@@ -172,12 +172,13 @@ geom_exe = GeomBankExecutable(workflow.cp, 'geom_aligned_bank',
 # store_file=False and relying on the sub-workflow to specify the PFN for this
 # file. Hopefully this will work if we need to add this file as a dependancy
 # for a later sub-workflow.
+geom_out_dir = os.path.abspath('initial_geom_bank')
 geom_out_file = wf.File(geom_exe.ifo_list, geom_exe.name,
                         workflow.analysis_time, extension='.xml',
-                        store_file=True, directory=geom_exe.out_dir,
+                        store_file=True, directory=geom_out_dir,
                         tags=[], use_tmp_subdirs=False)
 geom_node = geom_exe.create_node(workflow.analysis_time, geom_out_file,
-                                 os.path.abspath('initial_geom_bank'),
+                                 geom_out_dir,
                                  workflow_name='initial_geom_bank')
 workflow += geom_node
 

--- a/bin/workflows/pycbc_create_uberbank_workflow
+++ b/bin/workflows/pycbc_create_uberbank_workflow
@@ -61,7 +61,7 @@ class GeomBankExecutable(wf.Executable):
         
         # Output file: This one is done weirdly because this job doesn't
         # actually produce this file, the resulting dax will do that.
-        node.add_opt('--output-file', geom_out_file.name)
+        node.add_opt('--output-file', geom_out_file.storage_path)
       
 
         node.add_opt('--storage-path-base', out_storage_path)      
@@ -92,26 +92,34 @@ class SbankDaxGenerator(wf.Executable):
     file_input_options = []
  
     def create_node(self, analysis_time, config_file, out_storage_path,
-                    seed_file=None, use_seed_file_for_chirp_bins=True,
-                    workflow_name='sbank_workflow'):
+                    output_file, seed_files=None,
+                    workflow_name='sbank_workflow', sub_wf_tags=None):
         """ Create a sbank dax generator node.
         """
         node = wf.Executable.create_node(self)
+
+        # Output file: This one is done weirdly because this job doesn't
+        # actually produce this file, the resulting dax will do that.
+        node.add_opt('--output-file', output_file.storage_path)
+
 
         node.add_opt('--workflow-name', workflow_name)
         node.add_opt('--output-dir', out_storage_path)
         node.add_opt('--is-sub-workflow','')
 
+        if sub_wf_tags is not None:
+            node.add_opt('--tags', ' '.join(sub_wf_tags))
+
         node.add_input_opt('--config-files', config_file)
 
         config_overrides = []
 
-        if seed_file is not None:
-            seed_file = os.path.basename(seed_file)
-            config_overrides.append('workflow:seed-bank:%s' % seed_file)
-            if use_seed_file_for_chirp_bins:
-                config_overrides.append\
-                    ('workflow:use-seed-bank-for-chirp-bins:')
+        if seed_files is not None:
+            sfs = []
+            for seed_file in seed_files:
+                seed_file = os.path.basename(seed_file)
+                sfs.append(seed_file)
+            config_overrides.append('workflow:seed-bank:"%s"' % ' '.join(sfs))
 
         if len(config_overrides):
             node.add_opt('--config-overrides', ' '.join(config_overrides))
@@ -119,10 +127,10 @@ class SbankDaxGenerator(wf.Executable):
 
         node.new_output_file_opt(analysis_time, '.dax',
                                  '--dax-filename',
-                                 tags=self.tags + ['DAX'])
+                                 tags=self.tags + sub_wf_tags + ['DAX'])
         node.new_output_file_opt(analysis_time, '.map',
                                  '--map-filename',
-                                 tags=self.tags + ['MAP'])
+                                 tags=self.tags + sub_wf_tags + ['MAP'])
 
         return node
 
@@ -191,41 +199,41 @@ dax_job.addArguments('--basename %s' % \
 wf.Workflow.set_job_properties(dax_job, map_file.name)
 
 # Tell the dax job that it needs some input files
-# FIXME: I think we need to add some more functionality to our sub-dax classes
 dax_job.uses(metadata_file, link=dax.Link.INPUT, register=False, transfer=True)
 dax_job.uses(intermediate_file, link=dax.Link.INPUT, register=False,
              transfer=True)
 dax_job.uses(map_file, link=dax.Link.INPUT, register=False, transfer=True)
-# NOTE: Telling the dax that it uses the output file causes the sub-workflow
-#       to fail as the output file is then passed in the input map, and the
-#       sub-workflow believes it already exists and doesn't produce it!
+
+# And this output is used again so declare it. See notes at bottom!!!
 #dax_job.uses(geom_out_file, link=dax.Link.OUTPUT, register=False,
-#             transfer=True)
+#             transfer=False)
 
 workflow._adag.addJob(dax_job)
 dep = dax.Dependency(parent=geom_node._dax_node, child=dax_job)
 workflow._adag.addDependency(dep)
 geom_dax_job = dax_job
 
-workflow._outputs += [geom_out_file]
-
-##############################################
-# Run the sbank workflow for the first time  #
-##############################################
+###############################################
+# Run the sbank workflow for the first time   #
+###############################################
 
 sbank_exe = SbankDaxGenerator(workflow.cp, 'sbank_workflow',
                               ifos=workflow.ifos, out_dir='daxes')
 
+sbank_out_file_bbh = wf.File(sbank_exe.ifo_list, sbank_exe.name,
+                             workflow.analysis_time, extension='.xml',
+                             store_file=True, directory=sbank_exe.out_dir,
+                             tags=['sbank_bbh'], use_tmp_subdirs=False)
+
 config_path = os.path.abspath('daxes' + '/' + 'sbank_workflow.ini')
 workflow.cp.write(open(config_path, 'w'))
-
 config_file = wf.File.from_path(config_path)
 
 sbank_node = sbank_exe.create_node(workflow.analysis_time, config_file,
-                                   os.path.abspath('sbank_first'),
-                                   seed_file=geom_out_file.name,
-                                   use_seed_file_for_chirp_bins=False,
-                                   workflow_name='sbank_first')
+                                   os.path.abspath('sbank_bbh'),
+                                   sbank_out_file_bbh,
+                                   workflow_name='sbank_bbh',
+                                   sub_wf_tags=['bbh'])
 
 workflow += sbank_node
 
@@ -236,17 +244,75 @@ dax_job.addArguments('--basename %s' % \
                      os.path.splitext(os.path.basename(dax_file.name))[0])
 wf.Workflow.set_job_properties(dax_job, map_file.name)
 
-# Cannot tell the dax job it uses the geom_file because it doesn't understand
-# where this will come from until the sub-workflow gets planned.
-# dax_job.uses(geom_out_file, link=dax.Link.INPUT, register=False,
-#              transfer=True)
+#dax_job.uses(sbank_out_file_bbh, link=dax.Link.OUTPUT, register=False,
+#             transfer=False)
+dax_job.uses(map_file, link=dax.Link.INPUT, register=False,
+             transfer=False)
 
 workflow._adag.addJob(dax_job)
 dep = dax.Dependency(parent=sbank_node._dax_node, child=dax_job)
 workflow._adag.addDependency(dep)
-# We must explicitly connect the daxes to allow file dependancies across
-# sub-workflows
+sbank_bbh_dax_job = dax_job
+
+###############################################
+# Run the sbank workflow for the second time  #
+###############################################
+
+sbank_out_file_final = wf.File(sbank_exe.ifo_list, sbank_exe.name,
+                         workflow.analysis_time, extension='.xml',
+                         store_file=True, directory='.',
+                         tags=['sbank_final'], use_tmp_subdirs=False)
+
+sbank_node = sbank_exe.create_node(workflow.analysis_time, config_file,
+                                   os.path.abspath('sbank_final'),
+                                   sbank_out_file_final,
+                                   seed_files=[geom_out_file.name,
+                                               sbank_out_file_bbh.name],
+                                   workflow_name='sbank_final',
+                                   sub_wf_tags=['final'])
+
+workflow += sbank_node
+
+dax_file = sbank_node.output_files[0]
+map_file = sbank_node.output_files[1]
+dax_job = dax.DAX(dax_file)
+dax_job.addArguments('--basename %s' % \
+                     os.path.splitext(os.path.basename(dax_file.name))[0])
+wf.Workflow.set_job_properties(dax_job, map_file.name)
+
+dax_job.uses(map_file, link=dax.Link.INPUT, register=False,
+             transfer=True)
+
+workflow._adag.addJob(dax_job)
+dep = dax.Dependency(parent=sbank_node._dax_node, child=dax_job)
+workflow._adag.addDependency(dep)
+dep = dax.Dependency(parent=sbank_bbh_dax_job, child=dax_job)
+workflow._adag.addDependency(dep)
 dep = dax.Dependency(parent=geom_dax_job, child=dax_job)
 workflow._adag.addDependency(dep)
 
+
 workflow.save()
+
+# NOTES: Here are things that I found during writing this that will be useful
+#        if changing this around in the future.
+
+# 1: If we have two sub-daxes with a file dependancy (ie. dax B uses a file
+#    produced from dax A). Even if these are not *direct* parent-child related
+#    one must add an explicit dax dependency between the two sub-daxes:
+#    dep = dax.Dependency(parent=parent_dax_job, child=child_dax_job)
+
+# 2: If a sub-dax uses as input a file from the parent workflow, one can a
+#    dax.uses() command to list that file as an input. This is probably
+#    unncessary but it does avoid potential issues with cleanup jobs. The
+#    input mapper should be listed as an input! Should the dax file itself
+#    also be listed? Currently it is not
+
+# 3: The case of a sub-dax producing an output file used by a job (not another
+#    sub-dax) in the uberworkflow appears unsupported. If I do not list the
+#    file as an output of the dax job - with dax.uses - then the uberworkflow
+#    will not plan as it does not understand where that file comes from.
+#    However, if the file *is* listed as an output it will be sent in the
+#    input map catalog to the sub-dax (which contains the local locations of
+#    all files in the uber-workflow). Then the sub-workflow thinks that this
+#    file already exists and does not run the job that generates it.

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -304,7 +304,6 @@ class Executable(pegasus_workflow.Executable):
         sec : string
             The section containing options for this job.
         """
-
         for opt in cp.options(sec):
             namespace = opt.split('|')[0]
             if namespace == 'pycbc':
@@ -328,7 +327,6 @@ class Executable(pegasus_workflow.Executable):
         sec : string
             The section containing options for this job.
         """
-
         for opt in cp.options(sec):
             value = string.strip(cp.get(sec, opt))
             opt = '--%s' %(opt,)
@@ -359,7 +357,6 @@ class Executable(pegasus_workflow.Executable):
         value : string, (default=None)
             The value for the option (no value if set to None).
         """
-
         if value is None:
             self.common_options += [opt]
         else:
@@ -378,7 +375,6 @@ class Executable(pegasus_workflow.Executable):
         value : string
             The value for the option. Returns None if option not present.
         """
-
         for sec in self.sections:
             try:
                 key = self.cp.get(sec, opt)
@@ -397,7 +393,6 @@ class Executable(pegasus_workflow.Executable):
         opt : string
             Name of option (e.g. output-file-format)
         """
-
         for sec in self.sections:
             val = self.cp.has_option(sec, opt)
             if val:
@@ -429,7 +424,7 @@ class Executable(pegasus_workflow.Executable):
             global_retention_level = \
                 self.cp.get_opt_tags("workflow", "file-retention-level",
                                    self.tags+[self.name])
-        except:
+        except ConfigParser.Error:
             msg="Cannot find file-retention-level in [workflow] section "
             msg+="of the configuration file. Setting a default value of "
             msg+="retain all files."

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -282,7 +282,8 @@ class Executable(pegasus_workflow.Executable):
             self.add_profile('pegasus', 'clusters.size', self.group_jobs)        
     @property
     def ifo(self):
-        """
+        """Return the ifo.
+
         If only one ifo in the ifo list this will be that ifo. Otherwise an
         error is raised.
         """
@@ -294,6 +295,16 @@ class Executable(pegasus_workflow.Executable):
             raise TypeError(errMsg)
 
     def add_ini_profile(self, cp, sec):
+        """Add profile from configuration file.
+
+        Parameters
+        -----------
+        cp : ConfigParser object
+            The ConfigParser object holding the workflow configuration settings
+        sec : string
+            The section containing options for this job.
+        """
+
         for opt in cp.options(sec):
             namespace = opt.split('|')[0]
             if namespace == 'pycbc':
@@ -308,6 +319,16 @@ class Executable(pegasus_workflow.Executable):
                 self.execution_site = value
 
     def add_ini_opts(self, cp, sec):
+        """Add job-specific options from configuration file.
+
+        Parameters
+        -----------
+        cp : ConfigParser object
+            The ConfigParser object holding the workflow configuration settings
+        sec : string
+            The section containing options for this job.
+        """
+
         for opt in cp.options(sec):
             value = string.strip(cp.get(sec, opt))
             opt = '--%s' %(opt,)
@@ -329,12 +350,35 @@ class Executable(pegasus_workflow.Executable):
             self.common_options += [opt, value]
             
     def add_opt(self, opt, value=None):
+        """Add option to job.
+
+        Parameters
+        -----------
+        opt : string
+            Name of option (e.g. --output-file-format)
+        value : string, (default=None)
+            The value for the option (no value if set to None).
+        """
+
         if value is None:
             self.common_options += [opt]
         else:
             self.common_options += [opt, value]
             
     def get_opt(self, opt):
+        """Get value of option from configuration file
+
+        Parameters
+        -----------
+        opt : string
+            Name of option (e.g. output-file-format)
+
+        Returns
+        --------
+        value : string
+            The value for the option. Returns None if option not present.
+        """
+
         for sec in self.sections:
             try:
                 key = self.cp.get(sec, opt)
@@ -346,6 +390,14 @@ class Executable(pegasus_workflow.Executable):
         return None
 
     def has_opt(self, opt):
+        """Check if option is present in configuration file
+
+        Parameters
+        -----------
+        opt : string
+            Name of option (e.g. output-file-format)
+        """
+
         for sec in self.sections:
             val = self.cp.has_option(sec, opt)
             if val:
@@ -354,14 +406,22 @@ class Executable(pegasus_workflow.Executable):
         return False
 
     def create_node(self):
-        """ Default node constructor. This is usually overridden by subclasses
-        of Executable.
+        """Default node constructor.
+
+        This is usually overridden by subclasses of Executable.
         """
         return Node(self)
 
     def update_current_retention_level(self, value):
-        """ Update the value of self.retain_files for an updated value of the
+        """Set a new value for the current retention level.
+
+        This updates the value of self.retain_files for an updated value of the
         retention level.
+
+        Parameters
+        -----------
+        value : int
+            The new value to use for the retention level.
         """
         # Determine the level at which output files should be kept
         self.current_retention_level = value
@@ -391,7 +451,7 @@ class Executable(pegasus_workflow.Executable):
             except KeyError:
                 err_msg = "Cannot recognize the file-retention-level in the "
                 err_msg += "[workflow] section of the ini file. "
-                err_msg += "Got : %s." %(global_retention_level,)
+                err_msg += "Got : {0}.".format(global_retention_level)
                 err_msg += "Valid options are: 'all_files', 'all_triggers',"
                 err_msg += "'merged_triggers' or 'results' "
                 raise ValueError(err_msg)
@@ -401,7 +461,7 @@ class Executable(pegasus_workflow.Executable):
                     pass
                 else:
                     warn_msg = "Attribute current_retention_level has not "
-                    warn_msg += "been set in class %s. " %(type(self),)
+                    warn_msg += "been set in class {0}. ".format(type(self))
                     warn_msg += "This value should be set explicitly. "
                     warn_msg += "All output from this class will be stored."
                     logging.warn(warn_msg)

--- a/setup.py
+++ b/setup.py
@@ -474,6 +474,7 @@ setup (
                'bin/inference/pycbc_inference_table_summary',
                'bin/plotting/pycbc_plot_waveform',
                'bin/workflows/pycbc_create_sbank_workflow',
+               'bin/workflows/pycbc_create_uberbank_workflow',
                ],
     packages = [
                'pycbc',


### PR DESCRIPTION
Hi all,

This is the rest of the changes to implement an uberbank workflow in pegasus. To summarize: This, coupled with #986 #976 and #973, implements the following changes:

GEOM BANK

 * The geometric bank workflow is moved over from glue.pipeline to pycbc.workflow. (#973)
 * The geometric bank workflow is edited to use HDF files (and many less files) for internal data products (output is still XML in standard format) (#986)
 * The geometric bank codes are optimized with some numpy-isation (#986)
 * Support for running the geom bank as a sub-workflow is added (here)
 * The general structure of the geom_bank workflow, and scientific input choices, are unchanged. One should still be able to reproduce previous output with the new code.

SBANK

 * A new sbank workflow generator is created using pycbc.workflow, intended to deprecate the version in lalapps (#976).
 * This workflow uses recent changes in sbank to allow for more flexibility in the workflow (#976 and here)
   * Specifically we now have the concept of multiple parallel stages allowing the bank to built up over time, while the user can monitor the process, the chirp-mass binning is also updated each cycle allowing for more efficiency
   * A "readder" stage is added to ensure the parallel jobs do not place templates at the same point in parameter space.
 * Support is added to allow the sbank workflow generator to run as a sub-workflow as well as a standalone workflow. (here)

UBERBANK (all changes here)

 * A, let's call it "first draft", of the uberbank workflow is added, demonstrating how to tie sbank and geom_bank workflows together.
 * This implementation runs 1 sbank workflow and 1 geom_bank workflow independently at first, and then runs 1 further sbank workflow using input from the original two workflows as a seed bank.
 * It would be good to add more flexibility in the structure, but this makes a start, and we can add functionality as needed.
 * Handling of sub-daxes in pycbc.workflow is not as neat as normal files. We might want to consider extending upon the Dax class in workflow.core to make some of the stuff here a little more automatic.

CONFIG FILES

 * I'm still working an optimal config files for this. Especially sbank now has a bunch of knobs and dials to turn, which we want to do to balance efficiency with coverage.
 * For now I attach a short example ini file, which is not intended to produce a decent template bank, but is intended to demonstrate how this works.

[uberbank_config.ini.txt](https://github.com/ligo-cbc/pycbc/files/375415/uberbank_config.ini.txt)

At the moment it would be good to have some people try to run this, I'll try and provide a more meaningful ini file, and let me know if there are problems/suggestions etc. Please feel free to open pull requests against *this* branch, if you want to include functionality in this patch.
 