### PR TITLE
Allow pycbc_submit_dax to use more than a single cache file

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -420,21 +420,28 @@ if [ ! -e ${HOME}/.pegasus/workflow.db ] ; then
   echo
   exit 1
 fi
-  
+
+WORKFLOW_ID_STRING=""
 WORKFLOW_DB_CMD="sqlite3 -csv ${HOME}/.pegasus/workflow.db \"select submit_hostname,wf_id,wf_uuid from master_workflow where submit_dir = '${SUBMIT_DIR}/work';\""
 DB_TRY=0
-/bin/echo -n "Querying Pegasus database for job."
+/bin/echo -n "Querying Pegasus database for job:"
+# querying the database sometimes fails, so allow retries
+set +e
 until [ $DB_TRY -ge 10 ]
 do 
-  /bin/echo -n "."
+  /bin/echo -n "Querying..."
   WORKFLOW_ID_STRING=`eval $WORKFLOW_DB_CMD`
   if [ $? -eq 0 ] && [ ! -z $WORKFLOW_ID_STRING ] ; then
+    /bin/echo "Done."
     break
+  else
+    /bin/echo "Query failed: ${WORKFLOW_DB_CMD}"
+    /bin/echo "Sleeping for ${DB_TRY} seconds and retrying..."
   fi
   sleep $DB_TRY
   DB_TRY=$(( $DB_TRY + 1 ))
 done
-echo " done."
+set -e
 
 if [ -z $WORKFLOW_ID_STRING ] ; then
   echo "WARNING: Could not find the workflow in the Pegasus dashboard database."

--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -61,12 +61,10 @@ while true ; do
       case "$2" in
         "") shift 2 ;;
         *) CACHE_FILE=1
-           if [ -e $2 ] ; then 
-             cat $2 >> _reuse.cache
-             else
-               echo "Error: cache file $2 not found"
-               exit 1
-             fi
+           export IFS=","
+           for URL in $2; do
+               curl --fail "$URL" >> _reuse.cache
+           done
            shift 2 ;;
       esac ;;
     -g|--local-gsiftp-server)


### PR DESCRIPTION
Add the feature to put multiple cache and map files together into one cache file without user input.

Fails if one of the cache files is malformed or does not exist (Tested and this seems to fail when you give it a cache file that isn't in the form of `file:///` or `file:///foo.map` doesn't exist or `https://foo.cache` doesn't exist.

Current test workflow in progress. Do not merge yet. I noticed that this version of pycbc_submit_dax output a syntax error when generating:

`Querying Pegasus database for job..Error: near "wf_uuid": syntax error`

However, the workflow does not seem to have failed, nor does pegasus-dashboard signal that anything is wrong. The workflow is currently ~1/5 of the way complete.

