### PR TITLE
Adding tapering and cleanup

### DIFF
--- a/bin/pycbc_faithsim
+++ b/bin/pycbc_faithsim
@@ -23,11 +23,15 @@
 # =============================================================================
 #
 import sys
+import logging
 from numpy import loadtxt,complex64,float32
-from optparse import OptionParser
+import argparse
 from glue.ligolw import utils as ligolw_utils
 from glue.ligolw import table, lsctables, ligolw
 
+import pycbc.version
+import pycbc.strain
+import pycbc.psd
 from pycbc.pnutils import mass1_mass2_to_mchirp_eta
 from pycbc.waveform import td_approximants, fd_approximants
 from pycbc.waveform import get_two_pol_waveform_filter
@@ -35,7 +39,6 @@ from pycbc import DYN_RANGE_FAC
 from pycbc.types import FrequencySeries, zeros
 from pycbc.filter import match, overlap, sigma
 from pycbc.scheme import CPUScheme, CUDAScheme
-import pycbc.psd 
 
 class ContentHandler(ligolw.LIGOLWContentHandler):
     pass
@@ -48,7 +51,7 @@ def update_progress(progress):
     sys.stdout.flush()
 
 
-def get_waveform(approximant, phase_order, amplitude_order, spin_order, template_params, start_frequency, sample_rate, length):
+def get_waveform(approximant, phase_order, amplitude_order, spin_order, tapering, template_params, start_frequency, sample_rate, length):
 
     delta_f = sample_rate / length
     vecplus = FrequencySeries(zeros(filter_n), delta_f=delta_f,
@@ -56,12 +59,20 @@ def get_waveform(approximant, phase_order, amplitude_order, spin_order, template
     veccross = FrequencySeries(zeros(filter_n), delta_f=delta_f,
                               dtype=complex64)
 
+    if tapering is not None:
+       curr_taper = tapering
+    elif hasattr(template_params, 'taper'):
+       curr_taper = template_params.taper
+    else:
+       curr_taper = None
+
     # NOTE: for now only hplus is used! For precessing faithsims one would want
     #       to also specify a polarization phase, or "u_val".
     hplus, hcross = get_two_pol_waveform_filter(vecplus, veccross,
         template_params, approximant=approximant, spin_order=spin_order,
         phase_order=phase_order, delta_t=1.0 / sample_rate, delta_f=delta_f,
-        f_lower=start_frequency, amplitude_order=amplitude_order)
+        f_lower=start_frequency, amplitude_order=amplitude_order,
+        taper=curr_taper)
 
     return hplus*DYN_RANGE_FAC
 
@@ -70,42 +81,80 @@ def get_waveform(approximant, phase_order, amplitude_order, spin_order, template
 aprs = list(set(td_approximants() + fd_approximants()))
 psd_names = pycbc.psd.get_lalsim_psd_list()
 
-print "STARTING"
-
 #File I/O Settings
-parser = OptionParser()
-parser.add_option("--param-file", dest="bank_file", help="Sngl or Sim Inspiral Table containing waveform parameters", metavar="FILE")
-parser.add_option("--match-file", dest="out_file",help="file to output match results", metavar="FILE")
-
-parser.add_option("--asd-file", dest="asd_file",help="ASD data", metavar="FILE")
-parser.add_option("--psd", dest="psd", help="Analytic PSD model from LALSimulation", choices=psd_names)
-
+taper_choices = ["start","end","startend"]
+parser = argparse.ArgumentParser(usage='',
+    description="Calculate faithfulness for a set of waveforms.")
+parser.add_argument('--version', action='version',
+                    version=pycbc.version.git_verbose_msg)
+parser.add_argument("-V", "--verbose", action="store_true",
+                    help="print extra debugging information", default=False)
+parser.add_argument("--param-file", dest="bank_file", metavar="FILE",
+                    help="Sngl or Sim Inspiral Table containing waveform "
+                         "parameters.")
+parser.add_argument("--match-file", dest="out_file", metavar="FILE",
+                    help="File to output match results to.")
 
 #Waveform generation Settings
-parser.add_option("--waveform1-approximant",help="waveform1  Approximant Name: " + str(aprs), choices = aprs)
-parser.add_option("--waveform1-phase-order",help="PN order to use for the phase",default=-1,type=int) 
-parser.add_option("--waveform1-amplitude-order",help="PN order to use for the phase",default=-1,type=int) 
-parser.add_option("--waveform1-spin-order",help="Spin terms up to the given pN order are included",default=-1,type=int) 
-parser.add_option("--waveform1-start-frequency",help="Starting frequency for injections",type=float) 
+parser.add_argument("--waveform1-approximant", choices=aprs,
+                    help="Waveform 1's approximant.")
+parser.add_argument("--waveform1-phase-order", type=int, default=-1,
+                    help="PN order to use for the phase")
+parser.add_argument("--waveform1-amplitude-order", default=-1, type=int,
+                    help="PN order to use for the amplitude.")
+parser.add_argument("--waveform1-spin-order", default=-1, type=int,
+                    help="Spin terms up to the given pN order are included")
+parser.add_argument("--waveform1-start-frequency", type=float,
+                    help="Starting frequency for waveform generation.")
+parser.add_argument("--waveform1-taper-template", choices=taper_choices,
+                    default=None,
+                    help="For time-domain approximants, taper the start and/or"
+                    " end of the waveform before FFTing. This can also be"
+                    " provided in the sim_inspiral table. Providing this"
+                    " option will override any entry in that table.")
 
-parser.add_option("--waveform2-approximant",help="waveform2 Approximant Name: " + str(aprs), choices = aprs)
-parser.add_option("--waveform2-phase-order",help="PN order to use for the phase",default=-1,type=int) 
-parser.add_option("--waveform2-amplitude-order",help="PN order to use for the phase",default=-1,type=int) 
-parser.add_option("--waveform2-spin-order",help="Spin terms up to the given pN order are included",default=-1,type=int) 
-parser.add_option("--waveform2-start-frequency",help="Starting frequency for waveform1s",type=float)  
+parser.add_argument("--waveform2-approximant", choices=aprs,
+                    help="Waveform 2's approximant.")
+parser.add_argument("--waveform2-phase-order", type=int, default=-1,
+                    help="PN order to use for the phase")
+parser.add_argument("--waveform2-amplitude-order", default=-1, type=int,
+                    help="PN order to use for the amplitude.")
+parser.add_argument("--waveform2-spin-order", default=-1, type=int,
+                    help="Spin terms up to the given pN order are included")
+parser.add_argument("--waveform2-start-frequency", type=float,
+                    help="Starting frequency for waveform generation.")
+parser.add_argument("--waveform2-taper-template", choices=taper_choices,
+                    default=None,
+                    help="For time-domain approximants, taper the start and/or"
+                    " end of the waveform before FFTing. This can also be"
+                    " provided in the sim_inspiral table. Providing this"
+                    " option will override any entry in that table.")
 
 #Filter Settings
-parser.add_option('--filter-low-frequency-cutoff', metavar='FREQ', help='low frequency cutoff of matched filter', type=float)
-parser.add_option('--filter-high-frequency-cutoff', metavar='FREQ', help='high frequency cutoff of matched filter', type=float)
-parser.add_option("--filter-sample-rate",help="Filter Sample Rate [Hz]",type=float)
-parser.add_option("--filter-waveform-length",help="Length of waveform for filtering, shoud be longer than all waveforms and include some padding",type=int)
+parser.add_argument('--filter-low-frequency-cutoff', metavar='FREQ',
+                    type=float,
+                    help='Low frequency cutoff of matched filter.')
+parser.add_argument('--filter-high-frequency-cutoff', metavar='FREQ',
+                    type=float,
+                    help='High frequency cutoff of matched filter.')
+parser.add_argument("--filter-sample-rate", type=float,
+                    help="Filter Sample Rate [Hz]")
+parser.add_argument("--filter-waveform-length", type=int,
+                    help="Length of waveform for filtering, should be longer "
+                         "than all waveforms and include some padding.")
 
-parser.add_option("--cuda",action="store_true")            
-(options, args) = parser.parse_args()   
+parser.add_argument("--cuda", action="store_true",
+                    help="Use CUDA for calculations.")
 
-if options.psd and options.asd_file:
-    parser.error("PSD and asd-file options are mututally exclusive")
+# Insert the PSD options
+pycbc.psd.insert_psd_option_group(parser)
 
+# Insert the data reading options
+pycbc.strain.insert_strain_option_group(parser)
+
+options = parser.parse_args()
+
+pycbc.init_logging(options.verbose)
 
 if options.cuda:
     ctx = CUDAScheme()
@@ -121,48 +170,46 @@ except ValueError:
 
 # open the output file where the max overlaps over the bank are stored 
 fout = open(options.out_file, "w")
-print "Writing matches to " + options.out_file
+logging.info("Writing matches to " + options.out_file)
 
 filter_N = options.filter_waveform_length * options.filter_sample_rate
 filter_n = int(filter_N / 2) + 1
 delta_f = float(options.filter_sample_rate) / filter_N
 
-print("Number of Waveforms      : ",len(waveform_table))
+logging.info("Number of Waveforms      : %d" % len(waveform_table))
 
-print("Reading and Interpolating PSD")
-# Load the asd file
-
-if options.asd_file:
-    psd = pycbc.psd.from_txt(options.asd_file, filter_n,  
-                           delta_f, options.filter_low_frequency_cutoff)
-    psd *= DYN_RANGE_FAC **2
-    psd = FrequencySeries(psd,delta_f=psd.delta_f,dtype=float32)
-elif options.psd:
-    psd = pycbc.psd.from_string(options.psd, filter_n, delta_f, 
-                           options.filter_low_frequency_cutoff) 
-    psd *= DYN_RANGE_FAC **2
-    psd = FrequencySeries(psd,delta_f=psd.delta_f,dtype=float32) 
+logging.info("Reading and Interpolating PSD")
+# If we are going to use h(t) to estimate a PSD we need h(t)
+if options.psd_estimation:
+    logging.info("Obtaining h(t) for PSD generation")
+    strain = pycbc.strain.from_cli(options, pycbc.DYN_RANGE_FAC)
 else:
-    psd = None
+    strain = None
+
+psd = pycbc.psd.from_cli(options, length=filter_n, delta_f=delta_f,
+    low_frequency_cutoff=options.filter_low_frequency_cutoff, strain=strain,
+    dyn_range_factor=DYN_RANGE_FAC, precision='single')
 
 matches = []
 overlaps = []
 time_offsets = []
 s1s = []
 s2s = []
-print("Calculating Overlaps")
+logging.info("Calculating Overlaps")
 with ctx:
     index = 0 
     # Calculate the overlaps
     for waveform_params in waveform_table:
         index += 1
-        update_progress(index*100/len(waveform_table))
+        if options.verbose:
+            update_progress(index*100/len(waveform_table))
 
         try:
             htilde1 = get_waveform(options.waveform1_approximant, 
                                   options.waveform1_phase_order, 
                                   options.waveform1_amplitude_order,
                                   options.waveform1_spin_order, 
+                                  options.waveform1_taper_template,
                                   waveform_params, 
                                   options.waveform1_start_frequency, 
                                   options.filter_sample_rate, 
@@ -172,22 +219,26 @@ with ctx:
                                   options.waveform2_phase_order, 
                                   options.waveform2_amplitude_order,
                                   options.waveform2_spin_order, 
+                                  options.waveform2_taper_template,
                                   waveform_params, 
                                   options.waveform2_start_frequency, 
                                   options.filter_sample_rate, 
                                   filter_N)
 
             m,i = match(htilde1, htilde2, psd=psd, 
-                        low_frequency_cutoff=options.filter_low_frequency_cutoff, high_frequency_cutoff=options.filter_high_frequency_cutoff) 
-                        
-                        
+                low_frequency_cutoff=options.filter_low_frequency_cutoff,
+                high_frequency_cutoff=options.filter_high_frequency_cutoff)
+
             o = overlap(htilde1, htilde2, psd=psd, 
-                        low_frequency_cutoff=options.filter_low_frequency_cutoff, high_frequency_cutoff=options.filter_high_frequency_cutoff)   
-            
-            s1 = sigma(htilde1, psd=psd, 
-                        low_frequency_cutoff=options.filter_low_frequency_cutoff, high_frequency_cutoff=options.filter_high_frequency_cutoff)   
-            s2 = sigma(htilde2, psd=psd, 
-                        low_frequency_cutoff=options.filter_low_frequency_cutoff, high_frequency_cutoff=options.filter_high_frequency_cutoff)   
+                low_frequency_cutoff=options.filter_low_frequency_cutoff,
+                high_frequency_cutoff=options.filter_high_frequency_cutoff)
+
+            s1 = sigma(htilde1, psd=psd,
+                low_frequency_cutoff=options.filter_low_frequency_cutoff,
+                high_frequency_cutoff=options.filter_high_frequency_cutoff)
+            s2 = sigma(htilde2, psd=psd,
+                low_frequency_cutoff=options.filter_low_frequency_cutoff,
+                high_frequency_cutoff=options.filter_high_frequency_cutoff)
             matches.append(m)
             overlaps.append(o)
             if i > filter_n:
@@ -196,7 +247,7 @@ with ctx:
             s1s.append(s1)
             s2s.append(s2)
         except:
-            print "Unable to generate waveforms"
+            logging.info("Unable to generate waveforms")
             matches.append(-1)
             overlaps.append(-1)
             time_offsets.append(-1)


### PR DESCRIPTION
Here I hook up tapering options to pycbc_faithsim. One can provide these either through the sim_inspiral table (in the normal way) or through new command-line arguments (as faithsim can run with sngl_inspiral as well as sim_inspiral).

In doing this I also did some cleanup:

 * Moved from optparse to argparse
 * Move from print X to logging.info(X)
 * Put in the PSD option handling group
 * Did some line wrapping