### PR TITLE
Add append method to FieldArray

### DIFF
--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -143,8 +143,8 @@ for ii in range(imin, imax):
     # scratch space
     decomp_scratch = FrequencySeries(numpy.zeros(N, dtype=dtype), delta_f=df)
     # generate the waveform
-    htilde = bank[ii]
-    tmplt = bank.table[ii]
+    htilde = bank[ii-imin]
+    tmplt = bank.table[ii-imin]
     kmax = htilde.end_idx
     
     # get the compressed sample points

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1238,7 +1238,7 @@ class FieldArray(numpy.recarray):
 
         .. note::
             Increasing the length of strings only works for fields, not
-            sub-fields. 
+            sub-fields.
 
         Parameters
         ----------
@@ -1246,7 +1246,7 @@ class FieldArray(numpy.recarray):
             The array to append values from. It must have the same fields and
             dtype as this array, modulo the length of strings. If the other
             array does not have the same dtype, a TypeError is raised.
-        
+
         Returns
         -------
         array
@@ -1260,23 +1260,26 @@ class FieldArray(numpy.recarray):
             # see if the dtype error was due to string fields having different
             # lengths; if so, we'll make the joint field the larger of the
             # two
-            str_fields = [name for name in self.fieldnames 
-                               if _isstring(self.dtype[name])]
+            str_fields = [name for name in self.fieldnames
+                          if _isstring(self.dtype[name])]
             # get the larger of the two
-            new_strlens = dict([[name,
-                max(self.dtype[name].itemsize, other.dtype[name].itemsize)]
-                for name in str_fields])
+            new_strlens = dict(
+                [[name,
+                  max(self.dtype[name].itemsize, other.dtype[name].itemsize)]
+                 for name in str_fields]
+            )
             # cast both to the new string lengths
             new_dt = []
             for dt in self.dtype.descr:
                 name = dt[0]
                 if name in new_strlens:
-                    dt = (name, self.dtype[name].type,
-                                  new_strlens[name])
-                new_dt.append(dt) 
+                    dt = (name, self.dtype[name].type, new_strlens[name])
+                new_dt.append(dt)
             new_dt = numpy.dtype(new_dt)
             return numpy.append(self.astype(new_dt),
-                other.astype(new_dt)).view(type=self.__class__)
+                                other.astype(new_dt)
+                               ).view(type=self.__class__)
+
 
 def _isstring(dtype):
     """Given a numpy dtype, determines whether it is a string. Returns True

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1227,6 +1227,63 @@ class FieldArray(numpy.recarray):
             leftovers &= ~mask
         return out, numpy.where(leftovers)[0]
 
+    def append(self, other):
+        """Appends another array to this array.
+
+        The returned array will have all of the class methods and virutal
+        fields of this array, including any that were added using `add_method`
+        or `add_virtualfield`. If this array and other array have one or more
+        string fields, the dtype for those fields are updated to a string
+        length that can encompass the longest string in both arrays.
+
+        .. note::
+            Increasing the length of strings only works for fields, not
+            sub-fields. 
+
+        Parameters
+        ----------
+        other : array
+            The array to append values from. It must have the same fields and
+            dtype as this array, modulo the length of strings. If the other
+            array does not have the same dtype, a TypeError is raised.
+        
+        Returns
+        -------
+        array
+            An array with others values appended to this array's values. The
+            returned array is an instance of the same class as this array,
+            including all methods and virtual fields.
+        """
+        try:
+            return numpy.append(self, other).view(type=self.__class__)
+        except TypeError:
+            # see if the dtype error was due to string fields having different
+            # lengths; if so, we'll make the joint field the larger of the
+            # two
+            str_fields = [name for name in self.fieldnames 
+                               if _isstring(self.dtype[name])]
+            # get the larger of the two
+            new_strlens = dict([[name,
+                max(self.dtype[name].itemsize, other.dtype[name].itemsize)]
+                for name in str_fields])
+            # cast both to the new string lengths
+            new_dt = []
+            for dt in self.dtype.descr:
+                name = dt[0]
+                if name in new_strlens:
+                    dt = (name, self.dtype[name].type,
+                                  new_strlens[name])
+                new_dt.append(dt) 
+            new_dt = numpy.dtype(new_dt)
+            return numpy.append(self.astype(new_dt),
+                other.astype(new_dt)).view(type=self.__class__)
+
+def _isstring(dtype):
+    """Given a numpy dtype, determines whether it is a string. Returns True
+    if the dtype is string or unicode.
+    """
+    return dtype.type == numpy.unicode_ or dtype.type == numpy.string_
+
 
 def aliases_from_fields(fields):
     """Given a dictionary of fields, will return a dictionary mapping the

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1276,9 +1276,10 @@ class FieldArray(numpy.recarray):
                     dt = (name, self.dtype[name].type, new_strlens[name])
                 new_dt.append(dt)
             new_dt = numpy.dtype(new_dt)
-            return numpy.append(self.astype(new_dt),
-                                other.astype(new_dt)
-                               ).view(type=self.__class__)
+            return numpy.append(
+                self.astype(new_dt),
+                other.astype(new_dt)
+                ).view(type=self.__class__)
 
 
 def _isstring(dtype):


### PR DESCRIPTION
This adds an append method to FieldArray to so that two arrays can be easily combined. This is a bit smarter than a basic `numpy.append` in that if the two arrays have the same fields, but one or more of these are string with different lengths, the function will figure out what string length is needed to encompass both. Also, the type of the returned array is the same as the first array, so that any added virtual fields are preserved.

Example:
```
>>> bank1 = waveform.TemplateBank('compressed_bank-0_100.hdf', 'r').table
>>> bank2 = waveform.TemplateBank('compressed_bank-100_106.hdf', 'r').table
>>> combined = bank1.append(bank2)
>>> bank1.size, bank2.size, combined.size
(100, 6, 106)
>>> bank1.approximant.dtype, bank2.approximant.dtype, combined.approximant.dtype
(dtype('S23'), dtype('S8'), dtype('S23'))
```

This patch also fixes a bug I came across in `pycbc_compress_bank` while testing this patch. The bug would cause compress bank to fail if you used a starting template index that was not 0.