### PR TITLE
Workround for locking problem with PyInstaller (directory) bundles

### DIFF
--- a/pycbc/weave.py
+++ b/pycbc/weave.py
@@ -37,8 +37,11 @@ def pycbc_compile_function(code,arg_names,local_dict,global_dict,
     """
     from scipy.weave.inline_tools import _compile_function
     headers = [] if headers is None else headers
-    print("attempting to aquire lock for compiling code")
-    lockfile_name = os.path.join(os.path.dirname(module_dir), 'code_lockfile')
+    lockfile_dir = os.path.dirname(module_dir)
+    lockfile_name = os.path.join(lockfile_dir, 'code_lockfile')
+    print("attempting to aquire lock '%s' for compiling code" % lockfile_name)
+    if not os.path.exists(lockfile_dir):
+        os.makedirs(lockfile_dir)
     lockfile = open(lockfile_name, 'w')
     fcntl.lockf(lockfile, fcntl.LOCK_EX)
     print ("we have aquired the lock")


### PR DESCRIPTION
At least with the PyInstaller (v.2.1) directory bundles that are built for Einstein@Home the compilation locking doesn't work, as the path that gets passed as _module_dir_ doesn't exist in the bundle.

I suspect that the same will happen with other PyCBC PyInstaller bundles built with the same version of PyInstaller.

The attached patch fixes this by creating the missing directories. (it also augments the introductory log message to include the actual path).