### PR TITLE
Script to create ringdown injections

### DIFF
--- a/bin/pycbc_ringinj
+++ b/bin/pycbc_ringinj
@@ -111,7 +111,11 @@ if opts.approximant=='FdQNM' or opts.approximant=='TdQNM':
     # Create datasets for each argument
     injection.create_dataset('f_0', data=opts.f_0)
     injection.create_dataset('tau', data=opts.tau)
-
+    # These have default values, will not complain if not given
+    if opts.amp:
+        injection.create_dataset('amp', data=opts.amp)
+    if opts.phi:
+        injection.create_dataset('phi', data=opts.phi)
 
 # Multi-mode approximant
 if opts.approximant=='FdQNMmultiModes' or opts.approximant=='TdQNMmultiModes':

--- a/bin/pycbc_ringinj
+++ b/bin/pycbc_ringinj
@@ -111,11 +111,8 @@ if opts.approximant=='FdQNM' or opts.approximant=='TdQNM':
     # Create datasets for each argument
     injection.create_dataset('f_0', data=opts.f_0)
     injection.create_dataset('tau', data=opts.tau)
-    # These have default values, will not complain if not given
-    if opts.amp:
-        injection.create_dataset('amp', data=opts.amp)
-    if opts.phi:
-        injection.create_dataset('phi', data=opts.phi)
+    injection.create_dataset('amp', data=opts.amp)
+    injection.create_dataset('phi', data=opts.phi)
 
 # Multi-mode approximant
 if opts.approximant=='FdQNMmultiModes' or opts.approximant=='TdQNMmultiModes':

--- a/bin/pycbc_ringinj
+++ b/bin/pycbc_ringinj
@@ -32,26 +32,27 @@ import h5py
 from pycbc.waveform import ringdown
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--output',
+parser.add_argument('--output', required=True,
                     help='Path to output hdf file.')
 parser.add_argument('--approximant', required=True, 
                     help='Name of the ringdown approximant.')
-parser.add_argument('--gps-start-time', required=True,
-                    help='Time of the injection.')
-parser.add_argument('--f-0',
+parser.add_argument('--tc', required=True, type=float,
+                    help='Geocentric coalescence time '
+                         '(start time of the ringdown injection).')
+parser.add_argument('--f-0', type=float,
                     help='Central frequency of the ringdown for '
                          'single mode approximants.')
-parser.add_argument('--tau',
+parser.add_argument('--tau', type=float,
                     help='Damping time of the ringdown for '
                          'single mode approximants.')
-parser.add_argument('--amp',
+parser.add_argument('--amp', type=float,
                     help='Amplitude for single mode approximants.')
-parser.add_argument('--phi',
+parser.add_argument('--phi', type=float,
                     help='Phase for single mode approximants.')
-parser.add_argument('--Mfinal',
+parser.add_argument('--Mfinal', type=float,
                     help='Mass of the final black hole for '
                          'multi-mode approximants.')
-parser.add_argument('--Sfinal',
+parser.add_argument('--Sfinal', type=float,
                     help='Spin of the final black hole for ' 
                          'multi-mode approximants.')
 parser.add_argument('--lmns', nargs='+',
@@ -62,19 +63,27 @@ parser.add_argument('--amps-phis', nargs='+',
                     help='Amplitudes and phases for each mode. '
                          'Use format mode:amplitude:phase. '
                          'Example: 220:1e-21:0 221:0.1e-21:3.14 330:0.05e-21:3.14')
-parser.add_argument('--delta-t',
+parser.add_argument('--delta-t', type=float,
                     help='Time step for time domain approximants.')
-parser.add_argument('--t-final',
+parser.add_argument('--t-final', type=float,
                     help='Ending time of the output time series '
                          'for time domain approximants.')
-parser.add_argument('--delta-f',
+parser.add_argument('--delta-f', type=float,
                     help='Frequency step for frequency domain approximants.')
-parser.add_argument('--f-lower',
+parser.add_argument('--f-lower', type=float,
                     help='Starting frequency of the output freqeucny series '
                          'for frequency domain approximants.')
-parser.add_argument('--f-final',
+parser.add_argument('--f-final', type=float, 
                     help='Ending frequency of the output frequency series '
                          'for frequency domain approximants.')
+parser.add_argument('--distance', required=True, type=float,
+                    help='Distance in kpc for detector frame waveform generator class.')
+parser.add_argument('--ra', required=True, type=float,
+                    help='Right ascension for detector frame waveform generator class.')
+parser.add_argument('--dec', required=True, type=float,
+                    help='Declination for detector frame waveform generator class.')
+parser.add_argument('--polarization', required=True, type=float,
+                    help='Polarization for detector frame waveform generator class.')
 
 opts = parser.parse_args()
 
@@ -85,12 +94,42 @@ approxs.update(ringdown.ringdown_td_approximants)
 if opts.approximant not in approxs.keys():
     raise ValueError('Invalid ringdown approximant')
 
-# Check that the necessary arguments are given
+# Write hdf file with the parameters for the injection
+injection = h5py.File('%s' %opts.output, 'w')
+# Store common arguments
+injection.create_dataset('approximant', data=opts.approximant)
+injection.create_dataset('tc', data=opts.tc)
+injection.create_dataset('distance', data=opts.distance)
+injection.create_dataset('ra', data=opts.ra)
+injection.create_dataset('dec', data=opts.dec)
+injection.create_dataset('polarization', data=opts.polarization)
+if opts.approximant in ringdown.ringdown_fd_approximants:
+    if opts.delta_f is not None:
+        injection.create_dataset('delta_f', data=opts.delta_f)
+    if opts.f_lower is not None:
+        injection.create_dataset('f_lower', data=opts.f_lower)
+    if opts.f_final is not None:
+        injection.create_dataset('f_final', data=opts.f_final)
+else:
+    if opts.delta_t is not None:
+        injection.create_dataset('delta_t', data=opts.delta_t)
+    if opts.t_final is not None:
+        injection.create_dataset('t_final', data=opts.t_final)
+
+# Single mode approximant
 if opts.approximant=='FdQNM' or opts.approximant=='TdQNM':
+    # Check that the necessary arguments are given
     for parameter in ringdown.qnm_required_args:
         if getattr(opts, parameter) is None:
             raise ValueError('%s is required' %parameter)
-elif opts.approximant=='FdQNMmultiModes' or opts.approximant=='TdQNMmultiModes':
+    # Create datasets for each argument
+    injection.create_dataset('f_0', data=opts.f_0)
+    injection.create_dataset('tau', data=opts.tau)
+
+
+# Multi-mode approximant
+if opts.approximant=='FdQNMmultiModes' or opts.approximant=='TdQNMmultiModes':
+    # Check that the necessary arguments are given
     for parameter in ringdown.lm_allmodes_required_args:
         if getattr(opts, parameter) is None:
             raise ValueError('%s is required' %parameter)
@@ -100,13 +139,22 @@ elif opts.approximant=='FdQNMmultiModes' or opts.approximant=='TdQNMmultiModes':
         l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
         [all_modes.append('%d%d%d' %(l,m,n)) for n in range(nmodes)]
     info_modes=[info.split(':')[0] for info in opts.amps_phis]
+    amps, phis = {}, {}
     for mode in all_modes:
         if mode not in info_modes:
             raise ValueError('Amplitude and phase for mode %s are required' %mode)
-    try:
-        amps_modes=[info.split(':')[1] for info in opts.amps_phis]
-        phis_modes=[info.split(':')[2] for info in opts.amps_phis]
-    except:
-        raise ValueError('Amplitude or phase for one of the modes is missing')
+    for info in opts.amps_phis:
+        try:
+            amps['%s' %info.split(':')[0]]=info.split(':')[1]
+            phis['%s' %info.split(':')[0]]=info.split(':')[2]
+        except:
+            raise ValueError('Amplitude or phase for one of the modes is missing')
+    # Create datasets for each argument
+    injection.create_dataset('Mfinal', data=opts.Mfinal)
+    injection.create_dataset('Sfinal', data=opts.Sfinal)
+    injection.create_dataset('lmns', data=opts.lmns)
+    for mode in all_modes:
+        injection.create_dataset('amp%s' %mode, data=float(amps[mode]))
+        injection.create_dataset('phi%s' %mode, data=float(phis[mode]))
 
-# Write hdf file with the parameters for the injection
+injection.close()

--- a/bin/pycbc_ringinj
+++ b/bin/pycbc_ringinj
@@ -63,13 +63,9 @@ parser.add_argument('--amps-phis', nargs='+',
                     help='Amplitudes and phases for each mode. '
                          'Use format mode:amplitude:phase. '
                          'Example: 220:1e-21:0 221:0.1e-21:3.14 330:0.05e-21:3.14')
-parser.add_argument('--delta-t', type=float,
-                    help='Time step for time domain approximants.')
 parser.add_argument('--t-final', type=float,
                     help='Ending time of the output time series '
                          'for time domain approximants.')
-parser.add_argument('--delta-f', type=float,
-                    help='Frequency step for frequency domain approximants.')
 parser.add_argument('--f-lower', type=float,
                     help='Starting frequency of the output freqeucny series '
                          'for frequency domain approximants.')
@@ -77,7 +73,7 @@ parser.add_argument('--f-final', type=float,
                     help='Ending frequency of the output frequency series '
                          'for frequency domain approximants.')
 parser.add_argument('--distance', required=True, type=float,
-                    help='Distance in kpc for detector frame waveform generator class.')
+                    help='Distance in Mpc for detector frame waveform generator class.')
 parser.add_argument('--ra', required=True, type=float,
                     help='Right ascension for detector frame waveform generator class.')
 parser.add_argument('--dec', required=True, type=float,
@@ -104,15 +100,11 @@ injection.create_dataset('ra', data=opts.ra)
 injection.create_dataset('dec', data=opts.dec)
 injection.create_dataset('polarization', data=opts.polarization)
 if opts.approximant in ringdown.ringdown_fd_approximants:
-    if opts.delta_f is not None:
-        injection.create_dataset('delta_f', data=opts.delta_f)
     if opts.f_lower is not None:
         injection.create_dataset('f_lower', data=opts.f_lower)
     if opts.f_final is not None:
         injection.create_dataset('f_final', data=opts.f_final)
 else:
-    if opts.delta_t is not None:
-        injection.create_dataset('delta_t', data=opts.delta_t)
     if opts.t_final is not None:
         injection.create_dataset('t_final', data=opts.t_final)
 

--- a/bin/pycbc_ringinj
+++ b/bin/pycbc_ringinj
@@ -1,0 +1,112 @@
+# Copyright (C) 2016 Miriam Cabero Mueller
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+
+"""
+Create an HDF file with a ringdown injection
+"""
+
+import argparse
+import h5py
+from pycbc.waveform import ringdown
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--output',
+                    help='Path to output hdf file.')
+parser.add_argument('--approximant', required=True, 
+                    help='Name of the ringdown approximant.')
+parser.add_argument('--gps-start-time', required=True,
+                    help='Time of the injection.')
+parser.add_argument('--f-0',
+                    help='Central frequency of the ringdown for '
+                         'single mode approximants.')
+parser.add_argument('--tau',
+                    help='Damping time of the ringdown for '
+                         'single mode approximants.')
+parser.add_argument('--amp',
+                    help='Amplitude for single mode approximants.')
+parser.add_argument('--phi',
+                    help='Phase for single mode approximants.')
+parser.add_argument('--Mfinal',
+                    help='Mass of the final black hole for '
+                         'multi-mode approximants.')
+parser.add_argument('--Sfinal',
+                    help='Spin of the final black hole for ' 
+                         'multi-mode approximants.')
+parser.add_argument('--lmns', nargs='+',
+                    help='Modes desired for multi-mode approximants ' 
+                         '(lm modes available: 22, 21, 33, 44, 55). '
+                         'Example: 222 331 gives the modes 220, 221, and 330.')
+parser.add_argument('--amps-phis', nargs='+',
+                    help='Amplitudes and phases for each mode. '
+                         'Use format mode:amplitude:phase. '
+                         'Example: 220:1e-21:0 221:0.1e-21:3.14 330:0.05e-21:3.14')
+parser.add_argument('--delta-t',
+                    help='Time step for time domain approximants.')
+parser.add_argument('--t-final',
+                    help='Ending time of the output time series '
+                         'for time domain approximants.')
+parser.add_argument('--delta-f',
+                    help='Frequency step for frequency domain approximants.')
+parser.add_argument('--f-lower',
+                    help='Starting frequency of the output freqeucny series '
+                         'for frequency domain approximants.')
+parser.add_argument('--f-final',
+                    help='Ending frequency of the output frequency series '
+                         'for frequency domain approximants.')
+
+opts = parser.parse_args()
+
+# Check that the approximant given is a valid rindown approximant
+approxs = ringdown.ringdown_fd_approximants.copy()
+approxs.update(ringdown.ringdown_td_approximants)
+
+if opts.approximant not in approxs.keys():
+    raise ValueError('Invalid ringdown approximant')
+
+# Check that the necessary arguments are given
+if opts.approximant=='FdQNM' or opts.approximant=='TdQNM':
+    for parameter in ringdown.qnm_required_args:
+        if getattr(opts, parameter) is None:
+            raise ValueError('%s is required' %parameter)
+elif opts.approximant=='FdQNMmultiModes' or opts.approximant=='TdQNMmultiModes':
+    for parameter in ringdown.lm_allmodes_required_args:
+        if getattr(opts, parameter) is None:
+            raise ValueError('%s is required' %parameter)
+    # Amplitudes and phases for each mode have to be given
+    all_modes = []
+    for lmn in opts.lmns:
+        l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
+        [all_modes.append('%d%d%d' %(l,m,n)) for n in range(nmodes)]
+    info_modes=[info.split(':')[0] for info in opts.amps_phis]
+    for mode in all_modes:
+        if mode not in info_modes:
+            raise ValueError('Amplitude and phase for mode %s are required' %mode)
+    try:
+        amps_modes=[info.split(':')[1] for info in opts.amps_phis]
+        phis_modes=[info.split(':')[2] for info in opts.amps_phis]
+    except:
+        raise ValueError('Amplitude or phase for one of the modes is missing')
+
+# Write hdf file with the parameters for the injection

--- a/bin/pycbc_ringinj
+++ b/bin/pycbc_ringinj
@@ -84,10 +84,7 @@ parser.add_argument('--polarization', required=True, type=float,
 opts = parser.parse_args()
 
 # Check that the approximant given is a valid rindown approximant
-approxs = ringdown.ringdown_fd_approximants.copy()
-approxs.update(ringdown.ringdown_td_approximants)
-
-if opts.approximant not in approxs.keys():
+if opts.approximant not in ringdown.ringdown_fd_approximants.keys()+ringdown.ringdown_td_approximants.keys():
     raise ValueError('Invalid ringdown approximant')
 
 # Write hdf file with the parameters for the injection

--- a/bin/pycbc_ringinj
+++ b/bin/pycbc_ringinj
@@ -72,8 +72,6 @@ parser.add_argument('--f-lower', type=float,
 parser.add_argument('--f-final', type=float, 
                     help='Ending frequency of the output frequency series '
                          'for frequency domain approximants.')
-parser.add_argument('--distance', required=True, type=float,
-                    help='Distance in Mpc for detector frame waveform generator class.')
 parser.add_argument('--ra', required=True, type=float,
                     help='Right ascension for detector frame waveform generator class.')
 parser.add_argument('--dec', required=True, type=float,
@@ -92,7 +90,6 @@ injection = h5py.File('%s' %opts.output, 'w')
 # Store common arguments
 injection.create_dataset('approximant', data=opts.approximant)
 injection.create_dataset('tc', data=opts.tc)
-injection.create_dataset('distance', data=opts.distance)
 injection.create_dataset('ra', data=opts.ra)
 injection.create_dataset('dec', data=opts.dec)
 injection.create_dataset('polarization', data=opts.polarization)

--- a/pycbc/inject.py
+++ b/pycbc/inject.py
@@ -371,9 +371,6 @@ class RingdownInjectionSet(object):
             Time series to inject signals into, of type float32 or float64.
         detector_name : string
             Name of the detector used for projecting injections.
-        distance_scale: {1, float}, optional
-            Factor to scale the distance of an injection with. The default is 
-            no scaling. 
 
         Returns
         -------
@@ -417,9 +414,6 @@ class RingdownInjectionSet(object):
             Sample rate to make injection at.
         detector_name : string
             Name of the detector used for projecting injections.
-        distance_scale: {1, float}, optional
-            Factor to scale the distance of an injection with. The default is 
-            no scaling. 
 
         Returns
         --------

--- a/pycbc/inject.py
+++ b/pycbc/inject.py
@@ -354,7 +354,7 @@ class RingdownInjectionSet(object):
     table
     """
 
-    def __init__(self, hdf_file, **kwds):
+    def __init__(self, hdf_file):
         self.name = hdf_file
 
         injfile = h5py.File(hdf_file,'r')
@@ -385,14 +385,11 @@ class RingdownInjectionSet(object):
             For invalid types of `strain`.
         """
 
-        if not strain.dtype in (float32, float64):
+        if strain.dtype not in (float32, float64):
             raise TypeError("Strain dtype must be float32 or float64, not " \
                     + str(strain.dtype))
 
         lalstrain = strain.lal()
-        earth_travel_time = lal.REARTH_SI / lal.C_SI
-        t0 = float(strain.start_time) - earth_travel_time
-        t1 = float(strain.end_time) + earth_travel_time
 
         # pick lalsimulation injection function
         add_injection = injection_func_map[strain.dtype]

--- a/pycbc/inject.py
+++ b/pycbc/inject.py
@@ -443,6 +443,6 @@ class RingdownInjectionSet(object):
 
         # compute the detector response and add it to the strain
         signal = detector.project_wave(hp, hc,
-                             inj['ra'], inj['declination'], inj['polarization'])
+                             inj['ra'], inj['dec'], inj['polarization'])
 
         return signal

--- a/pycbc/inject.py
+++ b/pycbc/inject.py
@@ -362,7 +362,7 @@ class RingdownInjectionSet(object):
         self.table = dict([(p, injfile[p].value) for p in pnames])
         injfile.close()
 
-    def apply(self, strain, detector_name, distance_scale=1):
+    def apply(self, strain, detector_name):
         """Add injection (as seen by a particular detector) to a time series.
 
         Parameters
@@ -398,15 +398,14 @@ class RingdownInjectionSet(object):
         injection = self.table
 
         signal = self.make_strain_from_inj_object(injection, strain.delta_t,
-                     detector_name, distance_scale=distance_scale)
+                     detector_name)
         signal = signal.astype(strain.dtype)
         signal_lal = signal.lal()
         add_injection(lalstrain, signal_lal, None)
 
         strain.data[:] = lalstrain.data.data[:]
 
-    def make_strain_from_inj_object(self, inj, delta_t, detector_name,
-                                    distance_scale=1):
+    def make_strain_from_inj_object(self, inj, delta_t, detector_name):
         """Make a h(t) strain time-series from an injection object as read from
         an hdf file.
 
@@ -432,8 +431,6 @@ class RingdownInjectionSet(object):
         # compute the waveform time series
         hp, hc = ringdown_td_approximants[inj['approximant']](
             delta_t=delta_t, **inj)
-        hp /= distance_scale
-        hc /= distance_scale
 
         hp._epoch += inj['tc']
         hc._epoch += inj['tc']

--- a/pycbc/inject.py
+++ b/pycbc/inject.py
@@ -362,8 +362,6 @@ class RingdownInjectionSet(object):
         self.table = dict([(p, injfile[p].value) for p in pnames])
         injfile.close()
 
-        self.extra_args = kwds
-
     def apply(self, strain, detector_name, distance_scale=1):
         """Add injection (as seen by a particular detector) to a time series.
 

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -189,6 +189,10 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
 
     gating_info = {}
     injections = []
+<<<<<<< HEAD
+=======
+
+>>>>>>> Adapt changes to last update in strain.py
     if opt.frame_cache or opt.frame_files or opt.frame_type:
         if opt.frame_cache:
             frame_source = opt.frame_cache
@@ -224,19 +228,27 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
         if opt.injection_file:
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
+<<<<<<< HEAD
             injections += injector.apply(strain, opt.channel_name[0:2],        
+=======
+            injections += injector.apply(strain, opt.channel_name[0:2],
+>>>>>>> Adapt changes to last update in strain.py
                              distance_scale=opt.injection_scale_factor)
 
         if opt.sgburst_injection_file:
             logging.info("Applying sine-Gaussian burst injections")
+<<<<<<< HEAD
             injector =  SGBurstInjectionSet(opt.sgburst_injection_file)
+=======
+            injector = SGBurstInjectionSet(opt.sgburst_injection_file)
+>>>>>>> Adapt changes to last update in strain.py
             injector.apply(strain, opt.channel_name[0:2],
                              distance_scale=opt.injection_scale_factor)
 
         if opt.ringdown_injection_file:
             logging.info("Applying ringdown-only injection.")
-            injections = RingdownInjectionSet(opt.ringdown_injection_file)
-            injections.apply(strain, opt.channel_name[0:2],
+            injector = RingdownInjectionSet(opt.ringdown_injection_file)
+            injector.apply(strain, opt.channel_name[0:2],
                              distance_scale=opt.injection_scale_factor)
 
         logging.info("Highpass Filtering")
@@ -314,7 +326,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
         if opt.injection_file:
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
-            injections += injector.apply(strain, opt.channel_name[0:2],        
+            injections += injector.apply(strain, opt.channel_name[0:2],
                              distance_scale=opt.injection_scale_factor)
 
         if opt.sgburst_injection_file:
@@ -325,8 +337,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
 
         if opt.ringdown_injection_file:
             logging.info("Applying ringdown-only injection.")
-            injections = RingdownInjectionSet(opt.ringdown_injection_file)
-            injections.apply(strain, opt.channel_name[0:2],
+            injector = RingdownInjectionSet(opt.ringdown_injection_file)
+            injector.apply(strain, opt.channel_name[0:2],
                              distance_scale=opt.injection_scale_factor)
 
         if precision == 'single':

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -443,7 +443,7 @@ def insert_strain_option_group(parser, gps_times=True):
 
     data_reading_group.add_argument("--ringdown-injection-file", type=str,
                       help="(optional) Injection file used to add "
-                           "ringdown-only waveforms into the strain."
+                           "ringdown-only waveforms into the strain.")
 
     data_reading_group.add_argument("--injection-scale-factor", type=float,
                     default=1, help="Divide injections by this factor "

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -590,7 +590,7 @@ def insert_strain_option_group_multi_ifo(parser):
     data_reading_group.add_argument("--ringdown-injection-file", type=str,
                     nargs="+", action=MultiDetOptionAction, metavar='IFO:FILE',
                     help="(optional) Injection file used to add "
-                           "ringdown-only waveforms into the strain."
+                           "ringdown-only waveforms into the strain.")
 
     data_reading_group.add_argument("--injection-scale-factor", type=float,
                     nargs="+", action=MultiDetOptionAction, metavar="IFO:VAL",

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -189,10 +189,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
 
     gating_info = {}
     injections = []
-<<<<<<< HEAD
-=======
 
->>>>>>> Adapt changes to last update in strain.py
     if opt.frame_cache or opt.frame_files or opt.frame_type:
         if opt.frame_cache:
             frame_source = opt.frame_cache
@@ -228,20 +225,12 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
         if opt.injection_file:
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
-<<<<<<< HEAD
             injections += injector.apply(strain, opt.channel_name[0:2],        
-=======
-            injections += injector.apply(strain, opt.channel_name[0:2],
->>>>>>> Adapt changes to last update in strain.py
                              distance_scale=opt.injection_scale_factor)
 
         if opt.sgburst_injection_file:
             logging.info("Applying sine-Gaussian burst injections")
-<<<<<<< HEAD
-            injector =  SGBurstInjectionSet(opt.sgburst_injection_file)
-=======
             injector = SGBurstInjectionSet(opt.sgburst_injection_file)
->>>>>>> Adapt changes to last update in strain.py
             injector.apply(strain, opt.channel_name[0:2],
                              distance_scale=opt.injection_scale_factor)
 

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -237,8 +237,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
         if opt.ringdown_injection_file:
             logging.info("Applying ringdown-only injection.")
             injector = RingdownInjectionSet(opt.ringdown_injection_file)
-            injector.apply(strain, opt.channel_name[0:2],
-                             distance_scale=opt.injection_scale_factor)
+            injector.apply(strain, opt.channel_name[0:2])
 
         logging.info("Highpass Filtering")
         strain = highpass(strain, frequency=opt.strain_high_pass)
@@ -327,8 +326,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
         if opt.ringdown_injection_file:
             logging.info("Applying ringdown-only injection.")
             injector = RingdownInjectionSet(opt.ringdown_injection_file)
-            injector.apply(strain, opt.channel_name[0:2],
-                             distance_scale=opt.injection_scale_factor)
+            injector.apply(strain, opt.channel_name[0:2])
 
         if precision == 'single':
             logging.info("Converting to float32")

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -30,8 +30,8 @@ import lalsimulation as lalsim
 from pycbc.types import TimeSeries, FrequencySeries, complex128, zeros
 from pycbc.waveform.waveform import get_obj_attrs
 
-default_qnm_args = {'t_0':0, 'phi':0, 'amp':1}
-qnm_required_args = ['f_0', 'tau']
+default_qnm_args = {'t_0':0}
+qnm_required_args = ['f_0', 'tau', 'amp', 'phi']
 lm_required_args = ['Mfinal','Sfinal','l','m','nmodes']
 lm_allmodes_required_args = ['Mfinal','Sfinal', 'lmns']
 
@@ -242,9 +242,9 @@ def get_td_qnm(template=None, **kwargs):
         The ringdown-frequency.
     tau : float
         The damping time of the sinusoid.
-    phi : {0, float}, optional
+    phi : float
         The initial phase of the ringdown.
-    amp : {1, float}, optional
+    amp : float
         The amplitude of the ringdown (constant for now).
     delta_t : {None, float}, optional
         The time step used to generate the ringdown.
@@ -267,9 +267,8 @@ def get_td_qnm(template=None, **kwargs):
     
     f_0 = input_params.pop('f_0')
     tau = input_params.pop('tau')
-    # the following have defaults, and so will be populated
-    phi = input_params.pop('phi')
     amp = input_params.pop('amp')
+    phi = input_params.pop('phi')
     # the following may not be in input_params
     delta_t = input_params.pop('delta_t', None)
     t_final = input_params.pop('t_final', None)
@@ -306,12 +305,12 @@ def get_fd_qnm(template=None, **kwargs):
         The ringdown-frequency.
     tau : float
         The damping time of the sinusoid.
+    phi : float
+        The initial phase of the ringdown.
+    amp : float
+        The amplitude of the ringdown (constant for now).
     t_0 :  {0, float}, optional
         The starting time of the ringdown.
-    phi : {0, float}, optional
-        The initial phase of the ringdown.
-    amp : {1, float}, optional
-        The amplitude of the ringdown (constant for now).
     delta_f : {None, float}, optional
         The frequency step used to generate the ringdown.
         If None, it will be set to the inverse of the time at which the
@@ -336,10 +335,10 @@ def get_fd_qnm(template=None, **kwargs):
 
     f_0 = input_params.pop('f_0')
     tau = input_params.pop('tau')
+    amp = input_params.pop('amp')
+    phi = input_params.pop('phi')
     # the following have defaults, and so will be populated
     t_0 = input_params.pop('t_0')
-    phi = input_params.pop('phi')
-    amp = input_params.pop('amp')
     # the following may not be in input_params
     delta_f = input_params.pop('delta_f', None)
     f_lower = input_params.pop('f_lower', None)

--- a/setup.py
+++ b/setup.py
@@ -466,6 +466,7 @@ setup (
                'bin/workflows/pycbc_create_sbank_workflow',
                'bin/workflows/pycbc_create_uberbank_workflow',
                'bin/pycbc_compress_bank',
+               'bin/pycbc_ringinj',
                ],
     packages = [
                'pycbc',


### PR DESCRIPTION
Currently most of my ringdown parameter estimation runs are not reproducible because I had to hack pycbc_inference to perform ringdown injections. This script is a ringdown version of lalapps_inspinj, and the first step to make ringdown injections compatible with the master version of pycbc_inference. 
pycbc_ringinj takes the parameters of the injection as input, checks that all the required arguments are there (which are approximant dependent) and writes an hdf5 file with the parameters of the injection.
When this script is reviewed and merged, I will make the necessary changes in inject.py and strain.py to read this kind of files.