### PR TITLE
Fix glitch in sensitivity plots with huge errorbar

### DIFF
--- a/bin/hdfcoinc/pycbc_page_sensitivity
+++ b/bin/hdfcoinc/pycbc_page_sensitivity
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-""" Make plot of search sensitive distance
+""" Plot search sensitivity as a function of significance.
 """
 import argparse, h5py, numpy, logging, matplotlib, sys
 matplotlib.use('Agg')
@@ -7,12 +7,13 @@ from matplotlib.pyplot import cm
 import pylab, pycbc.pnutils, pycbc.results, pycbc, pycbc.version
 from pycbc import sensitivity
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
 parser.add_argument('--verbose', action='count')
 parser.add_argument('--injection-file', required=True,
                     help="Required. HDF format injection result file.")
-parser.add_argument('--output-file', required=True) # DOCUMENTME
+parser.add_argument('--output-file', required=True,
+                    help='Destination file for the plot')
 parser.add_argument('--bin-type', choices=['spin', 'mchirp',
                                            'total_mass', 'eta'],
                     default='mchirp',
@@ -28,9 +29,10 @@ parser.add_argument('--sig-bins', nargs='*',
                    help="Boundaries of x-axis significance bins. If not given"
                         ", hard-coded defaults will be used"),
 parser.add_argument('--dist-type', choices=['distance', 'volume', 'vt'],
-                    default='distance')
+                    default='distance',
+                    help="y-axis sensitivity measure. Default 'distance'")
 parser.add_argument('--log-dist', action='store_true', 
-                    help='Plot the sensitive distance axis in log scale')
+                    help='Plot the sensitivity axis in log scale')
 parser.add_argument('--min-dist', type=float,
                     help="Lower y-axis limit for sensitive distance")
 parser.add_argument('--max-dist', type=float,
@@ -207,8 +209,6 @@ for j in range(len(args.bins)-1):
                       found_mchirp, missed_mchirp, args.distance_param,
                       args.distribution, args.limits_param,
                       args.max_param, args.min_param)
-
-            sdist, ehigh, elow = sensitivity.volume_to_distance_with_errors(vol, vol_err)
 
             vols.append(vol)
             vol_errors.append(vol_err)

--- a/pycbc/sensitivity.py
+++ b/pycbc/sensitivity.py
@@ -19,7 +19,8 @@ def volume_to_distance_with_errors(vol, vol_err):
     """
     dist = (vol * 3.0/4.0/numpy.pi) ** (1.0/3.0)
     ehigh = ((vol + vol_err) * 3.0/4.0/numpy.pi) ** (1.0/3.0) - dist
-    elow = dist - ((vol - vol_err) * 3.0/4.0/numpy.pi) ** (1.0/3.0)
+    delta = numpy.where(vol >= vol_err, vol - vol_err, 0)
+    elow = dist - (delta * 3.0/4.0/numpy.pi) ** (1.0/3.0)
     return dist, ehigh, elow
 
 def volume_montecarlo(found_d, missed_d, found_mchirp, missed_mchirp,


### PR DESCRIPTION
When plotting distance on the y-axis, and the error is larger than the estimate, you get nan's in the error array and the error interval disappears. This patch catches those cases and makes the error as large as possible while remaining physically meaningful. See [before](https://www.atlas.aei.uni-hannover.de/~juan.bustillo/LSC/o1/imbh/injection_runs/o1-imbh-chunk123-c02-phenomd_50_300_R_HM/H1L1-PLOT_SENSITIVITY_SUMMARY_MTOTAL_ALLINJ-1126051217-3331800.png) and [after](https://www.atlas.aei.uni-hannover.de/~tito/LSC/o1/imbh/juans_allinj_debug.png).

The patch also includes a couple fixes to `--help` and removes an unused calculation.