### PR TITLE
Allow compression to use single precision and speed up decompression code

### DIFF
--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -33,7 +33,7 @@ import logging
 import pycbc
 from pycbc.waveform import compress
 from pycbc import waveform
-from pycbc.types import FrequencySeries
+from pycbc.types import FrequencySeries, real_same_precision_as
 from pycbc import pnutils
 from pycbc import filter
 
@@ -79,6 +79,10 @@ parser.add_argument("--interpolation", type=str, default="linear",
                      "waveforms for checking tolerance. Options are 'linear', "
                      "or any interpolation recognized by scipy's interp1d "
                      "kind argument. Default is linear.")
+parser.add_argument("--precision", type=str, choices=["double", "single"],
+                default="double",
+                help="What precision to generate and store the waveforms with;"
+                     " default is double.")
 parser.add_argument("--verbose", action="store_true", default=False)
 
 
@@ -91,8 +95,15 @@ fmax = args.sample_rate/2.
 
 # load the bank
 logging.info("loading bank")
+# set the dtype to use
+# FIXME: there really should be a funciont in pycbc.types that provides this
+# mapping
+if args.precision == "single":
+    dtype = numpy.complex64
+else:
+    dtype = numpy.complex128
 # we'll just use dummy values for N, df for now
-bank = waveform.FilterBank(args.bank_file, 5, 0.25, fmin, numpy.complex128,
+bank = waveform.FilterBank(args.bank_file, 5, 0.25, fmin, dtype,
     approximant=args.approximant)
 templates = bank.table
 if args.tmplt_index is not None:
@@ -133,8 +144,7 @@ for ii in range(imin, imax):
     bank.f_lower = fmin-df
     bank.kmin = int(bank.f_lower / df)
     # scratch space
-    decomp_scratch = FrequencySeries(numpy.zeros(N, dtype=numpy.complex128),
-                                 delta_f=df)
+    decomp_scratch = FrequencySeries(numpy.zeros(N, dtype=dtype), delta_f=df)
     # generate the waveform
     htilde = bank[ii]
     tmplt = bank.table[ii]
@@ -143,10 +153,11 @@ for ii in range(imin, imax):
     # get the compressed sample points
     if args.compression_algorithm == 'mchirp':
         sample_points = compress.mchirp_compression(tmplt.mass1, tmplt.mass2,
-            fmin, (kmax-1)*df, min_seglen=args.t_pad, df_multiple=df)
+            fmin, (kmax-1)*df, min_seglen=args.t_pad, df_multiple=df).astype(
+            real_same_precision_as(htilde))
     elif args.compression_algorithm == 'spa':
         sample_points = compress.spa_compression(htilde, fmin, (kmax-1)*df,
-            min_seglen=args.t_pad)
+            min_seglen=args.t_pad).astype(real_same_precision_as(htilde))
     else:
         raise ValueError("unrecognized compression algorithm %s" %(
             args.compression_algorithm))

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -68,7 +68,7 @@ parser.add_argument("--t-pad", type=float, default=0.001,
                      "inverse of this gives the maximum frequency step that "
                      "will be used in the compressed waveforms. Default is "
                      "0.001.")
-parser.add_argument("--precision", type=float, default=0.001,
+parser.add_argument("--tolerance", type=float, default=0.001,
                 help="The maximum mismatch to allow between the interpolated "
                      "waveform must and the full waveform. Points will be "
                      "added to the compressed waveform until its "
@@ -76,7 +76,7 @@ parser.add_argument("--precision", type=float, default=0.001,
                      "0.001.")
 parser.add_argument("--interpolation", type=str, default="linear",
                 help="The interpolation to use for decompressing the "
-                     "waveforms for checking precision. Options are 'linear', "
+                     "waveforms for checking tolerance. Options are 'linear', "
                      "or any interpolation recognized by scipy's interp1d "
                      "kind argument. Default is linear.")
 parser.add_argument("--verbose", action="store_true", default=False)
@@ -153,7 +153,7 @@ for ii in range(imin, imax):
             
     # compress
     hcompressed = compress.compress_waveform(
-        htilde, sample_points, args.precision, args.interpolation,
+        htilde, sample_points, args.tolerance, args.interpolation,
         decomp_scratch=decomp_scratch)
 
     # save results

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -25,7 +25,6 @@ domain waveforms.
 """
 import lalsimulation, lal, numpy, logging, h5py
 from pycbc import pnutils, filter
-from pycbc.types import Array
 from pycbc.opt import omp_libs, omp_flags
 from pycbc import WEAVE_FLAGS
 from scipy.weave import inline

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -402,7 +402,7 @@ _linear_decompress_code = r"""
     }
 
     // zero out the rest of the array
-    memset(outptr, 0, 2*(hlen-findex));
+    memset(outptr, 0, sizeof(*outptr)*2*(hlen-findex));
 """
 # for single precision
 _linear_decompress_code32 = _linear_decompress_code.replace('double', 'float')

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -331,7 +331,7 @@ _linear_decompress_code = r"""
     double dphi_re, dphi_im;
 
     // we will re-compute cos/sin of the phase at the following intervals:
-    int update_interval = 100;
+    int update_interval = 128;
 
     // zero out the beginning
     memset(outptr, 0, sizeof(*outptr)*2*start_index);

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -287,11 +287,10 @@ _linear_decompress_code = r"""
     // their real and imaginary values next to each other in memory
     double* outptr = (double*) h;
 
-    // zero out the beginning & end
-    memset(outptr, 0, sizeof(*outptr)*2*kmin);
-    memset(outptr+flen, 0, sizeof((double) h));
+    // zero out the beginning
+    memset(outptr, 0, sizeof(*outptr)*2*imin);
 
-    outptr += 2*kmin; // move to the start position
+    outptr += 2*imin; // move to the start position
 
     // variables for computing the interpolation
     double df = (double) delta_f;
@@ -339,6 +338,8 @@ _linear_decompress_code = r"""
             jj += 1;
             // if we have gone beyond the sampled frequencies, just break
             if ((jj+1) == sflen) {
+                // zero out the rest of the array
+                memset(outptr, 0, 2*(flen-ii));
                 break;
             }
             sf = (double) sample_frequencies[jj];
@@ -381,7 +382,7 @@ _linear_decompress_code = r"""
             kk += 1;
         }
         *outptr = h_re;
-        *outptr+1 = h_im;
+        *(outptr+1) = h_im;
         outptr += 2;
     }
 """

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -365,8 +365,8 @@ _linear_decompress_code = r"""
             dPhi_im = sin(mPhi * df);
             h_re = interpAmp * cos(interpPhi);
             h_im = interpAmp * sin(interpPhi);
-            g_re = mAmp * df * cos(mPhi * f);
-            g_im = mAmp * df * sin(mPhi * f);
+            g_re = mAmp * df * cos(interpPhi);
+            g_im = mAmp * df * sin(interpPhi);
             kk = 0;
         }
         else {
@@ -433,7 +433,6 @@ def fd_decompress(amp, phase, sample_frequencies, out=None, df=None,
         out = FrequencySeries(numpy.zeros(flen,
             dtype=numpy.complex128), copy=False, delta_f=df)
     else:
-        out.clear()
         df = out.delta_f
         flen = len(out)
     if f_lower is None:

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -29,7 +29,7 @@ from pycbc.opt import omp_libs, omp_flags
 from pycbc import WEAVE_FLAGS
 from scipy.weave import inline
 from scipy import interpolate
-from pycbc.types import Array, FrequencySeries, zeros, complex_same_precision_as, real_same_precision_as
+from pycbc.types import FrequencySeries, zeros, complex_same_precision_as, real_same_precision_as
 from pycbc.waveform import utils
 
 def rough_time_estimate(m1, m2, flow, fudge_length=1.1, fudge_min=0.02):
@@ -468,7 +468,7 @@ def fd_decompress(amp, phase, sample_frequencies, out=None, df=None,
         if df is None:
             raise ValueError("Either provide output memory or a df")
         hlen = int(numpy.ceil(sample_frequencies.max()/df+1))
-        out = FrequencySeries(numpy.zeros(flen,
+        out = FrequencySeries(numpy.zeros(hlen,
             dtype=_complex_dtypes[precision]), copy=False,
             delta_f=df)
     else:

--- a/pycbc/waveform/utils.py
+++ b/pycbc/waveform/utils.py
@@ -24,7 +24,7 @@
 #
 """This module contains convenience utilities for manipulating waveforms
 """
-from pycbc.types import TimeSeries, FrequencySeries, Array, float32, float64, complex_same_precision_as
+from pycbc.types import TimeSeries, FrequencySeries, Array, float32, float64, complex_same_precision_as, real_same_precision_as
 import lal
 import lalsimulation as sim
 from math import frexp
@@ -60,7 +60,8 @@ def phase_from_frequencyseries(htilde, remove_start_phase=True):
     FrequencySeries
         The phase of the waveform as a function of frequency.
     """
-    p = numpy.unwrap(numpy.angle(htilde.data))
+    p = numpy.unwrap(numpy.angle(htilde.data)).astype(
+            real_same_precision_as(htilde))
     if remove_start_phase:
         p += -p[0]    
     return FrequencySeries(p, delta_f=htilde.delta_f, epoch=htilde.epoch,
@@ -80,7 +81,7 @@ def amplitude_from_frequencyseries(htilde):
     FrequencySeries
         The amplitude of the waveform as a function of frequency.
     """
-    amp = abs(htilde.data)
+    amp = abs(htilde.data).astype(real_same_precision_as(htilde))
     return FrequencySeries(amp, delta_f=htilde.delta_f, epoch=htilde.epoch,
         copy=False)
 
@@ -132,7 +133,8 @@ def time_from_frequencyseries(htilde, sample_frequencies=None,
         kmax = min(kmax, kmin + discont_idx[0]-1)
     time[:kmin] = time[kmin]
     time[kmax:] = time[kmax]
-    return FrequencySeries(time, delta_f=htilde.delta_f, epoch=htilde.epoch,
+    return FrequencySeries(time.astype(real_same_precision_as(htilde)),
+        delta_f=htilde.delta_f, epoch=htilde.epoch,
         copy=False)
 
 def phase_from_polarizations(h_plus, h_cross, remove_start_phase=True):
@@ -164,7 +166,8 @@ def phase_from_polarizations(h_plus, h_cross, remove_start_phase=True):
     >>> phase = phase_from_polarizations(hp, hc)
 
     """
-    p = numpy.unwrap(numpy.arctan2(h_cross.data, h_plus.data))
+    p = numpy.unwrap(numpy.arctan2(h_cross.data, h_plus.data)).astype(
+        real_same_precision_as(h_plus))
     if remove_start_phase:
         p += -p[0]    
     return TimeSeries(p, delta_t=h_plus.delta_t, epoch=h_plus.start_time,
@@ -235,7 +238,8 @@ def frequency_from_polarizations(h_plus, h_cross):
     phase = phase_from_polarizations(h_plus, h_cross)
     freq = numpy.diff(phase) / ( 2 * lal.PI * phase.delta_t )
     start_time = phase.start_time + phase.delta_t / 2
-    return TimeSeries(freq, delta_t=phase.delta_t, epoch=start_time)
+    return TimeSeries(freq.astype(real_same_precision_as(h_plus)),
+        delta_t=phase.delta_t, epoch=start_time)
 
 # map between tapering string in sim_inspiral table or inspiral 
 # code option and lalsimulation constants


### PR DESCRIPTION
This patch allows the bank compress code to store and decompress waveforms using single precision. Concurrently, what previously was referred to as "precision" (the minimum mismatch allowed between compressed waveforms and their full counterparts) has been renamed to "tolerance".

This patch also speeds up the decompression C code using the trick of computing the output waveform based on what the last step was, similar to what is done in `apply_fd_time_shift`. On my laptop it takes 1-2ms to decompress waveforms to a frequency resolution of 1/256.

I tested the mismatch with both the single and double precision on the first 100 templates in the O1 bank. Results look good; here is the single precision test:
https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/bank_compression/class_test/speed_up_test-single/mismatch_compare.png
And the double:
https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/bank_compression/class_test/speed_up_test-double/mismatch_compare.png

This patch depends on PR #998, so I'm putting on hold until that is merged.