### PR TITLE
Change TemplateBank's approximant parsing, save approximants to file, and add support for compressed waveforms.

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_singles_timefreq
+++ b/bin/hdfcoinc/pycbc_plot_singles_timefreq
@@ -60,11 +60,11 @@ parser.add_argument('--detector', type=str, required=True)
 parser.add_argument('--center-time', type=float,
                     help='Center plot on the given GPS time')
 # add the approximant argument
-pycbc.waveform.bank.add_approximant_arg(parser,
+pycbc.waveform.bank.add_approximant_arg(parser, default='TaylorF2',
                     help='Waveform model used for computing inspiral tracks.'
                          ' Python expressions can be used to specify a '
                          'parameter-dependent approximant as done in '
-                         'pycbc_inspiral.')
+                         'pycbc_inspiral. Default is "TaylorF2".')
 pycbc.strain.insert_strain_option_group(parser)
 opts = parser.parse_args()
 

--- a/bin/hdfcoinc/pycbc_plot_singles_timefreq
+++ b/bin/hdfcoinc/pycbc_plot_singles_timefreq
@@ -60,11 +60,12 @@ parser.add_argument('--detector', type=str, required=True)
 parser.add_argument('--center-time', type=float,
                     help='Center plot on the given GPS time')
 # add the approximant argument
-pycbc.waveform.bank.add_approximant_arg(parser, default='TaylorF2',
+pycbc.waveform.bank.add_approximant_arg(parser,
                     help='Waveform model used for computing inspiral tracks.'
                          ' Python expressions can be used to specify a '
                          'parameter-dependent approximant as done in '
-                         'pycbc_inspiral. Default is "TaylorF2".')
+                         'pycbc_inspiral. Default is to use the approximant '
+                         'specified in the bank file.')
 pycbc.strain.insert_strain_option_group(parser)
 opts = parser.parse_args()
 

--- a/bin/hdfcoinc/pycbc_plot_singles_timefreq
+++ b/bin/hdfcoinc/pycbc_plot_singles_timefreq
@@ -37,6 +37,7 @@ import pycbc.pnutils
 import pycbc.strain
 import pycbc.results
 import pycbc.version
+import pycbc.waveform
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--version", action="version",
@@ -58,7 +59,8 @@ parser.add_argument('--interesting-trig', type=int,
 parser.add_argument('--detector', type=str, required=True)
 parser.add_argument('--center-time', type=float,
                     help='Center plot on the given GPS time')
-parser.add_argument('--approximant', type=str, default='TaylorF2',
+# add the approximant argument
+pycbc.waveform.bank.add_approximant_arg(parser,
                     help='Waveform model used for computing inspiral tracks.'
                          ' Python expressions can be used to specify a '
                          'parameter-dependent approximant as done in '
@@ -140,15 +142,18 @@ if mask.any():
         max_rank = None
 
     logging.info('Loading bank')
-    bank = h5py.File(opts.bank_file, 'r')
-    mass1s, mass2s = np.array(bank['mass1']), np.array(bank['mass2'])
-    spin1s, spin2s = np.array(bank['spin1z']), np.array(bank['spin2z'])
+    bank = pycbc.waveform.bank.TemplateBank(opts.bank_file,
+            approximant=opts.approximant,
+            parameters=['mass1', 'mass2', 'spin1z', 'spin2z', 'approximant'],
+            load_compressed=False)
+    tmplts = bank.table
 
     logging.info('Plotting %d trigs', len(sorted_end_time))
     for tc, rho, tid in zip(sorted_end_time, sorted_rank, sorted_template_ids):
         track_t, track_f = pycbc.pnutils.get_inspiral_tf(
-                tc - center_time, mass1s[tid], mass2s[tid], spin1s[tid],
-                spin2s[tid], opts.f_low, approximant=opts.approximant)
+                tc - center_time, tmplts.mass1[tid], tmplts.mass2[tid],
+                tmplts.spin1z[tid], tmplts.spin2z[tid],
+                opts.f_low, approximant=bank.approximant(tid))
         if max_rank and rho == max_rank:
             ax.plot(track_t, track_f, '-', color='#ff0000', zorder=3, lw=2)
         else:
@@ -161,8 +166,9 @@ if mask.any():
         interesting_trig_rank = rho
         tid = template_ids[interesting_id]
         track_t, track_f = pycbc.pnutils.get_inspiral_tf(
-            tc - center_time, mass1s[tid], mass2s[tid], spin1s[tid],
-            spin2s[tid], opts.f_low, approximant=opts.approximant)
+            tc - center_time, tmplts.mass1[tid], tmplts.mass2[tid],
+            tmplts.spin1z[tid], tmplts.spin2z[tid],
+            opts.f_low, approximant=bank.approximant(tid))
         ax.plot(track_t, track_f, '-', color='#00ff00', zorder=3, lw=2)
     else:
         interesting_trig_rank = None

--- a/bin/plotting/pycbc_plot_waveform
+++ b/bin/plotting/pycbc_plot_waveform
@@ -37,7 +37,8 @@ parser.add_argument('--version', action='version',
 parser.add_argument('--output-file', required=True)
 parser.add_argument("--low-frequency-cutoff", type=float,
                   help="The low frequency cutoff to use for generation.")
-parser.add_argument("--approximant", type=str,
+# add the approximant argument
+waveform.bank.add_approximant_arg(parser,
                   help="The name of the approximant to use for filtering. "
                       "Do not use if using --use-params-of-closest-injection.")
 parser.add_argument("--mass1", type=float, required=True,

--- a/bin/plotting/pycbc_plot_waveform
+++ b/bin/plotting/pycbc_plot_waveform
@@ -23,7 +23,7 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1.inset_locator import zoomed_inset_axes
 from mpl_toolkits.axes_grid1.inset_locator import mark_inset
-from pycbc import waveform
+from pycbc import waveform, io
 from pycbc import version
 from pycbc import results
 from pycbc.fft import ifft
@@ -90,32 +90,20 @@ delta_t = 1. / opt.sample_rate
 tlen = int(opt.waveform_length * opt.sample_rate)
 flen = tlen / 2 + 1
 
-class WaveformTemplate(object):
-    pass
-
-tmp_params = WaveformTemplate()
-tmp_params.mass1 = opt.mass1
-tmp_params.mass2 = opt.mass2
-tmp_params.spin1x = opt.spin1x
-tmp_params.spin1y = opt.spin1y
-tmp_params.spin1z = opt.spin1z
-tmp_params.spin2x = opt.spin2x
-tmp_params.spin2y = opt.spin2y
-tmp_params.spin2z = opt.spin2z
-tmp_params.inclination = opt.inclination
+tmp_params = io.WaveformArray.from_kwargs(
+                    mass1=opt.mass1, 
+                    mass2=opt.mass2,
+                    spin1x=opt.spin1x,
+                    spin1y=opt.spin1y,
+                    spin1z=opt.spin1z,
+                    spin2x=opt.spin2x,
+                    spin2y=opt.spin2y,
+                    spin2z=opt.spin2z,
+                    inclination=opt.inclination)
 
 # Deal with parameter-dependent approximant string
-def parse_option(row, arg):
-    safe_dict = {}
-    safe_dict.update(row.__dict__)
-    safe_dict.update(math.__dict__)
-    return eval(arg, {"__builtins__":None}, safe_dict)
-
-if 'params' in opt.approximant:
-    t = type('t', (object,), {'params' : tmp_params})
-    approximant = str(parse_option(t, opt.approximant))
-else:
-    approximant = opt.approximant
+approximant = waveform.bank.parse_approximant_arg(opt.approximant,
+                tmp_params)[0]
 
 # This is a hack. We don't have a two-pol SPATmplt, so use TaylorF2
 if approximant == 'SPAtmplt':
@@ -123,7 +111,7 @@ if approximant == 'SPAtmplt':
 
 hp, hc = waveform.get_two_pol_waveform_filter(zeros(flen, dtype=complex64),
                                     zeros(flen, dtype=complex64),
-                                    tmp_params, approximant=approximant,
+                                    tmp_params[0], approximant=approximant,
                                     taper=opt.taper_template, 
                                     f_lower=opt.low_frequency_cutoff,
                                     delta_f=delta_f, delta_t=delta_t)

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -47,10 +47,8 @@ parser.add_argument("--output", type=str,
 parser.add_argument("--low-frequency-cutoff", type=float, required=True,
                 help="The low frequency cutoff to use for generating "
                      "the waveforms (Hz)")
-parser.add_argument("--approximant", type=str,
-                help="The approximant to generate the waveforms with. If "
-                     "none provided, will attempt to retrieve the approximant "
-                     "from the bank file.")
+# add approximant arg
+pycbc.waveform.bank.add_approximant_arg(parser)
 parser.add_argument("--sample-rate", type=int, required=True,
                 help="Half this value sets the maximum frequency of the "
                      "compressed waveforms.")

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -47,14 +47,8 @@ parser.add_argument("--max-template-length", type=float,
                   help="The maximum length of a template is seconds. The "
                        "starting frequency of the template is modified to "
                        "ensure the proper length")
-parser.add_argument("--approximant", type=str,
-                  help="The name of the approximant to use for filtering. "
-                       "One may choose a single approximant by simple assignment. "
-                       "Choose multiple approximants to use in different mass "
-                       "regions by using math functions and the params keys as "
-                       " follows : \"'SPAtmplt' if (params.mass1 + params.mass2) < 10 "
-                       "  else 'SEOBNRv2_ROM_DoubleSpin'\". Approximant names should "
-                       "be single quoted with the entire expression in double quotes." )
+# add approximant arg
+pycbc.waveform.bank.add_approximant_arg(parser)
 parser.add_argument("--order", type=int,
                   help="The integer half-PN order at which to generate"
                        " the approximant. Default is -1 which indicates to use"

--- a/bin/pycbc_inspiral_skymax
+++ b/bin/pycbc_inspiral_skymax
@@ -42,14 +42,8 @@ parser.add_argument("--max-template-length", type=float,
                   help="The maximum length of a template is seconds. The "
                        "starting frequency of the template is modified to "
                        "ensure the proper length")
-parser.add_argument("--approximant", type=str,
-              help="The name of the approximant to use for filtering. "
-              "One may choose a single approximant by simple assignment. "
-              "Choose multiple approximants to use in different mass "
-              "regions by using math functions and the params keys as "
-              " follows : \"'SPAtmplt' if (params.mass1 + params.mass2) < 10 "
-              "  else 'SEOBNRv2_ROM_DoubleSpin'\". Approximant names should "
-              "be single quoted with the entire expression in double quotes." )
+# add approximant arg
+waveform.bank.add_approximant_arg(parser)
 parser.add_argument("--order", type=int,
                   help="The integer half-PN order at which to generate"
                        " the approximant. Default is -1 which indicates to use"

--- a/bin/pycbc_multi_inspiral
+++ b/bin/pycbc_multi_inspiral
@@ -39,8 +39,8 @@ parser.add_argument("--newsnr-threshold", type=float, metavar='THRESHOLD',
 parser.add_argument("--low-frequency-cutoff", type=float,
                   help="The low frequency cutoff to use for filtering (Hz)")
 
-parser.add_argument("--approximant", type=str,
-                  help="The name of the approximant to use for filtering")
+# add approximant arg
+pycbc.waveform.bank.add_approximant_arg(parser)
 parser.add_argument("--order", type=str,
                   help="The integer half-PN order at which to generate"
                        " the approximant.")

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -19,6 +19,7 @@ a specific Nth loudest coincident event.
 """
 import sys, logging, argparse, numpy, itertools, pycbc, h5py
 from pycbc import vetoes, psd, waveform, version, strain, scheme, fft, filter
+from pycbc.io import WaveformArray
 from pycbc import events
 from pycbc.filter import resample_to_delta_t
 from pycbc.types import zeros, float32, complex64, TimeSeries, FrequencySeries
@@ -91,7 +92,8 @@ parser.add_argument("--use-params-of-closest-injection", action="store_true",
                        "using this do not supply mass and spin options. "
                        "Using this requires trigger-time and injection-file "
                        "to be given.")
-parser.add_argument("--approximant", type=str,
+# add approximant arg
+waveform.bank.add_approximant_arg(parser,
                   help="The name of the approximant to use for filtering. "
                       "Do not use if using --use-params-of-closest-injection.")
 parser.add_argument("--mass1", type=float, 
@@ -187,15 +189,16 @@ ctx = scheme.from_cli(opt)
 gwstrain = strain.from_cli(opt, pycbc.DYN_RANGE_FAC)
 strain_segments = strain.StrainSegments.from_cli(opt, gwstrain)
 
-class t(object):
-    pass
- 
-row = t()
-row.params = t()
-row.params.mass1 = opt.mass1
-row.params.mass2 = opt.mass2
-row.params.spin1z = opt.spin1z
-row.params.spin2z = opt.spin2z
+if not opt.use_params_of_closest_injection:
+    row = WaveformArray.from_kwargs(
+            mass1=opt.mass1,
+            mass2=opt.mass2,
+            spin1x=opt.spin1x,
+            spin1y=opt.spin1y,
+            spin1z=opt.spin1z,
+            spin2x=opt.spin2x,
+            spin2y=opts.spin2y,
+            spin2z=opt.spin2z)
 
 with ctx:
     fft.from_cli(opt)
@@ -224,10 +227,15 @@ with ctx:
         inj_idx = abs(end_times - opt.trigger_time).argmin()
         inj = inj_set.table[inj_idx]
         # Use injection values for things like choosing number of chisq bins
-        row.params.mass1 = opt.mass1 = inj.mass1
-        row.params.mass2 = opt.mass2 = inj.mass2
-        row.params.spin1z = opt.spin1z = inj.spin1z
-        row.params.spin2z = opt.spin2z = inj.spin2z
+        row = WaveformArray.from_kwargs(
+            mass1=inj.mass1,
+            mass2=inj.mass2,
+            spin1x=inj.spin1x,
+            spin1y=inj.spin1y,
+            spin1z=inj.spin1z,
+            spin2x=inj.spin2x,
+            spin2y=inj.spin2y,
+            spin2z=inj.spin2z)
         # FIXME: Don't like hardcoded 16384 here
         # NOTE: f_lower is set in strain.py as inj.f_lower, but this is a
         #       little unclear to see and caused me some problems! Stating
@@ -239,23 +247,17 @@ with ctx:
                                           method='ldas')
         td_template = td_template * pycbc.DYN_RANGE_FAC
         td_template._epoch -= inj.get_end(site=opt.channel_name[0])
-        opt.approximant = inj.waveform
+        approximant = inj.waveform
         template = waveform.td_waveform_to_fd_waveform(td_template, length=flen)
         template = template.astype(complex_same_precision_as(segments[0]))
     else:
-        # FIXME: This check is hacky!
-        if opt.approximant and 'params' in opt.approximant:
-            opt.approximant = waveform.FilterBank.parse_option(row,
-                                                               opt.approximant)
+        approximant = waveform.bank.parse_approximant_arg(opt.approximant, row)[0] 
         logging.info("Making template: %s" % opt.approximant)
         if opt.u_val is None:
             template = waveform.get_waveform_filter(
                                     zeros(flen, dtype=complex64),
-                                    approximant=opt.approximant,
-                                    mass1=opt.mass1, mass2=opt.mass2,
-                                    spin1z=opt.spin1z, spin2z=opt.spin2z,
-                                    spin1y=opt.spin1y, spin2y=opt.spin2y,
-                                    spin1x=opt.spin1x, spin2x=opt.spin2x,
+                                    approximant=approximant,
+                                    template=row[0],
                                     inclination=opt.inclination,
                                     taper=opt.taper_template, 
                                     f_lower=flow, delta_f=delta_f,
@@ -263,19 +265,23 @@ with ctx:
         else:
             tp, tc = waveform.get_two_pol_waveform_filter(
                                     zeros(flen, dtype=complex64),
-                                    zeros(flen, dtype=complex64), None,
-                                    approximant=opt.approximant,
-                                    mass1=opt.mass1, mass2=opt.mass2,
-                                    spin1z=opt.spin1z, spin2z=opt.spin2z,
-                                    spin1y=opt.spin1y, spin2y=opt.spin2y,
-                                    spin1x=opt.spin1x, spin2x=opt.spin2x,
+                                    zeros(flen, dtype=complex64), row[0],
+                                    approximant=approximant,
                                     inclination=opt.inclination,
                                     taper=opt.taper_template,
                                     f_lower=flow, delta_f=delta_f,
                                     delta_t=gwstrain.delta_t)
             template = tc.multiply_and_add(tp, opt.u_val)
 
-    chisq_bins = int(vetoes.SingleDetPowerChisq.parse_option(row,
+    # FIXME: should probably switch to something like what is done for parsing
+    # the approximant for chisq bins at some point
+    class t(object):
+        pass
+    parse_row = t()
+    parse_row.params = t()
+    for param in row.fieldnames:
+        setattr(parse_row.params, param, row[param][0])
+    chisq_bins = int(vetoes.SingleDetPowerChisq.parse_option(parse_row,
                                                                opt.chisq_bins))
 
     f['template'] = template.numpy()                  
@@ -349,7 +355,7 @@ with ctx:
     f['chisq'] = numpy.concatenate([chisq.numpy() for chisq in chisqs])[sidx:eidx]
     f['chisq'].attrs['start_time'] = start_time
     f['chisq'].attrs['delta_t'] = snr.delta_t 
-    f.attrs['approximant'] = opt.approximant
+    f.attrs['approximant'] = approximant
     f.attrs['ifo'] = ifo
     
 logging.info("Finished")

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -197,7 +197,7 @@ if not opt.use_params_of_closest_injection:
             spin1y=opt.spin1y,
             spin1z=opt.spin1z,
             spin2x=opt.spin2x,
-            spin2y=opts.spin2y,
+            spin2y=opt.spin2y,
             spin2z=opt.spin2z)
 
 with ctx:

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -928,6 +928,41 @@ class FieldArray(numpy.recarray):
         return obj
 
     @classmethod
+    def from_kwargs(cls, **kwargs):
+        """Creates a new instance of self from the given keyword arguments.
+        Each argument will correspond to a field in the returned array, with
+        the name of the field given by the keyword, and the value(s) whatever
+        the keyword was set to. Each keyword may be set to a single value or
+        a list of values. The number of values that each argument is set to
+        must be the same; this will be the size of the returned array.
+
+        Examples
+        --------
+        Create an array with fields 'mass1' and 'mass2':
+        >>> a = FieldArray.from_kwargs(mass1=[1.1, 3.], mass2=[2., 3.])
+        >>> a.fieldnames
+        ('mass1', 'mass2')
+        >>> a.mass1, a.mass2
+        (array([ 1.1,  3. ]), array([ 2.,  3.]))
+
+        Create an array with only a single element in it:
+        >>> a = FieldArray.from_kwargs(mass1=1.1, mass2=2.)
+        >>> a.mass1, a.mass2
+        (array([ 1.1]), array([ 2.]))
+        """
+        arrays = []
+        names = []
+        for p,vals in kwargs.items():
+            if not isinstance(vals, numpy.ndarray):
+                if not isinstance(vals, list):
+                    vals = [vals]
+                vals = numpy.array(vals)
+            arrays.append(vals)
+            names.append(p)
+        return cls.from_arrays(arrays, names=names)
+
+
+    @classmethod
     def from_ligolw_table(cls, table, columns=None, cast_to_dtypes=None):
         """Converts the given ligolw table into an FieldArray. The `tableName`
         attribute is copied to the array's `name`.

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1024,16 +1024,20 @@ class FieldArray(numpy.recarray):
         return self.dtype.names
 
     @property
-    def virutalfields(self):
+    def virtualfields(self):
         """Returns a tuple listing the names of virtual fields in self.
         """
-        return tuple(self._virtualfields)
+        if self._virtualfields is None:
+            vfs = tuple()
+        else:
+            vfs = tuple(self._virtualfields)
+        return vfs
 
     @property
     def fields(self):
         """Returns a tuple listing the names of fields and virtual fields in
         self."""
-        return tuple(list(self.fieldnames) + self._virtualfields)
+        return tuple(list(self.fieldnames) + list(self.virtualfields))
 
     @property
     def aliases(self):

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1284,7 +1284,11 @@ class _FieldArrayWithDefaults(FieldArray):
             # no names are specified in the following initialization, this
             # block of code is skipped)
             arr = cls(1, field_kwargs=field_kwargs)
-            names = get_needed_fieldnames(arr, names)
+            # try to perserve order
+            sortdict = dict([[nm, ii] for ii,nm in enumerate(names)])
+            names = list(get_needed_fieldnames(arr, names))
+            names.sort(key=lambda x: sortdict[x] if x in sortdict
+                else len(names))
             # add the fields as the dtype argument for initializing 
             kwargs['dtype'] = [(fld, default_fields[fld]) for fld in names]
         if 'dtype' not in kwargs:
@@ -1321,7 +1325,11 @@ class _FieldArrayWithDefaults(FieldArray):
         default_fields = self.default_fields(include_virtual=False, **kwargs)
         # parse out any virtual fields
         arr = self.__class__(1, field_kwargs=kwargs)
-        names = get_needed_fieldnames(arr, names)
+        # try to perserve order
+        sortdict = dict([[nm, ii] for ii,nm in enumerate(names)])
+        names = list(get_needed_fieldnames(arr, names))
+        names.sort(key=lambda x: sortdict[x] if x in sortdict
+            else len(names))
         fields = [(name, default_fields[name]) for name in names]
         arrays = []
         names = []

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -289,7 +289,8 @@ class TemplateBank(object):
         else:
             raise ValueError("Unsupported template bank file extension %s" % ext)
 
-        if not hasattr(self.table, 'template_duration'):
+        if (parameters is None or 'template_duration' in parameters) \
+                and not hasattr(self.table, 'template_duration'):
             self.table = self.table.add_fields(numpy.zeros(len(self.table),
                                      dtype=numpy.float32), 'template_duration') 
         # if approximant is specified, override whatever was in the file

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -80,54 +80,190 @@ class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
     pass
 lsctables.use_in(LIGOLWContentHandler)
 
-class TemplateBank(object): 
-    """ Class to provide some basic helper functions and information
-    about elements of an xml template bank.
+# helper function for parsing approximant strings
+def boolargs_from_apprxstr(approximant_strs):
+    """Parses a list of strings specifying an approximant and where that
+    approximant should be used into a list that can be understood by
+    FieldArray.parse_boolargs.
+
+    Parameters
+    ----------
+    apprxstr : (list of) string(s)
+        The strings to parse. Each string should be formatted `APPRX:COND`,
+        where `APPRX` is the approximant and `COND` is a string specifying
+        where it should be applied (see `FieldArgs.parse_boolargs` for examples
+        of conditional strings). The last string in the list may exclude a
+        conditional argument, which is the same as specifying ':else'.
+
+    Returns
+    -------
+    boolargs : list
+        A list of tuples giving the approximant and where to apply them. This
+        can be passed directly to `FieldArray.parse_boolargs`.
     """
-    def __init__(self, filename, approximant=None, **kwds):
+    if not isinstance(approximant_strs, list):
+        approximant_strs = [approximant_strs]
+    return [tuple(arg.split(':')) for arg in approximant_strs]
+
+
+class TemplateBank(object):
+    """Class to provide some basic helper functions and information
+    about elements of a template bank.
+
+    Parameters
+    ----------
+    filename : string
+        The name of the file to load. Must end in '.xml[.gz]' or '.hdf'. If an
+        hdf file, it must have a 'parameters' in its `attrs` which gives a list
+        of the names of fields to load from the file. If an xml file, it must
+        have a `SnglInspiral` table.
+    approximant : {None, (list of) string(s)}
+        Specify the approximant(s) for each template in the bank. If None
+        provided, will try to load the approximant from the file. The
+        approximant may either be a single string (in which case the same
+        approximant will be used for all templates) or a list of strings and
+        conditionals specifying where to use the approximant. See
+        `boolargs_from_apprxstr` for syntax.
+    parameters : {None, (list of) sting(s)}
+        Specify what parameters to load from the file. If None, all of the
+        parameters in the file (if an xml file, this is all of the columns in
+        the SnglInspiral table, if an hdf file, this is given by the
+        parameters attribute in the file). The list may include parameters that
+        are derived from the file's parameters, or functions thereof. For a
+        full list of possible parameters, see `WaveformArray.default_fields`.
+        If a derived parameter is specified, only the parameters needed to
+        compute that parameter will be loaded from the file. For example, if
+        `parameters='mchirp'`, then only `mass1, mass2` will be loaded from
+        the file.
+    load_compressed : {True, bool}
+        If compressed waveforms are present in the file, load them. Only works
+        for hdf files.
+    load_compressed_now : {False, bool}
+        If compressed waveforms are present in the file, load all of them into
+        memory now. Otherwise, they will be loaded into memory on their first
+        use. Note: if not `load_compressed_now`, the filehandler to the hdf
+        file must be kept open.
+    \**kwds :
+        Any additional keyword arguments are stored to the `extra_args`
+        attribute.
+
+
+    Attributes
+    ----------
+    table : WaveformArray
+        An instance of a WaveformArray containing all of the information about
+        the parameters of the bank.
+    compressed_waveforms : {None, dict}
+        If compressed waveforms are present in the (hdf) file, a dictionary
+        of those waveforms. Keys are the template hashes, values are
+        `CompressedWaveform` instances.
+    parameters : tuple
+        The parameters loaded from the input file. Same as `table.fieldnames`.
+    indoc : {None, xmldoc}
+        If an xml file was provided, an in-memory representation of the xml.
+        Otherwise, None.
+    filehandler : {None, h5py.File}
+        If an hdf file was provided, the file handler pointing to the hdf file
+        (left open after initialization). Otherwise, None.
+    extra_args : {None, dict}
+        Any extra keyword arguments that were provided on initialization.
+    """
+    def __init__(self, filename, approximant=None, parameters=None,
+            load_compressed=True, load_compressed_now=False, **kwds):
         ext = os.path.basename(filename)
-        if 'xml' in ext:
+        self.compressed_waveforms = None
+        if ext.endswith('.xml') or ext.endswith('.xml.gz'):
+            self.filehandler = None
             self.indoc = ligolw_utils.load_filename(
                 filename, False, contenthandler=LIGOLWContentHandler)
             self.table = table.get_table(
                 self.indoc, lsctables.SnglInspiralTable.tableName)
-            self.table = pycbc.io.FieldArray.from_ligolw_table(self.table)
+            self.table = pycbc.io.WaveformArray.from_ligolw_table(self.table,
+                columns=parameters)
 
             # inclination stored in xml alpha3 column
             names = list(self.table.dtype.names)
             names = tuple([n if n != 'alpha3' else 'inclination' for n in names]) 
-            self.table.dtype.names = names    
+            self.table.dtype.names = names
 
-        elif 'hdf' in ext:
+        elif ext.endswith('hdf'):
+            self.indoc = None
             f = h5py.File(filename, 'r')
+            self.filehandler = f
+            fileparams = f.attrs['parameters']
+            # use WaveformArray's syntax parser to figure out what fields
+            # need to be loaded
+            if parameters is None:
+                parameters = fileparams
+            common_fields = list(pycbc.io.WaveformArray(1,
+                names=parameters).fieldnames)
+            add_fields = list(set(parameters) & 
+                (set(fileparams) - set(common_fields)))
+            # load
             dtype = []
             data = {}
-            for key in f.keys():
-                try:
-                    data[str(key)] = f[key][:]
-                    dtype.append((str(key), data[key].dtype))
-                except:
-                    pass
-
-            num = len(data[data.keys()[0]])
-            self.table = pycbc.io.FieldArray(num, dtype=dtype)
+            for key in common_fields+add_fields:
+                data[str(key)] = f[key][:]
+                dtype.append((str(key), data[key].dtype))
+            num = f[fileparams[0]].size
+            self.table = pycbc.io.WaveformArray(num, dtype=dtype)
             for key in data:
                 self.table[key] = data[key]
+            # add the compressed waveforms, if they exist
+            if load_compressed and 'compressed_waveforms' in f:
+                self.compressed_waveforms = {}
+                for tmplt_hash in self.table['template_hash']:
+                    self.compressed_waveforms[tmplt_hash] = \
+                        CompressedWaveform.from_hdf(f, tmplt_hash,
+                            load_now=load_compressed_now)
         else:
             raise ValueError("Unsupported template bank file extension %s" % ext)
 
         if not hasattr(self.table, 'template_duration'):
             self.table = self.table.add_fields(numpy.zeros(len(self.table),
                                      dtype=numpy.float32), 'template_duration') 
-        self.extra_args = kwds  
-        self.approximant_str = approximant
+        # if approximant is specified, override whatever was in the file
+        # (if anything was in the file)
+        if approximant is not None:
+            # get the approximant for each template
+            apprxs = self.parse_approximant_str(approximant)
+            if 'approximant' not in self.table.fieldnames:
+                self.table = self.table.add_fields(apprxs, 'approximant')
+            else:
+                self.table['approximant'] = apprxs
+        self.extra_args = kwds
 
-    @staticmethod
-    def parse_option(row, arg):
-        safe_dict = {}
-        safe_dict.update(row.__dict__)
-        safe_dict.update(math.__dict__)
-        return eval(arg, {"__builtins__":None}, safe_dict)
+
+    @property
+    def parameters(self):
+        return self.table.fieldnames
+
+    def write_to_hdf(self, filename, force=False):
+        """Writes self to the given hdf file.
+        
+        Parameters
+        ----------
+        filename : str
+            The name of the file to write to. Must end in '.hdf'.
+        force : {False, bool}
+            If the file already exists, it will be overwritten if True.
+            Otherwise, an OSError is raised if the file exists.
+        """
+        if not filename.endswith('.hdf'):
+            raise ValueError("Unrecoginized file extension")
+        if os.path.exists(filename) and not force:
+            raise IOError("File %s already exists" %(filename))
+        f = h5py.File(filename, 'w')
+        # save the parameters
+        f.attrs['parameters'] = self.parameters
+        for p in self.parameters:
+            f[p] = self.table[p]
+        if self.compressed_waveforms is not None:
+            for tmplt_hash, compwf in self.compressed_waveforms.items():
+                compwf.write_to_hdf(f, tmplt_hash) 
+        f.close()
+
+        return None
 
     def end_frequency(self, index):
         """ Return the end frequency of the waveform at the given index value
@@ -138,19 +274,19 @@ class TemplateBank(object):
                               approximant=self.approximant(index),
                               **self.extra_args)      
 
+    def parse_approximant_str(self, approximant_str):
+        """Parses the given approximant string, returning the approximant to
+        use for each template in self."""
+        return self.table.parse_boolargs(boolargs_from_apprxstr(
+                approximant_str))[0]
+
     def approximant(self, index):
         """ Return the name of the approximant ot use at the given index
         """
-        if self.approximant_str is not None:
-            if 'params' in self.approximant_str:
-                t = type('t', (object,), {'params' : self.table[index]})
-                approximant = str(self.parse_option(t, self.approximant_str)) 
-            else:
-                approximant = self.approximant_str
-        else:
-            raise ValueError("Reading approximant from template bank not yet supported")
-
-        return approximant
+        if 'approximant' not in self.table.fieldnames:
+            raise ValueError("approximant not found in input file and no "
+                "approximant was specified on initialization")
+        return self.table["approximant"][index]
 
     def __len__(self):
         return len(self.table)
@@ -176,7 +312,7 @@ class TemplateBank(object):
 
 class LiveFilterBank(TemplateBank):
     def __init__(self, filename, f_lower, sample_rate, minimum_buffer,
-                       approximant=None, increment=8,
+                       approximant=None, increment=8, parameters=None,
                        **kwds):
 
         self.increment = increment
@@ -185,7 +321,8 @@ class LiveFilterBank(TemplateBank):
         self.sample_rate = sample_rate
         self.minimum_buffer = minimum_buffer
 
-        super(LiveFilterBank, self).__init__(filename, approximant=approximant, **kwds)
+        super(LiveFilterBank, self).__init__(filename, approximant=approximant,
+                parameters=parameters, **kwds)
 
         from pycbc.pnutils import mass1_mass2_to_mchirp_eta
         self.table = sorted(self.table, key=lambda t: mass1_mass2_to_mchirp_eta(t.mass1, t.mass2)[0])
@@ -297,7 +434,7 @@ class LiveFilterBank(TemplateBank):
 class FilterBank(TemplateBank):
     def __init__(self, filename, filter_length, delta_f, f_lower, dtype,
                  out=None, max_template_length=None,
-                 approximant=None,
+                 approximant=None, parameters=None,
                  **kwds):
         self.out = out
         self.dtype = dtype
@@ -310,7 +447,8 @@ class FilterBank(TemplateBank):
         self.kmin = int(f_lower / delta_f)
         self.max_template_length = max_template_length
 
-        super(FilterBank, self).__init__(filename, approximant=approximant, **kwds)
+        super(FilterBank, self).__init__(filename, approximant=approximant,
+            parameters=parameters, **kwds)
 
     def __getitem__(self, index):
         # Make new memory for templates if we aren't given output memory

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -107,13 +107,15 @@ def boolargs_from_apprxstr(approximant_strs):
     return [tuple(arg.split(':')) for arg in approximant_strs]
 
 
-def add_approximant_arg(parser, help=None):
+def add_approximant_arg(parser, default=None, help=None):
     """Adds an approximant argument to the given parser.
 
     Parameters
     ----------
     parser : ArgumentParser
         The argument parser to add the argument to.
+    default : {None, str}
+        Specify a default for the approximant argument. Defaults to None.
     help : {None, str}
         Provide a custom help message. If None, will use a descriptive message
         on how to specify the approximant.
@@ -139,7 +141,7 @@ def add_approximant_arg(parser, help=None):
              "conditionals to, see WaveformArray.default_fields(). Math "
              "operations may also be used on parameters; syntax is python, "
              "with any operation recognized by numpy.")
-    parser.add_argument("--approximant", nargs='+', type=str, default=None,
+    parser.add_argument("--approximant", nargs='+', type=str, default=default,
                         metavar='APPRX[:COND]',
                         help=help)
 

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -106,6 +106,38 @@ def boolargs_from_apprxstr(approximant_strs):
     return [tuple(arg.split(':')) for arg in approximant_strs]
 
 
+def add_approximant_arg(parser):
+    """Adds an approximant argument to the given parser.
+
+    Parameters
+    ----------
+    parser : ArgumentParser
+        The argument parser to add the argument to.
+    """
+    parser.add_argument("--approximant", nargs='+', type=str, default=None,
+        metavar='APPRX[:COND]',
+        help="The approximant(s) to use. Multiple approximants to use "
+             "in different regions may be provided. If multiple "
+             "approximants are provided, every one but the last must be "
+             "be followed by a conditional statement defining where that "
+             "approximant should be used. Conditionals can be any boolean "
+             "test understood by numpy. For example, 'Apprx:(mtotal > 4) & "
+             "(mchirp <= 5)' would use approximant 'Apprx' where total mass "
+             "is > 4 and chirp mass is <= 5. "
+             "Conditionals are applied in order, with each successive one "
+             "only applied to regions not covered by previous arguments. "
+             "For example, `'TaylorF2:mtotal < 4' 'IMRPhenomD:mchirp < 3'` "
+             "would result in IMRPhenomD being used where chirp mass is < 3 "
+             "and total mass is >= 4. The last approximant given may use "
+             "'else' as the conditional or include no conditional. In either "
+             "case, this will cause the last approximant to be used in any "
+             "remaning regions after all the previous conditionals have been "
+             "applied. For the full list of possible parameters to apply "
+             "conditionals to, see WaveformArray.default_fields(). Math "
+             "operations may also be used on parameters; syntax is python, "
+             "with any operation recognized by numpy.")
+
+                       
 class TemplateBank(object):
     """Class to provide some basic helper functions and information
     about elements of a template bank.
@@ -529,7 +561,8 @@ def find_variable_start_frequency(approximant, parameters, f_start, max_length,
 class FilterBankSkyMax(TemplateBank):
     def __init__(self, filename, filter_length, delta_f, f_lower,
                  dtype, out_plus=None, out_cross=None,
-                 max_template_length=None, **kwds):
+                 max_template_length=None, parameters=None,
+                 **kwds):
         self.out_plus = out_plus
         self.out_cross = out_cross
         self.dtype = dtype
@@ -542,7 +575,8 @@ class FilterBankSkyMax(TemplateBank):
         self.kmin = int(f_lower / delta_f)
         self.max_template_length = max_template_length
 
-        super(FilterBankSkyMax, self).__init__(filename, **kwds)
+        super(FilterBankSkyMax, self).__init__(filename, parameters=parameters,
+            **kwds)
 
     def __getitem__(self, index):
         # Make new memory for templates if we aren't given output memory

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -106,17 +106,19 @@ def boolargs_from_apprxstr(approximant_strs):
     return [tuple(arg.split(':')) for arg in approximant_strs]
 
 
-def add_approximant_arg(parser):
+def add_approximant_arg(parser, help=None):
     """Adds an approximant argument to the given parser.
 
     Parameters
     ----------
     parser : ArgumentParser
         The argument parser to add the argument to.
+    help : {None, str}
+        Provide a custom help message. If None, will use a descriptive message
+        on how to specify the approximant.
     """
-    parser.add_argument("--approximant", nargs='+', type=str, default=None,
-        metavar='APPRX[:COND]',
-        help="The approximant(s) to use. Multiple approximants to use "
+    if help is None:
+        help=str("The approximant(s) to use. Multiple approximants to use "
              "in different regions may be provided. If multiple "
              "approximants are provided, every one but the last must be "
              "be followed by a conditional statement defining where that "
@@ -136,6 +138,9 @@ def add_approximant_arg(parser):
              "conditionals to, see WaveformArray.default_fields(). Math "
              "operations may also be used on parameters; syntax is python, "
              "with any operation recognized by numpy.")
+    parser.add_argument("--approximant", nargs='+', type=str, default=None,
+                        metavar='APPRX[:COND]',
+                        help=help)
 
 def parse_approximant_arg(approximant_arg, warray):
     """Given an approximant arg (see add_approximant_arg) and a field

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -27,6 +27,7 @@ This module provides classes that describe banks of waveforms
 """
 import types, numpy, logging, os.path, math, h5py
 import pycbc.waveform
+import pycbc.waveform.compress
 from pycbc.types import zeros
 from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
 from pycbc.filter import sigmasq
@@ -272,8 +273,8 @@ class TemplateBank(object):
                 self.compressed_waveforms = {}
                 for tmplt_hash in self.table['template_hash']:
                     self.compressed_waveforms[tmplt_hash] = \
-                        CompressedWaveform.from_hdf(f, tmplt_hash,
-                            load_now=load_compressed_now)
+                        pycbc.waveform.compress.CompressedWaveform.from_hdf(f,
+                            tmplt_hash, load_now=load_compressed_now)
         else:
             raise ValueError("Unsupported template bank file extension %s" % ext)
 

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -372,6 +372,7 @@ class TemplateBank(object):
 class LiveFilterBank(TemplateBank):
     def __init__(self, filename, f_lower, sample_rate, minimum_buffer,
                        approximant=None, increment=8, parameters=None,
+                       load_compressed=True, load_compressed_now=False, 
                        **kwds):
 
         self.increment = increment
@@ -381,7 +382,8 @@ class LiveFilterBank(TemplateBank):
         self.minimum_buffer = minimum_buffer
 
         super(LiveFilterBank, self).__init__(filename, approximant=approximant,
-                parameters=parameters, **kwds)
+                parameters=parameters, load_compressed=load_compressed,
+                load_compressed_now=load_compressed_now, **kwds)
 
         from pycbc.pnutils import mass1_mass2_to_mchirp_eta
         self.table = sorted(self.table, key=lambda t: mass1_mass2_to_mchirp_eta(t.mass1, t.mass2)[0])
@@ -494,6 +496,7 @@ class FilterBank(TemplateBank):
     def __init__(self, filename, filter_length, delta_f, f_lower, dtype,
                  out=None, max_template_length=None,
                  approximant=None, parameters=None,
+                 load_compressed=True, load_compressed_now=False, 
                  **kwds):
         self.out = out
         self.dtype = dtype
@@ -507,7 +510,9 @@ class FilterBank(TemplateBank):
         self.max_template_length = max_template_length
 
         super(FilterBank, self).__init__(filename, approximant=approximant,
-            parameters=parameters, **kwds)
+            parameters=parameters, load_compressed=load_compressed,
+            load_compressed_now=load_compressed_now,
+            **kwds)
 
     def __getitem__(self, index):
         # Make new memory for templates if we aren't given output memory
@@ -589,6 +594,7 @@ class FilterBankSkyMax(TemplateBank):
     def __init__(self, filename, filter_length, delta_f, f_lower,
                  dtype, out_plus=None, out_cross=None,
                  max_template_length=None, parameters=None,
+                 load_compressed=True, load_compressed_now=False, 
                  **kwds):
         self.out_plus = out_plus
         self.out_cross = out_cross
@@ -603,6 +609,7 @@ class FilterBankSkyMax(TemplateBank):
         self.max_template_length = max_template_length
 
         super(FilterBankSkyMax, self).__init__(filename, parameters=parameters,
+            load_compressed=True, load_compressed_now=False,
             **kwds)
 
     def __getitem__(self, index):

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -137,6 +137,27 @@ def add_approximant_arg(parser):
              "operations may also be used on parameters; syntax is python, "
              "with any operation recognized by numpy.")
 
+def parse_approximant_arg(approximant_arg, warray):
+    """Given an approximant arg (see add_approximant_arg) and a field
+    array, figures out what approximant to use for each template in the array.
+
+    Parameters
+    ----------
+    approximant_arg : list
+        The approximant argument to parse. Should be the thing returned by
+        ArgumentParser when parsing the argument added by add_approximant_arg.
+    warray : FieldArray
+        The array to parse. Must be an instance of a FieldArray, or a class
+        that inherits from FieldArray.
+
+    Returns
+    -------
+    array
+        A numpy array listing the approximants to use for each element in
+        the warray.
+    """
+    return warray.parse_boolargs(boolargs_from_apprxstr(approximant_arg))[0]
+        
                        
 class TemplateBank(object):
     """Class to provide some basic helper functions and information
@@ -258,7 +279,7 @@ class TemplateBank(object):
         # (if anything was in the file)
         if approximant is not None:
             # get the approximant for each template
-            apprxs = self.parse_approximant_str(approximant)
+            apprxs = self.parse_approximant(approximant)
             if 'approximant' not in self.table.fieldnames:
                 self.table = self.table.add_fields(apprxs, 'approximant')
             else:
@@ -306,11 +327,12 @@ class TemplateBank(object):
                               approximant=self.approximant(index),
                               **self.extra_args)      
 
-    def parse_approximant_str(self, approximant_str):
-        """Parses the given approximant string, returning the approximant to
-        use for each template in self."""
-        return self.table.parse_boolargs(boolargs_from_apprxstr(
-                approximant_str))[0]
+    def parse_approximant(self, approximant):
+        """Parses the given approximant argument, returning the approximant to
+        use for each template in self. This is done by calling
+        `parse_approximant_arg` using self's table as the array; see that
+        function for more details."""
+        return parse_approximant_arg(approximant, self.table)
 
     def approximant(self, index):
         """ Return the name of the approximant ot use at the given index


### PR DESCRIPTION
This patch makes some changes to the way the `TemplateBank` class loads and stores triggers. The most notable thing is that approximant parsing has changed. The patch does away with the parse_option; instead, the eval features built into FieldArray's `__getitem__` are used. This allows for more complicated compound experessions to be used (in case we end up using more than two approximants), and for a cleaner, more user-friendly syntax on the command line. The details:

Currently, the table attribute of `TemplateBank` stores the parameters of the templates as a `FieldArray`. FieldArrays allow numpy functions on fields in the array to be passed as indices, as if those functions were a field. For example, if you have a field array `foo` with two fields, `mass1` and `mass2`, then `foo['mass1*mass2/(mass1+mass2)**2']` will return an array of the symmetric mass ratios. Likewise, you can pass boolean expressions, such as `foo['mass1+mass2 < 4']`, which will return a boolean array.

This patch takes advantage of these feature for the approximant parsing. Now, when initializing `TemplateBank`, the approximant argument should be passed as a list of strings. Each string should be colon separated, with the first element giving the approximant name to use and the second element the boolean expression to pass to the table. The expressions are evaluated in order, applying each condition to elements for which all previous expressions were false. The last element can either omit a condition or use "else"; in that case that approximant will be used for all remaining templates. Thus, giving something like `approximant=['TaylorF2:mtotal<4', 'IMRPhenomD:(mass1/mass2 > 5) & (chi_eff > 0.8)' 'SEOBNRv2_ROM_DoubleSpin:else']` would cause TaylorF2 to be used for all templates with total mass < 4; IMRPhenomD for templates with total mass >=4, mass ratio > 5, and effective spin > 0.8; SEOBNRv2_ROM_DoubleSpin everywhere else. This expression is evaluated on initialization, with an array of the approximant names being stored to the template bank's table. If only a single approximant is used then just a string can be passed; e.g., `approximant='TaylorF2'` still works.

The patch also adds a function that adds a common approximant argument to an ArgumentParser to make use of this new syntax. Since several programs make use of this, I've gone through and tried to catch all places where this is done, updating the codes appropriately. Specifically, I've changed `pycbc_inspiral`, `pycbc_compress_bank`, `pycbc_multi_inspiral`, `pycbc_single_template`, `pycbc_plot_singles_timefreq`, `pycbc_plot_waveform`, and `pycbc_inspiral_skymax`. I've assigned this to the authors listed for each of those programs to make sure this is ok. Let me know if I've forgotten someone, or missed a program.

As described below, the new `write_to_hdf` method will write the parsed approximant array when writing an hdf file. This means that if some xml->hdf conversion code parses the approximant, approximants do not need to be specified on the command line for any program that uses the hdf file. So, e.g., if a bank xml file is converted to hdf, `pycbc_inspiral` would not need an approximant specified. If an approximant is specified, it will override whatever was in the bank file.

The other important change is a `parameters` attribute is now required to be set for hdf files. This is so that the code doesn't try to load the `compressed_waveforms` group as if it were a template parameter (see below about compressed waveforms). **This means that after this patch is merged, older bank hdf files will no longer be readable.**

The other changes this patch introduces:
 * A `load_compressed` and `load_compressed_now` keyword argument are also added to `TemplateBank`. If the former is True, compressed waveforms will be retrieved from the file (only for hdf files) if they are present, and stored in the `compressed_waveforms` attribute. If `load_compressed_now`, the waveforms will be loaded into memory immediately. Otherwise, they will be left on disk and only loaded on first use. This options have also been propagated to sub-classes of `TemplateBank`.
 * A `write_to_hdf` is added to `TemplateBank` to write hdf files with the format expected on initialization (i.e., that there is a `parameters` attribute, and that compressed waveforms are stored in the `compressed_waveforms` group). As stated above, this will also write out the approximants to the hdf file.
 * `TemplateBank`'s `table` attribute is now a `WaveformArray` rather than a `FieldArray`. `WaveformArray` inherits from `FieldArray`, adding some common instance methods (`virtualfields`) that are typically used on templates, such as chirp mass (`mchirp`), total mass (`mtotal`), effective spin (`chi_eff`); etc. This is why in the example above the approximant condition can be expressed as `mtotal < 4` rather than having to do `mass1+mass2 < 4`, even though `mtotal` is not a parameter stored in the bank file.
 * A `from_kwargs` class method is added to `FieldArray` that allows you to create a new instance by passing fields as keyword arguments. I make use of this in `pycbc_plot_waveform` and `pycbc_single_template`, where previously a custom `parse_option` was used to hack the approximant parsing. (Note that `pycbc_single_template` still needs the kludge for parsing the chisq bins.)
 * A `parameters` key word argument is added to `TemplateBank` and all classes that inherit from it. If a list of parameters is specified, then only those parameters will be loaded from the file. Parameters can be virtual fields in WaveformArray or functions of them. In that case only the fields that are needed to calculate that value will be retrieved. For instance, if `parameters='5*mchirp**(3./5)/6'`, then only `mass1` and `mass2` will be retrieved from the bank file. I thought this might be useful in the future for plotting codes. Right now, the parameters option is just used by `pycbc_plot_singles_timefreq`.
 * I've made the doc string for `TemplateBank` more descriptive.

I'm currently running a test dax to test these changes. I'll update when it is finished. Please let me know if you want me to run some other tests.