### PR TITLE
Implementing injcutter in PyCBC

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_mergetrigs
+++ b/bin/hdfcoinc/pycbc_coinc_mergetrigs
@@ -67,6 +67,7 @@ logging.info('reading the metadata from the files')
 start = numpy.array([], dtype=numpy.float64)
 end = numpy.array([], dtype=numpy.float64)
 tpc = numpy.array([], dtype=numpy.float64)
+frpc = numpy.array([], dtype=numpy.float64)
 stf = numpy.array([], dtype=numpy.float64)
 gating = {}
 for filename in args.trigger_files:
@@ -77,6 +78,8 @@ for filename in args.trigger_files:
 
     if 'templates_per_core' in ifo_data['search'].keys():
         tpc = numpy.append(tpc, ifo_data['search/templates_per_core'][:])
+    if 'filter_rate_per_core' in ifo_data['search'].keys():
+        frpc = numpy.append(frpc, ifo_data['search/filter_rate_per_core'][:])
     if 'setup_time_fraction' in ifo_data['search'].keys():
         stf = numpy.append(stf, ifo_data['search/setup_time_fraction'][:])
 
@@ -94,6 +97,8 @@ f['%s/search/start_time' % ifo], f['%s/search/end_time' % ifo] = start, end
 
 if len(tpc) > 0:
     f['%s/search/templates_per_core' % ifo] = tpc
+if len(frpc) > 0:
+    f['%s/search/filter_rate_per_core' % ifo] = frpc
 if len(stf) > 0:
     f['%s/search/setup_time_fraction' % ifo] = stf
 

--- a/bin/hdfcoinc/pycbc_plot_throughput
+++ b/bin/hdfcoinc/pycbc_plot_throughput
@@ -4,7 +4,7 @@ import argparse
 import logging
 import h5py
 import numpy as np
-import matplotlib
+import matplotlib; matplotlib.use('Agg')
 import pylab as pl
 from pycbc.results.color import ifo_color
 import pycbc.version

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -150,7 +150,7 @@ scheme.insert_processing_option_group(parser)
 fft.insert_fft_option_group(parser)
 pycbc.opt.insert_optimization_option_group(parser)
 pycbc.weave.insert_weave_option_group(parser)
-pycbc.injcuter.insert_injcutter_option_group(parser)
+pycbc.injcutter.insert_injcutter_option_group(parser)
 
 opt = parser.parse_args()
 
@@ -165,7 +165,7 @@ pycbc.weave.verify_weave_options(opt, parser)
 
 pycbc.init_logging(opt.verbose)
 
-injcutter = pycbc.injcutter.from_cli(opt)
+injcutter = pycbc.injcutter.InjCutter.from_cli(opt)
 ctx = scheme.from_cli(opt)
 gwstrain = strain.from_cli(opt, dyn_range_fac=DYN_RANGE_FAC,
                            injcutter=injcutter)
@@ -294,10 +294,6 @@ with ctx:
             if not injcutter.template_segment_checker(bank, t_num, gwstrain,
                                                       stilde, 
                                                       opt.gps_start_time):
-                continue
-            filter_check = bank.template_segment_checker(t_num,
-                gwstrain, stilde, opt.gps_start_time)
-            if filter_check is False:
                 continue
             if not tmplt_generated:
                 template = bank[t_num]

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -25,6 +25,7 @@ from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, complex64
 import pycbc.fft.fftw, pycbc.version
 import pycbc.opt
 import pycbc.weave
+import pycbc.injcutter
 import time
 
 tstart = time.time()
@@ -149,6 +150,7 @@ scheme.insert_processing_option_group(parser)
 fft.insert_fft_option_group(parser)
 pycbc.opt.insert_optimization_option_group(parser)
 pycbc.weave.insert_weave_option_group(parser)
+pycbc.injcuter.insert_injcutter_option_group(parser)
 
 opt = parser.parse_args()
 
@@ -163,8 +165,10 @@ pycbc.weave.verify_weave_options(opt, parser)
 
 pycbc.init_logging(opt.verbose)
 
+injcutter = pycbc.injcutter.from_cli(opt)
 ctx = scheme.from_cli(opt)
-gwstrain = strain.from_cli(opt, DYN_RANGE_FAC)
+gwstrain = strain.from_cli(opt, dyn_range_fac=DYN_RANGE_FAC,
+                           injcutter=injcutter)
 strain_segments = strain.StrainSegments.from_cli(opt, gwstrain)
       
 
@@ -271,7 +275,7 @@ with ctx:
     nfilters = 0
 
     logging.info("Full template bank size: %s", ntemplates)
-    bank.template_thinning(gwstrain)
+    bank.template_thinning(injcutter, gwstrain.injections)
     if not len(bank) == ntemplates:
         logging.info("Template bank size after thinning: %s", len(bank))
 
@@ -287,6 +291,10 @@ with ctx:
         for s_num, stilde in enumerate(segments):
             # Filter check checks the 'injcutter' options to determine whether
             # to filter this template/segment if injections are present.
+            if not injcutter.template_segment_checker(bank, t_num, gwstrain,
+                                                      stilde, 
+                                                      opt.gps_start_time):
+                continue
             filter_check = bank.template_segment_checker(t_num,
                 gwstrain, stilde, opt.gps_start_time)
             if filter_check is False:

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -140,11 +140,6 @@ parser.add_argument("--keep-loudest-interval", type=float,
 parser.add_argument("--keep-loudest-num", type=int,
                     help="Number of triggers to keep from each maximization interval")
 parser.add_argument("--gpu-callback-method", default='none')
-parser.add_argument("--threshold-template-filtering", type= float)
-
-
-
-
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -272,33 +267,47 @@ with ctx:
                     taper=opt.taper_template, approximant=opt.approximant,
                     out=template_mem, max_template_length=opt.max_template_length)
 
-    if opt.injection_file is not None and \
-            opt.threshold_template_filtering is not None:
-        logging.info("Template Bank Size Before Cut: %s", len(bank))
-        bank.table = bank.template_thinning(gwstrain.injections.table,
-                                            opt.threshold_template_filtering)
-        logging.info("Template Bank Size After Cut: %s", len(bank))
-      
     ntemplates = len(bank)
+    nfilters = 0
+
+    logging.info("Full template bank size: %s", ntemplates)
+    bank.template_thinning(gwstrain)
+    if not len(bank) == ntemplates:
+        logging.info("Template bank size after thinning: %s", len(bank))
+
     tsetup = time.time() - tstart
 
     # Note: in the class-based approach used now, 'template' is not explicitly used
     # within the loop.  Rather, the iteration simply fills the memory specifed in
     # the 'template_mem' argument to MatchedFilterControl with the next template
     # from the bank.
-    for t_num, template in enumerate(bank):
-        event_mgr.new_template(tmplt=template.params, sigmasq=template.sigmasq(segments[0].psd))
-
-        if opt.cluster_method == "window":
-            cluster_window = int(opt.cluster_window * gwstrain.sample_rate)
-        if opt.cluster_method == "template":
-            cluster_window = int(template.chirp_length * gwstrain.sample_rate)
-
+    for t_num in xrange(len(bank)):
+        tmplt_generated = False
 
         for s_num, stilde in enumerate(segments):
+            # Filter check checks the 'injcutter' options to determine whether
+            # to filter this template/segment if injections are present.
+            filter_check = bank.template_segment_checker(t_num,
+                gwstrain, stilde, opt.gps_start_time)
+            if filter_check is False:
+                continue
+            if not tmplt_generated:
+                template = bank[t_num]
+                event_mgr.new_template(tmplt=template.params,
+                    sigmasq=template.sigmasq(segments[0].psd))
+                tmplt_generated = True
+
+            if opt.cluster_method == "window":
+                cluster_window = int(opt.cluster_window * gwstrain.sample_rate)
+            if opt.cluster_method == "template":
+                cluster_window = \
+                    int(template.chirp_length * gwstrain.sample_rate)
+
+
             logging.info("Filtering template %d/%d segment %d/%d" %
                          (t_num + 1, len(bank), s_num + 1, len(segments)))
 
+            nfilters = nfilters + 1
             snr, norm, corr, idx, snrv = \
                matched_filter.matched_filter_and_cluster(s_num, template.sigmasq(stilde.psd), cluster_window)
 
@@ -362,7 +371,7 @@ if opt.maximization_interval:
 
 tstop = time.time()
 run_time = tstop - tstart
-event_mgr.save_performance(ncores, ntemplates, run_time, tsetup)
+event_mgr.save_performance(ncores, nfilters, ntemplates, run_time, tsetup)
 
 logging.info("Writing out triggers")
 event_mgr.write_events(opt.output)

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -373,13 +373,15 @@ class EventManager(object):
             if not os.path.exists(path) and path is not None:
                 os.makedirs(path)
 
-    def save_performance(self, ncores, ntemplates, run_time, setup_time):
+    def save_performance(self, ncores, nfilters, ntemplates, run_time,
+                         setup_time):
         """
         Calls variables from pycbc_inspiral to be used in a timing calculation
         """
         self.run_time = run_time
         self.setup_time = setup_time
         self.ncores = ncores
+        self.nfilters = nfilters
         self.ntemplates = ntemplates
         self.write_performance = True
 
@@ -480,8 +482,11 @@ class EventManager(object):
             self.analysis_time = search_end_time - search_start_time
             time_ratio = numpy.array([float(self.analysis_time) / float(self.run_time)])
             temps_per_core = float(self.ntemplates) / float(self.ncores)
+            filters_per_core = float(self.nfilters) / float(self.ncores)
             f['search/templates_per_core'] = \
                 numpy.array([float(temps_per_core) * float(time_ratio)])
+            f['search/filter_rate_per_core'] = \
+                numpy.array([filters_per_core / float(self.run_time)])
             f['search/setup_time_fraction'] = \
                 numpy.array([float(self.setup_time) / float(self.run_time)])
 

--- a/pycbc/injcutter.py
+++ b/pycbc/injcutter.py
@@ -1,0 +1,229 @@
+# Copyright (C) 2013 Ian Harry
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Generals
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This module contains functions to filter injections with only useful templates.
+
+This module implements a set of checks to test for each segment and template
+combination whether injections contained within the segment are sufficiently
+"similar" to the template to require a matched-filter. There are a few ways of
+testing the "similarity" of templates and injections.
+ * A chirp time threshold rejects templates if chirp time difference is large
+ * A coarse match threshold rejects templates if a coarse overlap is small
+"""
+
+from pycbc import DYN_RANGE_FAC
+from pycbc.pnutils import nearest_larger_binary_number
+
+_injcutter_group_help = ("Options that, if injections are present in this "
+                         "run, are responsible for performing pre-checks "
+                         "between injections in the data being filtered and "
+                         "the current search template "
+                         "to determine if the template has any chance of "
+                         "actually detecting the injection. The parameters "
+                         "of this test are given by the various injcutter "
+                         "options below. The --injcutter-chirp-time-threshold "
+                         "and --injcutter-match-threshold options need to be "
+                         "provided if those tests are desired. Other options "
+                         "will take default values unless overriden. More "
+                         "details on these options follow.")
+
+_enable_cutter_help = ("If given 'injcutter' will be enabled.")
+
+_injcutter_cthresh_help = ("If this value is not None and injcutter is "
+                           "enabled then we will calculate the difference in "
+                           "chirp time (tau_0) between the template and each "
+                           "injection in the analysis segment. If the "
+                           "difference is greate than this threshold for all "
+                           "injections then filtering is not performed. By "
+                           "default this will be None.")
+_injcutter_mthresh_help = ("If this value is not None and injcutter is "
+                           "enabled then we will calculate a 'coarse match' "
+                           "between the template and each injection in the "
+                           "analysis segment. If the match is less than this "
+                           "threshold for all injections filtering is not "
+                           "performed. Parameters for the 'coarse match' "
+                           "follow. By default this value will be None.")
+_injcutter_deltaf_help = ("If injcutter is enabled and "
+                          "injcutter-match-threshold is not None, this option "
+                          "specifies the frequency spacing that will be used "
+                          "for injections, templates and PSD when computing "
+                          "the 'coarse match'. Templates will be generated "
+                          "directly with this spacing. The PSD and injections "
+                          "will be resampled.")
+_injcutter_fmax_help = ("If injcutter is enabled and "
+                        "injcutter-match-threshold is not None, this option "
+                        "specifies the maximum frequency that will be used "
+                        "for injections, templates and PSD when computing "
+                        "the 'coarse match'. Templates will be generated "
+                        "directly with this max frequency. The PSD and "
+                        "injections frequency series will be truncated.")
+_injcutter_buffer_help = ("If injcutter is enabled, the injcutter tests "
+                          "will determine if injections are 'in' the "
+                          "specified analysis chunk by using the end times. "
+                          "If this value is non-zero the analysis chunk is "
+                          "extended on both sides by this amount before "
+                          "determining if injections are within the given "
+                          "window.")
+_injcutter_flower_help = ("If injcutter is enabled, the injcutter tests "
+                          "need a lower frequency for determine chirp times "
+                          "or for doing matches. If this value is None the "
+                          "lower frequency used for the full matched-filter "
+                          "if used. Otherwise this value is used instead.")
+
+def insert_injcutter_option_group(parser):
+    injcutter_group = parser.add_argument_group(_injcutter_group_help)
+    injcutter_group.add_argument("--enable-injcutter", action="store_true",
+                                 default=False, help=_enable_cutter_help)
+    injcutter_group.add_argument("--injcutter-chirp-time-threshold",
+                                 type=float, default=None,
+                                 help=_injcutter_cthresh_help)
+    injcutter_group.add_argument("--injcutter-match-threshold", type=float,
+                                 default=None, help=_injcutter_mthresh_help)
+    injcutter_group.add_argument("--injcutter-coarsematch-deltaf",
+                                 type=float, default=1.,
+                                 help=_injcutter_deltaf_help)
+    injcutter_group.add_argument("--injcutter-coarsematch-fmax", type=float,
+                                 default=256., help=_injcutter_fmax_help)
+    injcutter_group.add_argument("--injcutter-seg-buffer", type=int,
+                                 default=10, help=_injcutter_buffer_help)
+    injcutter_group.add_argument("--injcutter-f-lower", type=int,
+                                 default=None, help=_injcutter_flower_help)
+
+
+class InjCutter(object):
+    """
+    Class for holding parameters for using injection/template pre-filtering.
+    """
+    def __init__(self, injection_file, chirp_time_threshold,
+                 match_threshold, f_lower, coarsematch_deltaf=1.,
+                 seg_buffer=10):
+        """ Initialise injcutter instance.
+        """
+        # Determine if injcutter is to be enabled
+        if injection_file is None or injection_file == 'False' or\
+            (chirp_time_threshold is None and match_threshold is None):
+            self.enabled = False
+            return
+        else:
+            self.enabled = True
+
+        # Store parameters
+        self.chirp_time_threshold = chirp_time_threshold
+        self.match_threshold = match_threshold
+        self.coarsematch_deltaf = coarsematch_deltaf
+        self.coarsematch_fmax = coarsematch_fmax
+        self.seg_buffer = seg_buffer
+        self.f_lower = f_lower
+        assert(self.f_lower is not None)
+
+        # Variables for holding injcutter inputs (reduced injections, memory
+        # for templates, reduced PSDs ...)
+        self.short_injections = {}
+
+    @classmethod
+    def from_cli(self, opt):
+        """
+        Initialize an InjCutter instance from command-line options.
+        """
+        injection_file = opt.injection_file
+        chirp_time_threshold = opt.injcutter_chirp_time_threshold
+        match_threshold = opt.injcutter_match_threshold
+        coarsematch_deltaf = opt.injcutter_coarsematch_deltaf
+        coarsematch_fmax = opt.injcutter_coarsematch_fmax
+        seg_buffer = opt.injcutter_seg_buffer
+        if opt.injcutter_f_lower is not None:
+            f_lower = opt.injcutter_f_lower
+        else:
+            # NOTE: Uses main low-frequency cutoff as default option. This may
+            #       need some editing if using this in multi_inspiral, which I
+            #       leave for future work, or if this is being used in another
+            #       code which doesn't have --low-frequency-cutoff
+            f_lower = opt.low_frequency_cutoff
+        return cls(injection_file, chirp_time_threshold, match_threshold,
+                   f_lower, coarsematch_deltaf=coarsematch_deltaf,
+                   seg_buffer=seg_buffer)
+
+    def generate_short_inj_from_inj(self, inj_waveform, simulation_id):
+        """
+        Generate and a store a truncated representation of inj_waveform.
+        """
+        if not self.enabled:
+            # Do nothing!
+            return
+        if self.short_injections.has_key(simulation_id):
+            err_msg = "An injection with simulation id "
+            err_msg += str(simulation_id)
+            err_msg += " has already been added to injcutter. This suggests "
+            err_msg += "that your injection file contains injections with "
+            err_msg += "duplicate simulation_ids. This is not allowed."
+            raise ValueError(err_msg)
+        curr_length = len(inj_waveform)
+        new_length = int(nearest_larger_binary_number(inj_length))
+        # Don't want length less than 1/delta_f
+        while new_length * inj_waveform.delta_t < 1./self.coarsematch_deltaf:
+            new_length = new_length * 2
+        inj_waveform.resize(new_length)
+        inj_tilde = inj_waveform.to_frequencyseries()
+        # Dynamic range is important here!
+        inj_tilde_np = inj_tilde.numpy() * DYN_RANGE_FAC
+        delta_f = inj_tilde.get_delta_f()
+        new_freq_len = int(self.coarsematch_deltaf / delta_f + 1)
+        # This shouldn't be a problem if injections are generated at
+        # 16384 Hz ... It is only a problem of injection sample rate
+        # gives a lower Nyquist than the trunc_f_max. If this error is
+        # ever raised one could consider zero-padding the injection.
+        assert(new_freq_len <= len(inj_tilde))
+        df_ratio = int(self.coarsematch_deltaf/delta_f)
+        inj_tilde_np = inj_tilde_np[:new_freq_len:df_ratio]
+        new_inj = FrequencySeries(inj_tilde_np, dtype=np.complex64,
+                                  delta_f=self.coarsematch_deltaf)
+        self.short_injections[simulation_id] = new_inj
+
+    def template_segment_checker(self, bank, t_num, gwstrain, segment,
+                                 start_time):
+        """ Test if injections in segment are worth filtering with template.
+
+        Using the current template, current segment, and injections within that
+        segment. Test if the injections and sufficiently "similar" to any of
+        the injections to justify actually performing a matched-filter call.
+        Ther are two parts to this test: First we check if the chirp time of
+        the template is within a provided window of any of the injections. If
+        not then stop here, it is not worth filtering this template, segment
+        combination for this injection set. If this check passes we compute a
+        match between a coarse representation of the template and a coarse
+        representation of each of the injections. If that match is above a
+        user-provided value for any of the injections then filtering can
+        proceed. This is currently only available if using frequency-domain
+        templates.
+
+        Parameters
+        -----------
+        FIXME
+
+        Returns
+        --------
+        FIXME
+        """
+        if not self.enabled:
+            # Do nothing!
+            return
+
+        if self.chirp_time_threshold is not None:
+            m1 = bank.table[t_num]['mass1']
+            m2 = bank.table[t_num]['mass2']
+            tau0_temp, tau3_temp = \
+                pycbc.pnutils.mass1_mass2_to_tau0_tau3(m1, m2, f_ref)
+

--- a/pycbc/injcutter.py
+++ b/pycbc/injcutter.py
@@ -28,6 +28,7 @@ import numpy as np
 from pycbc import DYN_RANGE_FAC
 from pycbc.filter import match
 from pycbc.pnutils import nearest_larger_binary_number
+from pycbc.pnutils import mass1_mass2_to_tau0_tau3
 from pycbc.types import FrequencySeries, zeros
 
 _injcutter_group_help = ("Options that, if injections are present in this "
@@ -244,19 +245,18 @@ class InjCutter(object):
         if self.chirp_time_threshold is not None:
             m1 = bank.table[t_num]['mass1']
             m2 = bank.table[t_num]['mass2']
-            tau0_temp, tau3_temp = \
-                pycbc.pnutils.mass1_mass2_to_tau0_tau3(m1, m2, self.f_lower)
+            tau0_temp, tau3_temp = mass1_mass2_to_tau0_tau3(m1, m2,
+                                                            self.f_lower)
             for inj_idx, inj in enumerate(gwstrain.injections.table):
                 end_time = inj.geocent_end_time + \
                     1E-9 * inj.geocent_end_time_ns
                 if end_time > seg_end_time or end_time < seg_start_time:
                     continue
                 tau0_inj, tau3_inj = \
-                    pycbc.pnutils.mass1_mass2_to_tau0_tau3(inj.mass1,
-                                                           inj.mass2,
-                                                           self.f_lower)
+                    mass1_mass2_to_tau0_tau3(inj.mass1, inj.mass2,
+                                             self.f_lower)
                 tau_diff = abs(tau0_temp - tau0_inj)
-                if tau_diff <= ic_params['chirp_time_threshold']:
+                if tau_diff <= self.chirp_time_threshold:
                     break
             else:
                 # Get's here if all injections are outside chirp-time window
@@ -290,7 +290,7 @@ class InjCutter(object):
                     wav_len = 1 + int(self.coarsematch_fmax / \
                                       self.coarsematch_deltaf)
                     self._short_template_mem = zeros(wav_len,
-                                                     dtype=numpy.complex64)
+                                                     dtype=np.complex64)
                 # Generate short waveform
                 htilde = bank.generate_custom_size_waveform(
                     t_num, self.coarsematch_fmax, self.coarsematch_deltaf,

--- a/pycbc/inject.py
+++ b/pycbc/inject.py
@@ -172,7 +172,7 @@ class InjectionSet(object):
             signal_lal = signal.lal()
             add_injection(lalstrain, signal_lal, None)
             injection_parameters.append(inj)                            
-            if strain.injcutter is not None and \
+            if hasattr(strain, "injcutter") and strain.injcutter is not None and \
                     strain.injcutter['match_threshold'] is not None:
                 # If doing injcutter, store a coarse representation of each
                 # injection.

--- a/pycbc/inject.py
+++ b/pycbc/inject.py
@@ -35,7 +35,7 @@ from pycbc.waveform import get_td_waveform, utils as wfutils
 from pycbc.waveform import ringdown_td_approximants
 from glue.ligolw import utils as ligolw_utils
 from glue.ligolw import ligolw, table, lsctables
-from pycbc.types import float64, float32, TimeSeries, FrequencySeries
+from pycbc.types import float64, float32, TimeSeries
 from pycbc.detector import Detector
 
 injection_func_map = {

--- a/pycbc/inject.py
+++ b/pycbc/inject.py
@@ -177,7 +177,6 @@ class InjectionSet(object):
                 # If doing injcutter, store a coarse representation of each
                 # injection.
                 ic_params = strain.injcutter
-                f_ref = ic_params['f_lower']
                 trunc_f_max = ic_params['coarsematch_fmax']
                 trunc_delta_f = ic_params['coarsematch_deltaf']
                 inj_length = len(signal)

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -200,6 +200,34 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
     """
 
     gating_info = {}
+
+    # Set up injcutter options
+    if opt.injection_file and opt.enable_injcutter:
+        injcutter = {}
+        injcutter['chirp_time_threshold'] = opt.injcutter_chirp_time_threshold
+        injcutter['match_threshold'] = opt.injcutter_match_threshold
+        injcutter['coarsematch_deltaf'] = opt.injcutter_coarsematch_deltaf
+        injcutter['coarsematch_fmax'] = opt.injcutter_coarsematch_fmax
+        injcutter['seg_buffer'] = opt.injcutter_seg_buffer
+        if opt.injcutter_f_lower is not None:
+            injcutter['f_lower'] = opt.injcutter_f_lower
+        else:
+            # NOTE: pycbc_inspiral uses this as it's fallback option. This may
+            #       need some editing if using this in multi_inspiral, which I
+            #       leave for future work, or if this is being used in another
+            #       code which doesn't have --low-frequency-cutoff
+            injcutter['f_lower'] = opt.low_frequency_cutoff
+
+        # Sanity check:
+        if opt.injcutter_chirp_time_threshold is None and \
+                opt.injcutter_match_threshold is None:
+            warn_msg = 'You have enabled injcutter, but no injcutter tests '
+            warn_msg += 'are enabled. Therefore injcutter is being disabled.'
+            logging.warn(warn_msg)
+            injcutter = None
+    else:
+        injcutter = None
+
     if opt.frame_cache or opt.frame_files or opt.frame_type:
         if opt.frame_cache:
             frame_source = opt.frame_cache
@@ -232,6 +260,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
             l = opt.normalize_strain
             strain = strain / l
 
+        strain.injcutter = injcutter
         if opt.injection_file:
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
@@ -321,6 +350,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
                                                 seed=opt.fake_strain_seed)
         strain._epoch = lal.LIGOTimeGPS(opt.gps_start_time)
 
+        strain.injcutter = injcutter
         if opt.injection_file:
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
@@ -342,9 +372,6 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
             logging.info("Converting to float32")
             strain = (dyn_range_fac * strain).astype(pycbc.types.float32)
 
-    if opt.injection_file:
-        strain.injections = injections
-
     if opt.taper_data:
         logging.info("Tapering data")
         # Use auto-gating stuff for this, a one-sided gate is a taper
@@ -355,7 +382,11 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
         gate_data(strain, gate_params)
 
 
+    strain.injcutter = injcutter
+    if opt.injection_file:
+        strain.injections = injections
     strain.gating_info = gating_info
+
     return strain  
 
 def from_cli_single_ifo(opt, ifo, **kwargs):
@@ -760,6 +791,57 @@ def gate_data(data, gate_params):
 
     return data
 
+_enable_cutter_help=("If given 'injcutter' will be enabled. This means "
+                     "that if injections are present in this run, we "
+                     "will perform a pre-check between injections in the "
+                     "data being filtered and the current search template "
+                     "to determine if the template has any chance of "
+                     "actually detecting the injection. The parameters "
+                     "of this test are given by the various injcutter "
+                     "options below. The --injcutter-chirp-time-threshold "
+                     "and --injcutter-match-threshold options need to be "
+                     "provided if those tests are desired. Other options "
+                     "will take default values unless overriden. More "
+                     "details on these options follow.")
+_injcutter_cthresh_help=("If this value is not None and injcutter is enabled "
+                         "we will calculate the difference in chirp time "
+                         "(tau_0) between the template and each injection in "
+                         "the analysis segment. If the difference is greater "
+                         "than this threshold for all injections then "
+                         "filtering is not performed. By default this will "
+                         "be None.")
+_injcutter_mthresh_help=("If this value is not None and injcutter is enabled "
+                         "we will calculate a 'coarse match' between the "
+                         "template and each injection in the analysis "
+                         "segment. If the match is less than this threshold "
+                         "for all injections filtering is not performed. "
+                         "Parameters for the 'coarse match' follow. By "
+                         "default this value will be None.")
+_injcutter_deltaf_help=("If injcutter is enabled and "
+                        "injcutter-match-threshold is not None, this option "
+                        "specifies the frequency spacing that will be used "
+                        "for injections, templates and PSD when computing "
+                        "the 'coarse match'. Templates will be generated "
+                        "directly with this spacing. The PSD and injections "
+                        "will be resampled.")
+_injcutter_fmax_help=("If injcutter is enabled and "
+                      "injcutter-match-threshold is not None, this option "
+                      "specifies the maximum frequency that will be used "
+                      "for injections, templates and PSD when computing "
+                      "the 'coarse match'. Templates will be generated "
+                      "directly with this max frequency. The PSD and "
+                      "injections frequency series will be truncated.")
+_injcutter_buffer_help=("If injcutter is enabled, the injcutter tests "
+                        "will determine if injections are 'in' the specified "
+                        "analysis chunk by using the end times. If this "
+                        "value is non-zero the analysis chunk is extended "
+                        "on both sides by this amount before determing if "
+                        "injections are within the given window.")
+_injcutter_flower_help=("If injcutter is enabled, the injcutter tests "
+                        "need a lower frequency for determine chirp times or "
+                        "for doing matches. If this value is None the "
+                        "lower frequency used for the full matched-filter is "
+                        "used. Otherwise this value is used instead.")
 class StrainSegments(object):
     """ Class for managing manipulation of strain data for the purpose of
         matched filtering. This includes methods for segmenting and
@@ -971,6 +1053,10 @@ class StrainSegments(object):
         segment_group.add_argument("--segment-end-pad", type=int,
                           help="The time in seconds to ignore at the "
                                "end of each segment in seconds.")
+        segment_group.add_argument("--allow-zero-padding", action='store_true',
+                          help="Allow for zero padding of data to analyze "
+                          "requested times, if needed.")
+        # Injection optimization options
         segment_group.add_argument("--filter-inj-only", action='store_true',
                           help="Analyze only segments that contain an injection.")
         segment_group.add_argument("--injection-window", default=None,
@@ -982,9 +1068,22 @@ class StrainSegments(object):
                           filter at full rate where needed. NOTE: Reverts to
                           full analysis if two injections are in the same
                           segment.""")
-        segment_group.add_argument("--allow-zero-padding", action='store_true',
-                          help="Allow for zero padding of data to analyze "
-                          "requested times, if needed.")
+        segment_group.add_argument("--enable-injcutter", action="store_true",
+                                   default=False, help=_enable_cutter_help)
+        segment_group.add_argument("--injcutter-chirp-time-threshold",
+                                   type=float, default=None,
+                                   help=_injcutter_cthresh_help)
+        segment_group.add_argument("--injcutter-match-threshold", type=float,
+                                   default=None, help=_injcutter_mthresh_help)
+        segment_group.add_argument("--injcutter-coarsematch-deltaf",
+                                   type=float, default=1.,
+                                   help=_injcutter_deltaf_help)
+        segment_group.add_argument("--injcutter-coarsematch-fmax", type=float,
+                                   default=256., help=_injcutter_fmax_help)
+        segment_group.add_argument("--injcutter-seg-buffer", type=int,
+                                   default=10, help=_injcutter_buffer_help)
+        segment_group.add_argument("--injcutter-f-lower", type=int,
+                                   default=None, help=_injcutter_flower_help)
 
 
     @classmethod
@@ -1037,11 +1136,26 @@ class StrainSegments(object):
                     nargs='+', action=MultiDetOptionAction, metavar='IFO:TIME',
                     help="The time in seconds to ignore at the "
                          "end of each segment in seconds.")
-        segment_group.add_argument("--filter-inj-only", action='store_true',
-                    help="Analyze only segments that contain an injection.")
         segment_group.add_argument("--allow-zero-padding", action='store_true',
                           help="Allow for zero padding of data to analyze "
                           "requested times, if needed.")
+        segment_group.add_argument("--filter-inj-only", action='store_true',
+                    help="Analyze only segments that contain an injection.")
+        segment_group.add_argument("--enable-injcutter", action="store_true",                                      default=False, help=_enable_cutter_help)
+        segment_group.add_argument("--injcutter-chirp-time-threshold",
+                                   type=float, default=None,
+                                   help=_injcutter_cthresh_help)
+        segment_group.add_argument("--injcutter-match-threshold", type=float,
+                                   default=None, help=_injcutter_mthresh_help)
+        segment_group.add_argument("--injcutter-coarsematch-deltaf",
+                                   type=float, default=1.,
+                                   help=_injcutter_deltaf_help)
+        segment_group.add_argument("--injcutter-coarsematch-fmax", type=float,
+                                   default=1., help=_injcutter_fmax_help)
+        segment_group.add_argument("--injcutter-seg-buffer", type=int,
+                                   default=10, help=_injcutter_buffer_help)
+        segment_group.add_argument("--injcutter-f-lower", type=int,
+                                   default=None, help=_injcutter_flower_help)
 
     required_opts_list = ['--segment-length',
                    '--segment-start-pad',

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -381,7 +381,6 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
                              pd_taper_window) )
         gate_data(strain, gate_params)
 
-
     strain.injcutter = injcutter
     if opt.injection_file:
         strain.injections = injections
@@ -791,57 +790,58 @@ def gate_data(data, gate_params):
 
     return data
 
-_enable_cutter_help=("If given 'injcutter' will be enabled. This means "
-                     "that if injections are present in this run, we "
-                     "will perform a pre-check between injections in the "
-                     "data being filtered and the current search template "
-                     "to determine if the template has any chance of "
-                     "actually detecting the injection. The parameters "
-                     "of this test are given by the various injcutter "
-                     "options below. The --injcutter-chirp-time-threshold "
-                     "and --injcutter-match-threshold options need to be "
-                     "provided if those tests are desired. Other options "
-                     "will take default values unless overriden. More "
-                     "details on these options follow.")
-_injcutter_cthresh_help=("If this value is not None and injcutter is enabled "
-                         "we will calculate the difference in chirp time "
-                         "(tau_0) between the template and each injection in "
-                         "the analysis segment. If the difference is greater "
-                         "than this threshold for all injections then "
-                         "filtering is not performed. By default this will "
-                         "be None.")
-_injcutter_mthresh_help=("If this value is not None and injcutter is enabled "
-                         "we will calculate a 'coarse match' between the "
-                         "template and each injection in the analysis "
-                         "segment. If the match is less than this threshold "
-                         "for all injections filtering is not performed. "
-                         "Parameters for the 'coarse match' follow. By "
-                         "default this value will be None.")
-_injcutter_deltaf_help=("If injcutter is enabled and "
+_enable_cutter_help = ("If given 'injcutter' will be enabled. This means "
+                       "that if injections are present in this run, we "
+                       "will perform a pre-check between injections in the "
+                       "data being filtered and the current search template "
+                       "to determine if the template has any chance of "
+                       "actually detecting the injection. The parameters "
+                       "of this test are given by the various injcutter "
+                       "options below. The --injcutter-chirp-time-threshold "
+                       "and --injcutter-match-threshold options need to be "
+                       "provided if those tests are desired. Other options "
+                       "will take default values unless overriden. More "
+                       "details on these options follow.")
+_injcutter_cthresh_help = ("If this value is not None and injcutter is "
+                           "enabled then we will calculate the difference in "
+                           "chirp time (tau_0) between the template and each "
+                           "injection in the analysis segment. If the "
+                           "difference is greate than this threshold for all "
+                           "injections then filtering is not performed. By "
+                           "default this will be None.")
+_injcutter_mthresh_help = ("If this value is not None and injcutter is "
+                           "enabled then we will calculate a 'coarse match' "
+                           "between the template and each injection in the "
+                           "analysis segment. If the match is less than this "
+                           "threshold for all injections filtering is not "
+                           "performed. Parameters for the 'coarse match' "
+                           "follow. By default this value will be None.")
+_injcutter_deltaf_help = ("If injcutter is enabled and "
+                          "injcutter-match-threshold is not None, this option "
+                          "specifies the frequency spacing that will be used "
+                          "for injections, templates and PSD when computing "
+                          "the 'coarse match'. Templates will be generated "
+                          "directly with this spacing. The PSD and injections "
+                          "will be resampled.")
+_injcutter_fmax_help = ("If injcutter is enabled and "
                         "injcutter-match-threshold is not None, this option "
-                        "specifies the frequency spacing that will be used "
+                        "specifies the maximum frequency that will be used "
                         "for injections, templates and PSD when computing "
                         "the 'coarse match'. Templates will be generated "
-                        "directly with this spacing. The PSD and injections "
-                        "will be resampled.")
-_injcutter_fmax_help=("If injcutter is enabled and "
-                      "injcutter-match-threshold is not None, this option "
-                      "specifies the maximum frequency that will be used "
-                      "for injections, templates and PSD when computing "
-                      "the 'coarse match'. Templates will be generated "
-                      "directly with this max frequency. The PSD and "
-                      "injections frequency series will be truncated.")
-_injcutter_buffer_help=("If injcutter is enabled, the injcutter tests "
-                        "will determine if injections are 'in' the specified "
-                        "analysis chunk by using the end times. If this "
-                        "value is non-zero the analysis chunk is extended "
-                        "on both sides by this amount before determing if "
-                        "injections are within the given window.")
-_injcutter_flower_help=("If injcutter is enabled, the injcutter tests "
-                        "need a lower frequency for determine chirp times or "
-                        "for doing matches. If this value is None the "
-                        "lower frequency used for the full matched-filter is "
-                        "used. Otherwise this value is used instead.")
+                        "directly with this max frequency. The PSD and "
+                        "injections frequency series will be truncated.")
+_injcutter_buffer_help = ("If injcutter is enabled, the injcutter tests "
+                          "will determine if injections are 'in' the "
+                          "specified analysis chunk by using the end times. "
+                          "If this value is non-zero the analysis chunk is "
+                          "extended on both sides by this amount before "
+                          "determining if injections are within the given "
+                          "window.")
+_injcutter_flower_help = ("If injcutter is enabled, the injcutter tests "
+                          "need a lower frequency for determine chirp times "
+                          "or for doing matches. If this value is None the "
+                          "lower frequency used for the full matched-filter "
+                          "if used. Otherwise this value is used instead.")
 class StrainSegments(object):
     """ Class for managing manipulation of strain data for the purpose of
         matched filtering. This includes methods for segmenting and
@@ -1054,8 +1054,8 @@ class StrainSegments(object):
                           help="The time in seconds to ignore at the "
                                "end of each segment in seconds.")
         segment_group.add_argument("--allow-zero-padding", action='store_true',
-                          help="Allow for zero padding of data to analyze "
-                          "requested times, if needed.")
+                                   help="Allow for zero padding of data to "
+                                        "analyze requested times, if needed.")
         # Injection optimization options
         segment_group.add_argument("--filter-inj-only", action='store_true',
                           help="Analyze only segments that contain an injection.")
@@ -1140,8 +1140,10 @@ class StrainSegments(object):
                           help="Allow for zero padding of data to analyze "
                           "requested times, if needed.")
         segment_group.add_argument("--filter-inj-only", action='store_true',
-                    help="Analyze only segments that contain an injection.")
-        segment_group.add_argument("--enable-injcutter", action="store_true",                                      default=False, help=_enable_cutter_help)
+                                   help="Analyze only segments that contain "
+                                        "an injection.")
+        segment_group.add_argument("--enable-injcutter", action="store_true",
+                                   default=False, help=_enable_cutter_help)
         segment_group.add_argument("--injcutter-chirp-time-threshold",
                                    type=float, default=None,
                                    help=_injcutter_cthresh_help)

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -521,12 +521,12 @@ class TemplateBank(object):
 
         # Get times covered by segment analyze
         seg_start_time = \
-            segment.cumulative_index / float(gwstrain.sample_rate) \
-            + start_time
+            segment.cumulative_index / float(gwstrain.sample_rate) + \
+            start_time
         seg_end_time = \
-            (segment.cumulative_index
-             + (segment.analyze.stop - segment.analyze.start)) \
-            / float(gwstrain.sample_rate) + start_time
+            (segment.cumulative_index +
+             (segment.analyze.stop - segment.analyze.start)) / \
+            float(gwstrain.sample_rate) + start_time
         # And add buffer
         seg_start_time = seg_start_time - seg_buffer
         seg_end_time = seg_end_time + seg_buffer

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -310,12 +310,6 @@ class TemplateBank(object):
         self.extra_args = kwds
         self.ensure_hash()
 
-        # Variables for the injection-segment filter checker
-        self._tsc_short_template_id = None
-        self._tsc_short_template_mem = None
-        self._tsc_short_template_wav = None
-        self._tsc_short_psd_storage = {}
-
     @property
     def parameters(self):
         return self.table.fieldnames

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -38,8 +38,6 @@ import pycbc.pnutils
 import pycbc.waveform.compress
 from pycbc import DYN_RANGE_FAC
 from pycbc.types import zeros
-from pycbc.filter import match
-from pycbc.types import FrequencySeries
 import pycbc.io
 
 def sigma_cached(self, psd):
@@ -418,7 +416,6 @@ class TemplateBank(object):
             f_lower=low_freq_cutoff, f_final=max_freq, delta_f=delta_f,
             distance=1./DYN_RANGE_FAC, delta_t=1./(2.*max_freq))
         return htilde
-        
 
     def template_thinning(self, injcutter, injections):
         if not injcutter.enabled or injcutter.chirp_time_threshold is None:

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -30,14 +30,17 @@ import numpy
 import logging
 import os.path
 import h5py
-import pycbc.waveform
-import pycbc.waveform.compress
-from pycbc.types import zeros
-from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
-from pycbc import DYN_RANGE_FAC
-import pycbc.io
 from copy import copy
 import numpy as np
+from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
+import pycbc.waveform
+import pycbc.waveform.compress
+from pycbc import DYN_RANGE_FAC
+from pycbc.types import zeros
+from pycbc.filter import sigmasq, match
+from pycbc.pnutils import mass1_mass2_to_tau0_tau3
+from pycbc.types import FrequencySeries
+import pycbc.io
 
 def sigma_cached(self, psd):
     """ Cache sigma calculate for use in tandem with the FilterBank class
@@ -307,6 +310,12 @@ class TemplateBank(object):
         self.extra_args = kwds
         self.ensure_hash()
 
+        # Variables for the injection-segment filter checker
+        self._tsc_short_template_id = None
+        self._tsc_short_template_mem = None
+        self._tsc_short_template_wav = None
+        self._tsc_short_psd_storage = {}
+
     @property
     def parameters(self):
         return self.table.fieldnames
@@ -394,24 +403,156 @@ class TemplateBank(object):
     def __len__(self):
         return len(self.table)
 
-    def template_thinning(self, injection_parameters, threshold):
-        from pycbc.pnutils import mass1_mass2_to_tau0_tau3
+    def template_thinning(self, gwstrain):
+        if gwstrain.injcutter is None or \
+                gwstrain.injcutter['chirp_time_threshold'] is None:
+            return
+
+        injection_parameters = gwstrain.injections.table
+        fref = gwstrain.injcutter['f_lower']
+        threshold = gwstrain.injcutter['chirp_time_threshold']
         m1= self.table['mass1']
         m2= self.table['mass2']
         thinning_bank = []
-        fref = 30
-        tau0_temp, tau3_temp= pycbc.pnutils.mass1_mass2_to_tau0_tau3(m1, m2, fref)
+        tau0_temp, tau3_temp= pycbc.pnutils.mass1_mass2_to_tau0_tau3(m1, m2,
+                                                                     fref)
         indices = []
             
         for inj in injection_parameters:
-            tau0_inj, tau3_inj= pycbc.pnutils.mass1_mass2_to_tau0_tau3(inj.mass1, inj.mass2, fref)    
+            tau0_inj, tau3_inj = \
+                pycbc.pnutils.mass1_mass2_to_tau0_tau3(inj.mass1, inj.mass2,
+                                                       fref)
             inj_indices = np.where(abs(tau0_temp - tau0_inj) <= threshold)[0]
             indices.append(inj_indices)
             indices_combined = np.concatenate(indices)
 
         indices_unique= np.unique(indices_combined)
-        restricted= self.table[indices_unique]
-        return restricted 
+        self.table = self.table[indices_unique]
+
+    def template_segment_checker(self, t_num, gwstrain, segment, start_time):
+        """ Test if injections in segment are worth filtering with template.
+
+        Using the current template, current segment, and injections within that
+        segment. Test if the injections and sufficiently "similar" to any of the
+        injections to justify actually performing a matched-filter call. There
+        are two parts to this test: First we check if the chirp time of the
+        template is within a provided window of any of the injections. If not
+        then stop here, it is not worth filtering this template, segment
+        combination for this injection set. If this check passes we compute a
+        match between a coarse representation of the template and a coarse
+        representation of each of the injections. If that match is above a
+        user-provided value for any of the injections then filtering can
+        proceed. This is currently only available if using frequency-domain
+        templates.
+
+        Parameters
+        -----------
+
+        Returns
+        --------
+        """
+        if gwstrain.injcutter is None:
+            return True
+
+        ic_params = gwstrain.injcutter
+        match_test = ic_params['match_threshold'] is not None
+        chirp_test = ic_params['chirp_time_threshold'] is not None
+        f_ref = ic_params['f_lower']
+        trunc_f_max = ic_params['coarsematch_fmax']
+        trunc_delta_f = ic_params['coarsematch_deltaf']
+        seg_buffer = ic_params['seg_buffer']
+        injections = gwstrain.injections
+
+        if chirp_test:
+            # Get chirp times for template
+            m1 = self.table[t_num]['mass1']
+            m2 = self.table[t_num]['mass2']
+            tau0_temp, tau3_temp = \
+                pycbc.pnutils.mass1_mass2_to_tau0_tau3(m1, m2, f_ref)
+
+        if match_test and self._tsc_short_template_mem is None:
+            wav_len = int(trunc_f_max / trunc_delta_f) + 1
+            self._tsc_short_template_mem = zeros(wav_len,
+                                                 dtype=numpy.complex64)
+
+        if match_test:
+            # Don't want to use INTERP waveforms in here
+            approximant = self.approximant(t_num)
+            if approximant.endswith('_INTERP'):
+                approximant = approximant.replace('_INTERP', '')
+            # Using SPAtmplt here is bad as the stored cbrt and logv get
+            # recalculated as we change delta_f values. Fall back to TaylorF2
+            # in lalsimulation.
+            if approximant == 'SPAtmplt':
+                approximant = 'TaylorF2'
+
+            if not hasattr(injections, 'short_truncated_injs'):
+                err_msg = 'To use a match threshold using coarse ' + \
+                          'waveforms to decide whether to compute ' + \
+                          'full matched filter, one must have stored ' + \
+                          'the injection waveforms.'
+                raise ValueError(err_msg)
+
+            try:
+                red_psd = self._tsc_short_psd_storage[id(segment.psd)]
+            except KeyError:
+                curr_psd = segment.psd.numpy()
+                step_size = int(trunc_delta_f/segment.psd.delta_f)
+                max_idx = int(trunc_f_max/segment.psd.delta_f)+1
+                red_psd_data = curr_psd[:max_idx:step_size]
+                red_psd = FrequencySeries(red_psd_data, delta_f=trunc_delta_f,
+                                          copy=False)
+                self._tsc_short_psd_storage[id(curr_psd)] = red_psd
+
+            # Generate short template
+            # WARNING: This is f-domain only! T-domain *may* work, but many
+            #          waveforms will refuse to generate.
+            if not t_num == self._tsc_short_template_id:
+                htilde = pycbc.waveform.get_waveform_filter(\
+                    self._tsc_short_template_mem, self.table[t_num],
+                    approximant=approximant, f_lower=f_ref,
+                    f_final=trunc_f_max,
+                    delta_f=trunc_delta_f, distance=1./ DYN_RANGE_FAC,
+                    delta_t = 1./(2 * trunc_f_max))
+                self._tsc_short_template_id = t_num
+                self._tsc_short_template_wav = htilde
+            else:
+                htilde = self._tsc_short_template_wav
+
+        # Get times covered by segment analyze
+        seg_start_time = \
+            segment.cumulative_index / float(gwstrain.sample_rate) \
+            + start_time
+        seg_end_time = (segment.cumulative_index \
+            + (segment.analyze.stop - segment.analyze.start)) \
+            / float(gwstrain.sample_rate) + start_time
+        # And add buffer
+        seg_start_time = seg_start_time - seg_buffer
+        seg_end_time = seg_end_time + seg_buffer
+
+        # Then loop over injections
+        filter_segment = False
+        for inj_idx, inj in enumerate(injections.table):
+            end_time = inj.geocent_end_time + 1E-9 * inj.geocent_end_time_ns
+            if end_time > seg_end_time or end_time < seg_start_time:
+                continue
+            if chirp_test:
+                tau0_inj, tau3_inj = \
+                    pycbc.pnutils.mass1_mass2_to_tau0_tau3(inj.mass1,
+                                                           inj.mass2, f_ref)
+                tau_diff = abs(tau0_temp - tau0_inj)
+            if (not chirp_test) or \
+                    tau_diff <= ic_params['chirp_time_threshold']:
+                if not match_test:
+                    filter_segment=True
+                    break
+                o, i = match(htilde, injections.short_truncated_injs[inj_idx],
+                             psd=red_psd, low_frequency_cutoff=f_ref)
+                if o > ic_params['match_threshold']:
+                    filter_segment=True
+                    break
+
+        return filter_segment
 
 class LiveFilterBank(TemplateBank):
     def __init__(self, filename, f_lower, sample_rate, minimum_buffer,

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -403,6 +403,29 @@ class TemplateBank(object):
     def __len__(self):
         return len(self.table)
 
+    def generate_custom_size_waveform(self, t_num, max_freq, delta_f,
+                                      low_freq_cutoff=None, cached_mem=None):
+        """ Generate the template with index t_num using custom length.
+        """
+        approximant = self.approximant(t_num)
+        # Don't want to use INTERP waveforms in here
+        if approximant.endswith('_INTERP'):
+            approximant = approximant.replace('_INTERP', '')
+        # Using SPAtmplt here is bad as the stored cbrt and logv get
+        # recalculated as we change delta_f values. Fall back to TaylorF2
+        # in lalsimulation.
+        if approximant == 'SPAtmplt':
+            approximant = 'TaylorF2'
+        if cached_mem is None:
+            wav_len = int(max_freq / delta_f) + 1
+            cached_mem = zeros(wav_len, dtype=numpy.complex64)
+        htilde = pycbc.waveform.get_waveform_filter(
+            cached_mem, self.table[t_num], approximant=approximant,
+            f_lower=low_freq_cutoff, f_final=max_freq, delta_f=delta_f,
+            distance=1./DYN_RANGE_FAC, delta_t=1./(2.*max_freq))
+        return htilde
+        
+
     def template_thinning(self, injcutter, injections):
         if not injcutter.enabled or injcutter.chirp_time_threshold is None:
             # Do nothing!
@@ -428,132 +451,6 @@ class TemplateBank(object):
 
         indices_unique= np.unique(indices_combined)
         self.table = self.table[indices_unique]
-
-    def template_segment_checker(self, t_num, gwstrain, segment, start_time):
-        """ Test if injections in segment are worth filtering with template.
-
-        Using the current template, current segment, and injections within that
-        segment. Test if the injections and sufficiently "similar" to any of
-        the injections to justify actually performing a matched-filter call.
-        Ther are two parts to this test: First we check if the chirp time of
-        the template is within a provided window of any of the injections. If
-        not then stop here, it is not worth filtering this template, segment
-        combination for this injection set. If this check passes we compute a
-        match between a coarse representation of the template and a coarse
-        representation of each of the injections. If that match is above a
-        user-provided value for any of the injections then filtering can
-        proceed. This is currently only available if using frequency-domain
-        templates.
-
-        Parameters
-        -----------
-
-        Returns
-        --------
-        """
-        if gwstrain.injcutter is None:
-            return True
-
-        ic_params = gwstrain.injcutter
-        match_test = ic_params['match_threshold'] is not None
-        chirp_test = ic_params['chirp_time_threshold'] is not None
-        f_ref = ic_params['f_lower']
-        trunc_f_max = ic_params['coarsematch_fmax']
-        trunc_delta_f = ic_params['coarsematch_deltaf']
-        seg_buffer = ic_params['seg_buffer']
-        injections = gwstrain.injections
-
-        if chirp_test:
-            # Get chirp times for template
-            m1 = self.table[t_num]['mass1']
-            m2 = self.table[t_num]['mass2']
-            tau0_temp, tau3_temp = \
-                pycbc.pnutils.mass1_mass2_to_tau0_tau3(m1, m2, f_ref)
-
-        if match_test and self._tsc_short_template_mem is None:
-            wav_len = int(trunc_f_max / trunc_delta_f) + 1
-            self._tsc_short_template_mem = zeros(wav_len,
-                                                 dtype=numpy.complex64)
-
-        if match_test:
-            # Don't want to use INTERP waveforms in here
-            approximant = self.approximant(t_num)
-            if approximant.endswith('_INTERP'):
-                approximant = approximant.replace('_INTERP', '')
-            # Using SPAtmplt here is bad as the stored cbrt and logv get
-            # recalculated as we change delta_f values. Fall back to TaylorF2
-            # in lalsimulation.
-            if approximant == 'SPAtmplt':
-                approximant = 'TaylorF2'
-
-            if not hasattr(injections, 'short_truncated_injs'):
-                err_msg = 'To use a match threshold using coarse ' + \
-                          'waveforms to decide whether to compute ' + \
-                          'full matched filter, one must have stored ' + \
-                          'the injection waveforms.'
-                raise ValueError(err_msg)
-
-            try:
-                red_psd = self._tsc_short_psd_storage[id(segment.psd)]
-            except KeyError:
-                curr_psd = segment.psd.numpy()
-                step_size = int(trunc_delta_f/segment.psd.delta_f)
-                max_idx = int(trunc_f_max/segment.psd.delta_f)+1
-                red_psd_data = curr_psd[:max_idx:step_size]
-                red_psd = FrequencySeries(red_psd_data, delta_f=trunc_delta_f,
-                                          copy=False)
-                self._tsc_short_psd_storage[id(curr_psd)] = red_psd
-
-            # Generate short template
-            # WARNING: This is f-domain only! T-domain *may* work, but many
-            #          waveforms will refuse to generate.
-            if not t_num == self._tsc_short_template_id:
-                htilde = pycbc.waveform.get_waveform_filter(
-                    self._tsc_short_template_mem, self.table[t_num],
-                    approximant=approximant, f_lower=f_ref,
-                    f_final=trunc_f_max,
-                    delta_f=trunc_delta_f, distance=1./DYN_RANGE_FAC,
-                    delta_t=1./(2 * trunc_f_max))
-                self._tsc_short_template_id = t_num
-                self._tsc_short_template_wav = htilde
-            else:
-                htilde = self._tsc_short_template_wav
-
-        # Get times covered by segment analyze
-        seg_start_time = \
-            segment.cumulative_index / float(gwstrain.sample_rate) + \
-            start_time
-        seg_end_time = \
-            (segment.cumulative_index +
-             (segment.analyze.stop - segment.analyze.start)) / \
-            float(gwstrain.sample_rate) + start_time
-        # And add buffer
-        seg_start_time = seg_start_time - seg_buffer
-        seg_end_time = seg_end_time + seg_buffer
-
-        # Then loop over injections
-        filter_segment = False
-        for inj_idx, inj in enumerate(injections.table):
-            end_time = inj.geocent_end_time + 1E-9 * inj.geocent_end_time_ns
-            if end_time > seg_end_time or end_time < seg_start_time:
-                continue
-            if chirp_test:
-                tau0_inj, tau3_inj = \
-                    pycbc.pnutils.mass1_mass2_to_tau0_tau3(inj.mass1,
-                                                           inj.mass2, f_ref)
-                tau_diff = abs(tau0_temp - tau0_inj)
-            if (not chirp_test) or \
-                    tau_diff <= ic_params['chirp_time_threshold']:
-                if not match_test:
-                    filter_segment = True
-                    break
-                o, i = match(htilde, injections.short_truncated_injs[inj_idx],
-                             psd=red_psd, low_frequency_cutoff=f_ref)
-                if o > ic_params['match_threshold']:
-                    filter_segment = True
-                    break
-
-        return filter_segment
 
 class LiveFilterBank(TemplateBank):
     def __init__(self, filename, f_lower, sample_rate, minimum_buffer,

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -403,14 +403,14 @@ class TemplateBank(object):
     def __len__(self):
         return len(self.table)
 
-    def template_thinning(self, gwstrain):
-        if gwstrain.injcutter is None or \
-                gwstrain.injcutter['chirp_time_threshold'] is None:
+    def template_thinning(self, injcutter, injections):
+        if not injcutter.enabled or injcutter.chirp_time_threshold is None:
+            # Do nothing!
             return
 
-        injection_parameters = gwstrain.injections.table
-        fref = gwstrain.injcutter['f_lower']
-        threshold = gwstrain.injcutter['chirp_time_threshold']
+        injection_parameters = injections.table
+        fref = injcutter.f_lower
+        threshold = injcutter.chirp_time_threshold
         m1= self.table['mass1']
         m2= self.table['mass2']
         thinning_bank = []


### PR DESCRIPTION
These are the changes to implement injcutter in PyCBC. The basic idea is that 'injcutter' is used to determine whether to filter a segment against a template based on the parameters of the template and any injections made into the segment.

There are currently two tests in injcutter (though one could add more). A chirp-time test, as previously implemented, and a coarse-match test. Using both together speeds up injection runs by over an order of magnitude in tests I've done.

I'm running through some final checks with this version of the code now, to compare with and without injcutter, but I wanted to post the PR now to deal with any comments or code-quality issues. By default injcutter is not enabled, and if no injections are present it does nothing. Therefore to use this in O2 would require a few additional options ... But the resulting speedup might suggest that we would want to tune a few more settings to decrease start-up cost relative to cost doing matched-filtering.