### PR TITLE
Add seed to inference and catch blob

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -286,6 +286,7 @@ with ctx:
                 if param in idist.params:
                     p0[i][j] = idist.rvs(size=1, param=param)[0][0]
                     break
+
     # setup checkpointing
     if opts.checkpoint_interval:
 

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -102,6 +102,9 @@ parser.add_argument("--nprocesses", type=int, default=None,
     help="Number of processes to use. If not given then use maximum.")
 parser.add_argument("--skip-burn-in", action="store_true", default=False,
     help="Do not burn in with sampler.")
+parser.add_argument("--seed", type=int, default=0,
+    help="Seed to use for the random number generator that initially "
+         "distributes the walkers. Default is 0.")
 
 # add config options
 parser.add_argument("--config-files", type=str, nargs="+", required=True,
@@ -142,6 +145,10 @@ if opts.verbose:
 else:
     log_level = logging.WARN
 logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
+
+# set the seed
+numpy.random.seed(opts.seed)
+logging.info("Using seed %i" %(opts.seed))
 
 # change measure level for FFT to 0
 fft.fftw.set_measure_level(0)
@@ -279,7 +286,7 @@ with ctx:
                 if param in idist.params:
                     p0[i][j] = idist.rvs(size=1, param=param)[0][0]
                     break
-
+    print p0
     # setup checkpointing
     if opts.checkpoint_interval:
 

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -286,7 +286,6 @@ with ctx:
                 if param in idist.params:
                     p0[i][j] = idist.rvs(size=1, param=param)[0][0]
                     break
-    print p0
     # setup checkpointing
     if opts.checkpoint_interval:
 

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -138,7 +138,11 @@ class KombineSampler(_BaseSampler):
             with shape (nwalkers, ndim).
         """
         if self.burn_in_iterations == 0:
-            p, post, q = self._sampler.burnin(initial_values)
+            res = self._sampler.burnin(initial_values)
+            if len(res) == 4:
+                p, post, q, _ = res
+            else:
+                p, post, q = res
             self.burn_in_iterations = self.chain.shape[0]
         else:
             raise ValueError("Burn in has already been performed")


### PR DESCRIPTION
This patch does two things:

1. Sometimes, for as yet still unclear reasons, kombine can return "blob" as a fourth argument after burn in. This causes the sampler wrapping in pycbc/inference/sampler.py to crash. This fixes this by checking for the number of arguments returned, discarding the blob if it was returned.

2. Adds a seed argument to `pycbc_inference`. This makes the start positions of the walkers reproducible from run-to-run.