### PR TITLE
Add plot throughput in coinc workflow

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_mergetrigs
+++ b/bin/hdfcoinc/pycbc_coinc_mergetrigs
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+#previous path was usr/bin/python
 """ This program adds single detector hdf trigger files together.
 """
 import numpy, argparse, h5py, logging
@@ -65,12 +66,17 @@ for col in trigger_columns:
 logging.info('reading the metadata from the files')
 start = numpy.array([], dtype=numpy.float64)
 end = numpy.array([], dtype=numpy.float64)
+tpc = numpy.array([], dtype=numpy.float64)
 gating = {}
 for filename in args.trigger_files:
     data = h5py.File(filename, 'r')
     ifo_data = data[ifo]
     s, e = ifo_data['search/start_time'][:], ifo_data['search/end_time'][:]
     start, end = numpy.append(start, s), numpy.append(end, e)
+
+    if 'templates_per_core' in ifo_data['search'].keys():
+        tpc = numpy.append(tpc, ifo_data['search/templates_per_core'][:])
+
     if 'gating' in ifo_data:
         gating_keys = []
         ifo_data['gating'].visit(gating_keys.append)
@@ -81,7 +87,11 @@ for filename in args.trigger_files:
                     gating[gk] = numpy.array([], dtype=numpy.float64)
                 gating[gk] = numpy.append(gating[gk], gk_data[:])
     data.close()    
-f['%s/search/start_time' % ifo], f['%s/search/end_time' % ifo] = start, end   
+f['%s/search/start_time' % ifo], f['%s/search/end_time' % ifo] = start, end
+
+if len(tpc) > 0:
+    f['%s/search/templates_per_core' % ifo] = tpc
+
 for gk, gv in gating.items():
     f[ifo + '/gating/' + gk] = gv
 

--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -361,6 +361,10 @@ wf.make_segments_plot(workflow, [sci_ok_seg_file],
 wf.make_gating_plot(workflow, full_insps, rdir['analysis_time/gating'],
                     tags=['full_data'])
 
+if workflow.cp.has_option_tags('workflow-matchedfilter',
+                                   'plot-throughput', tags=[tag]):
+    wf.make_throughput_plot(workflow, full_insps, rdir['workflow/throughput'],
+                            tags=['full_data'])
 
 # make segment table and plot for summary page
 curr_files = [science_seg_file, sci_ok_seg_file, analyzable_file,
@@ -478,7 +482,13 @@ for inj_file, tag in zip(inj_files, inj_tags):
                                      insps,  hdfbank[0], insp_files_seg_file,
                                      data_analysed_name, trig_generated_name,
                                      'daxes', currdir, tags=[tag])
-        
+
+    # If option given, make throughput plots
+    if workflow.cp.has_option_tags('workflow-matchedfilter',
+                                   'plot-throughput', tags=[tag]):
+        wf.make_throughput_plot(workflow, insps, rdir['workflow/throughput'],
+                                tags=[tag])
+
 # Make combined injection plots
 inj_summ = []
 if len(files_for_combined_injfind) > 0:

--- a/bin/hdfcoinc/pycbc_plot_throughput
+++ b/bin/hdfcoinc/pycbc_plot_throughput
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import argparse
+import logging
+import h5py
+import numpy as np
+import matplotlib
+import pylab as pl
+from pycbc.results.color import ifo_color
+import pycbc.version
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--version", action="version",
+                    version=pycbc.version.git_verbose_msg)
+parser.add_argument('--input-file', nargs='+', required=True,
+                    help='Single-detector inspiral HDF5 files to get templates per core.')
+parser.add_argument('--output-file', required=True,
+                    help='Destination file for the plot.')
+args = parser.parse_args()
+
+fig, ax = pl.subplots(1,1,figsize=(10,5))
+
+for pa in args.input_file:
+    f = h5py.File(pa, 'r')
+    ifo = f.keys()[0]
+    if  'templates_per_core' in  f['%s/search' %ifo].keys():
+        tpc = f['%s/search/templates_per_core' % ifo][:]
+        ax.hist(tpc, 100, color=ifo_color(ifo), alpha = 0.65, label = str(ifo))
+        ax.set_title('Templates per Core')
+        ax.set_xlabel('Templates per Core')
+        ax.legend(loc = 'upper right')
+        ax.grid(True)
+
+fig.savefig(str(args.output_file))
+

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -25,8 +25,9 @@ from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, complex64
 import pycbc.fft.fftw, pycbc.version
 import pycbc.opt
 import pycbc.weave
+import time
 
-
+tstart = time.time()
 
 parser = argparse.ArgumentParser(usage='',
     description="Find single detector gravitational-wave triggers.")
@@ -143,6 +144,8 @@ parser.add_argument("--threshold-template-filtering", type= float)
 
 
 
+
+
 # Add options groups
 psd.insert_psd_option_group(parser)
 strain.insert_strain_option_group(parser)
@@ -203,6 +206,8 @@ with ctx:
         'bank_chisq_dof' : None,
         'cont_chisq'     : None
                }
+
+
     names = sorted(out_vals.keys())
 
     if len(strain_segments.segment_slices) == 0:
@@ -227,6 +232,12 @@ with ctx:
         use_cluster = False
     else:
         use_cluster = True
+
+    if hasattr(ctx, "num_threads"):
+            ncores = ctx.num_threads
+    else:
+            ncores = 1
+
 
     matched_filter = MatchedFilterControl(opt.low_frequency_cutoff, None,
                                    opt.snr_threshold, tlen, delta_f, complex64,
@@ -267,6 +278,8 @@ with ctx:
                                             opt.threshold_template_filtering)
         logging.info("Template Bank Size After Cut: %s", len(bank))
       
+    ntemplates = len(bank)
+
     # Note: in the class-based approach used now, 'template' is not explicitly used
     # within the loop.  Rather, the iteration simply fills the memory specifed in
     # the 'template_mem' argument to MatchedFilterControl with the next template
@@ -344,6 +357,10 @@ if opt.maximization_interval:
     window = int(opt.maximization_interval * gwstrain.sample_rate / 1000)
     event_mgr.maximize_over_bank("time_index", "snr", window)
     logging.info("%d remaining triggers" % len(event_mgr.events))
+
+tstop = time.time()
+run_time = tstop - tstart
+event_mgr.save_performance(run_time=run_time, ncores=ncores, ntemplates=ntemplates)
 
 logging.info("Writing out triggers")
 event_mgr.write_events(opt.output)

--- a/pycbc/waveform/spa_tmplt.py
+++ b/pycbc/waveform/spa_tmplt.py
@@ -192,7 +192,6 @@ def spa_tmplt(**kwds):
         phasing = lalsimulation.SimInspiralTaylorF2AlignedPhasing(float(mass1), 
                                         float(mass2), float(s1z), float(s2z), 1, 1,
                                         spin_order)
-        
                                            
     pfaN = phasing.v[0]
     pfa2 = phasing.v[2] / pfaN

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -118,6 +118,14 @@ def make_gating_plot(workflow, insp_files, out_dir, tags=None):
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow += node
 
+def make_throughput_plot(workflow, insp_files, out_dir, tags=[]):
+    makedir(out_dir)
+    node = PlotExecutable(workflow.cp, 'plot_throughput', ifos=workflow.ifos,
+                          out_dir=out_dir, tags=tags).create_node()
+    node.add_input_list_opt('--input-file', insp_files)
+    node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
+    workflow += node
+
 def make_foreground_table(workflow, trig_file, bank_file, ftag, out_dir, 
                           singles=None, extension='.html', tags=None):
     if tags is None:

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -118,7 +118,8 @@ def make_gating_plot(workflow, insp_files, out_dir, tags=None):
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow += node
 
-def make_throughput_plot(workflow, insp_files, out_dir, tags=[]):
+def make_throughput_plot(workflow, insp_files, out_dir, tags=None):
+    tags = [] if tags is None else tags
     makedir(out_dir)
     node = PlotExecutable(workflow.cp, 'plot_throughput', ifos=workflow.ifos,
                           out_dir=out_dir, tags=tags).create_node()

--- a/setup.py
+++ b/setup.py
@@ -445,6 +445,7 @@ setup (
                'bin/hdfcoinc/pycbc_stat_dtphase',
                'bin/hdfcoinc/pycbc_plot_singles_vs_params',
                'bin/hdfcoinc/pycbc_plot_singles_timefreq',
+               'bin/hdfcoinc/pycbc_plot_throughput',
                'bin/mvsc/pycbc_mvsc_get_features',
                'bin/pycbc_coinc_time',
                'bin/hdfcoinc/pycbc_plot_background_coincs',


### PR DESCRIPTION
This pull request adds the ability to measure throughput as templates per core to `pycbc_inspiral` jobs in the coinc search workflow and histogram those throughputs in the results pages.

If the option `plot-throughput` is given in the section `workflow-matchedfilter` of the configuration file, then the sub-section `Throughput` will be added to the `Workflow` section of the results page, and will contain histograms of the templates per core for the full data and each injection run. A sample output may be seen [here](https://www.atlas.aei.uni-hannover.de/~hannah.hamilton/LSC/dev/o2/o1_analysis8/throughput_test_real/8._workflow/8.01_throughput/).

If re-analyzing earlier data before this capability was added, then the `plot-throughput` option should be omitted, or the workflow will break. An example of re-running on older data to recreate the earlier output (without the throughput plots, to verify that the workflow does not break) is [here](https://www.atlas.aei.uni-hannover.de/~hannah.hamilton/LSC/dev/o2/o1_analysis8/throughput_test_real_noplot/8._workflow/).

