### PR TITLE
Change URL so that the OSG workflows can copy files properly.

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -250,8 +250,11 @@ fi
 export LOCAL_SITE_URL
 
 # add the local site
+# Set remote staging url to local
 if [ -z $SITE_LIST ] ; then
   SITE_LIST="local"
+  REMOTE_STAGING_URL=${LOCAL_SITE_URL}
+
 else
   SITE_LIST="local,${SITE_LIST}"
 fi
@@ -261,10 +264,13 @@ if [ -z ${PEGASUS_SITE_CATALOG_PATH} ] ; then
 fi
 
 # Create the site catalog
-if [ -z $REMOTE_STAGING_SERVER ] ; then
-  REMOTE_STAGING_URL="REMOTE_STAGING_SERVER_UNSET"   # this will be used as an error flag
-else
-  REMOTE_STAGING_URL="gsiftp://${REMOTE_STAGING_SERVER}${LOCAL_SITE_PATH}"
+# Don't overwrite remote staging URL if site list is local
+if [ ${SITE_LIST} != "local" ] ; then
+  if [ -z $REMOTE_STAGING_SERVER ] ; then
+    REMOTE_STAGING_URL="REMOTE_STAGING_SERVER_UNSET"   # this will be used as an error flag
+  else
+    REMOTE_STAGING_URL="gsiftp://${REMOTE_STAGING_SERVER}${LOCAL_SITE_PATH}"
+  fi
 fi
 export REMOTE_STAGING_URL
 

--- a/pycbc/workflow/pegasus_files/local-site-template.xml
+++ b/pycbc/workflow/pegasus_files/local-site-template.xml
@@ -1,6 +1,6 @@
   <site handle="local" arch="x86_64" os="LINUX">
     <directory  path="$LOCAL_SITE_PATH/local-site-scratch" type="shared-scratch" free-size="null" total-size="null">
-        <file-server  operation="all" url="$LOCAL_SITE_URL/local-site-scratch">
+        <file-server  operation="all" url="${REMOTE_STAGING_URL}/local-site-scratch">
         </file-server>
     </directory>
     <directory  path="$LOCAL_SITE_PATH" type="shared-storage" free-size="null" total-size="null">


### PR DESCRIPTION
This fixes the perl-ing problem for running PyCBC on OSG, but it may not work for running PyCBC on non-OSG.

Returns error:

```
`steven.reyes@sugar-dev3:aug19TestNoOSG$ ./submit.sh 
Enter your LIGO.ORG username in (e.g. albert.einstein): steven.reyes
Your identity: steven.reyes@LIGO.ORG
Enter pass phrase for this identity:
Creating proxy .................................... Done
Your proxy is valid until: Aug 22 19:54:11 2016 GMT


Attempt to use a remote site but --remote-staging-server not specified
```

Solution may be as simple as passing a remote-staging-server in pycbc_submit_dax, will conduct additional tests.