### PR TITLE
Patch to OSG site template

### DIFF
--- a/pycbc/workflow/pegasus_files/osg-site-template.xml
+++ b/pycbc/workflow/pegasus_files/osg-site-template.xml
@@ -1,8 +1,8 @@
   <!-- a separate staging site is added else, the intermediate files are symlinked from the home
        directory since symlinking is turned on -->
   <site handle="osg-scratch" arch="x86_64" os="LINUX">
-   <directory  path="$LOCAL_SITE_PATH/osg-scratch" type="shared-scratch" free-size="null" total-size="null">
-        <file-server  operation="all" url="${REMOTE_STAGING_URL}/osg-scratch">
+   <directory  path="$LOCAL_SITE_PATH/local-site-scratch" type="shared-scratch" free-size="null" total-size="null">
+         <file-server  operation="all" url="${REMOTE_STAGING_URL}/local-site-scratch">
         </file-server>
     </directory>
   </site>


### PR DESCRIPTION
Make the changes to the site catalog so that files copy to local-scratch for OSG staging and not osg-scratch.