### PR TITLE
Add setup time to throughput information

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_mergetrigs
+++ b/bin/hdfcoinc/pycbc_coinc_mergetrigs
@@ -67,6 +67,7 @@ logging.info('reading the metadata from the files')
 start = numpy.array([], dtype=numpy.float64)
 end = numpy.array([], dtype=numpy.float64)
 tpc = numpy.array([], dtype=numpy.float64)
+stf = numpy.array([], dtype=numpy.float64)
 gating = {}
 for filename in args.trigger_files:
     data = h5py.File(filename, 'r')
@@ -76,6 +77,8 @@ for filename in args.trigger_files:
 
     if 'templates_per_core' in ifo_data['search'].keys():
         tpc = numpy.append(tpc, ifo_data['search/templates_per_core'][:])
+    if 'setup_time_fraction' in ifo_data['search'].keys():
+        stf = numpy.append(stf, ifo_data['search/setup_time_fraction'][:])
 
     if 'gating' in ifo_data:
         gating_keys = []
@@ -91,6 +94,8 @@ f['%s/search/start_time' % ifo], f['%s/search/end_time' % ifo] = start, end
 
 if len(tpc) > 0:
     f['%s/search/templates_per_core' % ifo] = tpc
+if len(stf) > 0:
+    f['%s/search/setup_time_fraction' % ifo] = stf
 
 for gk, gv in gating.items():
     f[ifo + '/gating/' + gk] = gv

--- a/bin/hdfcoinc/pycbc_plot_throughput
+++ b/bin/hdfcoinc/pycbc_plot_throughput
@@ -25,7 +25,8 @@ for pa in args.input_file:
     ifo = f.keys()[0]
     if  'templates_per_core' in  f['%s/search' %ifo].keys():
         tpc = f['%s/search/templates_per_core' % ifo][:]
-        ax.hist(tpc, 100, color=ifo_color(ifo), alpha = 0.65, label = str(ifo))
+        label = str(ifo) + ': Mean average - ' + str(tpc.mean())
+        ax.hist(tpc, 100, color=ifo_color(ifo), alpha = 0.65, label = label)
         ax.set_title('Templates per Core')
         ax.set_xlabel('Templates per Core')
         ax.legend(loc = 'upper right')

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -280,6 +280,7 @@ with ctx:
         logging.info("Template Bank Size After Cut: %s", len(bank))
       
     ntemplates = len(bank)
+    tsetup = time.time() - tstart
 
     # Note: in the class-based approach used now, 'template' is not explicitly used
     # within the loop.  Rather, the iteration simply fills the memory specifed in
@@ -361,7 +362,7 @@ if opt.maximization_interval:
 
 tstop = time.time()
 run_time = tstop - tstart
-event_mgr.save_performance(run_time=run_time, ncores=ncores, ntemplates=ntemplates)
+event_mgr.save_performance(ncores, ntemplates, run_time, tsetup)
 
 logging.info("Writing out triggers")
 event_mgr.write_events(opt.output)

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -272,7 +272,8 @@ with ctx:
                     taper=opt.taper_template, approximant=opt.approximant,
                     out=template_mem, max_template_length=opt.max_template_length)
 
-    if opt.threshold_template_filtering is not None:
+    if opt.injection_file is not None and \
+            opt.threshold_template_filtering is not None:
         logging.info("Template Bank Size Before Cut: %s", len(bank))
         bank.table = bank.template_thinning(gwstrain.injections.table,
                                             opt.threshold_template_filtering)

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -480,9 +480,10 @@ class EventManager(object):
             self.analysis_time = search_end_time - search_start_time
             time_ratio = numpy.array([float(self.analysis_time) / float(self.run_time)])
             temps_per_core = float(self.ntemplates) / float(self.ncores)
-            f['search/templates_per_core'] = numpy.array([float(temps_per_core) * float(time_ratio)])
-            f['search/setup_time_fraction'] = numpy.array([float(self.setup_time) / float(self.run_time)])
-
+            f['search/templates_per_core'] = \
+                numpy.array([float(temps_per_core) * float(time_ratio)])
+            f['search/setup_time_fraction'] = \
+                numpy.array([float(self.setup_time) / float(self.run_time)])
 
         if 'gating_info' in self.global_params:
             gating_info = self.global_params['gating_info']

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -373,11 +373,12 @@ class EventManager(object):
             if not os.path.exists(path) and path is not None:
                 os.makedirs(path)
 
-    def save_performance(self, ncores, ntemplates, run_time):
+    def save_performance(self, ncores, ntemplates, run_time, setup_time):
         """
         Calls variables from pycbc_inspiral to be used in a timing calculation
         """
         self.run_time = run_time
+        self.setup_time = setup_time
         self.ncores = ncores
         self.ntemplates = ntemplates
         self.write_performance = True
@@ -480,6 +481,7 @@ class EventManager(object):
             time_ratio = numpy.array([float(self.analysis_time) / float(self.run_time)])
             temps_per_core = float(self.ntemplates) / float(self.ncores)
             f['search/templates_per_core'] = numpy.array([float(temps_per_core) * float(time_ratio)])
+            f['search/setup_time_fraction'] = numpy.array([float(self.setup_time) / float(self.run_time)])
 
 
         if 'gating_info' in self.global_params:


### PR DESCRIPTION
Here's a small addition to the throughput information: Specifically we now store the time it takes to make injections, condition, do gating, read data etc. This can be used to measure the fraction of time spent in setup, versus time spent in the main filtering loop. So far this is not added to the plotting code, but the information does get stored. (I have added a "mean average" entry to the plots' legends to have some number to clearly compare over runs).

This has been tested in a uberbank-style run with the injcutter stuff:

https://www.atlas.aei.uni-hannover.de/~spxiwh/LSC/aLIGO/O1/analyses/inj_cutter/chirp_time_window/o1_injcutter_v3cutter/8._workflow/8.01_throughput/

Also a test plot where I plot the new information ... Clearly the presentation is rubbish and we need to do something else. This just demonstrates that the number seems to be sane:

https://www.atlas.aei.uni-hannover.de/~spxiwh/LSC/H1L1-PLOT_THROUGHPUT_BNS01_INJ-1128299417-1083600.png