### PR TITLE
support template bank filename extension '.xmlgz'

### DIFF
--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -238,7 +238,7 @@ class TemplateBank(object):
             **kwds):
         ext = os.path.basename(filename)
         self.compressed_waveforms = None
-        if ext.endswith('.xml') or ext.endswith('.xml.gz'):
+        if ext.endswith('.xml') or ext.endswith('.xml.gz') or ext.endswith('.xmlgz'):
             self.filehandler = None
             self.indoc = ligolw_utils.load_filename(
                 filename, False, contenthandler=LIGOLWContentHandler)


### PR DESCRIPTION
The file handling of Condor-BOINC only preserves one filename extension 'level. Treat a template bank filename extension ".xmlgz" the same as ".xml.gz".
