### PR TITLE
Import corner after pyplot

### DIFF
--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -17,13 +17,13 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import argparse
-import corner
 import h5py
 import logging
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy
 import sys
+import corner
 from pycbc import pnutils, results
 from pycbc.inference import option_utils
 


### PR DESCRIPTION
The module corner doesn't have ```matplotlib.use('Agg')```.
Therefore pycbc_inference_plot_posterior fails when being run in a cluster because the corner module is imported before matplotlib.
Importing corner after the ```.use('Agg')``` and pyplot fixes this error.