### PR TITLE
Pegasus Replica Selector URL to URI

### DIFF
--- a/pycbc/workflow/pegasus_files/pegasus-properties.conf
+++ b/pycbc/workflow/pegasus_files/pegasus-properties.conf
@@ -7,8 +7,8 @@ pegasus.dir.storage.mapper.replica.file=output.map
 # Add Replica selection options so that it will try URLs first, then 
 # XrootD for OSG, then gridftp, then anything else
 pegasus.selector.replica=Regex
-pegasus.selector.replica.regex.rank.1=file://scratch.*
-pegasus.selector.replica.regex.rank.2=root://xrootd-local.unl.edu.*
+pegasus.selector.replica.regex.rank.1=file://.*
+pegasus.selector.replica.regex.rank.2=root://.*
 pegasus.selector.replica.regex.rank.3=gridftp://.*
 pegasus.selector.replica.regex.rank.4=.\*
 

--- a/pycbc/workflow/pegasus_files/pegasus-properties.conf
+++ b/pycbc/workflow/pegasus_files/pegasus-properties.conf
@@ -7,10 +7,11 @@ pegasus.dir.storage.mapper.replica.file=output.map
 # Add Replica selection options so that it will try URLs first, then 
 # XrootD for OSG, then gridftp, then anything else
 pegasus.selector.replica=Regex
-pegasus.selector.replica.regex.rank.1=file://.*
-pegasus.selector.replica.regex.rank.2=root://.*
-pegasus.selector.replica.regex.rank.3=gridftp://.*
-pegasus.selector.replica.regex.rank.4=.\*
+pegasus.selector.replica.regex.rank.1=file:///cvmfs/.*
+pegasus.selector.replica.regex.rank.2=file://.*
+pegasus.selector.replica.regex.rank.3=root://.*
+pegasus.selector.replica.regex.rank.4=gridftp://.*
+pegasus.selector.replica.regex.rank.5=.\*
 
 # Do not transfer files coming from outside the worklow, simply
 # create symbolic links


### PR DESCRIPTION
Addressing open issue #874, Pegasus replica selector should just select by URI not URL. This should tell pegasus to try using these different URI's rather than a very particular URL.