### PR TITLE
updated matched filter class

### DIFF
--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1375,9 +1375,7 @@ class LiveBatchMatchedFilter(object):
         return result
 
     def _process_vetoes(self, results, veto_info):
-        """Calculate signal based vetoes"""  
-        import pycbc.events
-   
+        """Calculate signal based vetoes"""            
         chisq = numpy.array(numpy.zeros(len(veto_info)), numpy.float32, ndmin=1)
         dof = numpy.array(numpy.zeros(len(veto_info)), numpy.uint32, ndmin=1)
         results['chisq'] = chisq
@@ -1392,7 +1390,7 @@ class LiveBatchMatchedFilter(object):
             dof[i] = d[0]
             
             if self.newsnr_threshold:
-                newsnr = pycbc.events.newsnr(results['snr'][i], chisq[i])
+                newsnr = events.newsnr(results['snr'][i], chisq[i])
                 if newsnr >= self.newsnr_threshold:
                     keep.append(i)
                     
@@ -1404,8 +1402,7 @@ class LiveBatchMatchedFilter(object):
         return results 
 
     def _process_batch(self):
-        """Process only a single batch group of data"""  
-
+        """Process only a single batch group of data"""
         if self.block_id == len(self.tgroups):
             return None, None
 

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1238,7 +1238,7 @@ class LiveBatchMatchedFilter(object):
                  snr_abort_threshold=None,
                  newsnr_threshold=None,
                  max_triggers_in_batch=None):
-        """ Create a batched matchedfilter instance
+        """Create a batched matchedfilter instance
 
         Parameters
         ----------
@@ -1276,7 +1276,7 @@ class LiveBatchMatchedFilter(object):
         templates = [templates[li] for li in lsort]
 
         # Figure out how to chunk together the templates into groups to process
-        sizes, counts = numpy.unique(durations, return_counts=True)
+        _, counts = numpy.unique(durations, return_counts=True)
         tsamples = [(len(t) - 1) * 2 for t in templates]
         grabs = maxelements / numpy.unique(tsamples) 
 
@@ -1376,6 +1376,8 @@ class LiveBatchMatchedFilter(object):
 
     def _process_vetoes(self, results, veto_info):
         """Calculate signal based vetoes"""  
+        import pycbc.events
+   
         chisq = numpy.array(numpy.zeros(len(veto_info)), numpy.float32, ndmin=1)
         dof = numpy.array(numpy.zeros(len(veto_info)), numpy.uint32, ndmin=1)
         results['chisq'] = chisq
@@ -1403,8 +1405,7 @@ class LiveBatchMatchedFilter(object):
 
     def _process_batch(self):
         """Process only a single batch group of data"""  
-        from pycbc.events import newsnr
-   
+
         if self.block_id == len(self.tgroups):
             return None, None
 

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -961,7 +961,7 @@ def _return_array(fn, *args, **kwds):
 def zeros(length, dtype=float64):
     """ Return an Array filled with zeros.
     """
-    pass
+    return
 
 def load_array(path, group=None):
     """


### PR DESCRIPTION
Reorganize the matched filter live class to calculate signal based vetos *after* the triggers are recorded from the entire bank (or rather from a single MPI process). This limits the number of points to calculate drastically when coupled with an option to only record the loudest X triggers. 