### PR TITLE
Force the thin interval to be an integer

### DIFF
--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -185,7 +185,7 @@ class InferenceFile(h5py.File):
 
         # default is to use stored ACL and accept every i-th sample
         if "acl" in self.attrs.keys():
-            thin_interval = int(self.acl) if thin_interval is None \
+            thin_interval = int(numpy.ceil(self.acl)) if thin_interval is None \
                 else thin_interval
         else:
             thin_interval = 1 if thin_interval is None else thin_interval

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -185,7 +185,7 @@ class InferenceFile(h5py.File):
 
         # default is to use stored ACL and accept every i-th sample
         if "acl" in self.attrs.keys():
-            thin_interval = self.acl if thin_interval is None \
+            thin_interval = int(self.acl) if thin_interval is None \
                 else thin_interval
         else:
             thin_interval = 1 if thin_interval is None else thin_interval


### PR DESCRIPTION
In my last run of pycbc_inference, I got an error when running pycbc_inference_plot_posterior because the thin-interval was a float instead of an integer. This patch defines the thin-interval as an integer to be able to plot the posterior.