### PR TITLE
Add single-detector minifollowups for non-coincidence time only

### DIFF
--- a/bin/hdfcoinc/pycbc_make_coinc_search_workflow
+++ b/bin/hdfcoinc/pycbc_make_coinc_search_workflow
@@ -347,6 +347,13 @@ for insp_file in full_insps:
                                   veto_file=censored_veto,
                                   veto_segment_name='closed_box',
                                   tags=insp_file.tags)
+    currdir = rdir['single_triggers/%s_snglifo_triggers' %(curr_ifo,)]
+    wf.setup_single_det_minifollowups(workflow, insp_file, hdfbank[0],
+                                  insp_files_seg_file, data_analysed_name,
+                                  trig_generated_name, 'daxes', currdir,
+                                  veto_file=censored_veto,
+                                  veto_segment_name='closed_box',
+                                  tags=insp_file.tags+['noncoinconly'])
 
 ################## Setup segment / veto related plots #########################
 # do plotting of segments / veto times

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -16,7 +16,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """ Followup foreground events
 """
-import os, argparse, logging, h5py, pycbc.workflow as wf
+import os, sys, argparse, logging, h5py, pycbc.workflow as wf
 from pycbc.results import layout
 from pycbc.types import MultiDetOptionAction
 import pycbc.workflow.minifollowups as mini
@@ -81,6 +81,13 @@ f = h5py.File(args.statmap_file, 'r')
 stat = f['foreground/stat'][:]
 
 sorting = stat.argsort()[::-1]
+
+if len(stat) == 0:
+    # There are no triggers, make no-op job and exit
+    noop_node = mini.create_noop_node()
+    workflow += noop_node
+    workflow.save(filename=args.output_file, output_map=args.output_map)
+    sys.exit(0)
 
 if len(stat) < num_events:
     num_events = len(stat)

--- a/bin/minifollowups/pycbc_page_snglinfo
+++ b/bin/minifollowups/pycbc_page_snglinfo
@@ -42,8 +42,12 @@ parser.add_argument('--veto-file',
 parser.add_argument('--veto-segment-name',
     help="If using veto file, the name of the segments to use as a veto.")
 parser.add_argument("--instrument", help="Name of ifo (e.g. H1)")
-parser.add_argument("--n-loudest", type=int,
-    help="Examine the n'th loudest trigger (loudest is n=0).  Required")
+parser.add_argument("--n-loudest", type=int, default=None,
+    help="Examine the n'th loudest trigger (loudest is n=0). Must supply "
+         "either this or --trigger-id.")
+parser.add_argument("--trigger-id", type=int, default=None,
+    help="Use the trigger with this ID in the HDF file. Must supply either "
+         "this option or --n-loudest.")
 parser.add_argument('--ranking-statistic', default='newsnr',
     help="How to rank triggers when determining loudest triggers. Default "
          "'newsnr'")
@@ -55,14 +59,23 @@ pycbc.init_logging(args.verbose)
 sngl_file = hdf.SingleDetTriggers(args.single_trigger_file, args.bank_file,
                 args.veto_file, args.veto_segment_name, None, args.instrument)
 
-# Cluster by a ranking statistic and retain only the loudest n clustered
-# triggers
-sngl_file.mask_to_n_loudest_clustered_events(n_loudest=args.n_loudest+1,
-                                      ranking_statistic=args.ranking_statistic)
 
-# Restrict to only the nth loudest, instead of all triggers up to nth loudest
-stat = sngl_file.stat[-1]
-sngl_file.mask = sngl_file.mask[-1]
+if args.trigger_id is not None:
+    sngl_file.mask = numpy.array([args.trigger_id])
+    sngl_file.mask_to_n_loudest_clustered_events(n_loudest=1,
+                                      ranking_statistic=args.ranking_statistic)
+    stat = sngl_file.stat[0]
+elif args.n_loudest is not None:
+    # Cluster by a ranking statistic and retain only the loudest n clustered
+    # triggers
+    sngl_file.mask_to_n_loudest_clustered_events(n_loudest=args.n_loudest+1,
+                                      ranking_statistic=args.ranking_statistic)
+    # Restrict to only the nth loudest, instead of all triggers up to nth
+    # loudest
+    stat = sngl_file.stat[-1]
+    sngl_file.mask = sngl_file.mask[-1]
+else:
+    raise ValueError("Must give --n-loudest or --trigger-id.")
 
 # make a table for the single detector information ############################
 time = sngl_file.end_time 
@@ -87,7 +100,15 @@ html = pycbc.results.dq.redirect_javascript + \
         str(pycbc.results.static_table(data, pycbc.results.sngl_table_headers))
 ###############################################################################
 
+if args.n_loudest:
+    title = 'Parameters of single-detector event ranked %s' \
+        % (args.n_loudest + 1)
+    caption = 'Parameters of the single-detector event ranked number %s by %s. The figures below show the mini-followup data for this event.' % (args.n_loudest + 1, sngl_file.stat_name)
+else:
+    title = 'Parameters of single-detector event'
+    caption = 'Parameters of the single-detector event. The figures below show the mini-followup data for this event.'
+
 pycbc.results.save_fig_with_metadata(html, args.output_file, {},
                         cmd = ' '.join(sys.argv),
-                        title = 'Parameters of single-detector event ranked %s' % (args.n_loudest + 1),
-                        caption = 'Parameters of the single-detector event ranked number %s by %s. The figures below show the mini-followup data for this event.' % (args.n_loudest + 1, sngl_file.stat_name))
+                        title = title,
+                        caption = caption)

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -110,8 +110,8 @@ if args.non_coinc_time_only:
     ifo_list.remove(args.instrument)
     for ifo in ifo_list:
         curr_veto_mask, segs = pycbc.events.veto.indices_outside_segments(
-            trigs.trigs['end_time'][:], [args.inspiral_segments],
-            ifo=args.instrument, segment_name=args.inspiral_data_analyzed_name)
+            trigs.end_time, [args.inspiral_segments],
+            ifo=ifo, segment_name=args.inspiral_data_analyzed_name)
         trigs.mask = trigs.mask[curr_veto_mask]
 
 if len(trigs.snr) == 0:

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -139,10 +139,9 @@ for num_event in range(num_events):
     ifo_tid = '%s:%s' %(args.instrument, str(tid))
     
     layouts += (mini.make_sngl_ifo(workflow, sngl_file, tmpltbank_file,
-                              num_event, args.output_dir, args.instrument,
-                              tags = args.tags + [str(num_event)],
-                              veto_file=veto_file,
-                              veto_segment_name=args.veto_segment_name),)
+                                   tid, args.output_dir, args.instrument,
+                                   tags=args.tags + [str(num_event)],
+                                   rank=num_event),)
     files += mini.make_trigger_timeseries(workflow, [sngl_file],
                               ifo_time, args.output_dir, special_tids=ifo_tid,
                               tags=args.tags + [str(num_event)])
@@ -167,12 +166,6 @@ for num_event in range(num_events):
     except:
         pass
 
-    files += mini.make_plot_waveform_plot(workflow, curr_params,
-                                        args.output_dir, [args.instrument],
-                                        tags=args.tags + [str(num_event)])
-    files += mini.make_trigger_timeseries(workflow, [sngl_file],
-                              ifo_time, args.output_dir, special_tids=ifo_tid,
-                              tags=args.tags + [str(num_event)])
     files += mini.make_single_template_plots(workflow, insp_segs,
                             args.inspiral_data_read_name,
                             args.inspiral_data_analyzed_name, curr_params,
@@ -182,7 +175,11 @@ for num_event in range(num_events):
     files += mini.make_singles_timefreq(workflow, sngl_file, tmpltbank_file, 
                             time - 10, time + 10, args.output_dir,
                             tags=args.tags + [str(num_event)])                 
-    
+
+    files += mini.make_plot_waveform_plot(workflow, curr_params,
+                                        args.output_dir, [args.instrument],
+                                        tags=args.tags + [str(num_event)])
+
     layouts += list(layout.grouper(files, 2))
     num_event += 1
 

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -16,12 +16,15 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """ Followup foreground events
 """
-import os, argparse, logging, h5py
+import os, sys, argparse, logging, h5py
+from glue.ligolw import lsctables, table
+from glue.ligolw import utils as ligolw_utils
 from pycbc.results import layout
 import pycbc.workflow.minifollowups as mini
 import pycbc.workflow.pegasus_workflow as wdax
 import pycbc.version
 import pycbc.workflow as wf
+import pycbc.events
 from pycbc.io import hdf
 
 def to_file(path, ifo=None):
@@ -102,14 +105,21 @@ if args.non_coinc_time_only:
                                           contenthandler=h)
     seg_def_table = table.get_table(segs_doc, 'segment_definer')
     def_ifos = seg_def_table.getColumnByName('ifos')
-    ifo_list = list(set(def_ifos)).remove(args.instrument)
-    print ifo_lists
-    raise NeedsTestingIssue
+    def_ifos = [str(ifo) for ifo in def_ifos]
+    ifo_list = list(set(def_ifos))
+    ifo_list.remove(args.instrument)
     for ifo in ifo_list:
-        curr_veto_mask, segs = events.veto.indices_inside_segments(
-            self.trigs['end_time'][:], [args.inspiral_segments],
-            ifo=detector, segment_name=segment_name)
+        curr_veto_mask, segs = pycbc.events.veto.indices_outside_segments(
+            trigs.trigs['end_time'][:], [args.inspiral_segments],
+            ifo=args.instrument, segment_name=args.inspiral_data_analyzed_name)
         trigs.mask = trigs.mask[curr_veto_mask]
+
+if len(trigs.snr) == 0:
+    # There are no triggers, make no-op job and exit
+    noop_node = mini.create_noop_node()
+    workflow += noop_node
+    workflow.save(filename=args.output_file, output_map=args.output_map)
+    sys.exit(0)
 
 trigs.mask_to_n_loudest_clustered_events(n_loudest=num_events,
                                       ranking_statistic=args.ranking_statistic)

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -57,6 +57,11 @@ parser.add_argument('--inspiral-data-analyzed-name',
                          "analyzed by each analysis job.")
 parser.add_argument('--ranking-statistic',
                 help="How to rank triggers when determining loudest triggers.")
+parser.add_argument('--non-coinc-time-only', default=False,
+                    action='store_true',
+                    help="If given remove (veto) single-detector triggers "
+                         "that occur during a time when at least one other "
+                         "instrument is taking science data.")
 parser.add_argument('--output-map')
 parser.add_argument('--output-file')
 parser.add_argument('--tags', nargs='+', default=[])
@@ -89,6 +94,22 @@ num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups',
 trigs = hdf.SingleDetTriggers(args.single_detector_file, args.bank_file,
                               args.veto_file, args.veto_segment_name,
                               None, args.instrument)
+
+if args.non_coinc_time_only:
+    from glue.ligolw.ligolw import LIGOLWContentHandler as h
+    lsctables.use_in(h)
+    segs_doc = ligolw_utils.load_filename(args.inspiral_segments,
+                                          contenthandler=h)
+    seg_def_table = table.get_table(segs_doc, 'segment_definer')
+    def_ifos = seg_def_table.getColumnByName('ifos')
+    ifo_list = list(set(def_ifos)).remove(args.instrument)
+    print ifo_lists
+    raise NeedsTestingIssue
+    for ifo in ifo_list:
+        curr_veto_mask, segs = events.veto.indices_inside_segments(
+            self.trigs['end_time'][:], [args.inspiral_segments],
+            ifo=detector, segment_name=segment_name)
+        trigs.mask = trigs.mask[curr_veto_mask]
 
 trigs.mask_to_n_loudest_clustered_events(n_loudest=num_events,
                                       ranking_statistic=args.ranking_statistic)

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -386,6 +386,9 @@ class SingleDetTriggers(object):
         # If this becomes memory intensive we can optimize
         if ranking_statistic == "newsnr":
             stat = self.newsnr
+            # newsnr doesn't return an array if len(stat) == 1
+            if len(self.snr) == 1:
+                stat = np.array([stat])
             self.stat_name = "Reweighted SNR"
         elif ranking_statistic == "snr":
             stat = self.snr

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -26,7 +26,7 @@ This module provides the worker functions and classes that are used when
 creating a workflow. For details about the workflow module see here:
 https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope.html
 """
-import sys, os, stat, subprocess, logging, math, string, urllib2, urlparse
+import sys, os, stat, subprocess, logging, math, string, urlparse
 import ConfigParser, copy, time
 import numpy, cPickle, random
 from itertools import combinations, groupby, permutations

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -485,8 +485,8 @@ def make_coinc_info(workflow, singles, bank, coinc, num, out_dir, tags=None):
     files += node.output_files
     return files
 
-def make_sngl_ifo(workflow, sngl_file, bank_file, num, out_dir, ifo,
-                  veto_file=None, veto_segment_name=None, tags=None):
+def make_sngl_ifo(workflow, sngl_file, bank_file, trigger_id, out_dir, ifo,
+                  tags=None, rank=None):
     """Setup a job to create sngl detector sngl ifo html summary snippet.
     """
     tags = [] if tags is None else tags
@@ -497,11 +497,9 @@ def make_sngl_ifo(workflow, sngl_file, bank_file, num, out_dir, ifo,
                               out_dir=out_dir, tags=tags).create_node()
     node.add_input_opt('--single-trigger-file', sngl_file)
     node.add_input_opt('--bank-file', bank_file)
-    if veto_file is not None:
-        assert(veto_segment_name is not None)
-        node.add_input_opt('--veto-file', veto_file)
-        node.add_opt('--veto-segment-name', veto_segment_name)
-    node.add_opt('--n-loudest', str(num))
+    node.add_opt('--trigger-id', str(trigger_id))
+    if rank is not None:
+        node.add_opt('--n-loudest', str(rank))
     node.add_opt('--instrument', ifo)
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow += node


### PR DESCRIPTION
This PR adds a new minifollowup page to our results page that is intended to run on non-coincident data only. Specifically the code currently uses the TRIGGERS_GENERATED segment lists to determine what is non-coincident data, so this will *not* include time where one detector was CAT_2 vetoed, for example (such triggers would show up in the full single-detector minifollowups though).

To enable this I make the following changes:

 * Create a no-op job for minifollowups, which are used in the case of 0 triggers. This is enabled for both single and coinc minifollowups.
 * Add ability in pycbc_page_snglinfo to followup a specific trigger instead of the nth loudest. This avoids having to recalculate what nth loudest means again.
 * Add option to use non-coinc time only in singles minifollowup and add this to coinc_workflow.
 * Reorder and remove duplication in singles minifollowup
 * For @tdent I generate a version of plot_waveform with log-axis for frequency domain waveforms for comparison: https://galahad.aei.mpg.de/~spxiwh/LVC/aLIGO/O1/analyses/workflow_testT15/L1-PLOT_WAVEFORM_P1_2-1128466607-520000.png Please advise if this change should be included with the rest of these changes.

One needs to add the following to our configuration files, which I will do if there are no issues with this:

```
[singles_minifollowup-noncoinconly]
non-coinc-time-only =
```

Also the test workflow with this patch used:

https://galahad.aei.mpg.de/~spxiwh/LVC/aLIGO/O1/analyses/workflow_testT12

Note that the test workflow includes no non-coinc time, so this becomes a test of the new no-op job functionality. Extending the time of the test workflow produces:

https://galahad.aei.mpg.de/~spxiwh/LVC/aLIGO/O1/analyses/workflow_testT15