### PR TITLE
fix critical bug which scrambles template ids

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_bank2hdf
+++ b/bin/hdfcoinc/pycbc_coinc_bank2hdf
@@ -107,9 +107,7 @@ bankf.table.dtype.names = tuple(params)
 
 # compute the hash
 logging.info("Getting template hashes")
-template_hash = numpy.array([hash(v) for v in zip(*[bankf.table[p]
-                         for p in bankf.table.fieldnames])])
-bankf.table = bankf.table.add_fields(template_hash, 'template_hash')
+bankf.ensure_hash()
 
 # write to output
 logging.info("Writing to %s" %(args.output_file))

--- a/bin/hdfcoinc/pycbc_coinc_mergetrigs
+++ b/bin/hdfcoinc/pycbc_coinc_mergetrigs
@@ -128,6 +128,6 @@ for col in trigger_columns:
     dset = f.create_dataset(key, data=data, compression='gzip',
                                  compression_opts=9, shuffle=True)
     del data
-    region(f, key, full_boundaries, bank_tids) 
+    region(f, key, full_boundaries, unsort) 
 f.close()
 logging.info('done')

--- a/bin/hdfcoinc/pycbc_coinc_mergetrigs
+++ b/bin/hdfcoinc/pycbc_coinc_mergetrigs
@@ -20,11 +20,11 @@ def collect(key, files):
         fin.close()
     return numpy.concatenate(data)
 
-def region(f, key, boundaries):
+def region(f, key, boundaries, ids):
     dset = f[key]
     refs = []
     for j in range(len(boundaries) - 1):
-        l, r = boundaries[j], boundaries[j+1]
+        l, r = boundaries[ids[j]], boundaries[ids[j]+1]
         refs.append(dset.regionref[l:r]) 
     f.create_dataset(key+'_template', data=refs,
                      dtype=h5py.special_dtype(ref=h5py.RegionReference))
@@ -99,6 +99,7 @@ logging.info('set up sorting of triggers and template ids')
 # For fast lookup we need the templates in hash order
 hashes = h5py.File(args.bank_file, 'r')['template_hash'][:]
 bank_tids = hashes.argsort()
+unsort = bank_tids.argsort()
 hashes = hashes[bank_tids]
 
 trigger_hashes = collect('%s/template_hash' % ifo, args.trigger_files)
@@ -110,12 +111,13 @@ template_ids = bank_tids[numpy.searchsorted(hashes, trigger_hashes[template_boun
 
 full_boundaries = numpy.searchsorted(trigger_hashes, hashes)
 full_boundaries = numpy.concatenate([full_boundaries, [len(trigger_hashes)]])
+# get the full boundaries in hash order 
 del trigger_hashes
 
 idlen = (template_boundaries[1:] - template_boundaries[:-1])
 f.create_dataset('%s/template_id' % ifo, data=numpy.repeat(template_ids, idlen), 
                  compression='gzip', shuffle=True, compression_opts=9)
-f['%s/template_boundaries' % ifo] = full_boundaries 
+f['%s/template_boundaries' % ifo] = full_boundaries[unsort]
 
 logging.info('reading the trigger columns from the input files')
 for col in trigger_columns:
@@ -126,6 +128,6 @@ for col in trigger_columns:
     dset = f.create_dataset(key, data=data, compression='gzip',
                                  compression_opts=9, shuffle=True)
     del data
-    region(f, key, full_boundaries) 
+    region(f, key, full_boundaries, bank_tids) 
 f.close()
 logging.info('done')

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -407,24 +407,7 @@ class EventManager(object):
                                       shuffle=True)
 
         self.events.sort(order='template_id')
-
-        # Template id hack
-        m1 = numpy.array([p['tmplt'].mass1 for p in self.template_params], dtype=numpy.float32)
-        m2 = numpy.array([p['tmplt'].mass2 for p in self.template_params], dtype=numpy.float32)
-        s1 = numpy.array([p['tmplt'].spin1z for p in self.template_params], dtype=numpy.float32)
-        s2 = numpy.array([p['tmplt'].spin2z for p in self.template_params], dtype=numpy.float32)
-    
-        # How to not store these in the case of not precession?
-        s1x = numpy.array([p['tmplt'].spin1x for p in self.template_params], dtype=numpy.float32)
-        s1y = numpy.array([p['tmplt'].spin1y for p in self.template_params], dtype=numpy.float32)
-        s2x = numpy.array([p['tmplt'].spin2x for p in self.template_params], dtype=numpy.float32)
-        s2y = numpy.array([p['tmplt'].spin2y for p in self.template_params], dtype=numpy.float32)
-        incl = numpy.array([p['tmplt'].inclination for p in self.template_params], dtype=numpy.float32)
-
-        th = numpy.zeros(len(m1), dtype=int)
-        for j, v in enumerate(zip(m1, m2, s1, s2, s1x, s1y, s2x, s2y, incl)):
-            th[j] = hash(v)
-
+        th = numpy.zeros([p['tmplt'].template_hash for p in self.template_params], dtype=int)
         tid = self.events['template_id']
         f = fw(outname, self.opt.channel_name[0:2])
 

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -407,7 +407,7 @@ class EventManager(object):
                                       shuffle=True)
 
         self.events.sort(order='template_id')
-        th = numpy.zeros([p['tmplt'].template_hash for p in self.template_params], dtype=int)
+        th = numpy.array([p['tmplt'].template_hash for p in self.template_params])
         tid = self.events['template_id']
         f = fw(outname, self.opt.channel_name[0:2])
 

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -303,7 +303,7 @@ class TemplateBank(object):
             else:
                 self.table['approximant'] = apprxs
         self.extra_args = kwds
-
+        self.ensure_hash()
 
     @property
     def parameters(self):
@@ -313,10 +313,16 @@ class TemplateBank(object):
         """Ensure that there is a correctly populated template_hash 
         if it doesnt not already exist.
         """
-        fields = bank.table.fieldnames
+        fields = self.table.fieldnames
         if 'template_hash' in fields:
              return
 
+        # The fields to use in making a template hash
+        hash_fields = ['mass1', 'mass2', 'inclination',
+                       'spin1x', 'spin1y', 'spin1z',
+                       'spin2x', 'spin2y', 'spin2z',]
+
+        fields = [f for f in hash_fields if f in fields]
         template_hash = numpy.array([hash(v) for v in zip(*[self.table[p]
                          for p in fields])]) 
         self.table = self.table.add_fields(template_hash, 'template_hash')

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -309,6 +309,18 @@ class TemplateBank(object):
     def parameters(self):
         return self.table.fieldnames
 
+    def ensure_hash(self):
+        """Ensure that there is a correctly populated template_hash 
+        if it doesnt not already exist.
+        """
+        fields = bank.table.fieldnames
+        if 'template_hash' in fields:
+             return
+
+        template_hash = numpy.array([hash(v) for v in zip(*[self.table[p]
+                         for p in fields])]) 
+        self.table = self.table.add_fields(template_hash, 'template_hash')
+
     def write_to_hdf(self, filename, force=False, skip_fields=None):
         """Writes self to the given hdf file.
         


### PR DESCRIPTION
* Centralize the generation of template hashes so all the code get the information from a consistent source
       I've tested this with a workflow and by hand. You now get consistent template hashes from pycbc_coinc_bank2hdf and pycbc_inspiral

* Relax requirement in pycbc_coinc_mergetrigs on templates being in hash order within the template bank. 
        I still need to test this point. DO NOT MERGE