### PR TITLE
Add a patch to get rid of curl error flag.

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -64,7 +64,7 @@ while true ; do
            export IFS=","
            set +e
            for URL in $2; do
-               curl --fail "$URL" >> _reuse.cache
+               curl --fail "$URL" >> _reuse.cache 2>/dev/null
                #If curl fails but the file exists, write to cache, else exit
                if [ $? != 0 ]; then
                    if [ -f $URL ]; then


### PR DESCRIPTION
This patch prevents stderr from `curl` from appearing on the screen, however `echo $?` still returns the error message of `curl`, so the next segment still works fine if the cache file doesn't exist.