### PR TITLE
Add emcee as a possible sampler to pycbc inference

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -286,6 +286,7 @@ with ctx:
                 if param in idist.params:
                     p0[i][j] = idist.rvs(size=1, param=param)[0][0]
                     break
+    sampler.set_p0(p0)
 
     # setup checkpointing
     if opts.checkpoint_interval:
@@ -310,8 +311,7 @@ with ctx:
     # position after burn in
     if not opts.skip_burn_in:
         logging.info("Burn in")
-        sampler.burn_in(p0)
-        p0 = None
+        sampler.burn_in()
         n_burnin = sampler.burn_in_iterations
         logging.info("Used %i burn in samples" % n_burnin)
     else:
@@ -360,8 +360,7 @@ with ctx:
         # picks up from where it left off next call
         logging.info("Running sampler for %i to %i out of %i iterations"%(
             start-n_burnin,end-n_burnin,opts.niterations))
-        sampler.run(end-start, p0=p0)
-        p0 = None
+        sampler.run(end-start)
 
         # write new samples
         with InferenceFile(opts.output_file, "a") as fp:

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -322,14 +322,26 @@ with ctx:
         fp.write_samples(variable_args, nwalkers=opts.nwalkers,
                          niterations=opts.niterations+n_burnin,
                          labels=labels)
-        fp.write_acceptance_fraction(niterations=opts.niterations+n_burnin)
+        # FIXME: kombine defines the acceptance fraction as the fraction of walkers
+        # that accepted each step, while emcee defines the acceptance fraction as
+        # the fraction of steps accepted by each walker; this means they have different
+        # lengths. For now, I'm just catching this here, but should come up with a more
+        # robust solution eventually
+        if opts.sampler == "kombine":
+            fp.write_acceptance_fraction(niterations=opts.niterations+n_burnin)
+        else:
+            fp.write_acceptance_fraction(niterations=opts.nwalkers)
         fp.write_lnpost(nwalkers=opts.nwalkers,
                         niterations=opts.niterations+n_burnin)
         # write the burn in
         if not opts.skip_burn_in:
             fp.write_samples_from_sampler(sampler, start=0, end=n_burnin)
-            fp.write_acceptance_fraction(data=sampler.acceptance_fraction,
-                                         start=0, end=n_burnin)
+            # FIXME: differenct definitions of acceptance fraction; see above
+            if opts.sampler == "kombine":
+                fp.write_acceptance_fraction(data=sampler.acceptance_fraction,
+                                             start=0, end=n_burnin)
+            else:
+                fp.write_acceptance_fraction(data=sampler.acceptance_fraction)
             fp.write_lnpost(data=sampler.lnpost, start=0, end=n_burnin)
 
     # write sampler attributes to file
@@ -354,8 +366,12 @@ with ctx:
         # write new samples
         with InferenceFile(opts.output_file, "a") as fp:
             fp.write_samples_from_sampler(sampler, start=start, end=end)
-            fp.write_acceptance_fraction(data=sampler.acceptance_fraction,
-                                         start=start, end=end)
+            # FIXME: differenct definitions of acceptance fraction; see above
+            if opts.sampler == "kombine":
+                fp.write_acceptance_fraction(data=sampler.acceptance_fraction,
+                                             start=start, end=end)
+            else:
+                fp.write_acceptance_fraction(data=sampler.acceptance_fraction)
             fp.write_lnpost(data=sampler.lnpost, start=start, end=end)
 
 # calculate ACL for each series of samples for each parameter for each walker

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -27,7 +27,7 @@ packages for parameter estimation.
 """
 
 class _BaseSampler(object):
-    """ Base container class for running the inference sampler that will
+    """Base container class for running the inference sampler that will
     generate the posterior distributions.
 
     Parameters
@@ -42,37 +42,37 @@ class _BaseSampler(object):
 
     @property
     def acceptance_fraction(self):
-        """ This function should return the fraction of walkers that accepted
+        """This function should return the fraction of walkers that accepted
         each step as an array.
         """
-        return ValueError("acceptance_fraction function not set.")
+        return NotImplementedError("acceptance_fraction function not set.")
 
     @property
     def lnpost(self):
-        """ This function should return the natural logarithm of the likelihood
+        """This function should return the natural logarithm of the likelihood
         as an niterations x nwalker array.
         """
-        return ValueError("lnpost function not set.")
+        return NotImplementedError("lnpost function not set.")
 
     @property
     def chain(self):
-        """ This function should return the past samples as a
+        """This function should return the past samples as a
         niterations x nwalker x ndim array.
         """
-        return ValueError("chain function not set.")
+        return NotImplementedError("chain function not set.")
 
     def burn_in(self, initial_values):
-        """ This function should burn in the sampler.
+        """This function should burn in the sampler.
         """
-        raise ValueError("This sampler has no burn_in function.")
+        raise NotImplementedError("This sampler has no burn_in function.")
 
     def run(self, niterations):
-        """ This function should run the sampler.
+        """This function should run the sampler.
         """
-        raise ValueError("run function not set.")
+        raise NotImplementedError("run function not set.")
 
 class _BaseMCMCSampler(_BaseSampler):
-    """ This class is used to construct the MCMC sampler from the kombine-like
+    """This class is used to construct the MCMC sampler from the kombine-like
     packages.
 
     Parameters
@@ -91,19 +91,13 @@ class _BaseMCMCSampler(_BaseSampler):
 
     @property
     def acceptance_fraction(self):
-        """ Get the fraction of walkers that accepted each step as an arary.
+        """Get the fraction of walkers that accepted each step as an arary.
         """
         return self._sampler.acceptance_fraction
 
-    @property
-    def chain(self):
-        """ Get all past samples as an niterations x nwalker x ndim array.
-        """
-        return self._sampler.chain
-
 
 class KombineSampler(_BaseMCMCSampler):
-    """ This class is used to construct the MCMC sampler from the kombine
+    """This class is used to construct the MCMC sampler from the kombine
     package.
 
     Parameters
@@ -142,7 +136,7 @@ class KombineSampler(_BaseMCMCSampler):
         super(KombineSampler, self).__init__(sampler, likelihood_evaluator)
 
     def run(self, niterations, **kwargs):
-        """ Advance the sampler for a number of samples.
+        """Advance the sampler for a number of samples.
 
         Parameters
         ----------
@@ -168,6 +162,11 @@ class KombineSampler(_BaseMCMCSampler):
         niterations x nwalkers array.
         """
         return self._sampler.lnpost
+
+    @property
+    def chain(self):
+        """Get all past samples as an niterations x nwalker x ndim array."""
+        return self._sampler.chain
 
     def burn_in(self, initial_values):
         """ Evolve an ensemble until the acceptance rate becomes roughly
@@ -252,8 +251,14 @@ class EmceeEnsembleSampler(_BaseMCMCSampler):
         """
         return self._sampler.lnprobability
 
+    @property
+    def chain(self):
+        """Get all past samples as an niterations x nwalker x ndim array."""
+        # emcee returns the chain as nwalker x niterations x ndim, so need to transpose
+        return self._sampler.chain.transpose((1,0,2))
+
     def run(self, niterations, **kwargs):
-        """ Advance the sampler for a number of samples.
+        """Advance the sampler for a number of samples.
 
         Parameters
         ----------

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'pycbc-pylal>=0.9.5',
                       'pycbc-glue>=0.9.8',
                       'kombine',
+                      'emcee>=2.2.0',
                       ]
 links = ['https://github.com/ligo-cbc/mpld3/tarball/master#egg=mpld3-0.3git']
 


### PR DESCRIPTION
This patch adds emcee's EnsembleSampler to the list of possible samplers in pycbc inference. Since emcee has no burn-in feature, `pycbc_inference` must be run with `--skip-burn-in` if using emcee. This patch also adds `emcee` to the list of required packages in `setup.py`. I tested this on my laptop with 4 processes and it seems to work well.