### PR TITLE
More updates to sampler.py

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -23,10 +23,10 @@ import pycbc.opt
 import pycbc.weave
 import random
 from pycbc import DYN_RANGE_FAC, fft, inference, psd, scheme, strain, waveform
-from pycbc.filter import autocorrelation
 from pycbc.io.inference_hdf import InferenceFile, read_label_from_config
 from pycbc.types import FrequencySeries, MultiDetOptionAction
 from pycbc.workflow import WorkflowConfigParser
+from pycbc.inference import option_utils
 
 def select_waveform_generator(approximant):
     """ Returns the generator for the approximant.
@@ -44,22 +44,6 @@ def select_waveform_generator(approximant):
         raise ValueError("Time domain ringdowns not supported")
     else:
         raise ValueError("%s is not a valid approximant."%approximant)
-
-def read_distributions_from_config(cp, section):
-    """ Returns a list of PyCBC distribution instances for a section in the
-    configuration file.
-    """
-    dists = []
-    variable_args = []
-    for subsection in cp.get_subsections(section):
-        name = cp.get_opt_tag(section, "name", subsection)
-        dist = inference.priors[name].from_config(cp, section, subsection)
-        if set(dist.params).isdisjoint(variable_args):
-            dists.append(dist)
-            variable_args += dist.params
-        else:
-            raise ValueError("Same parameter in more than one distribution.")
-    return dists
 
 def convert_liststring_to_list(lstring):
     """ Checks if an argument of the configuration file is a string of a list
@@ -88,23 +72,14 @@ parser.add_argument("--psd-end-time", type=float, default=None,
     help="End time to use for PSD estimation if different from analysis.")
 
 # add inference options
-parser.add_argument("--sampler", required=True,
-    choices=inference.samplers.keys(),
-    help="Sampler class to use for finding posterior.")
 parser.add_argument("--likelihood-evaluator", required=True,
     choices=inference.likelihood_evaluators.keys(),
     help="Evaluator class to use to calculate the likelihood.")
-parser.add_argument("--nwalkers", type=int, required=True,
-    help="Number of walkers to use in sampler.")
-parser.add_argument("--niterations", type=int, required=True,
-    help="Number of iterations to perform after burn in.")
-parser.add_argument("--nprocesses", type=int, default=None,
-    help="Number of processes to use. If not given then use maximum.")
-parser.add_argument("--skip-burn-in", action="store_true", default=False,
-    help="Do not burn in with sampler.")
 parser.add_argument("--seed", type=int, default=0,
     help="Seed to use for the random number generator that initially "
          "distributes the walkers. Default is 0.")
+# add sampler options
+option_utils.add_sampler_option_group(parser)
 
 # add config options
 parser.add_argument("--config-files", type=str, nargs="+", required=True,
@@ -237,7 +212,7 @@ with ctx:
 
     # get prior distribution for each variable parameter
     logging.info("Setting up priors for each parameter")
-    distributions = read_distributions_from_config(cp, "prior")
+    distributions = inference.read_distributions_from_config(cp, "prior")
 
     # construct class that will return the prior
     prior = inference.PriorEvaluator(variable_args, *distributions)
@@ -255,15 +230,12 @@ with ctx:
                         delta_f=delta_f_dict.values()[0], **static_args)
 
     # construct class that will return the natural logarithm of likelihood
-    likelihood = inference.likelihood_evaluators[opts.likelihood_evaluator](generator,
-                        stilde_dict, opts.low_frequency_cutoff,
+    likelihood = inference.likelihood_evaluators[opts.likelihood_evaluator](
+                        generator, stilde_dict, opts.low_frequency_cutoff,
                         psds=psd_dict, prior=prior)
 
     # create sampler that will run
-    ndim = len(variable_args)
-    sampler = inference.samplers[opts.sampler](likelihood, ndim=ndim,
-                                               nwalkers=opts.nwalkers,
-                                               processes=opts.nprocesses)
+    sampler = option_utils.sampler_from_cli(opts, likelihood)
 
     # get distribution to draw from for each walker initial position
     logging.info("Setting walkers initial conditions for varying parameters")
@@ -271,22 +243,14 @@ with ctx:
     # check if user wants to use different distributions than prior for setting
     # walkers initial positions
     if len(cp.get_subsections("initial")):
-        initial_distributions = read_distributions_from_config(cp, "initial")
+        initial_distributions = inference.read_distributions_from_config(cp,
+            section="initial")
     else:
-        initial_distributions = read_distributions_from_config(cp, "prior")
+        initial_distributions = inference.read_distributions_from_config(cp,
+            section="prior")
 
-    # set initial values for variable parameters for each walker
-    # loop over all walkers and then parameters
-    # find the distribution that has that parameter in it and draw a
-    # random value from the distribution
-    p0 = numpy.ones(shape=(opts.nwalkers, ndim))
-    for i,_ in enumerate(p0):
-        for j,param in enumerate(variable_args):
-            for idist in initial_distributions:
-                if param in idist.params:
-                    p0[i][j] = idist.rvs(size=1, param=param)[0][0]
-                    break
-    sampler.set_p0(p0)
+    # set the initial positions
+    sampler.set_p0(initial_distributions)
 
     # setup checkpointing
     if opts.checkpoint_interval:
@@ -335,27 +299,10 @@ with ctx:
 
         # write new samples
         with InferenceFile(opts.output_file, "a") as fp:
+            logging.info("Dumping results to file")
             sampler.write_results(fp, max_iterations=opts.niterations+n_burnin)
-
-# calculate ACL for each series of samples for each parameter for each walker
-logging.info("Calculating maximum ACL")
-acls = []
-with InferenceFile(opts.output_file, "r") as fp:
-    for i in range(opts.nwalkers):
-        for param in fp.variable_args:
-            acls.append( autocorrelation.calculate_acl(
-                fp.read_samples(param, walkers=i)[param], dtype=int) )
-
-# get max ACL to save to file
-# if ACL is infinity then set it to the length of the chain of samples
-max_acl = numpy.array(acls).max()
-if max_acl == numpy.inf:
-    max_acl = opts.niterations
-
-# write ACL as an int rounding up
-logging.info("Writing ACL of %f samples to file"%max_acl)
-with InferenceFile(opts.output_file, "a") as fp:
-    fp.write_acl(max_acl)
+            # compute the acls and write
+            sampler.write_acls(fp, sampler.compute_acls(fp))
 
 # exit
 logging.info("Done")

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -132,6 +132,7 @@ class _BaseLikelihoodEvaluator(object):
         ratio. If the log likelihood ratio is < 0, will return an imaginary
         number.
     """
+    name = None
 
     def __init__(self, waveform_generator, data, prior=None):
         self._waveform_generator = waveform_generator
@@ -349,6 +350,8 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
     >>> likelihood_eval.logplr([tsig]), likelihood_eval.logposterior([tsig])
     (ArrayWithAligned(278.84574353071264), ArrayWithAligned(0.9162907318741418))
     """
+    name = 'gaussian'
+
     def __init__(self, waveform_generator, data, f_lower, psds=None,
             f_upper=None, norm=None, prior=None):
         # set up the boiler-plate attributes; note: we'll compute the
@@ -477,7 +480,7 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
         return self.logplr(params)
 
 
-likelihood_evaluators = {'gaussian': GaussianLikelihood}
+likelihood_evaluators = {GaussianLikelihood.name: GaussianLikelihood}
 
 __all__ = ['_BaseLikelihoodEvaluator', 'GaussianLikelihood',
            'likelihood_evaluators']

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -1127,3 +1127,31 @@ class PriorEvaluator(object):
         params = dict(zip(self.variable_args, params))
         return sum([d(**params) for d in self.distributions])
 
+
+def read_distributions_from_config(cp, section="prior"):
+    """Returns a list of PyCBC distribution instances for a section in the
+    given configuration file.
+
+    Parameters
+    ----------
+    cp : WorflowConfigParser
+        An open config file to read.
+    section : {"prior", string}
+        Prefix on section names from which to retrieve the priors.
+
+    Returns
+    -------
+    list
+        A list of the parsed distributions.
+    """
+    dists = []
+    variable_args = []
+    for subsection in cp.get_subsections(section):
+        name = cp.get_opt_tag(section, "name", subsection)
+        dist = priors[name].from_config(cp, section, subsection)
+        if set(dist.params).isdisjoint(variable_args):
+            dists.append(dist)
+            variable_args += dist.params
+        else:
+            raise ValueError("Same parameter in more than one distribution.")
+    return dists

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -184,12 +184,9 @@ class _BaseSampler(object):
         fp.attrs['variable_args'] = self.variable_args
         fp.attrs["niterations"] = self.niterations
         sargs = self.likelihood_evaluator.waveform_generator.static_args
+        fp.attrs["static_args"] = sargs.keys()
         for arg,val in sargs.items():
-            try:
-                fp.attrs['static_args/{arg}'.format(arg=arg)] = val
-            except KeyError:
-                fp.attrs['static_args'] = {}
-                fp.attrs['static_args/{arg}'.format(arg=arg)] = val
+            fp.attrs[arg] = val
 
 
 class _BaseMCMCSampler(_BaseSampler):

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -93,6 +93,14 @@ class InferenceFile(h5py.File):
         return self.attrs["variable_args"]
 
     @property
+    def static_args(self):
+        """Returns a dictionary of the static_args. The keys are the argument
+        names, values are the value they were set to.
+        """
+        return dict([[arg, self.attrs[arg]]
+            for arg in self.attrs["static_args"]])
+
+    @property
     def niterations(self):
         """Returns number of iterations performed.
 
@@ -119,11 +127,6 @@ class InferenceFile(h5py.File):
             Number of walkers used.
         """
         return self.attrs["nwalkers"]
-
-    @property
-    def ntemps(self):
-        """Returns number of temperatures used."""
-        return self.attrs["ntemps"]
 
     @property
     def acl(self):

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -93,17 +93,6 @@ class InferenceFile(h5py.File):
         return self.attrs["variable_args"]
 
     @property
-    def nwalkers(self):
-        """Returns number of walkers used.
-
-        Returns
-        -------
-        nwalkesr : int
-            Number of walkers used.
-        """
-        return self.attrs["nwalkers"]
-
-    @property
     def niterations(self):
         """Returns number of iterations performed.
 
@@ -119,6 +108,22 @@ class InferenceFile(h5py.File):
         """Returns number of iterations in the burn in.
         """
         return self.attrs["burn_in_iterations"]
+
+    @property
+    def nwalkers(self):
+        """Returns number of walkers used.
+
+        Returns
+        -------
+        nwalkesr : int
+            Number of walkers used.
+        """
+        return self.attrs["nwalkers"]
+
+    @property
+    def ntemps(self):
+        """Returns number of temperatures used."""
+        return self.attrs["ntemps"]
 
     @property
     def acl(self):
@@ -156,15 +161,30 @@ class InferenceFile(h5py.File):
         sclass = pycbc.inference.sampler.samplers[self.sampler_name]
         return sclass.read_samples(self, parameters, **kwargs)
 
-    def read_acceptance_fraction(self):
+    def read_acceptance_fraction(self, **kwargs):
         """Returns the acceptance fraction that was written to the file.
 
+        Parameters
+        ----------
+        \**kwargs :
+            All keyword arguments are passed to the sampler's
+            `read_acceptance_fraction` function.
         Returns
         -------
         numpy.array
             The acceptance fraction.
         """
-        return self["acceptance_fraction"][:]
+        # get the appropriate sampler class
+        sclass = pycbc.inference.sampler.samplers[self.sampler_name]
+        return sclass.read_acceptance_fraction(self, **kwargs)
+
+    def read_acls(self):
+        """Returns all of the individual chains' acls. See the `read_acls`
+        function of this file's sampler for more details.
+        """
+        # get the appropriate sampler class
+        sclass = pycbc.inference.sampler.samplers[self.sampler_name]
+        return sclass.read_acls(self)
 
     def read_label(self, parameter, error_on_none=False):
         """Returns the label for the parameter.
@@ -219,13 +239,3 @@ class InferenceFile(h5py.File):
             psd_dim = self.create_dataset(key+"/psds/0",
                                           data=psds[key])
             psd_dim.attrs["delta_f"] = psds[key].delta_f
-
-    def write_acl(self, acl):
-        """ Writes the autocorrelation length (ACL) to file.
-
-        Parameters
-        ----------
-        acl : float
-            The ACL.
-        """
-        self.attrs["acl"] = acl

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -87,6 +87,11 @@ class BaseGenerator(object):
         # generation
         self.current_params = frozen_params.copy()
 
+    @property
+    def static_args(self):
+        """Returns a dictionary of the static arguments."""
+        return self.frozen_params
+
     def generate(self, *args):
         """Generates a waveform. The list of arguments must be in the same
         order as self's variable_args attribute.
@@ -266,6 +271,7 @@ class FDomainDetFrameGenerator(object):
             variable_args=(), **frozen_params):
         # initialize frozen & current parameters:
         self.current_params = frozen_params.copy()
+        self._static_args = frozen_params.copy()
         # we'll separate out frozen location parameters from the frozen
         # parameters that are sent to the rframe generator
         self.frozen_location_args = {}
@@ -300,6 +306,11 @@ class FDomainDetFrameGenerator(object):
     def set_epoch(self, epoch):
         """Sets the epoch; epoch should be a float or a LIGOTimeGPS."""
         self._epoch = float(epoch)
+
+    @property
+    def static_args(self):
+        """Returns a dictionary of the static arguments."""
+        return self._static_args
 
     @property
     def epoch(self):


### PR DESCRIPTION
This patch makes more changes to the sampler and related modules in order to prepare for adding the parallel tempered sampler. The changes include:

 * Setting the initial walker positions is now a class method for each sampler.
 * Calculating and writing acls are now also methods under each sampler. When writing acls, the acl of each chain is saved to the attribute of that chain's dataset. The maximum over all chains is still saved to the same spot (`fp.attrs['acl']`), with the default to use that value.
 * The indexing of the returned chains and lnpost have been transposed to be consistent between samplers and with emcee. Now, chains always have shape `[additional dimensions x] niterations x ndim`, where `additional dimensions` is specific to the sampler. For `emcee` and `kombine`, this means they have shape `nwalkers x niterations x ndim`. This has no affect on returned thinned chains, however, so it shouldn't affect any current post processing programs.
 * Additional metadata from the likelihood evaluator and waveform generator have been added to the output file's attributes. The name of the evaluator that was used, and the static arguments are now saved to the file's attributes. This necessitated giving the likelihood evaluators a `name` attribute, and the waveform generators a `static_args` attribute.
 * Options related to the samplers are moved to an option group in `option_utils`. Each sampler has it's own `from_cli` to initialize itself from these options.
 * A `min-burn-in` option has been added to `pycbc_inference` (via the sampler option group). If specified, this will cause `kombine`'s burn in to keep running until the value is satisfied. For `emcee`, the provided number will be the number of iterations used for burn in (since `emcee` has no burn in algorithm).

Sorry for all of the changes; prepping things for the parallel tempered sampler has been more difficult than anticipated. These changes do make `pycbc_inference` more agnostic to the type of sampling done though, which should hopefully make it easier to add more samplers (like a nested sampling routing) in the future.

One other aside: `sampler.py` is getting to be quite long now. I think we might want to consider sticking each sampler class into it's own module, but that's for another day.