### PR TITLE
Add bank compression executable

### DIFF
--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -129,9 +129,6 @@ parser.add_argument("--approximant", type=str,
 parser.add_argument("--sample-rate", type=int, required=True,
                 help="Half this value sets the maximum frequency of the "
                      "compressed waveforms.")
-parser.add_argument("--segment-length", type=float, required=True,
-                help="The inverse of this sets the delta-f used for "
-                     "generating waveforms prior to compressing.")
 parser.add_argument("--tmplt-index", nargs=2, type=int, default=None,
                 help="Only generate compressed waveforms for the given "
                      "indices in the bank file. Must provide both a start "
@@ -167,30 +164,26 @@ args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)
 
-df = 1./args.segment_length
 fmin = args.low_frequency_cutoff
 fmax = args.sample_rate/2.
-# figure out the length of the full waveforms in the frequency domain
-N = int(args.sample_rate*args.segment_length/2 + 1)
-# scratch space
-scratch = FrequencySeries(numpy.zeros(N, dtype=numpy.complex128), delta_f=df)
-decomp_scratch = FrequencySeries(numpy.zeros(N, dtype=numpy.complex128),
-                                 delta_f=df)
-# we'll need the full frequency series
-allf = numpy.arange(N)*df
 
 # load the bank
 logging.info("loading bank")
-# Note: we'll budge the waveform starting frequency down by 1df to ensure the
-# first point is correct
-bank = waveform.FilterBank(args.bank_file, N, df, fmin-df, numpy.complex128,
-    approximant=args.approximant, out=scratch)
+# we'll just use dummy values for N, df for now
+bank = waveform.FilterBank(args.bank_file, 5, 0.25, fmin, numpy.complex128,
+    approximant=args.approximant)
 templates = bank.table
 if args.tmplt_index is not None:
     imin, imax = args.tmplt_index
     templates = templates[imin:imax]
 else:
     imin, imax = 0, templates.size
+
+# figure out the dfs needed for each waveform
+logging.info("getting needed dfs")
+seg_lens = 2*numpy.array([
+    waveform.ceilpow2(compress.rough_time_estimate(m1, m2, fmin))
+    for m1,m2 in zip(templates.mass1, templates.mass2)])
 
 # generate output file
 # FIXME: this should be moved to a class or function
@@ -206,7 +199,20 @@ output['template_hash'] = templates['template_hash']
 logging.info("getting compressed amplitude and phase")
 mismatches = numpy.zeros(imax-imin, dtype=float)
 for ii in range(imin, imax):
-
+    # update the N, df to use based on this waveform
+    N = int(args.sample_rate*seg_lens[ii])
+    df = 1./seg_lens[ii]
+    bank.delta_f = df
+    bank.N = N
+    bank.filter_length = N/2 + 1
+    # We'll budge the waveform starting frequency down by 1df to ensure 
+    # the first point is correct
+    bank.f_lower = fmin-df
+    bank.kmin = int(bank.f_lower / df)
+    # scratch space
+    decomp_scratch = FrequencySeries(numpy.zeros(N, dtype=numpy.complex128),
+                                 delta_f=df)
+    # generate the waveform
     htilde = bank[ii]
     tmplt = bank.table[ii]
     kmax = htilde.end_idx
@@ -217,7 +223,7 @@ for ii in range(imin, imax):
             fmin, (kmax-1)*df, min_seglen=args.t_pad, df_multiple=df)
     elif args.compression_algorithm == 'spa':
         sample_points = compress.spa_compression(htilde, fmin, (kmax-1)*df,
-            min_seglen=args.t_pad, sample_frequencies=allf)
+            min_seglen=args.t_pad)
     else:
         raise ValueError("unrecognized compression algorithm %s" %(
             args.compression_algorithm))

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -106,9 +106,10 @@ else:
 
 # figure out the dfs needed for each waveform
 logging.info("getting needed dfs")
+
 seg_lens = 2*numpy.array([
-    waveform.ceilpow2(compress.rough_time_estimate(m1, m2, fmin))
-    for m1,m2 in zip(templates.mass1, templates.mass2)])
+    2**numpy.ceil(numpy.log2(compress.rough_time_estimate(m1, m2, fmin)))
+    for m1,m2 in zip(templates.mass1, templates.mass2)]).astype(int)
 
 # generate output file
 # FIXME: this should be moved to a class or function

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -37,81 +37,6 @@ from pycbc.types import FrequencySeries
 from pycbc import pnutils
 from pycbc import filter
 
-def _vecdiff(htilde, hinterp, fmin, fmax):
-    return abs(filter.overlap_cplx(htilde, htilde,
-                          low_frequency_cutoff=fmin,
-                          high_frequency_cutoff=fmax,
-                          normalized=False)
-                - filter.overlap_cplx(htilde, hinterp,
-                          low_frequency_cutoff=fmin,
-                          high_frequency_cutoff=fmax,
-                          normalized=False))
-
-def vecdiff(htilde, hinterp, sample_points):
-    """Computes a statistic indicating between which sample points a waveform
-    and the interpolated waveform differ the most.
-    """
-    vecdiffs = numpy.zeros(sample_points.size-1, dtype=float)
-    for kk,thisf in enumerate(sample_points[:-1]):
-        nextf = sample_points[kk+1]
-        vecdiffs[kk] = abs(_vecdiff(htilde, hinterp, thisf, nextf))
-    return vecdiffs
-
-def compress_waveform(htilde, sample_points, precision, interpolation,
-        decomp_scratch=None):
-    """Adds frequency points in order to ensure that the interpolated waveform
-    has a mismatch with the full waveform that is <= the desired precision.
-    """
-    fmin = sample_points.min()
-    df = htilde.delta_f
-    sample_index = (sample_points / df).astype(int)
-    amp = waveform.amplitude_from_frequencyseries(htilde)
-    phase = waveform.phase_from_frequencyseries(htilde)
-
-    comp_amp = amp.take(sample_index)
-    comp_phase = phase.take(sample_index)
-    hdecomp = compress.fd_decompress(comp_amp, comp_phase, sample_points,
-        out=decomp_scratch, f_lower=fmin, interpolation=args.interpolation)
-    mismatch = 1. - filter.overlap(hdecomp, htilde, low_frequency_cutoff=fmin)
-    if mismatch > precision:
-        # we'll need the difference in the waveforms as a function of frequency
-        vecdiffs = vecdiff(htilde, hdecomp, sample_points)
-
-    # We will find where in the frequency series the interpolated waveform
-    # has the smallest overlap with the full waveform, add a sample point
-    # there, and re-interpolate. We repeat this until the overall mismatch
-    # is > than the desired precision 
-    added_points = []
-    while mismatch > args.precision:
-        minpt = vecdiffs.argmax()
-        # add a point at the frequency halfway between minpt and minpt+1
-        add_freq = sample_points[[minpt, minpt+1]].mean()
-        addidx = int(add_freq/df)
-        new_index = numpy.zeros(sample_index.size+1, dtype=int)
-        new_index[:minpt+1] = sample_index[:minpt+1]
-        new_index[minpt+1] = addidx
-        new_index[minpt+2:] = sample_index[minpt+1:]
-        sample_index = new_index
-        sample_points = sample_index * df
-        # get the new compressed points
-        comp_amp = amp.take(sample_index)
-        comp_phase = phase.take(sample_index)
-        # update the vecdiffs and mismatch
-        hdecomp = compress.fd_decompress(comp_amp, comp_phase, sample_points,
-            out=decomp_scratch, f_lower=fmin, interpolation=args.interpolation)
-        new_vecdiffs = numpy.zeros(vecdiffs.size+1)
-        new_vecdiffs[:minpt] = vecdiffs[:minpt]
-        new_vecdiffs[minpt+2:] = vecdiffs[minpt+1:]
-        new_vecdiffs[minpt:minpt+2] = vecdiff(htilde, hdecomp,
-            sample_points[minpt:minpt+2])
-        vecdiffs = new_vecdiffs
-        mismatch = 1. - filter.overlap(hdecomp, htilde,
-            low_frequency_cutoff=fmin)
-        added_points.append(addidx)
-    logging.info("mismatch: %f, N points: %i (%i added)" %(mismatch,
-        len(comp_amp), len(added_points)))
-    return comp_amp, comp_phase, mismatch, numpy.array(added_points)*df
-
 
 parser = argparse.ArgumentParser(description=__description__)
 parser.add_argument("--bank-file", type=str,
@@ -229,7 +154,7 @@ for ii in range(imin, imax):
             args.compression_algorithm))
             
     # compress
-    comp_amp, comp_phase, mismatch, added_points = compress_waveform(
+    comp_amp, comp_phase, mismatch, added_points = compress.compress_waveform(
         htilde, sample_points, args.precision, args.interpolation,
         decomp_scratch=decomp_scratch)
 

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# Copyright (C) 2015  Alex Nitz
+# Copyright (C) 2016  Collin Capano
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -147,12 +147,14 @@ if args.fixed_sample_points:
     output['compressed_waveforms/frequency'] = fixed_points
 else:
     sample_points = None
+    
 # get the compressed sample points for each template
 logging.info("getting compressed amplitude and phase")
 for ii in range(imin, imax):
     htilde = bank[ii]
     tmplt = bank.table[ii]
     kmax = kmaxes[ii]
+    
     # get the compressed sample points
     if args.fixed_sample_points:
         sample_points = fixed_points[:kmax-1]
@@ -165,15 +167,19 @@ for ii in range(imin, imax):
     else:
         raise ValueError("unrecognized compression algorithm %s" %(
             args.compression_algorithm))
+            
     # compress
-    sample_index = (sample_points/df).astype(int)
+    sample_index = (sample_points / df).astype(int)
     amp = waveform.amplitude_from_frequencyseries(htilde)
     phase = waveform.phase_from_frequencyseries(htilde)
-    compAmp = amp[sample_index]
-    compPhase = phase[sample_index]
+    
+    
+    comp_amp = amp.take(sample_index)
+    comp_phase = phase.take(sample_index)
 
-    output['compressed_waveforms/%i/amplitude' %(ii-imin)] = compAmp.data 
-    output['compressed_waveforms/%i/phase' %(ii-imin)] = compPhase.data
+    output['compressed_waveforms/%i/amplitude' %(ii-imin)] = comp_amp.numpy()
+    output['compressed_waveforms/%i/phase' %(ii-imin)] = comp_phase.numpy()
+    
     if args.fixed_sample_points:
         output['compressed_waveforms/%i/frequency' %(ii-imin)] = \
             h5py.SoftLink('/compressed_waveforms/frequency')
@@ -181,11 +187,13 @@ for ii in range(imin, imax):
         output['compressed_waveforms/%i/frequency' %(ii-imin)] = \
             sample_points
     if args.check_compression:
-        hdecomp = compress.fd_decompress(compAmp, compPhase, sample_points,
+        hdecomp = compress.fd_decompress(comp_amp, comp_phase, sample_points,
             out=decomp_scratch, f_lower=fmin, interpolation=args.interpolation)
         ff = filter.overlap(hdecomp, htilde)
-        output['compressed_waveforms/%i' %(ii-imin)].attrs['interpolation'] = \
+        
+        logging.info('Overlap = %s' % ff)
+        output['compressed_waveforms/%i' %(ii - imin)].attrs['interpolation'] = \
             args.interpolation
-        output['compressed_waveforms/%i' %(ii-imin)].attrs['overlap'] = ff
+        output['compressed_waveforms/%i' %(ii - imin)].attrs['overlap'] = ff
 logging.info("finished")
 output.close()

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -206,9 +206,10 @@ output['template_hash'] = templates['template_hash']
 logging.info("getting compressed amplitude and phase")
 mismatches = numpy.zeros(imax-imin, dtype=float)
 for ii in range(imin, imax):
+
     htilde = bank[ii]
     tmplt = bank.table[ii]
-    kmax = min(N, len(htilde))
+    kmax = htilde.end_idx
     
     # get the compressed sample points
     if args.compression_algorithm == 'mchirp':

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -1,0 +1,191 @@
+#! /usr/bin/env python
+# Copyright (C) 2015  Alex Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+__description__ = \
+""""Loads a bank of waveforms and compresses them using the specified
+compression algorithm. The resulting compressed waveforms are saved to an
+hdf file."""
+
+import argparse
+import numpy
+import h5py
+import logging
+import pycbc
+from pycbc.waveform import compress
+from pycbc import waveform
+from pycbc.types import FrequencySeries
+from pycbc import pnutils
+from pycbc import filter
+
+parser = argparse.ArgumentParser(description=__description__)
+parser.add_argument("--bank-file", type=str,
+                help="Bank hdf file to load.")
+parser.add_argument("--output", type=str,
+                help="The hdf file to save the templates and compressed "
+                     "waveforms to.")
+parser.add_argument("--low-frequency-cutoff", type=float, required=True,
+                help="The low frequency cutoff to use for generating "
+                     "the waveforms (Hz)")
+parser.add_argument("--approximant", type=str,
+                help="The approximant to generate the waveforms with. If "
+                     "none provided, will attempt to retrieve the approximant "
+                     "from the bank file.")
+parser.add_argument("--sample-rate", type=int, required=True,
+                help="Half this value sets the maximum frequency of the "
+                     "compressed waveforms.")
+parser.add_argument("--segment-length", type=float, required=True,
+                help="The inverse of this sets the delta-f used for "
+                     "generating waveforms prior to compressing.")
+parser.add_argument("--tmplt-index", nargs=2, type=int, default=None,
+                help="Only generate compressed waveforms for the given "
+                     "indices in the bank file. Must provide both a start "
+                     "and a stop index. Default is to compress all of the "
+                     "templates in the bank file.")
+parser.add_argument("--compression-algorithm", type=str, default="mchirp",
+                help="The compression algorithm to use for selecting "
+                     "frequency points. Options are %s. Default is mchirp." %(
+                     ', '.join(compress.compression_algorithms.keys())))
+parser.add_argument("--fixed-sample-points", action="store_true",
+                help="Use the same frequency vector for all waveforms. "
+                     "To use, the compression algorithm must be 'mchirp'. In "
+                     "this case, the frequency vector will be based on the "
+                     "lowest-mass template in the desried range.")
+parser.add_argument("--t-pad", type=float, default=0.02,
+                help="The minimum duration used for t(f) in seconds. The "
+                     "inverse of this gives the maximum frequency step that "
+                     "will be used in the compressed waveforms. Default is "
+                     "0.02.")
+parser.add_argument("--check-compression", action="store_true", default=False,
+                help="Check the overlap between the compressed waveform and "
+                     "the full waveform. Results are saved to the output.")
+parser.add_argument("--interpolation", type=str, default="linear",
+                help="If check-compression, the interpolation to use for "
+                     "decompressing the waveforms. Options are 'linear', or "
+                     "any interpolation recognized by scipy's interp1d kind "
+                     "argument. Default is linear.")
+parser.add_argument("--verbose", action="store_true", default=False)
+
+
+args = parser.parse_args()
+
+pycbc.init_logging(args.verbose)
+
+if args.fixed_sample_points and args.compression_algorithm != 'mchirp':
+    raise ValueError("fixed-sample-points requires the mchirp algorithm")
+
+df = 1./args.segment_length
+fmin = args.low_frequency_cutoff
+# figure out the length of the full waveforms in the frequency domain
+N = int(args.sample_rate*args.segment_length/2 + 1)
+# scratch space
+scratch = FrequencySeries(numpy.zeros(N, dtype=numpy.complex128), delta_f=df)
+if args.check_compression is not None:
+    decomp_scratch = FrequencySeries(numpy.zeros(N, dtype=numpy.complex128),
+        delta_f=df)
+# we'll need the full frequency series
+allf = numpy.arange(N)*df
+
+# load the bank
+logging.info("loading bank")
+bank = waveform.FilterBank(args.bank_file, N, df, fmin, numpy.complex128,
+    approximant=args.approximant, out=scratch)
+templates = bank.table
+if args.tmplt_index is not None:
+    imin, imax = args.tmplt_index
+    templates = templates[imin:imax]
+else:
+    imin, imax = 0, templates.size
+
+# the index of the starting frequency in the full frequency series
+kmin = int(fmin*args.segment_length)
+
+# we'll use the SEOBNRv2 ringdown frequency as maximum frequencies for the
+# sample points
+logging.info("computing maximum frequencies")
+kmaxes = (args.segment_length*pnutils.get_freq('fSEOBNRv2RD',
+            templates.mass1, templates.mass2,
+            templates.spin1z, templates.spin2z)).astype(int)
+kmaxes[kmaxes > N] = N
+
+# generate output file
+# FIXME: this should be moved to a class or function
+logging.info("writing template info to output")
+output = h5py.File(args.output, 'w')
+output['mass1'] = templates['mass1']
+output['mass2'] = templates['mass2']
+output['spin1z'] = templates['spin1z']
+output['spin2z'] = templates['spin2z']
+output['template_hash'] = templates['template_hash']
+
+if args.fixed_sample_points:
+    logging.info("getting fixed sample points")
+    useidx = pnutils.mass1_mass2_to_mchirp_eta(
+        templates.mass1, templates.mass2)[0].argmin()
+    fixed_points = compress.mchirp_compression(templates.mass1[useidx],
+        templates.mass2[useidx], fmin, df*(kmaxes.max()-1),
+        min_seglen=args.t_pad, df_multiple=df)
+    output['compressed_waveforms/frequency'] = fixed_points
+else:
+    sample_points = None
+# get the compressed sample points for each template
+logging.info("getting compressed amplitude and phase")
+for ii in range(imin, imax):
+    htilde = bank[ii]
+    tmplt = bank.table[ii]
+    kmax = kmaxes[ii]
+    # get the compressed sample points
+    if args.fixed_sample_points:
+        sample_points = fixed_points[:kmax-1]
+    elif args.compression_algorithm == 'mchirp':
+        sample_points = compress.mchirp_compression(tmplt.mass1, tmplt.mass2,
+            fmin, (kmax-1)*df, min_seglen=args.t_pad, df_multiple=df)
+    elif args.compression_algorithm == 'spa':
+        sample_points = compress.spa_compression(htilde, fmin, (kmax-1)*df,
+            min_seglen=args.t_pad, sample_frequencies=allf)
+    else:
+        raise ValueError("unrecognized compression algorithm %s" %(
+            args.compression_algorithm))
+    # compress
+    sample_index = (sample_points/df).astype(int)
+    amp = waveform.amplitude_from_frequencyseries(htilde)
+    phase = waveform.phase_from_frequencyseries(htilde)
+    compAmp = amp[sample_index]
+    compPhase = phase[sample_index]
+
+    output['compressed_waveforms/%i/amplitude' %(ii-imin)] = compAmp.data 
+    output['compressed_waveforms/%i/phase' %(ii-imin)] = compPhase.data
+    if args.fixed_sample_points:
+        output['compressed_waveforms/%i/frequency' %(ii-imin)] = \
+            h5py.SoftLink('/compressed_waveforms/frequency')
+    else:
+        output['compressed_waveforms/%i/frequency' %(ii-imin)] = \
+            sample_points
+    if args.check_compression:
+        hdecomp = compress.fd_decompress(compAmp, compPhase, sample_points,
+            out=decomp_scratch, f_lower=fmin, interpolation=args.interpolation)
+        ff = filter.overlap(hdecomp, htilde)
+        output['compressed_waveforms/%i' %(ii-imin)].attrs['interpolation'] = \
+            args.interpolation
+        output['compressed_waveforms/%i' %(ii-imin)].attrs['overlap'] = ff
+logging.info("finished")
+output.close()

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -37,6 +37,82 @@ from pycbc.types import FrequencySeries
 from pycbc import pnutils
 from pycbc import filter
 
+def _vecdiff(htilde, hinterp, fmin, fmax):
+    return abs(filter.overlap_cplx(htilde, htilde,
+                          low_frequency_cutoff=fmin,
+                          high_frequency_cutoff=fmax,
+                          normalized=False)
+                - filter.overlap_cplx(htilde, hinterp,
+                          low_frequency_cutoff=fmin,
+                          high_frequency_cutoff=fmax,
+                          normalized=False))
+
+def vecdiff(htilde, hinterp, sample_points):
+    """Computes a statistic indicating between which sample points a waveform
+    and the interpolated waveform differ the most.
+    """
+    vecdiffs = numpy.zeros(sample_points.size-1, dtype=float)
+    for kk,thisf in enumerate(sample_points[:-1]):
+        nextf = sample_points[kk+1]
+        vecdiffs[kk] = abs(_vecdiff(htilde, hinterp, thisf, nextf))
+    return vecdiffs
+
+def compress_waveform(htilde, sample_points, precision, interpolation,
+        decomp_scratch=None):
+    """Adds frequency points in order to ensure that the interpolated waveform
+    has a mismatch with the full waveform that is <= the desired precision.
+    """
+    fmin = sample_points.min()
+    df = htilde.delta_f
+    sample_index = (sample_points / df).astype(int)
+    amp = waveform.amplitude_from_frequencyseries(htilde)
+    phase = waveform.phase_from_frequencyseries(htilde)
+
+    comp_amp = amp.take(sample_index)
+    comp_phase = phase.take(sample_index)
+    hdecomp = compress.fd_decompress(comp_amp, comp_phase, sample_points,
+        out=decomp_scratch, f_lower=fmin, interpolation=args.interpolation)
+    mismatch = 1. - filter.overlap(hdecomp, htilde, low_frequency_cutoff=fmin)
+    if mismatch > precision:
+        # we'll need the difference in the waveforms as a function of frequency
+        vecdiffs = vecdiff(htilde, hdecomp, sample_points)
+
+    # We will find where in the frequency series the interpolated waveform
+    # has the smallest overlap with the full waveform, add a sample point
+    # there, and re-interpolate. We repeat this until the overall mismatch
+    # is > than the desired precision 
+    added_points = []
+    while mismatch > args.precision:
+        minpt = vecdiffs.argmax()
+        # add a point at the frequency halfway between minpt and minpt+1
+        add_freq = sample_points[[minpt, minpt+1]].mean()
+        addidx = int(add_freq/df)
+        new_index = numpy.zeros(sample_index.size+1, dtype=int)
+        new_index[:minpt+1] = sample_index[:minpt+1]
+        new_index[minpt+1] = addidx
+        new_index[minpt+2:] = sample_index[minpt+1:]
+        sample_index = new_index
+        sample_points = sample_index * df
+        # get the new compressed points
+        comp_amp = amp.take(sample_index)
+        comp_phase = phase.take(sample_index)
+        # update the vecdiffs and mismatch
+        hdecomp = compress.fd_decompress(comp_amp, comp_phase, sample_points,
+            out=decomp_scratch, f_lower=fmin, interpolation=args.interpolation)
+        new_vecdiffs = numpy.zeros(vecdiffs.size+1)
+        new_vecdiffs[:minpt] = vecdiffs[:minpt]
+        new_vecdiffs[minpt+2:] = vecdiffs[minpt+1:]
+        new_vecdiffs[minpt:minpt+2] = vecdiff(htilde, hdecomp,
+            sample_points[minpt:minpt+2])
+        vecdiffs = new_vecdiffs
+        mismatch = 1. - filter.overlap(hdecomp, htilde,
+            low_frequency_cutoff=fmin)
+        added_points.append(addidx)
+    logging.info("mismatch: %f, N points: %i (%i added)" %(mismatch,
+        len(comp_amp), len(added_points)))
+    return comp_amp, comp_phase, mismatch, numpy.array(added_points)*df
+
+
 parser = argparse.ArgumentParser(description=__description__)
 parser.add_argument("--bank-file", type=str,
                 help="Bank hdf file to load.")
@@ -61,28 +137,29 @@ parser.add_argument("--tmplt-index", nargs=2, type=int, default=None,
                      "indices in the bank file. Must provide both a start "
                      "and a stop index. Default is to compress all of the "
                      "templates in the bank file.")
-parser.add_argument("--compression-algorithm", type=str, default="mchirp",
+parser.add_argument("--compression-algorithm", type=str, required=True,
+                choices=compress.compression_algorithms.keys(),
                 help="The compression algorithm to use for selecting "
-                     "frequency points. Options are %s. Default is mchirp." %(
-                     ', '.join(compress.compression_algorithms.keys())))
-parser.add_argument("--fixed-sample-points", action="store_true",
-                help="Use the same frequency vector for all waveforms. "
-                     "To use, the compression algorithm must be 'mchirp'. In "
-                     "this case, the frequency vector will be based on the "
-                     "lowest-mass template in the desried range.")
-parser.add_argument("--t-pad", type=float, default=0.02,
+                     "frequency points.")
+parser.add_argument("--t-pad", type=float, default=0.001,
                 help="The minimum duration used for t(f) in seconds. The "
                      "inverse of this gives the maximum frequency step that "
                      "will be used in the compressed waveforms. Default is "
-                     "0.02.")
-parser.add_argument("--check-compression", action="store_true", default=False,
-                help="Check the overlap between the compressed waveform and "
-                     "the full waveform. Results are saved to the output.")
+                     "0.001.")
+parser.add_argument("--precision", type=float, default=0.001,
+                help="The maximum mismatch to allow between the interpolated "
+                     "waveform must and the full waveform. Points will be "
+                     "added to the compressed waveform until its "
+                     "interpolation has a mismatch <= this value. Default is "
+                     "0.001.")
 parser.add_argument("--interpolation", type=str, default="linear",
-                help="If check-compression, the interpolation to use for "
-                     "decompressing the waveforms. Options are 'linear', or "
-                     "any interpolation recognized by scipy's interp1d kind "
-                     "argument. Default is linear.")
+                help="The interpolation to use for decompressing the "
+                     "waveforms for checking precision. Options are 'linear', "
+                     "or any interpolation recognized by scipy's interp1d "
+                     "kind argument. Default is linear.")
+parser.add_argument("--save-added-points", action="store_true", default=False,
+                help="Save the indices of points that had to be added in "
+                     "order for the mismatch to be <= the desired precision.")
 parser.add_argument("--verbose", action="store_true", default=False)
 
 
@@ -90,24 +167,23 @@ args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)
 
-if args.fixed_sample_points and args.compression_algorithm != 'mchirp':
-    raise ValueError("fixed-sample-points requires the mchirp algorithm")
-
 df = 1./args.segment_length
 fmin = args.low_frequency_cutoff
+fmax = args.sample_rate/2.
 # figure out the length of the full waveforms in the frequency domain
 N = int(args.sample_rate*args.segment_length/2 + 1)
 # scratch space
 scratch = FrequencySeries(numpy.zeros(N, dtype=numpy.complex128), delta_f=df)
-if args.check_compression is not None:
-    decomp_scratch = FrequencySeries(numpy.zeros(N, dtype=numpy.complex128),
-        delta_f=df)
+decomp_scratch = FrequencySeries(numpy.zeros(N, dtype=numpy.complex128),
+                                 delta_f=df)
 # we'll need the full frequency series
 allf = numpy.arange(N)*df
 
 # load the bank
 logging.info("loading bank")
-bank = waveform.FilterBank(args.bank_file, N, df, fmin, numpy.complex128,
+# Note: we'll budge the waveform starting frequency down by 1df to ensure the
+# first point is correct
+bank = waveform.FilterBank(args.bank_file, N, df, fmin-df, numpy.complex128,
     approximant=args.approximant, out=scratch)
 templates = bank.table
 if args.tmplt_index is not None:
@@ -115,17 +191,6 @@ if args.tmplt_index is not None:
     templates = templates[imin:imax]
 else:
     imin, imax = 0, templates.size
-
-# the index of the starting frequency in the full frequency series
-kmin = int(fmin*args.segment_length)
-
-# we'll use the SEOBNRv2 ringdown frequency as maximum frequencies for the
-# sample points
-logging.info("computing maximum frequencies")
-kmaxes = (args.segment_length*pnutils.get_freq('fSEOBNRv2RD',
-            templates.mass1, templates.mass2,
-            templates.spin1z, templates.spin2z)).astype(int)
-kmaxes[kmaxes > N] = N
 
 # generate output file
 # FIXME: this should be moved to a class or function
@@ -137,28 +202,16 @@ output['spin1z'] = templates['spin1z']
 output['spin2z'] = templates['spin2z']
 output['template_hash'] = templates['template_hash']
 
-if args.fixed_sample_points:
-    logging.info("getting fixed sample points")
-    useidx = pnutils.mass1_mass2_to_mchirp_eta(
-        templates.mass1, templates.mass2)[0].argmin()
-    fixed_points = compress.mchirp_compression(templates.mass1[useidx],
-        templates.mass2[useidx], fmin, df*(kmaxes.max()-1),
-        min_seglen=args.t_pad, df_multiple=df)
-    output['compressed_waveforms/frequency'] = fixed_points
-else:
-    sample_points = None
-    
 # get the compressed sample points for each template
 logging.info("getting compressed amplitude and phase")
+mismatches = numpy.zeros(imax-imin, dtype=float)
 for ii in range(imin, imax):
     htilde = bank[ii]
     tmplt = bank.table[ii]
-    kmax = kmaxes[ii]
+    kmax = min(N, len(htilde))
     
     # get the compressed sample points
-    if args.fixed_sample_points:
-        sample_points = fixed_points[:kmax-1]
-    elif args.compression_algorithm == 'mchirp':
+    if args.compression_algorithm == 'mchirp':
         sample_points = compress.mchirp_compression(tmplt.mass1, tmplt.mass2,
             fmin, (kmax-1)*df, min_seglen=args.t_pad, df_multiple=df)
     elif args.compression_algorithm == 'spa':
@@ -169,31 +222,25 @@ for ii in range(imin, imax):
             args.compression_algorithm))
             
     # compress
-    sample_index = (sample_points / df).astype(int)
-    amp = waveform.amplitude_from_frequencyseries(htilde)
-    phase = waveform.phase_from_frequencyseries(htilde)
-    
-    
-    comp_amp = amp.take(sample_index)
-    comp_phase = phase.take(sample_index)
+    comp_amp, comp_phase, mismatch, added_points = compress_waveform(
+        htilde, sample_points, args.precision, args.interpolation,
+        decomp_scratch=decomp_scratch)
 
+    mismatches[ii-imin] = mismatch
+
+    # save results
     output['compressed_waveforms/%i/amplitude' %(ii-imin)] = comp_amp.numpy()
     output['compressed_waveforms/%i/phase' %(ii-imin)] = comp_phase.numpy()
-    
-    if args.fixed_sample_points:
-        output['compressed_waveforms/%i/frequency' %(ii-imin)] = \
-            h5py.SoftLink('/compressed_waveforms/frequency')
-    else:
-        output['compressed_waveforms/%i/frequency' %(ii-imin)] = \
-            sample_points
-    if args.check_compression:
-        hdecomp = compress.fd_decompress(comp_amp, comp_phase, sample_points,
-            out=decomp_scratch, f_lower=fmin, interpolation=args.interpolation)
-        ff = filter.overlap(hdecomp, htilde)
-        
-        logging.info('Overlap = %s' % ff)
-        output['compressed_waveforms/%i' %(ii - imin)].attrs['interpolation'] = \
-            args.interpolation
-        output['compressed_waveforms/%i' %(ii - imin)].attrs['overlap'] = ff
+    output['compressed_waveforms/%i/frequency' %(ii-imin)] = sample_points
+    #output['compressed_waveforms/%i' %(ii - imin)].attrs['mismatch'] = mismatch
+    if args.save_added_points:
+        output['compressed_waveforms/%i/added_points' %(ii - imin)] = \
+            added_points
+
+output['compressed_waveforms/mismatch'] = mismatches
+# save metadata
+output['compressed_waveforms'].attrs['interpolation'] = args.interpolation
+output['compressed_waveforms'].attrs['precision'] = args.precision
+
 logging.info("finished")
 output.close()

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -106,10 +106,10 @@ else:
 
 # figure out the dfs needed for each waveform
 logging.info("getting needed dfs")
-
-seg_lens = 2*numpy.array([
-    2**numpy.ceil(numpy.log2(compress.rough_time_estimate(m1, m2, fmin)))
-    for m1,m2 in zip(templates.mass1, templates.mass2)]).astype(int)
+# we'll ensure that the there are atleast 2 samples in a waveform
+seg_lens = 2*numpy.array([max(4./args.sample_rate,
+    2**numpy.ceil(numpy.log2(compress.rough_time_estimate(m1, m2, fmin))))
+    for m1,m2 in zip(templates.mass1, templates.mass2)])
 
 # generate output file
 # FIXME: this should be moved to a class or function
@@ -126,8 +126,8 @@ logging.info("getting compressed amplitude and phase")
 mismatches = numpy.zeros(imax-imin, dtype=float)
 for ii in range(imin, imax):
     # update the N, df to use based on this waveform
-    N = int(args.sample_rate*seg_lens[ii])
-    df = 1./seg_lens[ii]
+    N = int(args.sample_rate*seg_lens[ii-imin])
+    df = 1./seg_lens[ii-imin]
     bank.delta_f = df
     bank.N = N
     bank.filter_length = N/2 + 1

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -79,9 +79,6 @@ parser.add_argument("--interpolation", type=str, default="linear",
                      "waveforms for checking precision. Options are 'linear', "
                      "or any interpolation recognized by scipy's interp1d "
                      "kind argument. Default is linear.")
-parser.add_argument("--save-added-points", action="store_true", default=False,
-                help="Save the indices of points that had to be added in "
-                     "order for the mismatch to be <= the desired precision.")
 parser.add_argument("--verbose", action="store_true", default=False)
 
 
@@ -107,7 +104,7 @@ else:
 # figure out the dfs needed for each waveform
 logging.info("getting needed dfs")
 # we'll ensure that the there are atleast 2 samples in a waveform
-seg_lens = 2*numpy.array([max(4./args.sample_rate,
+seg_lens = 4*numpy.array([max(4./args.sample_rate,
     2**numpy.ceil(numpy.log2(compress.rough_time_estimate(m1, m2, fmin))))
     for m1,m2 in zip(templates.mass1, templates.mass2)])
 
@@ -155,7 +152,7 @@ for ii in range(imin, imax):
             args.compression_algorithm))
             
     # compress
-    comp_amp, comp_phase, mismatch, added_points = compress.compress_waveform(
+    sample_points, comp_amp, comp_phase, mismatch = compress.compress_waveform(
         htilde, sample_points, args.precision, args.interpolation,
         decomp_scratch=decomp_scratch)
 
@@ -165,12 +162,8 @@ for ii in range(imin, imax):
     output['compressed_waveforms/%i/amplitude' %(ii-imin)] = comp_amp.numpy()
     output['compressed_waveforms/%i/phase' %(ii-imin)] = comp_phase.numpy()
     output['compressed_waveforms/%i/frequency' %(ii-imin)] = sample_points
-    #output['compressed_waveforms/%i' %(ii - imin)].attrs['mismatch'] = mismatch
-    if args.save_added_points:
-        output['compressed_waveforms/%i/added_points' %(ii - imin)] = \
-            added_points
+    output['compressed_waveforms/%i' %(ii - imin)].attrs['mismatch'] = mismatch
 
-output['compressed_waveforms/mismatch'] = mismatches
 # save metadata
 output['compressed_waveforms'].attrs['interpolation'] = args.interpolation
 output['compressed_waveforms'].attrs['precision'] = args.precision

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -297,7 +297,7 @@ class FilterBank(TemplateBank):
 
         self.table[index].template_duration = template_duration        
 
-        htilde = htilde.astype(numpy.complex64)
+        htilde = htilde.astype(self.dtype)
         htilde.f_lower = self.f_lower
         htilde.end_frequency = f_end
         htilde.end_idx = int(htilde.end_frequency / htilde.delta_f)

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -31,13 +31,14 @@ from pycbc import WEAVE_FLAGS
 from scipy.weave import inline
 from scipy import interpolate
 from pycbc.types import FrequencySeries, zeros, complex_same_precision_as
+from pycbc.waveform import utils
 
 def rough_time_estimate(m1, m2, flow, fudge_length=1.1, fudge_min=0.02):
     """ A very rough estimate of the duration of the waveform.
 
     An estimate of the waveform duration starting from flow. This is intended
-    to be fast but not necessarily accurate. It should be an overestimate of the
-    length. It is derived from a simplification of the 0PN post-newtonian
+    to be fast but not necessarily accurate. It should be an overestimate of
+    the length. It is derived from a simplification of the 0PN post-newtonian
     terms and includes a fudge factor for possible ringdown, etc.
 
     Parameters
@@ -49,10 +50,11 @@ def rough_time_estimate(m1, m2, flow, fudge_length=1.1, fudge_min=0.02):
     flow: float
         starting frequency of the waveform
     fudge_length: optional, {1.1, float}
-        Factor to multiply length estimate by to ensure it is a convservative value
+        Factor to multiply length estimate by to ensure it is a convservative
+        value
     fudge_min: optional, {0.2, float}
-        Minimum signal duration that can be returned. This should be long enough
-    to encompass the ringdown and errors in the precise end time.             
+        Minimum signal duration that can be returned. This should be long
+        enough to encompass the ringdown and errors in the precise end time.
 
     Returns
     -------
@@ -61,14 +63,15 @@ def rough_time_estimate(m1, m2, flow, fudge_length=1.1, fudge_min=0.02):
     """
     m = m1 + m2
     msun = m * lal.MTSUN_SI
-    t =  5.0 / 256.0 * m * m * msun / (m1 * m2) / (numpy.pi * msun * flow) **  (8.0 / 3.0)
+    t =  5.0 / 256.0 * m * m * msun / (m1 * m2) / \
+        (numpy.pi * msun * flow) **  (8.0 / 3.0)
 
     # fudge factoriness
     return .022 if t < 0 else (t + fudge_min) * fudge_length 
 
-def rough_frequency_samples(m1, m2, flow, fmax, df_min):
-    """ Return a quick estimate of the frequency values which are needed to reproduce
-    a waveform. Results are integer multiples of the df_min.
+def mchirp_compression(m1, m2, fmin, fmax, min_seglen=0.02, df_multiple=None):
+    """Return the frequencies needed to compress a waveform with the given
+    chirp mass. This is based on the estimate in rough_time_estimate.
 
     Parameters
     ----------
@@ -76,22 +79,83 @@ def rough_frequency_samples(m1, m2, flow, fmax, df_min):
         mass of first component object in solar masses
     m2: float
         mass of second component object in solar masses
-    flow: float
-        starting frequency of the waveform
-    fmax: float
-        ending frequency of the waveform
-    df_min: float
-        The size of a frequency sample step.
+    fmin : float
+        The starting frequency of the compressed waveform.
+    fmax : float
+        The ending frequency of the compressed waveform.
+    min_seglen : float
+        The inverse of this gives the maximum frequency step that is used.
+    df_multiple : {None, float}
+        Make the compressed sampling frequencies a multiple of the given value.
+        If None provided, the returned sample points can have any floating
+        point value.
+
+    Returns
+    -------
+    array
+        The frequencies at which to evaluate the compressed waveform.
     """
-    kmin = int(flow / df_min)
-    kmax = int(fmax / df_min)
-    k = kmin
-    ksamples = []
-    while k < kmax:
-        ksamples.append(k)
-        k += int(1.0 / rough_time_estimate(m1, m2, k * df_min) / df_min)
-    ksamples.append(kmax)
-    return numpy.array(ksamples) 
+    sample_points = []
+    f = fmin
+    while f < fmax:
+        if df_multiple is not None:
+            f = int(f/df_multiple)*df_multiple
+        sample_points.append(f)
+        f += 1.0 / rough_time_estimate(m1, m2, f, fudge_min=min_seglen)
+    # add the last point
+    if sample_points[-1] < fmax:
+        sample_points.append(fmax)
+    return numpy.array(sample_points)
+
+def spa_compression(htilde, fmin, fmax, min_seglen=0.02,
+        sample_frequencies=None):
+    """Returns the frequencies needed to compress the given frequency domain
+    waveform. This is done by estimating t(f) of the waveform using the
+    stationary phase approximation.
+
+    Parameters
+    ----------
+    htilde : FrequencySeries
+        The waveform to compress.
+    fmin : float
+        The starting frequency of the compressed waveform.
+    fmax : float
+        The ending frequency of the compressed waveform.
+    min_seglen : float
+        The inverse of this gives the maximum frequency step that is used.
+    sample_frequencies : {None, array}
+        The frequencies that the waveform is evaluated at. If None, will
+        retrieve the frequencies from the waveform's sample_frequencies
+        attribute.
+
+    Returns
+    -------
+    array
+        The frequencies at which to evaluate the compressed waveform.
+    """
+    if sample_frequencies is None:
+        sample_frequencies = htilde.sample_frequencies.numpy()
+    kmin = int(fmin/htilde.delta_f)
+    kmax = int(fmax/htilde.delta_f)
+    tf = abs(utils.time_from_frequencyseries(htilde,
+            sample_frequencies=sample_frequencies).data[kmin:kmax])
+    sample_frequencies = sample_frequencies[kmin:kmax]
+    sample_points = []
+    f = fmin
+    while f < fmax:
+        f = int(f/htilde.delta_f)*htilde.delta_f
+        sample_points.append(f)
+        jj = numpy.searchsorted(sample_frequencies, f)
+        f += 1./(tf[jj:].max()+min_seglen)
+    # add the last point
+    if sample_points[-1] < fmax:
+        sample_points.append(fmax)
+    return numpy.array(sample_points)
+
+compression_algorithms = {
+        'mchirp': mchirp_compression,
+        'spa': spa_compression
+        }
 
 
 def fd_decompress(amp, phase, sample_frequencies, out=None, df=None,

--- a/setup.py
+++ b/setup.py
@@ -475,6 +475,7 @@ setup (
                'bin/plotting/pycbc_plot_waveform',
                'bin/workflows/pycbc_create_sbank_workflow',
                'bin/workflows/pycbc_create_uberbank_workflow',
+               'bin/pycbc_compress_bank',
                ],
     packages = [
                'pycbc',


### PR DESCRIPTION
This patch adds `pycbc_compress_bank`, as well as updates some things in the compress module. This is an update from PR #882. In addition to the changes in that PR, this one introduces a precision argument. When compressing the bank, you now provide a desired precision. In the compress function, the code will use the sample points to do an initial compression. It then checks that 1-overlap of the decompressed waveform is less than the desired precision. If not, it will add points, one at a time, until the condition is met. Note that when this is done, no PSD is used; however, for sufficiently small precision (I used 0.001 here), this shouldn't matter.

I've tested this on the first 100 templates in the O1 bank, by running an independent script that loads the compressed waveforms from disk, decompresses them, then computes the mismatch between them and the full waveform. I tested the mismatch both using both no PSD ("flat") and the O1 H1 PSD ("psd"); here are the results:

https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/bank_compression/mismatch_compare.png

The dashed-red line was the target precision (0.001). As expected, all green points are below this line, which is what the compression code guarantees. When the PSD is used, the mismatch can exceed 0.001, but nothing is > 0.002.

I will do a test on the full bank, but that would be easier to do once I have the workflow that parallelizes the compression. Since implementing that will require a bit more work, I'd like to get this merged first.