### PR TITLE
Change name of parameters Mfinal and Sfinal in ringdown

### DIFF
--- a/bin/pycbc_ringinj
+++ b/bin/pycbc_ringinj
@@ -49,10 +49,10 @@ parser.add_argument('--amp', type=float,
                     help='Amplitude for single mode approximants.')
 parser.add_argument('--phi', type=float,
                     help='Phase for single mode approximants.')
-parser.add_argument('--Mfinal', type=float,
+parser.add_argument('--mtotal_f', type=float,
                     help='Mass of the final black hole for '
                          'multi-mode approximants.')
-parser.add_argument('--Sfinal', type=float,
+parser.add_argument('--s_f', type=float,
                     help='Spin of the final black hole for ' 
                          'multi-mode approximants.')
 parser.add_argument('--lmns', nargs='+',
@@ -137,8 +137,8 @@ if opts.approximant=='FdQNMmultiModes' or opts.approximant=='TdQNMmultiModes':
         except:
             raise ValueError('Amplitude or phase for one of the modes is missing')
     # Create datasets for each argument
-    injection.create_dataset('Mfinal', data=opts.Mfinal)
-    injection.create_dataset('Sfinal', data=opts.Sfinal)
+    injection.create_dataset('mtotal_f', data=opts.mtotal_f)
+    injection.create_dataset('s_f', data=opts.s_f)
     injection.create_dataset('lmns', data=opts.lmns)
     for mode in all_modes:
         injection.create_dataset('amp%s' %mode, data=float(amps[mode]))

--- a/bin/pycbc_ringinj
+++ b/bin/pycbc_ringinj
@@ -49,10 +49,10 @@ parser.add_argument('--amp', type=float,
                     help='Amplitude for single mode approximants.')
 parser.add_argument('--phi', type=float,
                     help='Phase for single mode approximants.')
-parser.add_argument('--final_mass', type=float,
+parser.add_argument('--final-mass', type=float,
                     help='Mass of the final black hole for '
                          'multi-mode approximants.')
-parser.add_argument('--final_spin', type=float,
+parser.add_argument('--final-spin', type=float,
                     help='Spin of the final black hole for ' 
                          'multi-mode approximants.')
 parser.add_argument('--lmns', nargs='+',

--- a/bin/pycbc_ringinj
+++ b/bin/pycbc_ringinj
@@ -49,10 +49,10 @@ parser.add_argument('--amp', type=float,
                     help='Amplitude for single mode approximants.')
 parser.add_argument('--phi', type=float,
                     help='Phase for single mode approximants.')
-parser.add_argument('--mtotal_f', type=float,
+parser.add_argument('--final_mass', type=float,
                     help='Mass of the final black hole for '
                          'multi-mode approximants.')
-parser.add_argument('--s_f', type=float,
+parser.add_argument('--final_spin', type=float,
                     help='Spin of the final black hole for ' 
                          'multi-mode approximants.')
 parser.add_argument('--lmns', nargs='+',
@@ -137,8 +137,8 @@ if opts.approximant=='FdQNMmultiModes' or opts.approximant=='TdQNMmultiModes':
         except:
             raise ValueError('Amplitude or phase for one of the modes is missing')
     # Create datasets for each argument
-    injection.create_dataset('mtotal_f', data=opts.mtotal_f)
-    injection.create_dataset('s_f', data=opts.s_f)
+    injection.create_dataset('final_mass', data=opts.final_mass)
+    injection.create_dataset('final_spin', data=opts.final_spin)
     injection.create_dataset('lmns', data=opts.lmns)
     for mode in all_modes:
         injection.create_dataset('amp%s' %mode, data=float(amps[mode]))

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -171,7 +171,7 @@ class FDomainMultiModeRingdownGenerator(BaseGenerator):
     --------
     Initialize a generator:
     >>> generator = waveform.FDomainMultiModeRingdownGenerator(
-            variable_args=['mtotal_f', 's_f', 'lmns','amp220','amp210','phi220','phi210'],
+            variable_args=['final_mass', 'final_spin', 'lmns','amp220','amp210','phi220','phi210'],
             delta_f=1./32, f_lower=30., f_final=500)
 
     Create a ringdown with the variable arguments:

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -171,7 +171,7 @@ class FDomainMultiModeRingdownGenerator(BaseGenerator):
     --------
     Initialize a generator:
     >>> generator = waveform.FDomainMultiModeRingdownGenerator(
-            variable_args=['Mfinal', 'Sfinal', 'lmns','amp220','amp210','phi220','phi210'],
+            variable_args=['mtotal_f', 's_f', 'lmns','amp220','amp210','phi220','phi210'],
             delta_f=1./32, f_lower=30., f_final=500)
 
     Create a ringdown with the variable arguments:

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -32,8 +32,8 @@ from pycbc.waveform.waveform import get_obj_attrs
 
 default_qnm_args = {'t_0':0}
 qnm_required_args = ['f_0', 'tau', 'amp', 'phi']
-lm_required_args = ['Mfinal','Sfinal','l','m','nmodes']
-lm_allmodes_required_args = ['Mfinal','Sfinal', 'lmns']
+lm_required_args = ['mtotal_f','s_f','l','m','nmodes']
+lm_allmodes_required_args = ['mtotal_f','s_f', 'lmns']
 
 max_freq = 16384.
 min_dt = 1. / (2 * max_freq)
@@ -385,9 +385,9 @@ def get_td_lm(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-    Mfinal : float
+    mtotal_f : float
         Mass of the final black hole.
-    Sfinal : float
+    s_f : float
         Spin of the final black hole.
     l : int
         l mode (lm modes available: 22, 21, 33, 44, 55).
@@ -419,8 +419,8 @@ def get_td_lm(template=None, **kwargs):
 
     # Get required args
     amps, phis = lm_amps_phases(**input_params)
-    Mfinal = input_params.pop('Mfinal')
-    Sfinal = input_params.pop('Sfinal')
+    mtotal_f = input_params.pop('mtotal_f')
+    s_f = input_params.pop('s_f')
     l, m = input_params.pop('l'), input_params.pop('m')
     nmodes = input_params.pop('nmodes')
     # The following may not be in input_params
@@ -428,15 +428,15 @@ def get_td_lm(template=None, **kwargs):
     t_final = input_params.pop('t_final', None)
 
     if delta_t is None:
-        delta_t = lm_deltat(Mfinal, Sfinal, ['%d%d%d' %(l,m,nmodes)]) 
+        delta_t = lm_deltat(mtotal_f, s_f, ['%d%d%d' %(l,m,nmodes)]) 
     if t_final is None:
-        t_final = lm_tfinal(Mfinal, Sfinal, ['%d%d%d' %(l, m, nmodes)])
+        t_final = lm_tfinal(mtotal_f, s_f, ['%d%d%d' %(l, m, nmodes)])
     kmax = int(t_final / delta_t) + 1
 
     outplus = TimeSeries(zeros(kmax, dtype=complex128), delta_t=delta_t)
     outcross = TimeSeries(zeros(kmax, dtype=complex128), delta_t=delta_t)
 
-    f_0, tau = get_lm_f0tau(Mfinal, Sfinal, l, m, nmodes)
+    f_0, tau = get_lm_f0tau(mtotal_f, s_f, l, m, nmodes)
     for n in range(nmodes):
         hplus, hcross = get_td_qnm(template=None, f_0=f_0[n], tau=tau[n],
                             phi=phis['%d%d%d' %(l,m,n)], amp=amps['%d%d%d' %(l,m,n)],
@@ -453,9 +453,9 @@ def get_fd_lm(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-    Mfinal : float
+    mtotal_f : float
         Mass of the final black hole.
-    Sfinal : float
+    s_f : float
         Spin of the final black hole.
     l : int
         l mode (lm modes available: 22, 21, 33, 44, 55).
@@ -490,8 +490,8 @@ def get_fd_lm(template=None, **kwargs):
 
     # Get required args
     amps, phis = lm_amps_phases(**input_params)
-    Mfinal = input_params.pop('Mfinal')
-    Sfinal = input_params.pop('Sfinal')
+    mtotal_f = input_params.pop('mtotal_f')
+    s_f = input_params.pop('s_f')
     l, m = input_params.pop('l'), input_params.pop('m')
     nmodes = input_params.pop('nmodes')
     # The following may not be in input_params
@@ -500,15 +500,15 @@ def get_fd_lm(template=None, **kwargs):
     f_final = input_params.pop('f_final', None)
 
     if delta_f is None:
-        delta_f = lm_deltaf(Mfinal, Sfinal, ['%d%d%d' %(l,m,nmodes)])
+        delta_f = lm_deltaf(mtotal_f, s_f, ['%d%d%d' %(l,m,nmodes)])
     if f_final is None:
-        f_final = lm_ffinal(Mfinal, Sfinal, ['%d%d%d' %(l, m, nmodes)])
+        f_final = lm_ffinal(mtotal_f, s_f, ['%d%d%d' %(l, m, nmodes)])
     kmax = int(f_final / delta_f) + 1
 
     outplus = FrequencySeries(zeros(kmax, dtype=complex128), delta_f=delta_f)
     outcross = FrequencySeries(zeros(kmax, dtype=complex128), delta_f=delta_f)
 
-    f_0, tau = get_lm_f0tau(Mfinal, Sfinal, l, m, nmodes)
+    f_0, tau = get_lm_f0tau(mtotal_f, s_f, l, m, nmodes)
     for n in range(nmodes):
         hplus, hcross = get_fd_qnm(template=None, f_0=f_0[n], tau=tau[n], 
                             phi=phis['%d%d%d' %(l,m,n)], amp=amps['%d%d%d' %(l,m,n)], delta_f=delta_f, 
@@ -525,9 +525,9 @@ def get_td_lm_allmodes(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-    Mfinal : float
+    mtotal_f : float
         Mass of the final black hole.
-    Sfinal : float
+    s_f : float
         Spin of the final black hole.
     lmns : list
         Desired lmn modes as strings (lm modes available: 22, 21, 33, 44, 55).
@@ -559,17 +559,17 @@ def get_td_lm_allmodes(template=None, **kwargs):
     input_params = props(template, lm_allmodes_required_args, **kwargs)
 
     # Get required args
-    Mfinal = input_params['Mfinal']
-    Sfinal = input_params['Sfinal']
+    mtotal_f = input_params['mtotal_f']
+    s_f = input_params['s_f']
     lmns = input_params['lmns']
     # The following may not be in input_params
     delta_t = input_params.pop('delta_t', None)
     t_final = input_params.pop('t_final', None)
 
     if delta_t is None:
-        delta_t = lm_deltat(Mfinal, Sfinal, lmns)
+        delta_t = lm_deltat(mtotal_f, s_f, lmns)
     if t_final is None:
-        t_final = lm_tfinal(Mfinal, Sfinal, lmns)
+        t_final = lm_tfinal(mtotal_f, s_f, lmns)
     kmax = int(t_final / delta_t) + 1
 
     outplus = TimeSeries(zeros(kmax, dtype=complex128), delta_t=delta_t)
@@ -590,9 +590,9 @@ def get_fd_lm_allmodes(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-    Mfinal : float
+    mtotal_f : float
         Mass of the final black hole.
-    Sfinal : float
+    s_f : float
         Spin of the final black hole.
     lmns : list
         Desired lmn modes as strings (lm modes available: 22, 21, 33, 44, 55).
@@ -627,8 +627,8 @@ def get_fd_lm_allmodes(template=None, **kwargs):
     input_params = props(template, lm_allmodes_required_args, **kwargs)
 
     # Get required args
-    Mfinal = input_params['Mfinal']
-    Sfinal = input_params['Sfinal']
+    mtotal_f = input_params['mtotal_f']
+    s_f = input_params['s_f']
     lmns = input_params['lmns']
     # The following may not be in input_params
     delta_f = input_params.pop('delta_f', None)
@@ -636,9 +636,9 @@ def get_fd_lm_allmodes(template=None, **kwargs):
     f_final = input_params.pop('f_final', None)
 
     if delta_f is None:
-        delta_f = lm_deltaf(Mfinal, Sfinal, lmns)
+        delta_f = lm_deltaf(mtotal_f, s_f, lmns)
     if f_final is None:
-        f_final = lm_ffinal(Mfinal, Sfinal, lmns)
+        f_final = lm_ffinal(mtotal_f, s_f, lmns)
     if f_lower is None:
         f_lower = delta_f
     kmax = int(f_final / delta_f) + 1

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -32,8 +32,8 @@ from pycbc.waveform.waveform import get_obj_attrs
 
 default_qnm_args = {'t_0':0}
 qnm_required_args = ['f_0', 'tau', 'amp', 'phi']
-lm_required_args = ['mtotal_f','s_f','l','m','nmodes']
-lm_allmodes_required_args = ['mtotal_f','s_f', 'lmns']
+lm_required_args = ['final_mass','final_spin','l','m','nmodes']
+lm_allmodes_required_args = ['final_mass','final_spin', 'lmns']
 
 max_freq = 16384.
 min_dt = 1. / (2 * max_freq)
@@ -385,9 +385,9 @@ def get_td_lm(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-    mtotal_f : float
+    final_mass : float
         Mass of the final black hole.
-    s_f : float
+    final_spin : float
         Spin of the final black hole.
     l : int
         l mode (lm modes available: 22, 21, 33, 44, 55).
@@ -419,8 +419,8 @@ def get_td_lm(template=None, **kwargs):
 
     # Get required args
     amps, phis = lm_amps_phases(**input_params)
-    mtotal_f = input_params.pop('mtotal_f')
-    s_f = input_params.pop('s_f')
+    final_mass = input_params.pop('final_mass')
+    final_spin = input_params.pop('final_spin')
     l, m = input_params.pop('l'), input_params.pop('m')
     nmodes = input_params.pop('nmodes')
     # The following may not be in input_params
@@ -428,15 +428,15 @@ def get_td_lm(template=None, **kwargs):
     t_final = input_params.pop('t_final', None)
 
     if delta_t is None:
-        delta_t = lm_deltat(mtotal_f, s_f, ['%d%d%d' %(l,m,nmodes)]) 
+        delta_t = lm_deltat(final_mass, final_spin, ['%d%d%d' %(l,m,nmodes)]) 
     if t_final is None:
-        t_final = lm_tfinal(mtotal_f, s_f, ['%d%d%d' %(l, m, nmodes)])
+        t_final = lm_tfinal(final_mass, final_spin, ['%d%d%d' %(l, m, nmodes)])
     kmax = int(t_final / delta_t) + 1
 
     outplus = TimeSeries(zeros(kmax, dtype=complex128), delta_t=delta_t)
     outcross = TimeSeries(zeros(kmax, dtype=complex128), delta_t=delta_t)
 
-    f_0, tau = get_lm_f0tau(mtotal_f, s_f, l, m, nmodes)
+    f_0, tau = get_lm_f0tau(final_mass, final_spin, l, m, nmodes)
     for n in range(nmodes):
         hplus, hcross = get_td_qnm(template=None, f_0=f_0[n], tau=tau[n],
                             phi=phis['%d%d%d' %(l,m,n)], amp=amps['%d%d%d' %(l,m,n)],
@@ -453,9 +453,9 @@ def get_fd_lm(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-    mtotal_f : float
+    final_mass : float
         Mass of the final black hole.
-    s_f : float
+    final_spin : float
         Spin of the final black hole.
     l : int
         l mode (lm modes available: 22, 21, 33, 44, 55).
@@ -490,8 +490,8 @@ def get_fd_lm(template=None, **kwargs):
 
     # Get required args
     amps, phis = lm_amps_phases(**input_params)
-    mtotal_f = input_params.pop('mtotal_f')
-    s_f = input_params.pop('s_f')
+    final_mass = input_params.pop('final_mass')
+    final_spin = input_params.pop('final_spin')
     l, m = input_params.pop('l'), input_params.pop('m')
     nmodes = input_params.pop('nmodes')
     # The following may not be in input_params
@@ -500,15 +500,15 @@ def get_fd_lm(template=None, **kwargs):
     f_final = input_params.pop('f_final', None)
 
     if delta_f is None:
-        delta_f = lm_deltaf(mtotal_f, s_f, ['%d%d%d' %(l,m,nmodes)])
+        delta_f = lm_deltaf(final_mass, final_spin, ['%d%d%d' %(l,m,nmodes)])
     if f_final is None:
-        f_final = lm_ffinal(mtotal_f, s_f, ['%d%d%d' %(l, m, nmodes)])
+        f_final = lm_ffinal(final_mass, final_spin, ['%d%d%d' %(l, m, nmodes)])
     kmax = int(f_final / delta_f) + 1
 
     outplus = FrequencySeries(zeros(kmax, dtype=complex128), delta_f=delta_f)
     outcross = FrequencySeries(zeros(kmax, dtype=complex128), delta_f=delta_f)
 
-    f_0, tau = get_lm_f0tau(mtotal_f, s_f, l, m, nmodes)
+    f_0, tau = get_lm_f0tau(final_mass, final_spin, l, m, nmodes)
     for n in range(nmodes):
         hplus, hcross = get_fd_qnm(template=None, f_0=f_0[n], tau=tau[n], 
                             phi=phis['%d%d%d' %(l,m,n)], amp=amps['%d%d%d' %(l,m,n)], delta_f=delta_f, 
@@ -525,9 +525,9 @@ def get_td_lm_allmodes(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-    mtotal_f : float
+    final_mass : float
         Mass of the final black hole.
-    s_f : float
+    final_spin : float
         Spin of the final black hole.
     lmns : list
         Desired lmn modes as strings (lm modes available: 22, 21, 33, 44, 55).
@@ -559,17 +559,17 @@ def get_td_lm_allmodes(template=None, **kwargs):
     input_params = props(template, lm_allmodes_required_args, **kwargs)
 
     # Get required args
-    mtotal_f = input_params['mtotal_f']
-    s_f = input_params['s_f']
+    final_mass = input_params['final_mass']
+    final_spin = input_params['final_spin']
     lmns = input_params['lmns']
     # The following may not be in input_params
     delta_t = input_params.pop('delta_t', None)
     t_final = input_params.pop('t_final', None)
 
     if delta_t is None:
-        delta_t = lm_deltat(mtotal_f, s_f, lmns)
+        delta_t = lm_deltat(final_mass, final_spin, lmns)
     if t_final is None:
-        t_final = lm_tfinal(mtotal_f, s_f, lmns)
+        t_final = lm_tfinal(final_mass, final_spin, lmns)
     kmax = int(t_final / delta_t) + 1
 
     outplus = TimeSeries(zeros(kmax, dtype=complex128), delta_t=delta_t)
@@ -590,9 +590,9 @@ def get_fd_lm_allmodes(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-    mtotal_f : float
+    final_mass : float
         Mass of the final black hole.
-    s_f : float
+    final_spin : float
         Spin of the final black hole.
     lmns : list
         Desired lmn modes as strings (lm modes available: 22, 21, 33, 44, 55).
@@ -627,8 +627,8 @@ def get_fd_lm_allmodes(template=None, **kwargs):
     input_params = props(template, lm_allmodes_required_args, **kwargs)
 
     # Get required args
-    mtotal_f = input_params['mtotal_f']
-    s_f = input_params['s_f']
+    final_mass = input_params['final_mass']
+    final_spin = input_params['final_spin']
     lmns = input_params['lmns']
     # The following may not be in input_params
     delta_f = input_params.pop('delta_f', None)
@@ -636,9 +636,9 @@ def get_fd_lm_allmodes(template=None, **kwargs):
     f_final = input_params.pop('f_final', None)
 
     if delta_f is None:
-        delta_f = lm_deltaf(mtotal_f, s_f, lmns)
+        delta_f = lm_deltaf(final_mass, final_spin, lmns)
     if f_final is None:
-        f_final = lm_ffinal(mtotal_f, s_f, lmns)
+        f_final = lm_ffinal(final_mass, final_spin, lmns)
     if f_lower is None:
         f_lower = delta_f
     kmax = int(f_final / delta_f) + 1


### PR DESCRIPTION
Currently the final mass and the final spin are 'Mfinal' and 'Sfinal' in the ringdown module. This is an issue for pycbc_inference because when reading the ini file it converts those names to 'mfinal' and 'sfinal', not finding therefore the priors for 'Mfinal' and 'Sfinal'.
This PR changes the names of the parameters to 'mtotal_f' and 's_f', following the convention that there should be no capital letters.