### PR TITLE
Add cartesian and spherical coordinates map

### DIFF
--- a/pycbc/coordinates.py
+++ b/pycbc/coordinates.py
@@ -40,8 +40,8 @@ def cartesian_to_spherical(x, y, z):
         The azimuthal angle.
     theta : {numpy.array, float}
     """
-    if type(x) is int or type(y) is int or type(z) is int:
-        x, y, z = map(float, [x, y, z])
+    if type(y) is int:
+       y = float(y)
     rho = numpy.sqrt(x**2 + y**2 + z**2)
     phi = numpy.arctan(y / x)
     theta = numpy.arccos(z / rho)
@@ -69,8 +69,6 @@ def spherical_to_cartesian(rho, phi, theta):
     z : {numpy.array, float}
         Z-coordinate.
     """
-    if type(rho) is int or type(phi) is int or type(theta) is int:
-        rho, phi, theta = map(float, [rho, phi, theta])
     x = rho * numpy.cos(phi) * numpy.sin(theta)
     y = rho * numpy.sin(phi) * numpy.sin(theta)
     z = rho * numpy.cos(theta)

--- a/pycbc/coordinates.py
+++ b/pycbc/coordinates.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2016 Christopher M. Biwer
+#
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+""" Coordinate transformations.
+"""
+import numpy
+
+
+def cartesian_to_spherical(x, y, z):
+    """ Maps cartesian coordinates (x,y,z) to spherical coordinates
+    (rho,phi,theta) where phi is in [0,2*pi] and theta is in [0,pi].
+
+    Parameters
+    ----------
+    x : {numpy.array, float}
+        X-coordinate.
+    y : {numpy.array, float}
+        Y-coordinate.
+    z : {numpy.array, float}
+        Z-coordinate.
+
+    Returns
+    -------
+    rho : {numpy.array, float}
+        The radial amplitude.
+    phi : {numpy.array, float}
+        The azimuthal angle.
+    theta : {numpy.array, float}
+    """
+    if type(x) is int or type(y) is int or type(z) is int:
+        x, y , z  = map(float, [x, y, z])
+    rho = numpy.sqrt(x**2 + y**2 + z**2)
+    phi = numpy.arctan( y / x)
+    theta = numpy.arccos( z / rho )
+    return rho, phi, theta
+
+
+def spherical_to_cartesian(rho, phi, theta):
+    """ Maps spherical coordinates (rho,phi,theta) to cartesian coordinates
+    (x,y,z) where phi is in [0,2*pi] and theta is in [0,pi].
+
+    Parameters
+    ----------
+    rho : {numpy.array, float}
+        The radial amplitude.
+    phi : {numpy.array, float}
+        The azimuthal angle.
+    theta : {numpy.array, float}
+
+    Returns
+    -------
+    x : {numpy.array, float}
+        X-coordinate.
+    y : {numpy.array, float}
+        Y-coordinate.
+    z : {numpy.array, float}
+        Z-coordinate.
+    """
+    if type(rho) is int or type(phi) is int or type(theta) is int:
+        rho, phi, theta = map(float, [rho, phi, theta])
+    x = rho * numpy.cos(phi) * numpy.sin(theta)
+    y = rho * numpy.sin(phi) * numpy.sin(theta)
+    z = rho * numpy.cos(theta)
+    return x, y, z

--- a/pycbc/coordinates.py
+++ b/pycbc/coordinates.py
@@ -41,10 +41,10 @@ def cartesian_to_spherical(x, y, z):
     theta : {numpy.array, float}
     """
     if type(x) is int or type(y) is int or type(z) is int:
-        x, y , z  = map(float, [x, y, z])
+        x, y, z = map(float, [x, y, z])
     rho = numpy.sqrt(x**2 + y**2 + z**2)
-    phi = numpy.arctan( y / x)
-    theta = numpy.arccos( z / rho )
+    phi = numpy.arctan(y / x)
+    theta = numpy.arccos(z / rho)
     return rho, phi, theta
 
 

--- a/pycbc/coordinates.py
+++ b/pycbc/coordinates.py
@@ -41,7 +41,7 @@ def cartesian_to_spherical(x, y, z):
     theta : {numpy.array, float}
     """
     if type(y) is int:
-       y = float(y)
+        y = float(y)
     rho = numpy.sqrt(x**2 + y**2 + z**2)
     phi = numpy.arctan(y / x)
     theta = numpy.arccos(z / rho)


### PR DESCRIPTION
I couldn't find a Cartesian -> spherical -> Cartesian map that's already implemented in numpy or scipy. So I just added the functions, unless someone knows and I missed then I'll close the PR. I would have thought one exists.

I didn't just dump this in pnutils but there's kind of similar functions in there.

This is something I plan to use because I'd like to add sampling with spin magnitude and angles, instead of component spins in the Cartesian directions. Steven will also need that for part of the injection code hes writing.

EDIT:
Example:
```
In [2]: coordinates.cartesian_to_spherical(1,1,1)
Out[2]: (1.7320508075688772, 0.78539816339744828, 0.95531661812450919)

In [3]: coordinates.spherical_to_cartesian(1.7320508075688772, 0.78539816339744828, 0.95531661812450919)
Out[3]: (1.0, 0.99999999999999989, 1.0)
```