### PR TITLE
Install script use non-deprecated lalsuite env script

### DIFF
--- a/docs/install_lalsuite.rst
+++ b/docs/install_lalsuite.rst
@@ -61,17 +61,17 @@ From the top-level lalsuite directory, you can use the master configure script t
     make
     make install
 
-The install process creates a shell script called ``lalsuiterc`` that sources all of the ``$NAME/opt/lalsuite/etc/lal*-user-env.sh`` scripts that set up the environment for lalsuite. You can add this to your virtualenv ``activate`` script so that it gets set up when you enter your virtual environment. To do this, run the commands
+The install process creates a shell script called ``lalsuite-user-env.sh`` that sources all of the ``$NAME/opt/lalsuite/etc/lal*-user-env.sh`` scripts that set up the environment for lalsuite. You can add this to your virtualenv ``activate`` script so that it gets set up when you enter your virtual environment. To do this, run the commands
 
 .. code-block:: bash
 
-    echo 'source ${VIRTUAL_ENV}/opt/lalsuite/etc/lalsuiterc' >> $NAME/bin/activate
+    echo 'source ${VIRTUAL_ENV}/opt/lalsuite/etc/lalsuite-user-env.sh' >> $NAME/bin/activate
     deactivate
     source $NAME/bin/activate
 
 .. note::
 
-    If you want to manage multiple versions of lalsuite, it is not reccommended to source the lalsuiterc script from your activate script.  You should just source it when you enter your virtual environment with the command ``source ${VIRTUAL_ENV}/opt/lalsuite/etc/lalsuiterc``
+    If you want to manage multiple versions of lalsuite, it is not reccommended to source the ``lalsuite-user-env.sh`` script from your activate script.  You should just source it when you enter your virtual environment with the command ``source ${VIRTUAL_ENV}/opt/lalsuite/etc/lalsuite-user-env.sh``
 
 lalsuite is now installed in your virtual environment. You can check this with the command
 

--- a/install_pycbc.sh
+++ b/install_pycbc.sh
@@ -539,8 +539,8 @@ make -j $nproc
 make install
 
 #Add to virtualenv activate script
-echo 'source ${VIRTUAL_ENV}/opt/lalsuite/etc/lalsuiterc' >> ${VIRTUAL_ENV}/bin/activate
-source ${VIRTUAL_ENV}/opt/lalsuite/etc/lalsuiterc
+echo 'source ${VIRTUAL_ENV}/opt/lalsuite/etc/lalsuite-user-env.sh' >> ${VIRTUAL_ENV}/bin/activate
+source ${VIRTUAL_ENV}/opt/lalsuite/etc/lalsuite-user-env.sh
 
 #Build a static lalapps_inspinj and install it
 cd $VIRTUAL_ENV/src/lalsuite/lalsuite/lalapps


### PR DESCRIPTION
I keep getting this warning every single time I source my virtualenv created with the install script:
```
lalsuiterc is deprecated; source /home/cbiwer/opt/pycbc-dev/opt/lalsuite/etc/lalsuite-user-env.[c]sh instead
```

I changed the install script and the documentation to use the new lalsuite env script.