### PR TITLE
Add emcee's parallel tempered sampler

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -299,10 +299,18 @@ with ctx:
 
         # write new samples
         with InferenceFile(opts.output_file, "a") as fp:
-            logging.info("Dumping results to file")
+            logging.info("Writing results to file")
             sampler.write_results(fp, max_iterations=opts.niterations+n_burnin)
             # compute the acls and write
+            logging.info("Computing acls")
             sampler.write_acls(fp, sampler.compute_acls(fp))
+            # compute evidence, if supported
+            try:
+                logging.info("Computing evidence")
+                lnz, dlnz = sampler.calculate_logevidence(fp)
+                sampler.write_logevidence(fp, lnz, dlnz)
+            except NotImplementedError:
+                pass
 
 # exit
 logging.info("Done")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -306,8 +306,8 @@ with ctx:
             sampler.write_acls(fp, sampler.compute_acls(fp))
             # compute evidence, if supported
             try:
-                logging.info("Computing evidence")
                 lnz, dlnz = sampler.calculate_logevidence(fp)
+                logging.info("Saving evidence")
                 sampler.write_logevidence(fp, lnz, dlnz)
             except NotImplementedError:
                 pass

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -85,7 +85,7 @@ class _BaseLikelihoodEvaluator(object):
 
     Instances of this class can be called like a function. The default is for
     this class to call its `logposterior` function, but this can be changed by
-    setting the `__call__` method.
+    with the `set_callfunc` method.
 
     Parameters
     ----------
@@ -138,6 +138,8 @@ class _BaseLikelihoodEvaluator(object):
         A function that returns the square root of twice the log likelihood
         ratio. If the log likelihood ratio is < 0, will return an imaginary
         number.
+    set_callfunc :
+        Set the function to use when the class is called as a function.
     """
     name = None
 
@@ -244,7 +246,7 @@ class _BaseLikelihoodEvaluator(object):
         """Returns the log of the prior-weighted likelihood ratio.
         """
         # if the prior returns -inf, just return
-        logp = self._prior(*params)
+        logp = self._prior(params)
         if logp == -numpy.inf:
             return self._formatreturn(logp, prior=logp)
         llr = self.loglr(params)
@@ -254,7 +256,7 @@ class _BaseLikelihoodEvaluator(object):
         """Returns the log of the posterior of the given params.
         """
         # if the prior returns -inf, just return
-        logp = self._prior(*params)
+        logp = self._prior(params)
         if logp == -numpy.inf:
             return self._formatreturn(logp, prior=logp)
         ll = self.loglikelihood(params)
@@ -266,8 +268,22 @@ class _BaseLikelihoodEvaluator(object):
         """
         return numpy.lib.scimath.sqrt(2*self.loglr(params))
 
+    _callfunc = logposterior
+
+    @classmethod
+    def set_callfunc(cls, funcname):
+        """Sets the function used when the class is called as a function.
+
+        Parameters
+        ----------
+        funcname : str
+            The name of the function to use; must be the name of an instance
+            method.
+        """
+        cls._callfunc = getattr(cls, funcname)
+
     def __call__(self, params):
-        return self.logposterior(params)
+        return self._callfunc(params)
 
 
 
@@ -302,8 +318,8 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
         \log \hat{\mathcal{L}} = \log p(\Theta) + \sum_i \left\[\left<h_i(\Theta)|d_i\right> - \frac{1}{2} \left<h_i(\Theta)|h_i(\Theta)\right>\right]
 
     For this reason, by default this class returns `logplr` when called as a
-    function instead of `logposterior`. This can be changed by setting the
-    `__call__` method to the desired function after initialization.
+    function instead of `logposterior`. This can be changed via the
+    `set_callfunc` method.
 
     Upon initialization, the data is whitened using the given PSDs. If no PSDs
     are given the data and waveforms returned by the waveform generator are
@@ -368,14 +384,14 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
     >>> signal = generator.generate(tsig)
     >>> psd = pypsd.aLIGOZeroDetHighPower(N, 1./seglen, 20.)
     >>> psds = {'H1': psd, 'L1': psd}
-    >>> likelihood_eval = inference.GaussianLikelihood(generator, signal, fmin, psds=psds)
+    >>> likelihood_eval = inference.GaussianLikelihood(generator, signal, fmin, psds=psds, return_meta=False)
 
     Now compute the log likelihood ratio and prior-weighted likelihood ratio;
     since we have not provided a prior, these should be equal to each other:
     >>> likelihood_eval.loglr([tsig]), likelihood_eval.logplr([tsig])
     (ArrayWithAligned(277.92945279883855), ArrayWithAligned(277.92945279883855))
 
-    Compute the log likelihood ratio and log posterior; since we have not
+    Compute the log likelihood and log posterior; since we have not
     provided a prior, these should both be equal to zero:
     >>> likelihood_eval.loglikelihood([tsig]), likelihood_eval.logposterior([tsig])
     (ArrayWithAligned(0.0), ArrayWithAligned(0.0))
@@ -402,7 +418,7 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
     >>> from pycbc.inference import prior
     >>> uniform_prior = prior.Uniform(tc=(tsig-0.2,tsig+0.2))
     >>> prior_eval = prior.PriorEvaluator(['tc'], uniform_prior)
-    >>> likelihood_eval = inference.GaussianLikelihood(generator, signal, 20., psds=psds, prior=prior_eval)
+    >>> likelihood_eval = inference.GaussianLikelihood(generator, signal, 20., psds=psds, prior=prior_eval, return_meta=False)
     >>> likelihood_eval.logplr([tsig]), likelihood_eval.logposterior([tsig])
     (ArrayWithAligned(278.84574353071264), ArrayWithAligned(0.9162907318741418))
     """
@@ -441,9 +457,11 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
         for det in self._data:
             self._data[det][kmin:kmax] *= self._weight[det][kmin:kmax]
         # compute the log likelihood function of the noise and save it
-        self.set_lognl(sum([
-            d[kmin:kmax].inner(d[kmin:kmax]).real/2.
+        self.set_lognl(-0.5*sum([
+            d[kmin:kmax].inner(d[kmin:kmax]).real
             for d in self._data.values()]))
+        # set default call function to logplor
+        self.set_callfunc('logplr')
 
     @property
     def lognl(self):
@@ -454,7 +472,7 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
         
         .. math::
             
-            \log \mathcal{L}(\Theta) = \sum_i \left<h_i(\Theta)|d_i\right> - \left<h_i(\Theta)|h_i(\Theta)\right>,
+            \log \mathcal{L}(\Theta) = \sum_i \left<h_i(\Theta)|d_i\right> - \frac{1}{2}\left<h_i(\Theta)|h_i(\Theta)\right>,
 
         at the given point in parameter space :math:`\Theta`.
 
@@ -501,8 +519,7 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
         """
         # since the loglr has fewer terms, we'll call that, then just add
         # back the noise term that canceled in the log likelihood ratio
-        logp = self.loglr(params)
-        return logp - self._lognl
+        return self.loglr(params) + self._lognl
 
 
     def logposterior(self, params):
@@ -525,18 +542,12 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
         """
         # since the logplr has fewer terms, we'll call that, then just add
         # back the noise term that canceled in the log likelihood ratio
-        logp = self.logplr(params)
-        kwargs = {}
+        logplr = self.logplr(params)
         if self.return_meta:
-            logp, (pr, lr) = logp
+            logplr, (pr, lr) = logplr
         else:
             pr = lr = None
-        return self._formatreturn(logp - self._lognl, prior=pr, loglr=lr)
-
-    # set the default call to be the logplr
-    def __call__(self, params):
-        return self.logplr(params)
-
+        return self._formatreturn(logplr + self._lognl, prior=pr, loglr=lr)
 
 likelihood_evaluators = {GaussianLikelihood.name: GaussianLikelihood}
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -46,6 +46,9 @@ def add_sampler_option_group(parser):
     sampler_group.add_argument("--nwalkers", type=int, default=None,
         help="Number of walkers to use in sampler. Required for MCMC "
              "samplers.")
+    sampler_group.add_argument("--ntemps", type=int, default=None,
+        help="Number of temperatures to use in sampler. Required for parallel "
+             "tempered MCMC samplers.")
     sampler_group.add_argument("--min-burn-in", type=int, default=None,
         help="Force the burn-in to be at least the given number of "
              "iterations. If a sampler has an internal algorithm for "

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -1121,7 +1121,7 @@ class PriorEvaluator(object):
             raise ValueError("variable_args %s " %(','.join(extra_params)) +
                 "are not in any of the provided distributions")
 
-    def __call__(self, *params):
+    def __call__(self, params):
         """ Evalualate prior for parameters.
         """
         params = dict(zip(self.variable_args, params))

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -367,51 +367,6 @@ class _BaseMCMCSampler(_BaseSampler):
                     else:
                         fp[dataset_name] = samples[wi,:,pi]
 
-    def write_lnpost(self, fp, max_iterations=None):
-        """Writes the `lnpost`s to the given file. Results are written to:
-        `fp[fp.stats_group/lnpost/walker{i}]`, where `{i}` is the index of
-        a walker.
-
-        Parameters
-        -----------
-        fp : InferenceFile
-            A file handler to an open inference file.
-        max_iterations : {None, int}
-            If `lnpost`s have not previously been written to the file, a new
-            dataset will be created. By default, the size of this dataset will
-            be whatever the length of the sampler's chain is at this point. If
-            you intend to run more iterations, set this value to that size so
-            that the array in the file will be large enough to accomodate
-            future data.
-        """
-        # lnposts are an nwalkers x niterations array
-        lnposts = self.lnpost
-        nwalkers, niterations = lnposts.shape
-
-        group = fp.stats_group + '/lnpost/walker{wi}'
-
-        # create an empty array if desired, in case this is the first time
-        # writing
-        if max_iterations is not None:
-            if max_iterations < niterations:
-                raise IndexError("The provided max size is less than the "
-                    "number of iterations")
-            out = numpy.zeros(max_iterations, dtype=lnposts.dtype)
-
-        # loop over number of walkers
-        for wi in range(nwalkers):
-            dataset_name = group.format(wi=wi)
-            try:
-                fp[dataset_name][:niterations] = lnposts[wi,:]
-            except KeyError:
-                # dataset doesn't exist yet, see if a larger array is
-                # desired
-                if max_iterations is not None:
-                    out[:niterations] = lnposts[wi,:]
-                    fp[dataset_name] = out
-                else:
-                    fp[dataset_name] = lnposts[wi,:]
-
     def write_likelihood_stats(self, fp, max_iterations=None):
         """Writes the `likelihood_stats` to the given file.  Results are
         written to: `fp[fp.stats_group/{field}/walker{i}]`, where `{i}` is
@@ -1191,7 +1146,745 @@ class EmceeEnsembleSampler(_BaseMCMCSampler):
         self.write_likelihood_stats(fp, max_iterations=max_iterations)
         self.write_acceptance_fraction(fp)
 
+
+class EmceePTSampler(_BaseMCMCSampler):
+    """This class is used to construct a parallel-tempered MCMC sampler from
+    the emcee package's PTSampler.
+
+    Parameters
+    ----------
+    likelihood_evaluator : likelihood class
+        An instance of the likelihood class from the
+        pycbc.inference.likelihood module.
+    ntemps : int
+        Number of temeratures to use in the sampler.
+    nwalkers : int
+        Number of walkers to use in sampler.
+    processes : {None, int}
+        Number of processes to use with multiprocessing. If None, all available
+        cores are used.
+    burn_in_iterations : {None, int}
+        Set the number of burn in iterations to use. If None,
+        `burn_in_ieterations` will be initialized to 0.
+    """
+    name = "emcee_pt"
+
+    def __init__(self, likelihood_evaluator, ntemps, nwalkers, processes=None,
+                 burn_in_iterations=None):
+
+        try:
+            import emcee
+        except ImportError:
+            raise ImportError("emcee is not installed.")
+
+        # initialize the pool to use
+        if processes == 1:
+            pool = None
+        else:
+            pool = emcee.interruptible_pool.InterruptiblePool(
+                processes=processes)
+
+        # construct the sampler: PTSampler needs the likelihood and prior
+        # functions separately
+        ndim = len(likelihood_evaluator.waveform_generator.variable_args)
+        sampler = emcee.PTSampler(ntemps, nwalkers, ndim,
+            likelihood_evaluator.loglikelihood, likelihood_evaluator._prior,
+            pool=pool)
+
+        # initialize
+        super(EmceePTSampler, self).__init__(sampler,
+            likelihood_evaluator, min_burn_in=burn_in_iterations)
+
+    @classmethod
+    def from_cli(cls, opts, likelihood_evaluator):
+        """Create an instance of this sampler from the given command-line
+        options.
+
+        Parameters
+        ----------
+        opts : ArgumentParser options
+            The options to parse.
+        likelihood_evaluator : LikelihoodEvaluator
+            The likelihood evaluator to use with the sampler.
+
+        Returns
+        -------
+        EmceePTSampler
+            An emcee sampler initialized based on the given arguments.
+        """
+        # check that if not skipping burn in, more than one burn in iteration
+        # has been specified
+        if not opts.skip_burn_in and (
+                opts.min_burn_in is None or opts.min_burn_in == 0):
+            raise ValueError("%s requires that you provide a non-zero "%(
+                cls.name) + "--min-burn-in if not skipping burn-in")
+        return cls(likelihood_evaluator, opts.ntemps, opts.nwalkers,
+                   processes=opts.nprocesses,
+                   burn_in_iterations=opts.min_burn_in)
+
+    @property
+    def ntemps(self):
+        return self.chain.shape[-4]
+
+    @property
+    def chain(self):
+        """Get all past samples as an ntemps x nwalker x niterations x ndim
+        array.
+        """
+        # emcee returns the chain as ntemps x nwalker x niterations x ndim
+        return self._sampler.chain
+
+    @property
+    def likelihood_stats(self):
+        """Returns the log likelihood ratio and log prior as a FieldArray.
+        The returned array has shape ntemps x nwalkers x niterations.
+        """
+        # likelihood has shape ntemps x nwalkers x niterations
+        logl = self._sampler.lnlikelihood
+        # get prior from posterior
+        logp = self._sampler.lnprobability - logl
+        # compute the likelihood ratio
+        loglr = logl - self.likelihood_evaluator.lognl
+        return FieldArray.from_kwargs(loglr=loglr, prior=logp)
+
+    @property
+    def lnpost(self):
+        """Get the natural logarithm of the likelihood + the prior as an 
+        ntemps x nwalkers x niterations array.
+        """
+        # emcee returns ntemps x nwalkers x niterations
+        return self._sampler.lnprobability
+
+    def set_p0(self, prior_distributions):
+        """Sets the initial position of the walkers.
+
+        Parameters
+        ----------
+        prior_distributions : list 
+            A list of priors to retrieve random values from (the sort of
+            thing returned by `prior.read_distributions_from_config`).
+
+        Returns
+        -------
+        p0 : array
+            An ntemps x nwalkers x ndim array of the initial positions that
+            were set.
+        """
+        # loop over all walkers and then parameters
+        # find the distribution that has that parameter in it and draw a
+        # random value from the distribution
+        ntemps = self.ntemps
+        nwalkers = self.nwalkers
+        ndim = len(self.variable_args)
+        pmap = dict([[param,k] for k,param in enumerate(self.variable_args)])
+        p0 = numpy.ones((ntemps, nwalkers, ndim))
+        for dist in prior_distributions:
+            ps = dist.rvs(size=ntemps*nwalkers).reshape(ntemps, nwalkers)
+            for param in dist.params:
+                p0[:,:,pmap[param]] = ps[param]
+        self._p0 = p0
+        return p0
+
+    def run(self, niterations, **kwargs):
+        """Advance the ensemble for a number of samples.
+
+        Parameters
+        ----------
+        niterations : int
+            Number of samples to get from sampler.
+
+        Returns
+        -------
+        p : numpy.array
+            An array of current walker positions with shape (nwalkers, ndim).
+        lnpost : numpy.array
+            The list of log posterior probabilities for the walkers at
+            positions p, with shape (nwalkers, ndim).
+        rstate : 
+            The current state of the random number generator.
+        """
+        pos = self._pos
+        if pos is None:
+            pos = self.p0
+        res = self._sampler.run_mcmc(pos, niterations, **kwargs)
+        p, lnpost, rstate = res[0], res[1], res[2] 
+        # update the positions
+        self._pos = p
+        return p, lnpost, rstate
+
+    def burn_in(self, **kwargs):
+        """Advance the ensemble by the number of the sampler's
+        `burn_in_iterations`.
+
+        Returns
+        -------
+        p : numpy.array
+            An array of current walker positions with shape (nwalkers, ndim).
+        lnpost : {None, numpy.array}
+            The list of log posterior probabilities for the walkers at
+            positions p, with shape (nwalkers, ndim).
+        rstate : 
+            The current state of the random number generator.
+        """
+        if self.burn_in_iterations == 0:
+            raise ValueError("must specify a non-zero number of iterations "
+                             "to burn in")
+        return self.run(self.burn_in_iterations, **kwargs)
+
+    # read/write functions
+
+    # add ntemps to metadata
+    def write_metadata(self, fp):
+        """Writes metadata about this sampler to the given file. Metadata is
+        written to the file's `attrs`.
+
+        Parameters
+        ----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        """
+        super(EmceePTSampler, self).write_metadata(fp)
+        fp.attrs["ntemps"] = self.ntemps
+
+    def write_acceptance_fraction(self, fp):
+        """Write acceptance_fraction data to file. Results are written to
+        `fp[acceptance_fraction/temp{k}]` where k is the temperature.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        """
+        group = "acceptance_fraction/temp{tk}"
+        # acf has shape ntemps x nwalkers
+        acf = self.acceptance_fraction
+        for tk in range(fp.ntemps):
+            try:
+                fp[group.format(tk=tk)][:] = acf[tk,:]
+            except KeyError:
+                # dataset doesn't exist yet, create it
+                fp[group.format(tk=tk)] = acf[tk,:]
+
+    @staticmethod
+    def read_acceptance_fraction(fp, temps=None, walkers=None):
+        """Reads the acceptance fraction from the given file.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            An open file handler to read the samples from.
+        temps : {None, (list of) int}
+            The temperature index (or a list of indices) to retrieve. If None,
+            acfs from all temperatures and all walkers will be retrieved.
+        walkers : {None, (list of) int}
+            The walker index (or a list of indices) to retrieve. If None,
+            samples from all walkers will be obtained.
+
+        Returns
+        -------
+        array
+            Array of acceptance fractions with shape (requested temps,
+            requested walkers).
+        """
+        group = 'acceptance_fraction/temp{tk}'
+        if temps is None:
+            temps = numpy.arange(fp.ntemps)
+        if walkers is None:
+            wmask = numpy.ones(fp.nwalkers, dtype=bool)
+        else:
+            wmask = numpy.zeros(fp.nwalkers, dtype=bool)
+            wmask[walkers] = True
+        arrays = []
+        for tk in temps:
+            arrays.append(fp[group.format(tk=tk)][wmask])
+        return numpy.vstack(arrays)
+
+    def write_chain(self, fp, max_iterations=None):
+        """Writes the samples from the current chain to the given file. Results
+        are written to: `fp[fp.samples_group/{vararg}/temp{k}/walker{i}]`,
+        where `{vararg}` is the name of a variable arg, `{k}` is a temperature
+        index (smaller = colder), and `{i}` is the index of a walker.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        max_iterations : {None, int}
+            If samples have not previously been written to the file, a new
+            dataset will be created. By default, the size of this dataset will
+            be whatever the length of the sampler's chain is at this point. If
+            you intend to run more iterations, set this value to that size so
+            that the array in the file will be large enough to accomodate
+            future data.
+        """
+        # chain is ntemps x nwalkers x niterations x ndim
+        samples = self.chain
+        ntemps, nwalkers, niterations, _ = samples.shape
+
+        group = fp.samples_group + '/{name}/temp{tk}/walker{wi}'
+
+        # create an empty array if desired, in case this is the first time
+        # writing
+        if max_iterations is not None:
+            if max_iterations < niterations:
+                raise IndexError("The provided max size is less than the "
+                    "number of iterations")
+            out = numpy.zeros(max_iterations, dtype=samples.dtype)
+
+        # create indices for faster sub-looping
+        widx = numpy.arange(nwalkers)
+        tidx = numpy.arange(ntemps)
+
+        # loop over number of dimensions
+        for pi,param in enumerate(self.variable_args):
+            # loop over number of temps
+            for tk in tidx:
+                # loop over number of walkers
+                for wi in widx:
+                    dataset_name = group.format(name=param, tk=tk, wi=wi)
+                    try:
+                        fp[dataset_name][:niterations] = samples[tk,wi,:,pi]
+                    except KeyError:
+                        # dataset doesn't exist yet, see if a larger array is
+                        # desired
+                        if max_iterations is not None:
+                            out[:niterations] = samples[tk,wi,:,pi]
+                            fp[dataset_name] = out
+                        else:
+                            fp[dataset_name] = samples[tk,wi,:,pi]
+
+    def write_likelihood_stats(self, fp, max_iterations=None):
+        """Writes the given likelihood array to the given file. Results are
+        written to: `fp[fp.samples_group/{field}/temp{k}/walker{i}]`, where
+        `{field}` is the name of stat (`loglr`, `prior`), `{k}` is a
+        temperature index (smaller = colder) and `{i}` is the index of a
+        walker.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        max_iterations : {None, int}
+            See `write_chain` for details.
+        """
+        lls = self.likelihood_stats
+        ntemps, nwalkers, niterations = arr.shape
+
+        group = fp.samples_group + '/{field}/temp{tk}/walker{wi}'
+
+        # create an empty array if desired, in case this is the first time
+        # writing
+        if max_iterations is not None:
+            if max_iterations < niterations:
+                raise IndexError("The provided max size is less than the "
+                    "number of iterations")
+            out = numpy.zeros(max_iterations, dtype=arr.dtype)
+
+        # create indices for faster sub-looping
+        widx = numpy.arange(nwalkers)
+        tidx = numpy.arange(ntemps)
+
+        # loop over stats
+        for stat in lls.fieldnames:
+            arr = lls[stat]
+            # loop over temps
+            for tk in tidx:
+                # loop over number of walkers
+                for wi in widx:
+                    dataset_name = group.format(field=stat, tk=tk, wi=wi)
+                    try:
+                        fp[dataset_name][:niterations] = arr[tk,wi,:]
+                    except KeyError:
+                        # dataset doesn't exist yet, see if a larger array is
+                        # desired
+                        if max_iterations is not None:
+                            out[:niterations] = arr[tk,wi,:]
+                            fp[dataset_name] = out
+                        else:
+                            fp[dataset_name] = arr[tk,wi,:]
+
+    def write_results(self, fp, max_iterations=None):
+        """Writes metadata, samples, lnpost, lnprior,  and acceptance fraction
+        to the given file. See the write function for each of those for
+        details.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        max_iterations : {None, int}
+            If results have not previously been written to the
+            file, new datasets will be created. By default, the size of these
+            datasets will be whatever the length of the sampler's chain is at
+            this point. If you intend to run more iterations in the future,
+            set this value to that size so that the array in the file will be
+            large enough to accomodate future data.
+        """
+        self.write_metadata(fp)
+        self.write_chain(fp, max_iterations=max_iterations)
+        self.write_likelihood_stats(fp, max_iterations=max_iterations)
+        self.write_acceptance_fraction(fp, max_iterations=max_iterations)
+
+    @classmethod
+    def _read_fields(cls, fp, fields_group, fields, array_class,
+            thin_start=None, thin_interval=None, thin_end=None, iteration=None,
+            temps=None, walkers=None, flatten=True):
+        """Base function for reading samples and likelihood stats. See
+        `read_samples` and `read_likelihood_stats` for details.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            An open file handler to read the samples from.
+        fields_group : str
+            The name of the group to retrieve the desired fields.
+        fields : list
+            The list of field names to retrieve. Must be names of groups in
+            `fp[fields_group/]`.
+        array_class : FieldArray or similar
+            The type of array to return. Must have a `from_kwargs` attribute.
+
+        For other details on keyword arguments, see `read_samples` and
+        `read_likelihood_stats`.
+
+        Returns
+        -------
+        array_class
+            An instance of the given array class populated with values
+            retrieved from the fields.
+        """
+        # walkers to load
+        if walkers is None:
+            walkers = range(fp.nwalkers)
+        if isinstance(walkers, int):
+            walkers = [walkers]
+
+        # temperatures to load
+        if temps is None:
+            temps = range(fp.ntemps)
+        if isinstance(temps, int):
+            temps = [temps]
+
+        # get the slice to use
+        if iteration is not None:
+            get_index = iteration
+        else:
+            if thin_end is None:
+                # use the number of current iterations
+                thin_end = fp.niterations
+            get_index = get_slice(fp, thin_start=thin_start, thin_end=thin_end,
+                thin_interval=thin_interval)
+
+        # load
+        arrays = {}
+        group = fields_group + '/{name}/temp{tk}/walker{wi}'
+        for name in fields:
+            these_arrays = numpy.array([
+                    [fp[group.format(name=name, wi=wi, tk=tk)][get_index]
+                    for wi in walkers]
+                for tk in temps])
+            if flatten:
+                these_arrays = these_arrays.flatten()
+            arrays[name] = these_arrays
+        return array_class.from_kwargs(**arrays)
+
+        # load
+        arrays = {}
+        group = fields_group + '/{name}/walker{wi}'
+        for name in fields:
+            these_arrays = [
+                    fp[group.format(name=name, wi=wi)][get_index]
+                    for wi in walkers]
+
+    @classmethod
+    def read_samples(cls, fp, parameters,
+            thin_start=None, thin_interval=None, thin_end=None, iteration=None,
+            temps=None, walkers=None, flatten=True, samples_group=None,
+            array_class=None):
+        """Reads samples for the given parameter(s).
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            An open file handler to read the samples from.
+        parameters : (list of) strings
+            The parameter(s) to retrieve. A parameter can be the name of any
+            field in `fp[fp.samples_group]`, a virtual field or method of
+            `WaveformArray` (as long as the file contains the necessary fields
+            to derive the virtual field or method), and/or a function of
+            these.
+        thin_start : int
+            Index of the sample to begin returning samples. Default is to read
+            samples after burn in. To start from the beginning set thin_start
+            to 0.
+        thin_interval : int
+            Interval to accept every i-th sample. Default is to use the
+            `fp.acl`. If `fp.acl` is not set, then use all samples
+            (set thin_interval to 1).
+        thin_end : int
+            Index of the last sample to read. If not given then
+            `fp.niterations` is used.
+        iteration : int
+            Get a single iteration. If provided, will override the
+            `thin_{start/interval/end}` arguments.
+        walkers : {None, (list of) int}
+            The walker index (or a list of indices) to retrieve. If None,
+            samples from all walkers will be obtained.
+        temps : {None, (list of) int}
+            The temperature index (or list of indices) to retrieve. If None,
+            samples from all temperatures will be obtained.
+        flatten : {True, bool}
+            The returned array will be one dimensional, with all desired
+            samples from all desired walkers concatenated together. If False,
+            the returned array will have dimension requested temps x requested 
+            walkers x requested iterations.
+        samples_group : {None, str}
+            The group in `fp` from which to retrieve the parameter fields. If
+            None, searches in `fp.samples_group`.
+        array_class : {None, array class}
+            The type of array to return. The class must have a `from_kwargs`
+            class method and a `parse_parameters` method. If None, will return
+            a WaveformArray.
+
+        Returns
+        -------
+        array_class
+            Samples for the given parameters, as an instance of a the given
+            `array_class` (`WaveformArray` if `array_class` is None).
+        """
+        # get the group to load from
+        if samples_group is None:
+            samples_group = fp.samples_group
+        # get the type of array class to use
+        if array_class is None:
+            array_class = WaveformArray
+        # get the names of fields needed for the given parameters
+        possible_fields = dict([[str(name), float]
+            for name in fp[fp.samples_group].keys()])
+        loadfields = array_class.parse_parameters(parameters,
+            possible_fields=possible_fields)
+        return cls._read_fields(fp, samples_group, loadfields, array_class,
+                thin_start=thin_start, thin_interval=thin_interval,
+                thin_end=thin_end, iteration=iteration, temps=temps,
+                walkers=walkers, flatten=flatten)
+
+    @classmethod
+    def read_likelihood_stats(cls, fp,
+            thin_start=None, thin_interval=None, thin_end=None, iteration=None,
+            temps=None, walkers=None, flatten=True, stats_group=None,
+            array_class=None):
+        """Reads the likelihood stats from the given file.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            An open file handler to read the stats from.
+        thin_start : int
+            Index of the sample to begin returning stats. Default is to read
+            stats after burn in. To start from the beginning set thin_start
+            to 0.
+        thin_interval : int
+            Interval to accept every i-th sample. Default is to use the
+            `fp.acl`. If `fp.acl` is not set, then use all stats
+            (set thin_interval to 1).
+        thin_end : int
+            Index of the last sample to read. If not given then
+            `fp.niterations` is used.
+        iteration : int
+            Get a single iteration. If provided, will override the
+            `thin_{start/interval/end}` arguments.
+        temps : {None, (list of) int}
+            The temperature index (or list of indices) to retrieve. If None,
+            samples from all temperatures will be obtained.
+        walkers : {None, (list of) int}
+            The walker index (or a list of indices) to retrieve. If None,
+            stats from all walkers will be obtained.
+        flatten : {True, bool}
+            The returned array will be one dimensional, with all desired
+            stats from all desired walkers concatenated together. If False,
+            the returned array will have dimension requested temps x requested 
+            walkers x requested iterations.
+        stats_group : {None, str}
+            The group in `fp` from which to retrieve the stats. If
+            None, searches in `fp.stats_group`.
+        array_class : {None, array class}
+            The type of array to return. The class must have a `from_kwargs`
+            class method. If None, will return a FieldArray.
+
+        Returns
+        -------
+        array_class
+            The likelihood stats, as an instance of the given
+            `array_class` (`FieldArray` if `array_class` is None).
+        """
+        if stats_group is None:
+            stats_group = fp.stats_group
+        if array_class is None:
+            array_class = FieldArray
+        fields = fp[stats_group].keys()
+        return cls._read_fields(fp, stats_group, fields, array_class,
+                thin_start=thin_start, thin_interval=thin_interval,
+                thin_end=thin_end, iteration=iteration, temps=temps,
+                walkers=walkers, flatten=flatten)
+
+    @classmethod
+    def compute_acls(cls, fp, start_index=None, end_index=None):
+        """Computes the autocorrleation length for all variable args for all
+        walkers for all temps in the given file. If the returned acl is inf,
+        will default to the number of requested iterations.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            An open file handler to read the samples from.
+        start_index : {None, int}
+            The start index to compute the acl from. If None, will try to use
+            the number of burn-in iterations in the file; otherwise, will start
+            at the first sample.
+        end_index : {None, int}
+            The end index to compute the acl to. If None, will go to the end
+            of the current iteration.
+
+        Returns
+        -------
+        WaveformArray
+            An ntemps x nwalkers `WaveformArray` containing the acl for each
+            walker and temp for each variable argument, with the variable
+            arguments as fields.
+        """
+        acls = {}
+        if end_index is None:
+            end_index = fp.niterations
+        tidx = numpy.arange(fp.ntemps)
+        widx = numpy.arange(fp.nwalkers)
+        for param in fp.variable_args:
+            these_acls = numpy.zeros((fp.ntemps, fp.nwalkers), dtype=int)
+            for tk in tidx:
+                for wi in widx:
+                    samples = cls.read_samples(fp, param,
+                            thin_start=start_index, thin_interval=1,
+                            thin_end=end_index,
+                            walkers=wi, temps=tk)[param]
+                    acl = autocorrelation.calculate_acl(samples)
+                    these_acls[tk,wi] = int(min(acl, samples.size))
+            acls[param] = these_acls
+        return WaveformArray.from_kwargs(**acls)
+
+    @staticmethod
+    def write_acls(fp, acls):
+        """Writes the given autocorrelation lengths to the given file. The acl
+        of each walker at each temperature and each parameter is saved to
+        `fp[fp.samples_group/{param}/temp{k}/walker{i}].attrs['acl']`; the
+        maximum over all the walkers for a given temperature and param is
+        saved to `fp[fp.samples_group/{param}/temp{k}].attrs['acl']`; the
+        maximum over all of the temperatures and walkers is saved to
+        `fp[fp.samples_group/{param}].attrs['acl']`; the maximum over all the
+        parameters, temperatures, and walkers is saved to the file's 'acl'
+        attribute.
+
+        Parameters
+        ----------
+        fp : InferenceFile
+            An open file handler to write the samples to.
+        acls : WaveformArray
+            An array of autocorrelation lengths (the sort of thing returned by
+            `compute_acls`).
+
+        Returns
+        -------
+        acl
+            The maximum of the acls that was written to the file.
+        """
+        # write the individual acls
+        pgroup = fp.samples_group + '/{param}'
+        tgroup = pgroup + '/temp{k}'
+        group = tgroup + '/walker{wi}'
+        tidx = numpy.arange(fp.ntemps)
+        overall_max = 0
+        for param in acls.fieldnames:
+            max_acls = []
+            for tk in tidx:
+                max_acl = 0
+                for wi,acl in enumerate(acls[param][tk,:]): 
+                    fp[group.format(param=param, tk=tk,
+                                    wi=wi)].attrs['acl'] = acl
+                    max_acl = max(max_acl, acl)
+                # write the maximum over the walkers
+                fp[tgroup.format(param=param, tk=tk)].attrs['acl'] = max_acl
+                max_acls.append(max_acl)
+            # write the maximum over the temperatures
+            this_max = max(max_acls)
+            fp[pgroup.format(param=param)].attrs['acl'] = this_max
+            overall_max = max(overall_max, this_max)
+            # write the maximum over the params
+            fp[pgroup.format(param=param)].attrs['acl'] = max_acl
+        # write the maximum over all params
+        fp.attrs['acl'] = overall_max
+        return fp.attrs['acl']
+
+    @staticmethod
+    def read_acls(fp):
+        """Reads the acls of all the walker chains saved in the given file.
+
+        Parameters
+        ----------
+        fp : InferenceFile
+            An open file handler to read the acls from.
+
+        Returns
+        -------
+        WaveformArray
+            An ntemps x nwalkers `WaveformArray` containing the acls for
+            every temp and walker, with the variable arguments as fields.
+        """
+        group = fp.samples_group + '/{param}/temp{tk}/walker{wi}'
+        widx = numpy.arange(fp.nwalkers)
+        tidx = numpy.arange(fp.ntemps)
+        arrays = {}
+        for param in fp.variable_args:
+            arrays[param] = numpy.array([
+                [fp[group.format(param=param, tk=tk, wi=wi)].attrs['acl']
+                    for wi in widx]
+                 for tk in tidx])
+        return WaveformArray.from_kwargs(**arrays)
+    
+    @classmethod
+    def calculate_logevidence(cls, fp, thin_start=None, thin_end=None,
+            thin_interval=None):
+        """Calculates the log evidence from the given file using emcee's
+        thermodynamic integration.
+
+        Parameters
+        ----------
+        fp : InferenceFile
+            An open file handler to read the stats from.
+        thin_start : int
+            Index of the sample to begin returning stats. Default is to read
+            stats after burn in. To start from the beginning set thin_start
+            to 0.
+        thin_interval : int
+            Interval to accept every i-th sample. Default is to use the
+            `fp.acl`. If `fp.acl` is not set, then use all stats
+            (set thin_interval to 1).
+        thin_end : int
+            Index of the last sample to read. If not given then
+            `fp.niterations` is used.
+        
+        Returns
+        -------
+        lnZ : float
+            The estimate of log of the evidence.
+        dlnZ : float
+            The error on the estimate.
+        """
+        logstats = cls.read_likelihood_stats(fp, thin_start=thin_start,
+            thin_end=thin_end, thin_interval=thin_interval, flatten=False)
+        # get the likelihoods
+        logls = logstats['loglr'] + fp.lognl + logstats['prior']
+        return emcee.PTSampler(logls=logls, fburnin=0.)
+
 samplers = {
     KombineSampler.name : KombineSampler,
     EmceeEnsembleSampler.name : EmceeEnsembleSampler,
+    EmceePTSampler.name : EmceePTSampler,
 }

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -100,20 +100,8 @@ class _BaseSampler(object):
 
     @classmethod
     def from_cli(cls, opts, likelihood_evaluator):
-        """Create an instance of this sampler from the given command-line
-        options.
-
-        Parameters
-        ----------
-        opts : ArgumentParser options
-            The options to parse.
-        likelihood_evaluator : LikelihoodEvaluator
-            The likelihood evaluator to use with the sampler.
-
-        Returns
-        -------
-        cls
-            A sampler initialized based on the given arguments.
+        """This function create an instance of this sampler from the given
+        command-line options.
         """
         raise NotImplementedError("from_cli function not set")
 
@@ -504,8 +492,8 @@ class _BaseMCMCSampler(_BaseSampler):
         self.write_likelihood_stats(fp, max_iterations=max_iterations)
         self.write_acceptance_fraction(fp, max_iterations=max_iterations)
 
-    @classmethod
-    def _read_fields(cls, fp, fields_group, fields, array_class,
+    @staticmethod
+    def _read_fields(fp, fields_group, fields, array_class,
             thin_start=None, thin_interval=None, thin_end=None, iteration=None,
             walkers=None, flatten=True):
         """Base function for reading samples and likelihood stats. See
@@ -1044,8 +1032,9 @@ class EmceeEnsembleSampler(_BaseMCMCSampler):
         # has been specified
         if not opts.skip_burn_in and (
                 opts.min_burn_in is None or opts.min_burn_in == 0):
-            raise ValueError("%s requires that you provide a non-zero "%(
-                cls.name) + "--min-burn-in if not skipping burn-in")
+            raise ValueError("{name} requires that you provide a ".format(
+                name=cls.name) + " non-zero --min-burn-in if not skipping "
+                "burn-in")
         return cls(likelihood_evaluator, opts.nwalkers,
                    processes=opts.nprocesses,
                    burn_in_iterations=opts.min_burn_in)
@@ -1558,8 +1547,8 @@ class EmceePTSampler(_BaseMCMCSampler):
         self.write_likelihood_stats(fp, max_iterations=max_iterations)
         self.write_acceptance_fraction(fp)
 
-    @classmethod
-    def _read_fields(cls, fp, fields_group, fields, array_class,
+    @staticmethod
+    def _read_fields(fp, fields_group, fields, array_class,
             thin_start=None, thin_interval=None, thin_end=None, iteration=None,
             temps=None, walkers=None, flatten=True):
         """Base function for reading samples and likelihood stats. See
@@ -1620,14 +1609,6 @@ class EmceePTSampler(_BaseMCMCSampler):
                 these_arrays = these_arrays.flatten()
             arrays[name] = these_arrays
         return array_class.from_kwargs(**arrays)
-
-        # load
-        arrays = {}
-        group = fields_group + '/{name}/walker{wi}'
-        for name in fields:
-            these_arrays = [
-                    fp[group.format(name=name, wi=wi)][get_index]
-                    for wi in walkers]
 
     @classmethod
     def read_samples(cls, fp, parameters,
@@ -1926,9 +1907,8 @@ class EmceePTSampler(_BaseMCMCSampler):
         ntemps = fp.ntemps
         nwalkers = fp.nwalkers
         ndim = len(fp.variable_args)
-        dummyfunc = lambda x: x
-        dummy_sampler = emcee.PTSampler(ntemps, nwalkers, ndim, dummyfunc,
-            dummyfunc, betas=betas)
+        dummy_sampler = emcee.PTSampler(ntemps, nwalkers, ndim, None,
+            None, betas=betas)
         return dummy_sampler.thermodynamic_integration_log_evidence(
                     logls=logls, fburnin=0.)
 

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -1583,6 +1583,8 @@ class EmceePTSampler(_BaseMCMCSampler):
 
         # temperatures to load
         if temps is None:
+            temps = 0
+        if temps == 'all':
             temps = range(fp.ntemps)
         if isinstance(temps, int):
             temps = [temps]
@@ -1613,7 +1615,7 @@ class EmceePTSampler(_BaseMCMCSampler):
     @classmethod
     def read_samples(cls, fp, parameters,
             thin_start=None, thin_interval=None, thin_end=None, iteration=None,
-            temps=None, walkers=None, flatten=True, samples_group=None,
+            temps=0, walkers=None, flatten=True, samples_group=None,
             array_class=None):
         """Reads samples for the given parameter(s).
 
@@ -1644,9 +1646,11 @@ class EmceePTSampler(_BaseMCMCSampler):
         walkers : {None, (list of) int}
             The walker index (or a list of indices) to retrieve. If None,
             samples from all walkers will be obtained.
-        temps : {None, (list of) int}
+        temps : {None, (list of) int, 'all'}
             The temperature index (or list of indices) to retrieve. If None,
-            samples from all temperatures will be obtained.
+            only samples from the coldest (= 0) temperature chain will be
+            retrieved. To retrieve all temperates pass 'all', or a list of
+            all of the temperatures.
         flatten : {True, bool}
             The returned array will be one dimensional, with all desired
             samples from all desired walkers concatenated together. If False,
@@ -1707,9 +1711,11 @@ class EmceePTSampler(_BaseMCMCSampler):
         iteration : int
             Get a single iteration. If provided, will override the
             `thin_{start/interval/end}` arguments.
-        temps : {None, (list of) int}
+        temps : {None, (list of) int, 'all'}
             The temperature index (or list of indices) to retrieve. If None,
-            samples from all temperatures will be obtained.
+            only samples from the coldest (= 0) temperature chain will be
+            retrieved. To retrieve all temperates pass 'all', or a list of
+            all of the temperatures.
         walkers : {None, (list of) int}
             The walker index (or a list of indices) to retrieve. If None,
             stats from all walkers will be obtained.
@@ -1897,7 +1903,8 @@ class EmceePTSampler(_BaseMCMCSampler):
             raise ImportError("emcee is not installed.")
 
         logstats = cls.read_likelihood_stats(fp, thin_start=thin_start,
-            thin_end=thin_end, thin_interval=thin_interval, flatten=False)
+            thin_end=thin_end, thin_interval=thin_interval,
+            temps='all', flatten=False)
         # get the likelihoods
         logls = logstats['loglr'] + fp.lognl
         # we need the betas that were used

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -141,6 +141,11 @@ class InferenceFile(h5py.File):
         return self.attrs["nwalkers"]
 
     @property
+    def ntemps(self):
+        """Returns number of temperatures used."""
+        return self.attrs["ntemps"]
+
+    @property
     def acl(self):
         """ Returns the saved autocorelation length (ACL).
 

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -156,6 +156,13 @@ class InferenceFile(h5py.File):
         """
         return self.attrs["acl"]
 
+    @property
+    def log_evidence(self):
+        """Returns the log of the evidence and its error, if they exist in the
+        file. Raises a KeyError otherwise.
+        """
+        return self.attrs["log_evidence"], self.attrs["dlog_evidence"]
+
     def read_samples(self, parameters, **kwargs):
         """Reads samples from the file.
 


### PR DESCRIPTION
Adds emcee's PTSampler to `sampler.py` to allow for multiple temperature MCMC sampling. This allows for an accurate evidence calculation.

To get this to work, some further changes were needed to the likelihood and prior evaluators. For priors, instead of taking a list of args, PriorEvaluator's `__call__` now just takes a list, as likelihood does (that this didn't raise an error before was a bit lucky anyway). For likelihood, I added a class method to set the call function. I had to do this as a class function to allow for multi-pooling. This was necessary for PTSampler because it expects the likelihood function and prior functions to be separate.

I've also made it so that inference will try to compute evidence and save it when checkpointing, if the sampler supports it.

This patch depends on #1058, so putting on hold until that is merged.