### PR TITLE
Allow pycbc_inference to take a list from config file and keep it as a list

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -209,7 +209,11 @@ with ctx:
         try:
             static_args[key] = float(val)
         except:
-            pass
+            if val[0]=='[' and val[-1]==']':
+                static_args[key] = [str(val[1:-1].split(',')[n].strip().strip("'")) 
+                                        for n in range(len(val[1:-1].split(',')))]
+            else:
+                pass
 
     # get labels for each parameter from configuration file
     labels = [read_label_from_config(cp, param) for param in variable_args]

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -218,6 +218,8 @@ with ctx:
         try:
             static_args[key] = float(val)
             continue
+        except:
+            pass
         try:
             static_args[key] = convert_liststring_to_list(val) 
         except:

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -61,6 +61,15 @@ def read_distributions_from_config(cp, section):
             raise ValueError("Same parameter in more than one distribution.")
     return dists
 
+def convert_liststring_to_list(lstring):
+    """ Checks if an argument of the configuration file is a string of a list
+    and returns the corresponding list (of strings)
+    """
+    if lstring[0]=='[' and lstring[-1]==']':
+        lvalue = [str(lstring[1:-1].split(',')[n].strip().strip("'"))
+                      for n in range(len(lstring[1:-1].split(',')))]
+    return lvalue
+
 # command line usage
 parser = argparse.ArgumentParser(usage="pycbc_inference [--options]",
                   description="Runs an sampler to find the posterior.")
@@ -208,12 +217,11 @@ with ctx:
     for key,val in static_args.iteritems():
         try:
             static_args[key] = float(val)
+            continue
+        try:
+            static_args[key] = convert_liststring_to_list(val) 
         except:
-            if val[0]=='[' and val[-1]==']':
-                static_args[key] = [str(val[1:-1].split(',')[n].strip().strip("'")) 
-                                        for n in range(len(val[1:-1].split(',')))]
-            else:
-                pass
+            pass
 
     # get labels for each parameter from configuration file
     labels = [read_label_from_config(cp, param) for param in variable_args]


### PR DESCRIPTION
Currently, pycbc_inference reads the static_args from the configuration file and either converts them to floats or leaves them as strings. However, the ringdown approximant with higher modes expects a list of strings as argument for the number of modes desired. This patch adds the option (in pycbc_inference) to check if one of the strings in the static_args is a list and converts it to a list of strings.