### PR TITLE
added PyInstaller runtime-hook to crate tcl&tk directories for tkinter

### DIFF
--- a/tools/static/runtime-tkinter.py
+++ b/tools/static/runtime-tkinter.py
@@ -1,0 +1,7 @@
+import os, sys
+d = os.path.join(sys._MEIPASS, 'tcl')
+if not os.path.exists(d):
+    os.makedirs(d)
+d = os.path.join(sys._MEIPASS, 'tk')
+if not os.path.exists(d):
+    os.makedirs(d)


### PR DESCRIPTION
Some (recent) PyCBC requirement apparently pulls in tkinter, which fails when the "TCL directory" and "TK directory" don't exist. I don't know which these refer to in normal runs; in PyInstaller bundles these are directories "tcl" and "tk" below the "bundle" directory. The proposed patch adds a PyInstaller runtime-hook that creates these directories if needed, to avoid such failure of "bundled" applications.