### PR TITLE
Reorganize read/write samples

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -307,46 +307,17 @@ with ctx:
     intervals = numpy.array(intervals)
 
     # check if user wants to skip the burn in
-    # if burn in then switch p0 to None and sampler should pick up from last
-    # position after burn in
     if not opts.skip_burn_in:
         logging.info("Burn in")
         sampler.burn_in()
         n_burnin = sampler.burn_in_iterations
         logging.info("Used %i burn in samples" % n_burnin)
+        with InferenceFile(opts.output_file, "a") as fp:
+            # write the burn in results
+            sampler.write_results(fp, max_iterations=opts.niterations+n_burnin)
     else:
         n_burnin = 0
 
-    with InferenceFile(opts.output_file, "a") as fp:
-        # create arrays in the file for the burnin + samples
-        fp.write_samples(variable_args, nwalkers=opts.nwalkers,
-                         niterations=opts.niterations+n_burnin,
-                         labels=labels)
-        # FIXME: kombine defines the acceptance fraction as the fraction of walkers
-        # that accepted each step, while emcee defines the acceptance fraction as
-        # the fraction of steps accepted by each walker; this means they have different
-        # lengths. For now, I'm just catching this here, but should come up with a more
-        # robust solution eventually
-        if opts.sampler == "kombine":
-            fp.write_acceptance_fraction(niterations=opts.niterations+n_burnin)
-        else:
-            fp.write_acceptance_fraction(niterations=opts.nwalkers)
-        fp.write_lnpost(nwalkers=opts.nwalkers,
-                        niterations=opts.niterations+n_burnin)
-        # write the burn in
-        if not opts.skip_burn_in:
-            fp.write_samples_from_sampler(sampler, start=0, end=n_burnin)
-            # FIXME: differenct definitions of acceptance fraction; see above
-            if opts.sampler == "kombine":
-                fp.write_acceptance_fraction(data=sampler.acceptance_fraction,
-                                             start=0, end=n_burnin)
-            else:
-                fp.write_acceptance_fraction(data=sampler.acceptance_fraction)
-            fp.write_lnpost(data=sampler.lnpost, start=0, end=n_burnin)
-
-    # write sampler attributes to file
-    with InferenceFile(opts.output_file, "a") as fp:
-        fp.write_sampler_attrs(sampler)
 
     # increase the intervals to account for the burn in
     intervals += n_burnin
@@ -364,14 +335,7 @@ with ctx:
 
         # write new samples
         with InferenceFile(opts.output_file, "a") as fp:
-            fp.write_samples_from_sampler(sampler, start=start, end=end)
-            # FIXME: differenct definitions of acceptance fraction; see above
-            if opts.sampler == "kombine":
-                fp.write_acceptance_fraction(data=sampler.acceptance_fraction,
-                                             start=start, end=end)
-            else:
-                fp.write_acceptance_fraction(data=sampler.acceptance_fraction)
-            fp.write_lnpost(data=sampler.lnpost, start=start, end=end)
+            sampler.write_results(fp, max_iterations=opts.niterations+n_burnin)
 
 # calculate ACL for each series of samples for each parameter for each walker
 logging.info("Calculating maximum ACL")

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -44,7 +44,7 @@ def add_inference_results_option_group(parser):
         metavar="PARAM[:LABEL]",
         help="Name of parameters to plot. If none provided will load all of "
              "the variable args in the input-file. If provided, the "
-             "parameters can be any of the variable args in "
+             "parameters can be any of the variable args or posteriors in "
              "the input file, derived parameters from them, or any function "
              "of them. Syntax for functions is python; any math functions in "
              "the numpy libary may be used. Can optionally also specify a "
@@ -65,6 +65,10 @@ def add_inference_results_option_group(parser):
     results_reading_group.add_argument("--thin-end", type=int, default=None,
         help="Sample number to stop collecting samples to plot. If none "
              "provided, will stop at the last sample from the sampler.")
+    results_reading_group.add_argument("--iteration", type=int, default=None,
+        help="Only retrieve the given iteration. To load the last n-th sampe "
+             "use -n, e.g., -1 will load the last iteration. This overrides "
+             "the thin-start/interval/end options.")
 
     return results_reading_group
 
@@ -113,7 +117,7 @@ def results_from_cli(opts, load_samples=True, walkers=None):
         logging.info("Loading samples")
         samples = fp.read_samples(parameters, walkers=walkers,
             thin_start=opts.thin_start, thin_interval=opts.thin_interval,
-            thin_end=opts.thin_end)
+            thin_end=opts.thin_end, iteration=opts.iteration)
     else:
         samples = None
     return fp, parameters, labels, samples

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -26,6 +26,62 @@ This modules provides classes and functions for using different sampler
 packages for parameter estimation.
 """
 
+import numpy
+from pycbc.io import WaveformArray
+
+#
+# =============================================================================
+#
+#                                   Helper functions
+#
+# =============================================================================
+#
+def get_slice(fp, thin_start=None, thin_interval=None, thin_end=None):
+    """Formats a slice using the given arguments that can be used to retrieve
+    a thinned array from an InferenceFile.
+
+    Parameters
+    ----------
+    fp : InferenceFile
+        An open inference file. The `burn_in_iterations` and acl will try to
+        be obtained from the file's attributes.
+    thin_start : {None, int}
+        The starting index to use. If None, will try to retrieve the
+        `burn_in_iterations` from the given file. If no `burn_in_iterations`            exists, will default to the start of the array.
+    thin_interval : {None, int}
+        The interval to use. If None, will try to retrieve the acl from the
+        given file. If no acl attribute exists, will default to 1.
+    thin_end : {None, int}
+        The end index to use. If None, will retrieve to the end of the array.
+
+    Returns
+    -------
+    slice :
+        The slice needed.
+    """
+    # default is to skip burn in samples
+    if thin_start is None:
+        try:
+            thin_start = fp.burn_in_iterations
+        except KeyError:
+            pass
+    # default is to use stored ACL and accept every i-th sample
+    if thin_interval is None:
+        try:
+            thin_interval = int(numpy.ceil(fp.acl))
+        except KeyError:
+            pass
+    return slice(thin_start, thin_end, thin_interval)
+
+
+#
+# =============================================================================
+#
+#                                   Samplers
+#
+# =============================================================================
+#
+
 class _BaseSampler(object):
     """Base container class for running the inference sampler that will
     generate the posterior distributions.
@@ -35,10 +91,27 @@ class _BaseSampler(object):
     sampler : sampler class
         An instance of the sampler class from its package.
     """
+    name = None
 
     def __init__(self, likelihood_evaluator):
         self.likelihood_evaluator = likelihood_evaluator
         self.burn_in_iterations = 0
+
+    @property
+    def ifos(self):
+        """Returns the ifos that were sampled over."""
+        return self.likelihood_evaluator.waveform_generator.detector_names
+
+    @property
+    def variable_args(self):
+        """Returns the variable args used by the likelihood evaluator.
+        """
+        return self.likelihood_evaluator.waveform_generator.variable_args
+
+    @property
+    def niterations(self):
+        """Get the current number of iterations."""
+        return self.chain.shape[0]
 
     @property
     def acceptance_fraction(self):
@@ -71,6 +144,22 @@ class _BaseSampler(object):
         """
         raise NotImplementedError("run function not set.")
 
+    # write and read functions
+    def write_metadata(self, fp):
+        """Writes metadata about this sampler to the given file. Metadata is
+        written to the file's `attrs`.
+
+        Parameters
+        ----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        """
+        fp.attrs['sampler'] = self.name
+        fp.attrs['ifos'] = self.ifos
+        fp.attrs['variable_args'] = self.variable_args
+        fp.attrs["niterations"] = self.niterations
+
+
 class _BaseMCMCSampler(_BaseSampler):
     """This class is used to construct the MCMC sampler from the kombine-like
     packages.
@@ -88,16 +177,17 @@ class _BaseMCMCSampler(_BaseSampler):
     sampler :
         The MCMC sampler instance used.
     p0 : nwalkers x ndim array
-        The initial position of the walkers. Set by using set_p0. If not set yet, a
-        ValueError is raised when the attribute is accessed.
+        The initial position of the walkers. Set by using set_p0. If not set
+        yet, a ValueError is raised when the attribute is accessed.
     pos : {None, array}
         An array of the current walker positions.
     """
+    name = None
     def __init__(self, sampler, likelihood_evaluator):
         self._sampler = sampler 
         self._pos = None
         self._p0 = None
-
+        self.burn_in_iterations = 0
         # initialize
         super(_BaseMCMCSampler, self).__init__(likelihood_evaluator)
 
@@ -126,10 +216,252 @@ class _BaseMCMCSampler(_BaseSampler):
         return self._p0
 
     @property
+    def nwalkers(self):
+        """Get the number of walkers."""
+        return self.chain.shape[1]
+
+    @property
     def acceptance_fraction(self):
         """Get the fraction of walkers that accepted each step as an arary.
         """
         return self._sampler.acceptance_fraction
+
+    # write and read functions
+    def write_metadata(self, fp):
+        """Writes metadata about this sampler to the given file. Metadata is
+        written to the file's `attrs`.
+
+        Parameters
+        ----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        """
+        super(_BaseMCMCSampler, self).write_metadata(fp)
+        # add info about walkers, burn in
+        fp.attrs["nwalkers"] = self.nwalkers
+        fp.attrs['burn_in_iterations'] = self.burn_in_iterations
+
+    def write_chain(self, fp, max_iterations=None):
+        """Writes the samples from the current chain to the given file. Results
+        are written to: `fp[fp.samples_group/{vararg}/walker{i}]`, where
+        `{vararg}` is the name of a variable arg, and `{i}` is the index of
+        a walker.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        max_iterations : {None, int}
+            If samples have not previously been written to the file, a new
+            dataset will be created. By default, the size of this dataset will
+            be whatever the length of the sampler's chain is at this point. If
+            you intend to run more iterations, set this value to that size so
+            that the array in the file will be large enough to accomodate
+            future data.
+        """
+        # transpose samples to get an (ndim,nwalkers,niteration) array
+        samples = numpy.transpose(self.chain)
+        _, nwalkers, niterations = samples.shape
+
+        group = fp.samples_group + '/{name}/walker{wnum}'
+
+        # create an empty array if desired, in case this is the first time
+        # writing
+        if max_iterations is not None:
+            if max_iterations < niterations:
+                raise IndexError("The provided max size is less than the "
+                    "number of iterations")
+            out = numpy.zeros(max_iterations, dtype=samples.dtype)
+
+        # loop over number of dimensions
+        for i,dim_name in enumerate(self.variable_args):
+            # loop over number of walkers
+            for j in range(nwalkers):
+                dataset_name = group.format(name=dim_name, wnum=j)
+                try:
+                    fp[dataset_name][:niterations] = samples[i,j,:]
+                except KeyError:
+                    # dataset doesn't exist yet, see if a larger array is
+                    # desired
+                    if max_iterations is not None:
+                        out[:niterations] = samples[i,j,:]
+                        fp[dataset_name] = out
+                    else:
+                        fp[dataset_name] = sample[i,j,:]
+
+    def write_lnpost(self, fp, max_iterations=None):
+        """Writes the `lnpost`s to the given file. Results are written to:
+        `fp[fp.samples_group/lnpost/walker{i}]`, where `{i}` is the index of
+        a walker.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        max_iterations : {None, int}
+            If `lnpost`s have not previously been written to the file, a new
+            dataset will be created. By default, the size of this dataset will
+            be whatever the length of the sampler's chain is at this point. If
+            you intend to run more iterations, set this value to that size so
+            that the array in the file will be large enough to accomodate
+            future data.
+        """
+        # lnposts are an (niterations,nwalkers) array
+        lnposts = self.lnpost
+        niterations, nwalkers = lnposts.shape
+
+        group = fp.samples_group + '/lnpost/walker{wnum}'
+
+        # create an empty array if desired, in case this is the first time
+        # writing
+        if max_iterations is not None:
+            if max_iterations < niterations:
+                raise IndexError("The provided max size is less than the "
+                    "number of iterations")
+            out = numpy.zeros(max_iterations, dtype=lnposts.dtype)
+
+        # loop over number of walkers
+        for j in range(nwalkers):
+            dataset_name = group.format(wnum=j)
+            try:
+                fp[dataset_name][:niterations] = lnposts[:,j]
+            except KeyError:
+                # dataset doesn't exist yet, see if a larger array is
+                # desired
+                if max_iterations is not None:
+                    out[:niterations] = lnposts[:,j]
+                    fp[dataset_name] = out
+                else:
+                    fp[dataset_name] = lnposts[:,j]
+
+    def write_acceptance_fraction(self, fp, max_iterations=None):
+        """Write acceptance_fraction data to file. Results are written to
+        `fp[acceptance_fraction]`.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        max_iterations : {None, int}
+            If acceptance fraction have not previously been written to the
+            file, a new dataset will be created. By default, the size of this
+            dataset will be whatever the length of the sampler's chain is at
+            this point. If you intend to run more iterations, set this value
+            to that size so that arrays in the file will be large enough to
+            accomodate future data.
+        """
+        dataset_name = "acceptance_fraction"
+        acf = self.acceptance_fraction
+        try:
+            fp[dataset_name][:acf.size] = acf
+        except KeyError:
+            # dataset doesn't exist yet, see if a larger array is
+            # desired
+            if max_iterations is not None:
+                out = numpy.zeros(max_iterations, dtype=acf.dtype)
+                out[:acf.size] = acf
+            else:
+                out = acf
+            fp[dataset_name] = out
+
+    def write_results(self, fp, max_iterations=None):
+        """Writes metadata, samples, lnpost, and acceptance fraction to the
+        given file. See the write function for each of those for details.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        max_iterations : {None, int}
+            If results have not previously been written to the
+            file, new datasets will be created. By default, the size of these
+            datasets will be whatever the length of the sampler's chain is at
+            this point. If you intend to run more iterations in the future,
+            set this value to that size so that the array in the file will be
+            large enough to accomodate future data.
+        """
+        self.write_metadata(fp)
+        self.write_chain(fp, max_iterations=max_iterations)
+        self.write_lnpost(fp, max_iterations=max_iterations)
+        self.write_acceptance_fraction(fp, max_iterations=max_iterations)
+
+    @staticmethod
+    def read_samples(fp, parameters,
+             thin_start=None, thin_interval=None, thin_end=None,
+             iteration=None,
+             walkers=None, flatten=True):
+        """Reads samples for the given parameter(s).
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            An open file handler to read the samples from.
+        parameters : (list of) strings
+            The parameter(s) to retrieve. A parameter can be the name of any
+            field in `fp[fp.samples_group]`, a virtual field or method of
+            `WaveformArray` (as long as the file contains the necessary fields
+            to derive the virtual field or method), and/or a function of
+            these.
+        thin_start : int
+            Index of the sample to begin returning samples. Default is to read
+            samples after burn in. To start from the beginning set thin_start
+            to 0.
+        thin_interval : int
+            Interval to accept every i-th sample. Default is to use the
+            `fp.acl`. If `fp.acl` is not set, then use all samples
+            (set thin_interval to 1).
+        thin_end : int
+            Index of the last sample to read. If not given then
+            `fp.niterations` is used.
+        iteration : int
+            Get a single iteration. If provided, will override the
+            `thin_{start/interval/end}` arguments.
+        walkers : {None, (list of) int}
+            The walker index (or a list of indices) to retrieve. If None,
+            samples from all walkers will be obtained.
+        flatten : {True, bool}
+            The returned array will be one dimensional, with all desired
+            samples from all desired walkers concatenated together. If False,
+            the returned array will have dimension requested iterations x
+            requested walkers.
+
+        Returns
+        -------
+        WaveformArray
+            Samples for the given parameters, as an instance of a
+            WaveformArray.
+        """
+        # get the names of fields needed for the given parameters
+        possible_fields = dict([[str(name), float]
+            for name in fp[fp.samples_group].keys()])
+        loadfields = WaveformArray.parse_parameters(parameters,
+            possible_fields=possible_fields)
+
+        # walkers to load
+        if walkers is None:
+            walkers = range(fp.nwalkers)
+        if isinstance(walkers, int):
+            walkers = [walkers]
+
+        # get the slice to use
+        if iteration is not None:
+            get_index = iteration
+        else:
+            get_index = get_slice(fp, thin_start=thin_start, thin_end=thin_end,
+                thin_interval=thin_interval)
+
+        # load
+        arrays = {}
+        group = fp.samples_group + '/{name}/walker{wnum}'
+        for name in loadfields:
+            these_arrays = [
+                    fp[group.format(name=name, wnum=ii)][get_index]
+                    for ii in walkers]
+            if flatten:
+                arrays[name] = numpy.hstack(these_arrays)
+            else:
+                arrays[name] = numpy.vstack(these_arrays).transpose()
+        return WaveformArray.from_kwargs(**arrays)
 
 
 class KombineSampler(_BaseMCMCSampler):
@@ -155,10 +487,10 @@ class KombineSampler(_BaseMCMCSampler):
         Number of processes to use with multiprocessing. If None, all available
         cores are used.
     """
+    name = "kombine"
 
     def __init__(self, likelihood_evaluator, nwalkers=0, ndim=0,
                         transd=False, processes=None):
-
         try:
             import kombine
         except ImportError:
@@ -167,7 +499,6 @@ class KombineSampler(_BaseMCMCSampler):
         # construct sampler for use in KombineSampler
         sampler = kombine.Sampler(nwalkers, ndim, likelihood_evaluator,
                                           transd=transd, processes=processes)
-
         # initialize
         super(KombineSampler, self).__init__(sampler, likelihood_evaluator)
 
@@ -195,7 +526,8 @@ class KombineSampler(_BaseMCMCSampler):
             p0 = self.p0
         else:
             p0 = None
-        p, lnpost, lnprop = self._sampler.run_mcmc(niterations, p0=p0, **kwargs)
+        p, lnpost, lnprop = self._sampler.run_mcmc(niterations, p0=p0,
+            **kwargs)
         # update the positions
         self._pos = p
         return p, lnpost, lnprop
@@ -216,8 +548,8 @@ class KombineSampler(_BaseMCMCSampler):
         """Evolve an ensemble until the acceptance rate becomes roughly
         constant. This is done by splitting acceptances in half and checking
         for statistical consistency. This isn't guaranteed to return a fully
-        burned-in ensemble, but usually does. The initial positions (p0) must be
-        set prior to running.
+        burned-in ensemble, but usually does. The initial positions (p0) must
+        be set prior to running.
 
         Returns
         -------
@@ -263,6 +595,8 @@ class EmceeEnsembleSampler(_BaseMCMCSampler):
         cores are used.
     """
 
+    name = "emcee"
+
     def __init__(self, likelihood_evaluator, nwalkers=0, ndim=0,
                         processes=None):
 
@@ -296,7 +630,8 @@ class EmceeEnsembleSampler(_BaseMCMCSampler):
     @property
     def chain(self):
         """Get all past samples as an niterations x nwalker x ndim array."""
-        # emcee returns the chain as nwalker x niterations x ndim, so need to transpose
+        # emcee returns the chain as nwalker x niterations x ndim, so need to
+        # transpose
         return self._sampler.chain.transpose((1,0,2))
 
     def run(self, niterations, **kwargs):
@@ -326,8 +661,43 @@ class EmceeEnsembleSampler(_BaseMCMCSampler):
         self._pos = p
         return p, lnpost, lnprop
 
+    # Emcee defines acceptance fraction differently, so have to override
+    # write functions
+    def write_acceptance_fraction(self, fp):
+        """Write acceptance_fraction data to file. Results are written to
+        `fp[acceptance_fraction]`.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        """
+        dataset_name = "acceptance_fraction"
+        fp[dataset_name] = self.acceptance_fraction
+
+    def write_results(self, fp, max_iterations=None):
+        """Writes metadata, samples, lnpost, and acceptance fraction to the
+        given file. See the write function for each of those for details.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        max_iterations : {None, int}
+            If results have not previously been written to the
+            file, new datasets will be created. By default, the size of these
+            datasets will be whatever the length of the sampler's chain is at
+            this point. If you intend to run more iterations in the future,
+            set this value to that size so that the array in the file will be
+            large enough to accomodate future data.
+        """
+        self.write_metadata(fp)
+        self.write_chain(fp, max_iterations=max_iterations)
+        self.write_lnpost(fp, max_iterations=max_iterations)
+        self.write_acceptance_fraction(fp)
+
 
 samplers = {
-    "kombine" : KombineSampler,
-    "emcee" : EmceeEnsembleSampler,
+    KombineSampler.name : KombineSampler,
+    EmceeEnsembleSampler.name : EmceeEnsembleSampler,
 }

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -288,7 +288,7 @@ class _BaseMCMCSampler(_BaseSampler):
                         out[:niterations] = samples[i,j,:]
                         fp[dataset_name] = out
                     else:
-                        fp[dataset_name] = sample[i,j,:]
+                        fp[dataset_name] = samples[i,j,:]
 
     def write_lnpost(self, fp, max_iterations=None):
         """Writes the `lnpost`s to the given file. Results are written to:

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -26,9 +26,7 @@ inference samplers generate.
 """
 
 import h5py
-import numpy
 from pycbc import pnutils
-from pycbc.io.record import WaveformArray
 from pycbc.waveform import parameters as wfparams
 import pycbc.inference.sampler
 

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -30,6 +30,7 @@ import numpy
 from pycbc import pnutils
 from pycbc.io.record import WaveformArray
 from pycbc.waveform import parameters as wfparams
+import pycbc.inference.sampler
 
 def read_label_from_config(cp, variable_arg, section="labels"):
     """ Returns the label for the variable_arg.
@@ -72,34 +73,19 @@ class InferenceFile(h5py.File):
     mode : {None, str}
         The mode to open the file, eg. "w" for write and "r" for read.
     """
+    samples_group = 'samples'
 
     def __init__(self, path, mode=None, **kwargs):
         super(InferenceFile, self).__init__(path, mode, **kwargs)
-        # create a result class to return values as. This is a sub-class
-        # WaveformArray, with the _staticfields set to the variable args
-        # that are in the file. We can only do this if there are actual
-        # results in the file
-        try:
-            self._arraycls = self._create_arraycls()
-        except KeyError:
-            self._arraycls = None
 
-    def _create_arraycls(self):
-        """Returns a sub-class of WaveformArray, with the _staticfields
-        set to the variable args that are in the file.
-        """
-        # we'll need the name of a walker to get the dtypes
-        refwalker = self[self.variable_args[0]].keys()[0]
-        # get the names, dtypes of the variable args
-        fields = dict([[name, self[name][refwalker].dtype]
-            for name in self.variable_args])
-        class ResultArray(WaveformArray):
-            _staticfields = fields
-        return ResultArray
+    @property
+    def sampler_name(self):
+        """Returns the name of the sampler that was used."""
+        return self.attrs["sampler"]
 
     @property
     def variable_args(self):
-        """ Returns list of variable_args.
+        """Returns list of variable_args.
 
         Returns
         -------
@@ -110,7 +96,7 @@ class InferenceFile(h5py.File):
 
     @property
     def nwalkers(self):
-        """ Returns number of walkers used.
+        """Returns number of walkers used.
 
         Returns
         -------
@@ -121,7 +107,7 @@ class InferenceFile(h5py.File):
 
     @property
     def niterations(self):
-        """ Returns number of iterations performed.
+        """Returns number of iterations performed.
 
         Returns
         -------
@@ -129,6 +115,12 @@ class InferenceFile(h5py.File):
             Number of iterations performed.
         """
         return self.attrs["niterations"]
+
+    @property
+    def burn_in_iterations(self):
+        """Returns number of iterations in the burn in.
+        """
+        return self.attrs["burn_in_iterations"]
 
     @property
     def acl(self):
@@ -141,32 +133,20 @@ class InferenceFile(h5py.File):
         """
         return self.attrs["acl"]
 
-    def read_samples(self, parameters, walkers=None, thin_start=None,
-                    thin_interval=None, thin_end=None):
-        """Reads samples from the specified walker(s) for the given
-        parameter(s).
+    def read_samples(self, parameters, **kwargs):
+        """Reads samples from the file.
 
         Parameters
         -----------
         parameters : (list of) strings
-            The parameter(s) to retrieve. A parameter can be the name of a
-            variable argument, a virtual field or method of WaveformArray
-            (as long as the file contains the necessary variables to derive
-            the virtual field or method), and/or a function of these.
-        walkers : {None, (list of) int}
-            The walker index (or a list of indices) to retrieve. If None,
-            samples from all walkers will be obtained.
-        thin_start : int
-            Index of the sample to begin returning samples. Default is to read
-            samples after burn in. To start from the beginning set thin_start
-            to 0.
-        thin_interval : int
-            Interval to accept every i-th sample. Default is to use the
-            self.acl attribute. If self.acl is not set, then use all samples
-            (set thin_interval to 1).
-        thin_end : int
-            Index of the last sample to read. If not given then
-            self.niterations is used.
+            The parameter(s) to retrieve. A parameter can be the name of any
+            field in `samples_group`, a virtual field or method of
+            `WaveformArray` (as long as the file contains the necessary fields
+            to derive the virtual field or method), and/or a function of
+            these.
+        \**kwargs :
+            The rest of the keyword args are passed to the sampler's
+            `read_samples` method.
 
         Returns
         -------
@@ -174,115 +154,19 @@ class InferenceFile(h5py.File):
             Samples for the given parameters, as an instance of a
             WaveformArray.
         """
-        if walkers is None:
-            walkers = range(self.nwalkers)
-        if isinstance(walkers, int):
-            walkers = [walkers]
+        # get the appropriate sampler class
+        sclass = pycbc.inference.sampler.samplers[self.sampler_name]
+        return sclass.read_samples(self, parameters, **kwargs)
 
-        # default is to skip burn in samples
-        thin_start = self.attrs["burn_in_iterations"] if thin_start is None \
-            else thin_start
-
-        # default is to use stored ACL and accept every i-th sample
-        if "acl" in self.attrs.keys():
-            thin_interval = int(numpy.ceil(self.acl)) if thin_interval is None \
-                else thin_interval
-        else:
-            thin_interval = 1 if thin_interval is None else thin_interval
-
-        # default is to read only as far as niterations
-        thin_end = self.niterations if thin_end is None else thin_end
-
-        # figure out the size of the output array to create
-        n_per_walker = self[self.variable_args[0]]['walker0'] \
-                                       [thin_start:thin_end:thin_interval].size
-        arrsize = len(walkers) * n_per_walker
-
-        # create an array to store the results
-        arr = self._arraycls(arrsize, names=parameters)
-        # populate
-        for name in arr.fieldnames:
-            for ii,walker in enumerate(walkers):
-                arr[name][ii*n_per_walker:(ii+1)*n_per_walker] = self[name] \
-                         ['walker%i'%walker][thin_start:thin_end:thin_interval]
-        return arr
-
-    def read_lnpost(self, walkers=None, thin_start=None,
-                    thin_interval=None, thin_end=None):
-        """Reads ln(likelihood) from the specified walker(s).
-
-        Parameters
-        -----------
-        walkers : {None, (list of) int}
-            The walker index (or a list of indices) to retrieve. If None,
-            ln(likelihood) from all walkers will be obtained.
-        thin_start : int
-            Index of the sample to begin returning ln(likelihood). Default is to read
-            samples after burn in. To start from the beginning set thin_start
-            to 0.
-        thin_interval : int
-            Interval to accept every i-th sample. Default is to use the
-            self.acl attribute. If self.acl is not set, then use all samples
-            (set thin_interval to 1).
-        thin_end : int
-            Index of the last sample to read. If not given then
-            self.niterations is used.
-
-        Returns
-        -------
-        Array
-            ln(likelihood) for the specified walkers
-        """
-        if walkers is None:
-            walkers = range(self.nwalkers)
-        if isinstance(walkers, int):
-            walkers = [walkers]
-
-        # default is to skip burn in samples
-        thin_start = self.attrs["burn_in_iterations"] if thin_start is None \
-            else thin_start
-
-        # default is to use stored ACL and accept every i-th sample
-        if "acl" in self.attrs.keys():
-            thin_interval = int(numpy.ceil(self.acl)) if thin_interval is None \
-                else thin_interval
-        else:
-            thin_interval = 1 if thin_interval is None else thin_interval
-
-        # default is to read only as far as niterations
-        thin_end = self.niterations if thin_end is None else thin_end
-
-        # figure out the size of the output array to create
-        n_per_walker = self[self.variable_args[0]]['walker0'] \
-                                       [thin_start:thin_end:thin_interval].size
-        arrsize = len(walkers) * n_per_walker
-
-        # create an array to store the results
-        arr = numpy.array(numpy.zeros(arrsize))
-        # populate
-        for ii, walker in enumerate(walkers):
-            arr[ii*n_per_walker:(ii+1)*n_per_walker] = self['ln_likelihood'] \
-                ['walker%i' %walker][thin_start:thin_end:thin_interval]
-
-        return arr 
-
-    def read_acceptance_fraction(self, thin_start=None, thin_interval=None):
-        """ Returns a numpy.array of the fraction of samples acceptanced at
-        each iteration in the sampler..
-
-        Parameters
-        -----------
-        thin_start : int
-            Index of the sample to begin returning samples.
-        thin_interval : int
-            Interval to accept every i-th sample.
+    def read_acceptance_fraction(self):
+        """Returns the acceptance fraction that was written to the file.
 
         Returns
         -------
         numpy.array
             The acceptance fraction.
         """
-        return self["acceptance_fraction"][thin_start::thin_interval]
+        return self["acceptance_fraction"][:]
 
     def read_label(self, parameter, error_on_none=False):
         """Returns the label for the parameter.
@@ -338,171 +222,6 @@ class InferenceFile(h5py.File):
                                           data=psds[key])
             psd_dim.attrs["delta_f"] = psds[key].delta_f
 
-    def write_sampler_attrs(self, sampler):
-        """ Write information about the sampler to the file attrs. If sampler
-        will run burn in, this should be called after sampler has already
-        run burn in.
-
-        Parameters
-        -----------
-        sampler : pycbc.inference._BaseSampler
-            An instance of a sampler class from pycbc.inference.sampler.
-        """
-
-        # get attributes from waveform generator
-        variable_args = sampler.likelihood_evaluator.waveform_generator.variable_args
-        ifo_list = sampler.likelihood_evaluator.waveform_generator.detector_names
-
-        # get shape of data from a (niterations,nwalkers,ndim) array
-        niterations, nwalkers, _ = sampler.chain.shape
-
-        # save parameters
-        self.attrs["variable_args"] = variable_args
-        self.attrs["ifo_list"] = ifo_list
-        self.attrs["nwalkers"] = nwalkers
-        self.attrs["burn_in_iterations"] = sampler.burn_in_iterations
-
-        # save number of iterations so far
-        if "niterations" not in self.attrs.keys():
-            self.attrs["niterations"] = niterations
-
-    def write_samples(self, variable_args, data=None, start=None, end=None,
-                      nwalkers=0, niterations=0, labels=None):
-        """ Writes samples to the file. To write to a subsample of the array
-        use start and end. To initialize an empty array of length niterations
-        for each walker use nwalkers and niterations.
-
-        Parameters
-        -----------
-        variable_args : {list, str}
-            List of names of parameters.
-        data : numpy.array
-            Data to be saved with shape (niterations,nwalkers,ndim). if data is
-            None then create an array of zeros for each walker with
-            length niterations.
-        start : int
-            If given then begin inserting this data at this index.
-        end : int
-            If given then stop inserting data at this index.
-        nwalkers : int
-            Number of walkers should be given if data is None.
-        niterations : int
-            Number of iterations should be given if data is None.
-        labels : {list, str}
-            A list of str to use as dislay by downsteam executables.
-        """
-
-        # transpose past samples to get an (ndim,nwalkers,niteration) array
-        if data is not None:
-            samples = numpy.transpose(data)
-            _, nwalkers, niterations = samples.shape
-
-        # sanity check options
-        elif nwalkers == 0 and niterations != 0:
-            raise ValueError("If nwalkers is 0 then niterations must be 0")
-
-        # if no data is given then initialize to array of numpy.NAN
-        # with shape (ndim,nwalkers,niterations)
-        else:
-            shape = (len(variable_args), nwalkers, niterations)
-            samples = numpy.zeros(shape)
-
-        # save number of iterations so far
-        if "niterations" in self.attrs.keys():
-            self.attrs["niterations"] += niterations - self.attrs["niterations"]
-        else:
-            self.attrs["niterations"] = niterations
-
-        # loop over number of dimensions
-        for i,dim_name in enumerate(variable_args):
-
-            # create a group in the output file for this dimension
-            if dim_name not in self.keys():
-                group_dim = self.create_group(dim_name)
-                if "label" in group_dim.attrs.keys():
-                    pass
-                elif labels is not None:
-                    group_dim.attrs["label"] = labels[i]
-                else:
-                    group_dim.attrs["label"] = dim_name
-
-            # loop over number of walkers
-            for j in range(nwalkers):
-
-                # create dataset with shape (ndim,nwalkers,niterations)
-                dataset_name = "walker%d"%j
-                if dataset_name not in self[dim_name].keys():
-                    samples_subset = numpy.zeros(niterations)
-                    if data is not None:
-                        samples_subset[start:end] = samples[i,j,start:end]
-                    group_dim.create_dataset(dataset_name,
-                                             data=samples_subset)
-
-                # write all samples in range from walker for this dimension
-                else:
-                    if end > len(samples[i,j,:]):
-                        end = None
-                    samples_subset = samples[i,j,start:end]
-                    self[dim_name+"/"+dataset_name][start:end] = samples_subset
-
-    def write_acceptance_fraction(self, data=None, start=None, end=None,
-                                  niterations=None):
-        """ Write acceptance_fraction data to file. To write to a subsample
-        of the array use start and end. To initialize an array of zeros, set
-        data to None and specify niterations.
-
-        Parameters
-        -----------
-        data : numpy.array
-            Data to be saved with shape (niterations,nwalkers,ndim). if data is
-            None then create an array fo zeros for each walker with
-            length niterations.
-        start : int
-            If given then begin inserting this data at this index.
-        end : int
-            If given then stop inserting data at this index.
-        niterations : int
-            Number of iterations should be given if data is None.
-        """
-
-        # sanity check options and if data is not given then make empty array
-        if data is None and niterations is None:
-            raise ValueError("Must specify either data or niterations")
-        elif data is None:
-            data = numpy.zeros(niterations)
-
-        # write data
-        if "acceptance_fraction" not in self.keys():
-            self.create_dataset("acceptance_fraction",
-                                data=data)
-        else:
-            self["acceptance_fraction"][start:end] = data[start:end]
-
-    def write_samples_from_sampler(self, sampler, start=None, end=None,
-                      nwalkers=0, niterations=0, labels=None):
-        """ Write data from sampler to file.
-
-        Parameters
-        -----------
-        sampler : pycbc.inference._BaseSampler
-            An instance of a sampler class from pycbc.inference.sampler.
-        start : int
-            If given then begin inserting this data at this index.
-        end : int
-            If given then stop inserting data at this index.
-        nwalkers : int
-            Number of walkers should be given if data is None.
-        niterations : int
-            Number of iterations should be given if data is None.
-        labels : {list, str}
-            A list of str to use as dislay by downsteam executables.
-        """
-        variable_args = sampler.likelihood_evaluator.waveform_generator.variable_args
-        self.write_samples(variable_args, data=sampler.chain,
-                           start=start, end=end,
-                           nwalkers=nwalkers, niterations=niterations,
-                           labels=labels)
-
     def write_acl(self, acl):
         """ Writes the autocorrelation length (ACL) to file.
 
@@ -512,63 +231,3 @@ class InferenceFile(h5py.File):
             The ACL.
         """
         self.attrs["acl"] = acl
-
-    def write_lnpost(self, data=None, start=None, end=None,
-                      nwalkers=0, niterations=0):
-        """ Writes log likelihood to the file. To write to a subsample of the array
-        use start and end. To initialize an empty array of length niterations
-        for each walker use nwalkers and niterations.
-
-        Parameters
-        -----------
-        data : numpy.array
-            Data to be saved with shape (niterations,nwalkers). if data is
-            None then create an array of zeros for each walker with
-            length niterations.
-        start : int
-            If given then begin inserting this data at this index.
-        end : int
-            If given then stop inserting data at this index.
-        nwalkers : int
-            Number of walkers should be given if data is None.
-        niterations : int
-            Number of iterations should be given if data is None.
-        """
-
-        # transpose past likelihoods to get an (nwalkers,niteration) array
-        if data is not None:
-            lnlikelihood = numpy.transpose(data)
-            nwalkers, niterations = lnlikelihood.shape 
-
-        # sanity check options
-        elif nwalkers == 0 and niterations != 0:
-            raise ValueError("If nwalkers is 0 then niterations must be 0")
-
-        # if no data is given then initialize to array of numpy.NAN
-        # with shape (nwalkers,niterations)
-        else:
-            shape = (nwalkers, niterations)
-            lnlikelihood = numpy.zeros(shape)
-
-        # create a group in the output file for the ln(likelihood)
-        if "ln_likelihood" not in self.keys():
-            group_name = self.create_group("ln_likelihood")
-
-        # loop over number of walkers
-        for i in range(nwalkers):
-
-            # create dataset with shape (nwalkers, niterations)
-            dataset_name = "walker%d" %i
-            if dataset_name not in self["ln_likelihood"].keys():
-                lnlikelihood_subset = numpy.zeros(niterations)
-                if data is not None:
-                    lnlikelihood_subset[start:end] = lnlikelihood[i,start:end]
-                group_name.create_dataset(dataset_name,
-                                         data=lnlikelihood_subset)
-
-            # write all samples in range from walker
-            else:
-                if end > len(lnlikelihood[i,:]):
-                    end = None
-                lnlikelihood_subset = lnlikelihood[i,start:end]
-                self["ln_likelihood/" + dataset_name][start:end] = lnlikelihood_subset

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1403,6 +1403,35 @@ class _FieldArrayWithDefaults(FieldArray):
             names.append(name)
         return self.add_fields(arrays, names)
 
+    @classmethod
+    def parse_parameters(cls, parameters, possible_fields=None):
+        """Parses a list of parameters to get the list of fields needed in
+        order to evaluate those parameters.
+
+        Parameters
+        ----------
+        parameters : (list of) strings
+            The list of desired parameters. These can be (functions of) fields
+            or virtual fields.
+        possible_fields : {None, dict}
+            Specify the list of possible fields. Must be a dictionary given
+            the names, and dtype of each possible field. If None, will use this
+            class's `_staticfields`.
+
+        Returns
+        -------
+        list :
+            The list of names of the fields that are needed in order to
+            evaluate the given parameters.
+        """
+        if possible_fields is not None:
+            # make sure field names are strings and not unicode
+            possible_fields = dict([[f, dt]
+                for f,dt in possible_fields.items()])
+            class ModifiedArray(cls):
+                _staticfields = possible_fields
+            cls = ModifiedArray
+        return cls(1, names=parameters).fieldnames
 
 #
 # =============================================================================


### PR DESCRIPTION
This patch moves the read/write samples to methods defined for the individual samplers. The read method in InferenceFile is now just a thin wrapper that calls the appropriate sampler's read function. This is to make it easier to add new samplers which may not have a similar structure as the current two MCMC samplers. For instance, I will be adding emcee's parallel tempered samplers (patch coming soon), which needs to be able to store temperature chains for each walker. Also, if anyone adds a nested sampling routine, I'm not sure they have a concept of walkers.

This results in a slight reorganization of the output in the hdf file; now, the sample chains and log posteriors are written to a `samples` group; acceptance fraction still lives in the top level.

I've also added the ability to have the samples returned as a (niterations x nwalkers) WaveformArray, to make it easier to access each walker if needed. This is controlled by a flatten key word argument. By default, `flatten=True`, which combines all the walkers into a single 1D array, as is done currently. This means that `read_samples` still looks the same to current plotting programs.

Finally, I've added an `iteration` key word argument to read samples, and a corresponding option to the argument parser group, which allows you to easily pick a specific iteration; e.g., if we just want the last iteration from all the walkers, you can just set `iteration=-1`.