### PR TITLE
Fix index issue with pycbc_page_injtable

### DIFF
--- a/bin/hdfcoinc/pycbc_page_injtable
+++ b/bin/hdfcoinc/pycbc_page_injtable
@@ -33,8 +33,8 @@ else:
     found_names = [tdiff_str, 'Ranking Stat.', 'Inc. IFAR (yrs)', 'Exc. IFAR']
     found_formats =  ['##.##', '##.##', '##', '##']
 
-    ids = {f.attrs['detector_1']: found['trigger_id1'],
-           f.attrs['detector_2']: found['trigger_id2'],}
+    ids = {f.attrs['detector_1']: found['trigger_id1'][:],
+           f.attrs['detector_2']: found['trigger_id2'][:],}
 
     if args.single_trigger_files:
         for ifo in args.single_trigger_files:


### PR DESCRIPTION
This small change adds the [:] command to the trigger ids in pycbc_page_injtable to ensure that the ids dictionary is populated with numpy arrays of integers. This matches what is done elsewhere, but I don't understand why sometimes this is necessary and sometimes it is not. I also feel we might be wasting RAM by doing this.

This is tested and works.