### PR TITLE
More parallelization

### DIFF
--- a/bin/hdfcoinc/pycbc_make_psd_estimation_workflow
+++ b/bin/hdfcoinc/pycbc_make_psd_estimation_workflow
@@ -90,7 +90,7 @@ datafind_files, analyzable_file, analyzable_segs, analyzable_name = \
 
 psd_job_length = int(workflow.cp.get('workflow-matchedfilter', 'analysis-length'))
 pad_data = int(workflow.cp.get('calculate_psd', 'pad-data'))
-max_segs_per_job = 100
+max_segs_per_job = 10
 
 # calculate noise PSDs over analyzable segments
 psd_files = {}


### PR DESCRIPTION
Hi Tito, I would suggest this change to the PSD estimation workflow to use more jobs reading less data each. This speeds up run time considerably on vulcan, where I only have easy access to 4-core nodes (the larger ones PE folks are always using). Don't know if this would break atlas though!