### PR TITLE
Update bank2hdf, compress bank to use new write hdf function

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_bank2hdf
+++ b/bin/hdfcoinc/pycbc_coinc_bank2hdf
@@ -61,8 +61,8 @@ parser.add_argument('--bank-file', required=True,
                          "and must contain a SnglInspiral table.")
 parser.add_argument('--output-file', required=True,
                     help="The ouput file name. Must end in '.hdf'.")
-parser.add_argument("--parameters", metavar="parameter[:xml_column]", nargs="+",
-                    default=default_parameters,
+parser.add_argument("--parameters", metavar="parameter[:xml_column]",
+                    nargs="+", default=default_parameters,
                     help="The parameters to load from the xml file and to "
                          "write to the hdf file. The given name will be the "
                          "dataset's name in the hdf file. If this is "

--- a/bin/hdfcoinc/pycbc_coinc_bank2hdf
+++ b/bin/hdfcoinc/pycbc_coinc_bank2hdf
@@ -22,6 +22,7 @@ with their template.
 """
 import argparse
 import logging
+import numpy
 import pycbc
 from pycbc.waveform import bank
 
@@ -103,6 +104,12 @@ for ii,p in enumerate(params):
     except KeyError:
         pass
 bankf.table.dtype.names = tuple(params)
+
+# compute the hash
+logging.info("Getting template hashes")
+template_hash = numpy.array([hash(v) for v in zip(*[bankf.table[p]
+                         for p in bankf.table.fieldnames])])
+bankf.table = bankf.table.add_fields(template_hash, 'template_hash')
 
 # write to output
 logging.info("Writing to %s" %(args.output_file))

--- a/bin/hdfcoinc/pycbc_coinc_bank2hdf
+++ b/bin/hdfcoinc/pycbc_coinc_bank2hdf
@@ -1,62 +1,108 @@
 #!/usr/bin/python
+
+# Copyright (C) 2014 Alex Nitz, Ian Harry, Collin Capano
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 """ This program converts a standard sngl_inspiral table based template bank
 into an hdf format that includes a template hash used to associate triggers
 with their template.
 """
-import numpy, argparse, pycbc.version
-from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
+import argparse
+import logging
+import pycbc
+from pycbc.waveform import bank
 
-import h5py, os
-# dummy class needed for loading LIGOLW files
-class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
-    pass
-lsctables.use_in(LIGOLWContentHandler)
+# the following are the default parameters that will be loaded from the
+# xml file (and what they are called in the xml file)
+default_parameters = [
+    "mass1", "mass2",
+    "spin1x", "spin1y", "spin1z",
+    "spin2x", "spin2y", "spin2z",
+    "inclination:alpha3"
+    ]
+
+def parse_parameters(parameters):
+    """Parses the parameters argument into names to write to and columns
+    to read from.
+    """
+    outnames = []
+    columns = []
+    for p in parameters:
+        ps = p.split(":")
+        if len(ps) == 1:
+            outname = column = p
+        elif len(ps) == 2:
+            outname, column = ps
+        else:
+            raise ValueError("parameter %s not formatted correctly; " %(p) +
+                             "see help")
+        outnames.append(outname)
+        columns.append(column)
+    return outname, column
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg)
-parser.add_argument('--bank-file')
-parser.add_argument('--output-file')
+parser.add_argument('--version', action='version',
+                    version=pycbc.version.git_verbose_msg)
+parser.add_argument('--bank-file', required=True,
+                    help="The bank xml file to load. Must end in '.xml[.gz]' "
+                         "and must contain a SnglInspiral table.")
+parser.add_argument('--output-file', required=True,
+                    help="The ouput file name. Must end in '.hdf'.")
+parser.add_argument("--paramters", metavar="parameter[:xml_column]", nargs="+",
+                    default=default_parameters,
+                    help="The parameters to load from the xml file and to "
+                         "write to the hdf file. The given name will be the "
+                         "dataset's name in the hdf file. If this is "
+                         "different than the column name in the xml file, "
+                         "provide the column name after a colon, e.g., "
+                         "'inclination:alpha3'. Otherwise, the given name "
+                         "will assumed to be the same as the column name.")
+# add the ability to specify the approximant to use
+bank.add_approximant_arg(parser,
+                         help="Specify the approximant to use with each "
+                              "template. See pycbc_inspiral's help message "
+                              "for syntax details. If provided, 'approximant'"
+                              "will be added to the list of parameters.")
+parser.add_argument("--force", action="store_true", default=False,
+                    help="Overwrite the given hdf file if it exists. "
+                         "Otherwise, an error is raised.")
+parser.add_argument("--verbose", action="store_true", default=False,
+                    help="Be verbose.")
 args = parser.parse_args()
 
-indoc = ligolw_utils.load_filename(args.bank_file, False, contenthandler=LIGOLWContentHandler)
-sngl_table = table.get_table(indoc, lsctables.SnglInspiralTable.tableName)
+pycbc.init_logging(args.verbose)
 
-m1 = numpy.array(sngl_table.get_column('mass1'), dtype=numpy.float32)
-m2 = numpy.array(sngl_table.get_column('mass2'), dtype=numpy.float32)
-s1 = numpy.array(sngl_table.get_column('spin1z'), dtype=numpy.float32)
-s2 = numpy.array(sngl_table.get_column('spin2z'), dtype=numpy.float32)
-# How to not store these in the case of not precession?
-s1x = numpy.array(sngl_table.get_column('spin1x'), dtype=numpy.float32)
-s1y = numpy.array(sngl_table.get_column('spin1y'), dtype=numpy.float32)
-s2x = numpy.array(sngl_table.get_column('spin2x'), dtype=numpy.float32)
-s2y = numpy.array(sngl_table.get_column('spin2y'), dtype=numpy.float32)
-incl = numpy.array(sngl_table.get_column('alpha3'), dtype=numpy.float32)
-th = numpy.zeros(len(m1), dtype=int)
-for j, v in enumerate(zip(m1, m2, s1, s2, s1x, s1y, s2x, s2y, incl)):
-    th[j] = hash(v)
+# parse the parameters
+outnames, columns = parse_parameters(args.parameters)
+name_map = dict(zip(columns, outnames))
 
-# Store the templates by sorted id
-sorted_ind = th.argsort()
-m1 = m1[sorted_ind]
-m2 = m2[sorted_ind]
-s1 = s1[sorted_ind]
-s2 = s2[sorted_ind]
-s1x = s1x[sorted_ind]
-s1y = s1y[sorted_ind]
-s2x = s2x[sorted_ind]
-s2y = s2y[sorted_ind]
-incl = incl[sorted_ind]
-th = th[sorted_ind]
-    
-f = h5py.File(args.output_file, "w")
-f.create_dataset("mass1", data=m1)
-f.create_dataset("mass2", data=m2)
-f.create_dataset("spin1z", data=s1)
-f.create_dataset("spin2z", data=s2)
-f.create_dataset("spin1x", data=s1x)
-f.create_dataset("spin2x", data=s2x)
-f.create_dataset("spin1y", data=s1y)
-f.create_dataset("spin2y", data=s2y)
-f.create_dataset("inclination", data=incl)
-f.create_dataset("template_hash", data=th)
-f.close()
+# load the file
+logging.info("Loading %s" %(args.bank_file))
+bankf = bank.TemplateBank(args.bank_file, approximant=args.approximant,
+                          parameters=columns)
+
+# rename the columns to the outnames
+params = list(bankf.table.fieldnames)
+for ii,p in enumerate(params):
+    try:
+        params[ii] = name_map[p]
+    except KeyError:
+        pass
+bankf.table.dtype.names = tuple(params)
+
+# write to output
+logging.infog("Writing to %s" %(args.output_file))
+bankf.write_to_hdf(args.output_file, force=args.force)

--- a/bin/hdfcoinc/pycbc_coinc_bank2hdf
+++ b/bin/hdfcoinc/pycbc_coinc_bank2hdf
@@ -69,7 +69,8 @@ parser.add_argument("--paramters", metavar="parameter[:xml_column]", nargs="+",
                          "different than the column name in the xml file, "
                          "provide the column name after a colon, e.g., "
                          "'inclination:alpha3'. Otherwise, the given name "
-                         "will assumed to be the same as the column name.")
+                         "will assumed to be the same as the column name. "
+                         "Default is '%s'." %(' '.join(default_parameters)))
 # add the ability to specify the approximant to use
 bank.add_approximant_arg(parser,
                          help="Specify the approximant to use with each "

--- a/bin/hdfcoinc/pycbc_coinc_bank2hdf
+++ b/bin/hdfcoinc/pycbc_coinc_bank2hdf
@@ -51,7 +51,7 @@ def parse_parameters(parameters):
                              "see help")
         outnames.append(outname)
         columns.append(column)
-    return outname, column
+    return outnames, columns
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--version', action='version',
@@ -61,7 +61,7 @@ parser.add_argument('--bank-file', required=True,
                          "and must contain a SnglInspiral table.")
 parser.add_argument('--output-file', required=True,
                     help="The ouput file name. Must end in '.hdf'.")
-parser.add_argument("--paramters", metavar="parameter[:xml_column]", nargs="+",
+parser.add_argument("--parameters", metavar="parameter[:xml_column]", nargs="+",
                     default=default_parameters,
                     help="The parameters to load from the xml file and to "
                          "write to the hdf file. The given name will be the "
@@ -105,5 +105,5 @@ for ii,p in enumerate(params):
 bankf.table.dtype.names = tuple(params)
 
 # write to output
-logging.infog("Writing to %s" %(args.output_file))
+logging.info("Writing to %s" %(args.output_file))
 bankf.write_to_hdf(args.output_file, force=args.force)

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -81,6 +81,9 @@ parser.add_argument("--precision", type=str, choices=["double", "single"],
                 default="double",
                 help="What precision to generate and store the waveforms with;"
                      " default is double.")
+parser.add_argument("--force", action="store_true", default=False,
+                    help="Overwrite the given hdf file if it exists. "
+                         "Otherwise, an error is raised.")
 parser.add_argument("--verbose", action="store_true", default=False)
 
 
@@ -94,7 +97,7 @@ fmax = args.sample_rate/2.
 # load the bank
 logging.info("loading bank")
 # set the dtype to use
-# FIXME: there really should be a funciont in pycbc.types that provides this
+# FIXME: there really should be a function in pycbc.types that provides this
 # mapping
 if args.precision == "single":
     dtype = numpy.complex64
@@ -107,6 +110,7 @@ templates = bank.table
 if args.tmplt_index is not None:
     imin, imax = args.tmplt_index
     templates = templates[imin:imax]
+    bank.table = templates
 else:
     imin, imax = 0, templates.size
 
@@ -118,14 +122,8 @@ seg_lens = 4*numpy.array([max(4./args.sample_rate,
     for m1,m2 in zip(templates.mass1, templates.mass2)])
 
 # generate output file
-# FIXME: this should be moved to a class or function
 logging.info("writing template info to output")
-output = h5py.File(args.output, 'w')
-output['mass1'] = templates['mass1']
-output['mass2'] = templates['mass2']
-output['spin1z'] = templates['spin1z']
-output['spin2z'] = templates['spin2z']
-output['template_hash'] = templates['template_hash']
+bank.write_to_hdf(args.output, force=args.force)
 
 # get the compressed sample points for each template
 logging.info("getting compressed amplitude and phase")
@@ -166,7 +164,7 @@ for ii in range(imin, imax):
         decomp_scratch=decomp_scratch)
 
     # save results
-    hcompressed.write_to_hdf(output, tmplt.template_hash)
+    hcompressed.write_to_hdf(bank.filehandler, tmplt.template_hash)
 
 logging.info("finished")
-output.close()
+bank.filehandler.close()

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -123,7 +123,8 @@ seg_lens = 4*numpy.array([max(4./args.sample_rate,
 
 # generate output file
 logging.info("writing template info to output")
-bank.write_to_hdf(args.output, force=args.force)
+output = bank.write_to_hdf(args.output, force=args.force,
+    skip_fields='template_duration')
 
 # get the compressed sample points for each template
 logging.info("getting compressed amplitude and phase")
@@ -164,7 +165,7 @@ for ii in range(imin, imax):
         decomp_scratch=decomp_scratch)
 
     # save results
-    hcompressed.write_to_hdf(bank.filehandler, tmplt.template_hash)
+    hcompressed.write_to_hdf(output, tmplt.template_hash)
 
 logging.info("finished")
 bank.filehandler.close()

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -997,7 +997,7 @@ class FieldArray(numpy.recarray):
             new_columns = {}
             for col in columns:
                 new_columns[col] = table.validcolumns[col]
-
+        columns = new_columns
         if cast_to_dtypes is not None:
             dtype = [cast_to_dtypes[col] for col in columns]
         else:

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -322,6 +322,11 @@ class TemplateBank(object):
         skip_fields : {None, (list of) strings}
             Do not write the given fields to the hdf file. Default is None,
             in which case all fields in self.table.fieldnames are written.
+
+        Returns
+        -------
+        h5py.File
+            The file handler to the output hdf file (left open).
         """
         if not filename.endswith('.hdf'):
             raise ValueError("Unrecoginized file extension")
@@ -340,9 +345,7 @@ class TemplateBank(object):
         if self.compressed_waveforms is not None:
             for tmplt_hash, compwf in self.compressed_waveforms.items():
                 compwf.write_to_hdf(f, tmplt_hash) 
-        f.close()
-
-        return None
+        return f
 
     def end_frequency(self, index):
         """ Return the end frequency of the waveform at the given index value


### PR DESCRIPTION
This patch updates `pycbc_coinc_bank2hdf` and `pycbc_compress_bank` to make use of `TemplateBank`'s new `write_to_hdf` function. 

`bank2hdf` has also been changed so that it makes use of `TemplateBank`'s new ability to only load specific parameters. Rather than hard code specific columns and parameter names, the list of columns to load from the xml file and what to call them in the output hdf file is now a command line option. There is a default list provided, currently set to mass1, mass2, spin(1|2)(x|y|z), and inclination. This means fewer/more parameters can be added in a workflow just using the ini file.

There is one minor change to `TemplateBank.write_to_hdf` so that it returns the file handler to the hdf file it wrote to; `compress_bank` makes use of this for writing compressed files later on.

This patch depends on #1023, so I'm putting on hold until that is merged.