### PR TITLE
Amplitudes ringdown as relative amplitudes

### DIFF
--- a/bin/pycbc_ringinj
+++ b/bin/pycbc_ringinj
@@ -62,7 +62,7 @@ parser.add_argument('--lmns', nargs='+',
 parser.add_argument('--amps-phis', nargs='+',
                     help='Amplitudes and phases for each mode. '
                          'Use format mode:amplitude:phase. '
-                         'Example: 220:1e-21:0 221:0.1e-21:3.14 330:0.05e-21:3.14')
+                         'Example: 220:1e-21:0 221:0.1:3.14 330:0.05:3.14')
 parser.add_argument('--t-final', type=float,
                     help='Ending time of the output time series '
                          'for time domain approximants.')

--- a/bin/pycbc_ringinj
+++ b/bin/pycbc_ringinj
@@ -62,6 +62,9 @@ parser.add_argument('--lmns', nargs='+',
 parser.add_argument('--amps-phis', nargs='+',
                     help='Amplitudes and phases for each mode. '
                          'Use format mode:amplitude:phase. '
+                         'Always give amplitude and phase for 220 mode, even if '
+                         'not included in lmns, and specifiy amplitudes of '
+                         'subdominant modes as fraction of 220 amplitude. '
                          'Example: 220:1e-21:0 221:0.1:3.14 330:0.05:3.14')
 parser.add_argument('--t-final', type=float,
                     help='Ending time of the output time series '
@@ -143,5 +146,11 @@ if opts.approximant=='FdQNMmultiModes' or opts.approximant=='TdQNMmultiModes':
     for mode in all_modes:
         injection.create_dataset('amp%s' %mode, data=float(amps[mode]))
         injection.create_dataset('phi%s' %mode, data=float(phis[mode]))
+    # Amplitude of 220 mode is always required, even if 22 not included
+    if 220 not in all_modes:
+        try:
+            injection.create_dataset('amp220', data=float(amps['220']))
+        except:
+            raise ValueError('Please provide information of 220 mode')
 
 injection.close()

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -180,7 +180,7 @@ class FDomainMultiModeRingdownGenerator(BaseGenerator):
             delta_f=1./32, f_lower=30., f_final=500)
 
     Create a ringdown with the variable arguments:
-    >>> generator.generate(65., 0.7, ['221','211'], 1e-21, 0.1e-21, 0., 0.)
+    >>> generator.generate(65., 0.7, ['221','211'], 1e-21, 1./10, 0., 0.)
     (<pycbc.types.frequencyseries.FrequencySeries at 0x51614d0>,
     <pycbc.types.frequencyseries.FrequencySeries at 0x5161550>)
     """

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -32,8 +32,8 @@ from pycbc.waveform.waveform import get_obj_attrs
 
 default_qnm_args = {'t_0':0}
 qnm_required_args = ['f_0', 'tau', 'amp', 'phi']
-lm_required_args = ['final_mass','final_spin','l','m','nmodes']
-lm_allmodes_required_args = ['final_mass','final_spin', 'lmns']
+lm_required_args = ['final_mass','final_spin','l','m','nmodes', 'amp220']
+lm_allmodes_required_args = ['final_mass','final_spin', 'lmns', 'amp220']
 
 max_freq = 16384.
 min_dt = 1. / (2 * max_freq)
@@ -69,11 +69,19 @@ def lm_amps_phases(**kwargs):
     """
     l, m = kwargs['l'], kwargs['m']
     amps, phis = {}, {}
+    # amp220 is always required, because the amplitudes of subdominant modes 
+    # are given as fractions of amp220. The props function qill therefore
+    # already complain if it is not given and we do not need to check here.
+    amps['220'] = kwargs['amp220']
+
+    # Get amplitudes of subdominant modes and all phases
     for n in range(kwargs['nmodes']):
-        try:
-            amps['%d%d%d' %(l,m,n)] = kwargs['amp%d%d%d' %(l,m,n)]
-        except KeyError:
-            raise ValueError('amp%d%d%d is required' %(l,m,n))
+        # If it is the 22 mode, skip 220
+        if (l, m, n) != (2, 2, 0):
+            try:
+                amps['%d%d%d' %(l,m,n)] = kwargs['amp%d%d%d' %(l,m,n)] * amps['220']
+            except KeyError:
+                raise ValueError('amp%d%d%d is required' %(l,m,n))
         try:
             phis['%d%d%d' %(l,m,n)] = kwargs['phi%d%d%d' %(l,m,n)]
         except KeyError:
@@ -395,8 +403,11 @@ def get_td_lm(template=None, **kwargs):
         m mode (lm modes available: 22, 21, 33, 44, 55).
     nmodes: int
         Number of overtones desired (maximum n=8)
+    amp220 : float
+        Amplitude of the fundamental 220 mode, needed for any lm.
     amplmn : float
-        Amplitude of the lmn overtone, as many as the number of nmodes.
+        Fraction of the amplitude of the lmn overtone relative to the 
+        fundamental mode, as many as the number of subdominant modes.
     philmn : float
         Phase of the lmn overtone, as many as the number of nmodes.
     delta_t : {None, float}, optional
@@ -534,8 +545,11 @@ def get_td_lm_allmodes(template=None, **kwargs):
         The n specifies the number of overtones desired for the corresponding
         lm pair (maximum n=8).
         Example: lmns = ['223','331'] are the modes 220, 221, 222, and 330
+    amp220 : float
+        Amplitude of the fundamental 220 mode.
     amplmn : float
-        Amplitude of the lmn overtone, as many as the number of modes.
+        Fraction of the amplitude of the lmn overtone relative to the 
+        fundamental mode, as many as the number of subdominant modes.
     philmn : float
         Phase of the lmn overtone, as many as the number of modes.
     delta_t : {None, float}, optional
@@ -599,8 +613,11 @@ def get_fd_lm_allmodes(template=None, **kwargs):
         The n specifies the number of overtones desired for the corresponding
         lm pair (maximum n=8).
         Example: lmns = ['223','331'] are the modes 220, 221, 222, and 330
+    amp220 : float
+        Amplitude of the fundamental 220 mode.
     amplmn : float
-        Amplitude of the lmn overtone, as many as the number of modes.
+        Fraction of the amplitude of the lmn overtone relative to the 
+        fundamental mode, as many as the number of subdominant modes.
     philmn : float
         Phase of the lmn overtone, as many as the number of modes.
     delta_f : {None, float}, optional

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -70,7 +70,7 @@ def lm_amps_phases(**kwargs):
     l, m = kwargs['l'], kwargs['m']
     amps, phis = {}, {}
     # amp220 is always required, because the amplitudes of subdominant modes 
-    # are given as fractions of amp220. The props function qill therefore
+    # are given as fractions of amp220. The props function will therefore
     # already complain if it is not given and we do not need to check here.
     amps['220'] = kwargs['amp220']
 

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -32,8 +32,8 @@ from pycbc.waveform.waveform import get_obj_attrs
 
 default_qnm_args = {'t_0':0}
 qnm_required_args = ['f_0', 'tau', 'amp', 'phi']
-lm_required_args = ['final_mass','final_spin','l','m','nmodes', 'amp220']
-lm_allmodes_required_args = ['final_mass','final_spin', 'lmns', 'amp220']
+lm_required_args = ['final_mass','final_spin','l','m','nmodes']
+lm_allmodes_required_args = ['final_mass','final_spin', 'lmns']
 
 max_freq = 16384.
 min_dt = 1. / (2 * max_freq)
@@ -70,9 +70,11 @@ def lm_amps_phases(**kwargs):
     l, m = kwargs['l'], kwargs['m']
     amps, phis = {}, {}
     # amp220 is always required, because the amplitudes of subdominant modes 
-    # are given as fractions of amp220. The props function will therefore
-    # already complain if it is not given and we do not need to check here.
-    amps['220'] = kwargs['amp220']
+    # are given as fractions of amp220.
+    try:
+        amps['220'] = kwargs['amp220']
+    except KeyError:
+        raise ValueError('amp220 is always required')
 
     # Get amplitudes of subdominant modes and all phases
     for n in range(kwargs['nmodes']):


### PR DESCRIPTION
The current ringdown module doesn't know that the amplitudes of the subdominant modes will be smaller than the amplitude of the fundamental mode. Therefore, when running pycbc_inference with ringdowns that have higher modes, it can confuse the modes and think that the fundamental mode is the one with lower amplitude.
With this patch, when calling the ringdown approximant, one has to give the amplitude of the fundamental (220) mode and the fraction of the amplitudes of the subdominant modes relative to the fundamental mode. This way in pycbc_inference it will only be allowed that the subdominant modes have amplitudes up to a certain fraction of the fundamental mode.