### PR TITLE
Add extra option to pycbc_submit_dax to use relative paths for regular files.

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -68,6 +68,7 @@ while true ; do
                #If curl fails but the file exists, write to cache, else exit
                if [ $? != 0 ]; then
                    if [ -f $URL ]; then
+                       echo "$URL cache file found. Appending..."
                        cat $URL >> _reuse.cache
                    else
                        echo "$URL not found!"

--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -62,9 +62,20 @@ while true ; do
         "") shift 2 ;;
         *) CACHE_FILE=1
            export IFS=","
+           set +e
            for URL in $2; do
                curl --fail "$URL" >> _reuse.cache
+               #If curl fails but the file exists, write to cache, else exit
+               if [ $? != 0 ]; then
+                   if [ -f $URL ]; then
+                       cat $URL >> _reuse.cache
+                   else
+                       echo "$URL not found!"
+                       exit
+                   fi
+               fi
            done
+           set -e
            shift 2 ;;
       esac ;;
     -g|--local-gsiftp-server)


### PR DESCRIPTION
Ran a test workflow that made it through and the cache is filled out by both an absolute path (`file:///`) and relative path. Though the routine of sleeping and trying to query the pegasus database seems to not work well on atlas8.

```
Querying Pegasus database for job:Querying...Error: near "wf_uuid": syntax error
Query failed: sqlite3 -csv /home/steven.reyes/.pegasus/workflow.db "select submit_hostname,wf_id,wf_uuid from master_workflow where submit_dir = '/local/user/steven.reyes/pycbc-tmp.uIt65kuB8s/work';"
Sleeping for 0 seconds and retrying...
```
...
```
Sleeping for 8 seconds and retrying...
Querying...Error: near "wf_uuid": syntax error
Query failed: sqlite3 -csv /home/steven.reyes/.pegasus/workflow.db "select submit_hostname,wf_id,wf_uuid from master_workflow where submit_dir = '/local/user/steven.reyes/pycbc-tmp.uIt65kuB8s/work';"
Sleeping for 9 seconds and retrying...
WARNING: Could not find the workflow in the Pegasus dashboard database.
         Workflow has been submitted but the results page will not contain
         a link to the dashboard page. If this is a production workflow,
         please remove the workflow, check for the origin of this error,
         and re-submit the workflow by re-running this script.
```