### PR TITLE
Changes to prevent the process of building bundles from failing,added option in install script to delete an existing virtual environment location

### DIFF
--- a/install_pycbc.sh
+++ b/install_pycbc.sh
@@ -63,7 +63,7 @@ while true; do
 
   if [[ $OSG_PYTHON == "yes" ]] ; then
     if [ ! -e /cvmfs/oasis.opensciencegrid.org/osg/modules/lmod/current/init/bash ] ; then
-      echo "Error: Could not find sctipt to set up OSG modules."
+      echo "Error: Could not find script to set up OSG modules."
       echo "Check that /cvmfs/oasis.opensciencegrid.org is mounted on this machine."
       exit 1
     fi
@@ -138,7 +138,21 @@ while true ; do
 
     if [[ -d $NAME ]] ; then
        echo "ERROR: the directory $NAME already exists."
-       echo "If you want to use this path, remove the directory and try again."
+       echo "Do you want to remove the previous directory and overwrite the existing location?"
+       echo
+       read -p "Enter yes or no: " DEL_EXISTING_VIRTENV
+       echo
+
+       if [[ $DEL_EXISTING_VIRTENV == "yes" ]] ; then
+         echo "Deleting previous virtual environment directory with the same name"
+         rm -rf $NAME
+         break
+       elif [[ $DEL_EXISTING_VIRTENV == "no" ]] ; then
+          echo "You have to enter a new location for your virtual environment."
+       else
+          echo "Please enter yes or no."
+       fi
+
     else
       break
     fi
@@ -151,7 +165,7 @@ done
 
 #Virualenv check
 echo
-echo "You are installing PyCBC in $NAME."
+echo "You are installing PyCBC in $NAME ."
 echo
 
 

--- a/install_pycbc.sh
+++ b/install_pycbc.sh
@@ -151,7 +151,7 @@ while true ; do
           echo "You have to enter a new location for your virtual environment."
        else
           echo "Please enter yes or no."
-       fi
+       fi    
 
     else
       break
@@ -165,7 +165,7 @@ done
 
 #Virualenv check
 echo
-echo "You are installing PyCBC in $NAME ."
+echo "You are installing PyCBC in $NAME."
 echo
 
 
@@ -519,6 +519,7 @@ if [[ $dev_or_rel -eq 1 ]] ; then
   #Installing a released version of pyCBC
   curl https://raw.githubusercontent.com/ligo-cbc/pycbc/${reltag}/requirements.txt > ${VIRTUAL_ENV}/requirements.txt
   sed -i 's/https:\/\/github.com\/duncan-brown\/dqsegdb.git/git+https:\/\/github.com\/duncan-brown\/dqsegdb.git/g' ${VIRTUAL_ENV}/requirements.txt
+  sed -i '/MySQL-python\|psycopg2/d' ${VIRTUAL_ENV}/requirements.txt
   perl -pi.bak -e 's/pegasus-wms==4.5.2/pegasus-wms==4.6.1/g' ${VIRTUAL_ENV}/requirements.txt  
   pylal_version=`grep pycbc-pylal ${VIRTUAL_ENV}/requirements.txt`
   glue_version=`grep pycbc-glue ${VIRTUAL_ENV}/requirements.txt`
@@ -553,6 +554,8 @@ git config --global http.cookiefile /tmp/ecpcookie.u`id -u`
 
 #Get Copy of LalSuite Repository
 LALSUITE_BUILD_DIR=`mktemp --tmpdir -d -t lalsuite-XXXXXXXXXX`
+echo " LALSUITE_BUILD_DIR= "
+echo "${LALSUITE_BUILD_DIR}"
 ln -sf ${LALSUITE_BUILD_DIR} $VIRTUAL_ENV/src/lalsuite
 cd $VIRTUAL_ENV/src/lalsuite
 git clone https://versions.ligo.org/git/lalsuite.git
@@ -788,6 +791,9 @@ if [[ $IS_BUNDLE_ENV == "yes" ]] ; then
   echo "Making bundled executables."
   echo 
 
+  echo "Virtual env directory is:"
+  echo "  ${VIRTUAL_ENV}"
+  read -rp "Ready to continue? If yes hit [Enter] " ready
   #Make the dag that makes the bundles
   cd ${VIRTUAL_ENV}/src/pycbc/tools/static
   mkdir dist
@@ -812,7 +818,7 @@ if [[ $IS_BUNDLE_ENV == "yes" ]] ; then
   export PYINSTALLER_CONFIG_DIR=`mktemp --tmpdir -d -t pyinstaller-XXXXXXXXXX`
   pushd ${VIRTUAL_ENV}/bin
   for prog in ligolw_add ligolw_combine_segments ligolw_segments_from_cats_dqsegdb ligolw_segment_query_dqsegdb
-  do pyinstaller ${prog} --strip --onefile
+  do pyinstaller ${prog} --strip --onefile --hidden-import M2Crypto --hidden-import cjson --hidden-import Cookie
   done
   popd
   rm -rf ${PYINSTALLER_CONFIG_DIR}

--- a/tools/static/build_dag.sh
+++ b/tools/static/build_dag.sh
@@ -7,9 +7,9 @@ then
 fi
 
 cat > build_one.sub <<EOT
-universe = vanilla
+universe = local
 priority = 100
-request_memory = 32000
+request_memory = 500
 executable = ${PWD}/build_one.sh
 arguments = \$(prog)
 output = pyinstaller_build.\$(cluster).\$(process).out
@@ -37,13 +37,9 @@ do
 
 			echo "JOB ${NEW_UUID} ${PWD}/build_one.sub DIR ${PWD}"
 			echo "VARS ${NEW_UUID} prog=\"${prog}\""
-			echo
+			echo "RETRY ${NEW_UUID} 3"
+                        echo
 		fi
 	fi
 done > build_static.dag
 
-echo "JOB ligolw_segment_query_dqsegdb ${PWD}/build_one.sub DIR ${PWD}" >> build_static.dag
-echo "VARS ligolw_segment_query_dqsegdb prog=\"../../../../bin/ligolw_segment_query_dqsegdb\"" >> build_static.dag
-
-echo "JOB ligolw_segments_from_cats_dqsegdb ${PWD}/build_one.sub DIR ${PWD}" >> build_static.dag
-echo "VARS ligolw_segments_from_cats_dqsegdb prog=\"../../../../bin/ligolw_segments_from_cats_dqsegdb\"" >> build_static.dag


### PR DESCRIPTION
@duncan-brown  I updated this PR so that it does the following edits in install_pycbc.sh and build_dag.sh

In install_pycbc.sh:

*  Removed MySQL-python and psycopg2 from the requirements.txt used because the script was unable to build them (when tested on sugar-test1) . Larne thinks we might not need MySQL-python anywhere. Not sure about where psycopg2
*  Added extra options --hidden-import M2Crypto --hidden-import cjson --hidden-import Cookie when pyinstaller builds ligolw bundles. ( Issue #1046 )
*  Added a prompt to ask users if they are ready to proceed with making bundles before the dag to make them is created. This provides an option to the user to make edits to files involved in creating the dag like build_dag.sh, cant_be_built and needs_full_build before the dag is created.
*  Added an option for deleting an existing virtual environment directory with same name as the one being installed (this is the case of not building bundles) and continuing with the script. Thus the user does not have to terminate the script, delete the existing virtual environment and start from scratch in such a case. This is in reference to issue #869, and a resubmission of PR #902 because the commit history of that one was messed up.

In build_dag.sh:
*  Changed universe=local so that all bundling jobs run on the head node which would ensure that the Python version is common for all jobs ( Issue #1043 )
*  Reduced request_memory from 32Gb to 500Mb because Pyinstaller requires a few hundred Mb for the build ( Issue #1043 )
*  Added a RETRY _Jobname_ 3 option for all jobs so that the dag retries three times to run a job before it fails. 
* Removed lines to make the dag build ligolw_segment_query_dqsegdb and ligolw_segments_from_cats_dqsegdb bundles, because they are built from install_pycbc.sh which contain commands for PyInstaller to run on these executables .