### PR TITLE
fix the injection thinning

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -269,7 +269,7 @@ with ctx:
 
     if opt.threshold_template_filtering is not None:
         logging.info("Template Bank Size Before Cut: %s", len(bank))
-        bank.table = bank.template_thinning(gwstrain.injections,
+        bank.table = bank.template_thinning(gwstrain.injections.table,
                                             opt.threshold_template_filtering)
         logging.info("Template Bank Size After Cut: %s", len(bank))
       

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -259,7 +259,7 @@ class EventManager(object):
         if len(self.events) == 0:
             return
         
-        inj_time = numpy.array([inj.get_time_geocent() for inj in injections])
+        inj_time = numpy.array(injections.get_times())
         gpstime = self.events['time_index'].astype(numpy.float64)
         gpstime = gpstime / self.opt.sample_rate + self.opt.gps_start_time
         i = indices_within_times(gpstime, inj_time - window, inj_time + window)

--- a/pycbc/inject.py
+++ b/pycbc/inject.py
@@ -28,6 +28,7 @@
 
 import numpy as np
 import lal
+import copy
 import lalsimulation as sim
 import h5py
 from pycbc.waveform import get_td_waveform, utils as wfutils
@@ -78,12 +79,10 @@ class InjectionSet(object):
     indoc
     table
     """
-
     def __init__(self, sim_file, **kwds):
-        self.indoc = ligolw_utils.load_filename(
+        indoc = ligolw_utils.load_filename(
             sim_file, False, contenthandler=LIGOLWContentHandler)
-        self.table = table.get_table(
-            self.indoc, lsctables.SimInspiralTable.tableName)
+        self.table = table.get_table(indoc, lsctables.SimInspiralTable.tableName)
         self.extra_args = kwds
 
     def getswigrow(self, glue_row):
@@ -173,7 +172,10 @@ class InjectionSet(object):
             
         strain.data[:] = lalstrain.data.data[:]
 
-        return injection_parameters
+        injected = copy.copy(self)
+        injected.table = lsctables.SimInspiralTable()
+        injected.table += injection_parameters
+        return injected
        
     def make_strain_from_inj_object(self, inj, delta_t, detector_name,
                                     f_lower=None, distance_scale=1):

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -188,8 +188,6 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
     """
 
     gating_info = {}
-    injections = []
-
     if opt.frame_cache or opt.frame_files or opt.frame_type:
         if opt.frame_cache:
             frame_source = opt.frame_cache
@@ -225,7 +223,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
         if opt.injection_file:
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
-            injections += injector.apply(strain, opt.channel_name[0:2],        
+            injections = injector.apply(strain, opt.channel_name[0:2],        
                              distance_scale=opt.injection_scale_factor)
 
         if opt.sgburst_injection_file:
@@ -314,7 +312,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
         if opt.injection_file:
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
-            injections += injector.apply(strain, opt.channel_name[0:2],
+            injections = injector.apply(strain, opt.channel_name[0:2],        
                              distance_scale=opt.injection_scale_factor)
 
         if opt.sgburst_injection_file:
@@ -332,7 +330,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
             logging.info("Converting to float32")
             strain = (dyn_range_fac * strain).astype(pycbc.types.float32)
 
-    if opt.injection_file or opt.sgburst_injection_file or opt.ringdown_injection_file:
+    if opt.injection_file:
         strain.injections = injections
 
     if opt.taper_data:
@@ -863,9 +861,8 @@ class StrainSegments(object):
         trig_end_idx = (trigger_end - int(strain.start_time)) * strain.sample_rate
 
         if filter_inj_only and hasattr(strain, 'injections'):
-            end_times= [inj.get_time_geocent() for inj in strain.injections]   
+            end_times = strain.injections.end_time()   
             end_times = [time for time in end_times if float(time) < trigger_end and float(time) > trigger_start]
-
             inj_idx = [(float(time) - float(strain.start_time)) * strain.sample_rate for time in end_times]
 
         for seg, ana in zip(self.segment_slices, self.analyze_slices):


### PR DESCRIPTION
Return the minimal version of injections set when you apply injections. This fixes a bug that was introduced by the template thinning into the single template code (as it was expecting a different object). 