### PR TITLE
Standarize Gaussian distribution input.

### DIFF
--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -877,6 +877,7 @@ class Gaussian(Uniform):
     >> dist = Gaussian(mass1=(1.3,1.5,1.4,0.01)
     """
     name = "gaussian"
+
     def __init__(self, **params):
 
         # save distribution parameters as dict

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1038,13 +1038,13 @@ class Gaussian(Uniform):
         for param in variable_args:
             params[param] = (None, None, None, None)
             params[param][0] = float(cp.get_opt_tag(section,
-                                                   "min-%s"%param, tag))
+                                                   "min-%s" % param, tag))
             params[param][1] = float(cp.get_opt_tag(section,
-                                                   "max-%s"%param, tag))
+                                                   "max-%s" % param, tag))
             params[param][2] = float(cp.get_opt_tag(section,
-                                                   "mean-%s"%param, tag))
+                                                   "mean-%s" % param, tag))
             params[param][3] = float(cp.get_opt_tag(section,
-                                                   "var-%s"%param, tag))
+                                                   "var-%s" % param, tag))
 
         # add any additional options that user put in that section
         dist_args = {}

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1038,13 +1038,13 @@ class Gaussian(Uniform):
         for param in variable_args:
             params[param] = (None, None, None, None)
             params[param][0] = float(cp.get_opt_tag(section,
-                                                   "min-%s" % param, tag))
+                                                    "min-%s" % param, tag))
             params[param][1] = float(cp.get_opt_tag(section,
-                                                   "max-%s" % param, tag))
+                                                    "max-%s" % param, tag))
             params[param][2] = float(cp.get_opt_tag(section,
-                                                   "mean-%s" % param, tag))
+                                                    "mean-%s" % param, tag))
             params[param][3] = float(cp.get_opt_tag(section,
-                                                   "var-%s" % param, tag))
+                                                    "var-%s" % param, tag))
 
         # add any additional options that user put in that section
         dist_args = {}


### PR DESCRIPTION
Makes the ``Gaussian`` distribution similar to the other distributions ``__init__`` in ``distributions.py``.

For Gaussian with bounds 1.4 and 1.5 and mean 1.3 and variance 0.01 do:
```
gauss = Gaussian(mass1=(1.3, 1.5, 1.4, 0.01))
```

This example is also in the docstring.