### PR TITLE
Add ability to use mchirp, eta as variable/frozen params

### DIFF
--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -30,6 +30,7 @@ import waveform
 import ringdown
 from pycbc.waveform.utils import apply_fd_time_shift
 from pycbc.detector import Detector
+from pycbc import pnutils
 import lal as _lal
 
 #
@@ -98,21 +99,89 @@ class BaseGenerator(object):
         """
         if len(args) != len(self.variable_args):
             raise ValueError("variable argument length mismatch")
-        self.current_params.update(dict(zip(self.variable_args, args)))
-        return self.generator(**self.current_params)
+        return self.generate_from_kwargs(**dict(zip(self.variable_args, args)))
 
     def generate_from_kwargs(self, **kwargs):
         """Generates a waveform from the keyword args. The current params
         are updated with the given kwargs, then the generator is called.
         """
         self.current_params.update(kwargs)
+        return self._generate_from_current()
+
+    def _pregenerate(self):
+        """Allows the current parameters to be manipulated before calling
+        the waveform generator.
+        """
+        pass
+
+    def _postgenerate(self, res):
+        """Allows the waveform returned by the generator function to be
+        manipulated before returning.
+        """
+        return res
+
+    def _gdecorator(generate_func):
+        """A decorator that allows for seemless pre/post manipulation of
+        the waveform generator function.
+        """
+        def dostuff(self):
+            self._pregenerate()
+            res = generate_func(self)
+            return self._postgenerate(res)
+        return dostuff
+
+    @_gdecorator
+    def _generate_from_current(self):
+        """Generates a waveform from the current parameters.
+        """
         return self.generator(**self.current_params)
 
 
-class FDomainCBCGenerator(BaseGenerator):
-    """Uses waveform.get_fd_waveform as a generator function to create frequency-
-    domain CBC waveforms in the radiation frame; i.e., with no detector response
-    function applied. For more details, see BaseGenerator.
+class BaseCBCGenerator(BaseGenerator):
+    """Adds ability to convert from various derived parameters to parameters
+    needed by the waveform generators.
+    """
+    def __init__(self, generator, variable_args=(), **frozen_params):
+        super(BaseCBCGenerator, self).__init__(generator,
+            variable_args=variable_args, **frozen_params)
+        # if mchirp, eta are parameters, decorate the generator function
+        # to convert them to m1, m2; we'll just check for mchirp, if eta
+        # isn't specified, it'll get caught by convert_params
+        if 'mchirp' in self.frozen_params or 'mchirp' in self.variable_args:
+            self._pregenerate = self.convert_params
+
+    def convert_params(self):
+        """Converts parameters in current params into parameters that are
+        understood by the waveform generator.
+        """
+        try:
+            mchirp = self.current_params['mchirp']
+            try:
+                eta = self.current_params['eta']
+                m1, m2 = pnutils.mchirp_eta_to_mass1_mass2(mchirp, eta)
+                self.current_params['mass1'] = m1
+                self.current_params['mass2'] = m2
+            except KeyError:
+                raise ValueError("mchirp requires eta to be specified")
+        except KeyError:
+            # make sure eta isn't specified
+            if 'eta' in self.current_params:
+                raise ValueError("eta requires mchirp to be specified")
+            pass
+
+
+class FDomainCBCGenerator(BaseCBCGenerator):
+
+    """Uses `waveform.get_fd_waveform` as a generator function to create
+    frequency- domain CBC waveforms in the radiation frame; i.e., with no
+    detector response function applied. For more details, see `BaseGenerator`.
+
+    Derived parameters not understood by `get_fd_waveform` may be used as
+    variable args and/or frozen parameters, as long as they can be converted
+    into parameters that `get_fd_waveform` can use. For example, `mchirp` and
+    `eta` (currently, the only supported derived parameters) may be used as
+    variable/frozen params; these are converted to `mass1` and `mass2` prior to
+    calling the waveform generator function.
 
     Examples
     --------
@@ -123,25 +192,58 @@ class FDomainCBCGenerator(BaseGenerator):
     >>> generator.generate(1.4, 1.4)
     (<pycbc.types.frequencyseries.FrequencySeries at 0x1110c1450>,
      <pycbc.types.frequencyseries.FrequencySeries at 0x1110c1510>)
+
+    Initialize a generator using mchirp, eta as the variable args, and generate
+    a waveform:
+    >>> generator = waveform.FDomainCBCGenerator(variable_args=['mchirp', 'eta'], delta_f=1./32, f_lower=30., approximant='TaylorF2')
+    >>> generator.generate(1.5, 0.25)
+    (<pycbc.types.frequencyseries.FrequencySeries at 0x109a104d0>,
+     <pycbc.types.frequencyseries.FrequencySeries at 0x109a10b50>)
+
+    Note that the `current_params` contains the mchirp and eta values, along
+    with the mass1 and mass2 they were converted to:
+    >>> generator.current_params
+    {'approximant': 'TaylorF2',
+     'delta_f': 0.03125,
+     'eta': 0.25,
+     'f_lower': 30.0,
+     'mass1': 1.7230475324955525,
+     'mass2': 1.7230475324955525,
+     'mchirp': 1.5}
     """
     def __init__(self, variable_args=(), **frozen_params):
         super(FDomainCBCGenerator, self).__init__(waveform.get_fd_waveform,
             variable_args=variable_args, **frozen_params)
 
-class TDomainCBCGenerator(BaseGenerator):
+
+class TDomainCBCGenerator(BaseCBCGenerator):
     """Uses waveform.get_td_waveform as a generator function to create time-
-    domain CBC waveforms in the radiation frame; i.e., with no detector response
-    function applied. For more details, see BaseGenerator.
+    domain CBC waveforms in the radiation frame; i.e., with no detector
+    response function applied. For more details, see `BaseGenerator`.
+
+    Derived parameters not understood by `get_td_waveform` may be used as
+    variable args and/or frozen parameters, as long as they can be converted
+    into parameters that `get_td_waveform` can use. For example, `mchirp` and
+    `eta` (currently, the only supported derived parameters) may be used as
+    variable/frozen params; these are converted to `mass1` and `mass2` prior to
+    calling the waveform generator function.
 
     Examples
     --------
     Initialize a generator:
     >>> generator = waveform.TDomainCBCGenerator(variable_args=['mass1', 'mass2'], delta_t=1./4096, f_lower=30., approximant='TaylorT4')
 
-    Create a waveform with the variable arguments (in this casee, mass1, mass2):
+    Create a waveform with the variable arguments (in this case, mass1, mass2):
     >>> generator.generate(2., 1.3)
     (<pycbc.types.timeseries.TimeSeries at 0x10e546710>,
      <pycbc.types.timeseries.TimeSeries at 0x115f37690>)
+
+    Initialize a generator using mchirp, eta as the variable args, and generate
+    a waveform:
+    >>> generator = waveform.TDomainCBCGenerator(variable_args=['mchirp', 'eta'], delta_t=1./4096, f_lower=30., approximant='TaylorT4')
+    >>> generator.generate(1.75, 0.2)
+    (<pycbc.types.timeseries.TimeSeries at 0x116ac6050>,
+     <pycbc.types.timeseries.TimeSeries at 0x116ac6950>)
     """
     def __init__(self, variable_args=(), **frozen_params):
         super(TDomainCBCGenerator, self).__init__(waveform.get_td_waveform,


### PR DESCRIPTION
This patch adds the ability to use mchirp and eta as variable args and/or frozen parameters in the CBC waveform generators, even though mchirp and eta are not understood by `get_fd_waveform` and `get_td_waveform`. This is done by adding a decorator around the class method that calls the underlying generator function. If 'mchirp' and 'eta' are in the parameters, the decorator converts them to mass1 and mass2 before calling the generator functions. Right now only mchirp and eta are supported, but we could add more derived parameters in the future, such as chi_eff and chi_p. My hope is that by sampling in better measured parameters, the sampler will converge more quickly (I'm testing this now).

I've also added the ability to decorate the returned result. This patch doesn't make use of that, but I'm planning to take advantage of it for adding time-domain support to pycbc inference (the idea is to add a class that will use the `_postgenerate` function to convert the time domain waveforms to frequency domain). 

I tested this on my laptop and the decorator adds a negligible amount to the generation time, at least compared to how long it takes to generate the waveform itself.