### PR TITLE
Adds spin magnitude and angles Parameter classes

### DIFF
--- a/pycbc/coordinates.py
+++ b/pycbc/coordinates.py
@@ -19,8 +19,9 @@
 import numpy
 
 
-def spherical_rho(x, y, z):
-    """ Calculates rho from Cartesian coordinates.
+def cartesian_to_spherical_rho(x, y, z):
+    """ Calculates the magnitude in spherical coordinates from Cartesian
+    coordinates.
 
     Parameters
     ----------
@@ -39,8 +40,9 @@ def spherical_rho(x, y, z):
     return numpy.sqrt(x**2 + y**2 + z**2)
 
 
-def spherical_phi(x, y):
-    """ Calculates phi from Cartesian coordinates. phi is in [0,2*pi].
+def cartesian_to_spherical_azmuthal(x, y):
+    """ Calculates the azmuthal angle in spherical coordinates from Cartesian
+    coordinates. The azmuthal angle is in [0,2*pi].
 
     Parameters
     ----------
@@ -59,8 +61,9 @@ def spherical_phi(x, y):
     return numpy.arctan(y / x)
 
 
-def spherical_theta(x, y, z):
-    """ Calculates theta from Cartesian coordinates. theta is in [0,pi].
+def cartesian_to_spherical_polar(x, y, z):
+    """ Calculates the polar angle in spherical coordinates from Cartesian
+    coordinates. The polar angle is in [0,pi].
 
     Parameters
     ----------
@@ -76,7 +79,7 @@ def spherical_theta(x, y, z):
     theta : {numpy.array, float}
         The polar angle.
     """
-    return numpy.arccos(z / spherical_rho(x, y, z))
+    return numpy.arccos(z / cartesian_to_spherical_rho(x, y, z))
 
 
 def cartesian_to_spherical(x, y, z):
@@ -101,9 +104,9 @@ def cartesian_to_spherical(x, y, z):
     theta : {numpy.array, float}
         The polar angle.
     """
-    rho = spherical_rho(x, y, z)
-    phi = spherical_phi(x, y)
-    theta = spherical_theta(x, y, z)
+    rho = cartesian_to_spherical_rho(x, y, z)
+    phi = cartesian_to_spherical_azmuthal(x, y)
+    theta = cartesian_to_spherical_polar(x, y, z)
     return rho, phi, theta
 
 

--- a/pycbc/coordinates.py
+++ b/pycbc/coordinates.py
@@ -40,9 +40,9 @@ def cartesian_to_spherical_rho(x, y, z):
     return numpy.sqrt(x**2 + y**2 + z**2)
 
 
-def cartesian_to_spherical_azmuthal(x, y):
-    """ Calculates the azmuthal angle in spherical coordinates from Cartesian
-    coordinates. The azmuthal angle is in [0,2*pi].
+def cartesian_to_spherical_azimuthal(x, y):
+    """ Calculates the azimuthal angle in spherical coordinates from Cartesian
+    coordinates. The azimuthal angle is in [0,2*pi].
 
     Parameters
     ----------
@@ -54,7 +54,7 @@ def cartesian_to_spherical_azmuthal(x, y):
     Returns
     -------
     phi : {numpy.array, float}
-        The azmuthal angle.
+        The azimuthal angle.
     """
     if type(y) is int:
         y = float(y)
@@ -105,7 +105,7 @@ def cartesian_to_spherical(x, y, z):
         The polar angle.
     """
     rho = cartesian_to_spherical_rho(x, y, z)
-    phi = cartesian_to_spherical_azmuthal(x, y)
+    phi = cartesian_to_spherical_azimuthal(x, y)
     theta = cartesian_to_spherical_polar(x, y, z)
     return rho, phi, theta
 

--- a/pycbc/coordinates.py
+++ b/pycbc/coordinates.py
@@ -39,6 +39,7 @@ def cartesian_to_spherical(x, y, z):
     phi : {numpy.array, float}
         The azimuthal angle.
     theta : {numpy.array, float}
+        The polar angle.
     """
     if type(y) is int:
         y = float(y)
@@ -59,6 +60,7 @@ def spherical_to_cartesian(rho, phi, theta):
     phi : {numpy.array, float}
         The azimuthal angle.
     theta : {numpy.array, float}
+        The polar angle.
 
     Returns
     -------

--- a/pycbc/coordinates.py
+++ b/pycbc/coordinates.py
@@ -19,6 +19,66 @@
 import numpy
 
 
+def spherical_rho(x, y, z):
+    """ Calculates rho from Cartesian coordinates.
+
+    Parameters
+    ----------
+    x : {numpy.array, float}
+        X-coordinate.
+    y : {numpy.array, float}
+        Y-coordinate.
+    z : {numpy.array, float}
+        Z-coordinate.
+
+    Returns
+    -------
+    rho : {numpy.array, float}
+        The radial amplitude.
+    """
+    return numpy.sqrt(x**2 + y**2 + z**2)
+
+
+def spherical_phi(x, y):
+    """ Calculates phi from Cartesian coordinates. phi is in [0,2*pi].
+
+    Parameters
+    ----------
+    x : {numpy.array, float}
+        X-coordinate.
+    y : {numpy.array, float}
+        Y-coordinate.
+
+    Returns
+    -------
+    phi : {numpy.array, float}
+        The azmuthal angle.
+    """
+    if type(y) is int:
+        y = float(y)
+    return numpy.arctan(y / x)
+
+
+def spherical_theta(x, y, z):
+    """ Calculates theta from Cartesian coordinates. theta is in [0,pi].
+
+    Parameters
+    ----------
+    x : {numpy.array, float}
+        X-coordinate.
+    y : {numpy.array, float}
+        Y-coordinate.
+    z : {numpy.array, float}
+        Z-coordinate.
+
+    Returns
+    -------
+    theta : {numpy.array, float}
+        The polar angle.
+    """
+    return numpy.arccos(z / spherical_rho(x, y, z))
+
+
 def cartesian_to_spherical(x, y, z):
     """ Maps cartesian coordinates (x,y,z) to spherical coordinates
     (rho,phi,theta) where phi is in [0,2*pi] and theta is in [0,pi].
@@ -41,11 +101,9 @@ def cartesian_to_spherical(x, y, z):
     theta : {numpy.array, float}
         The polar angle.
     """
-    if type(y) is int:
-        y = float(y)
-    rho = numpy.sqrt(x**2 + y**2 + z**2)
-    phi = numpy.arctan(y / x)
-    theta = numpy.arccos(z / rho)
+    rho = spherical_rho(x, y, z)
+    phi = spherical_phi(x, y)
+    theta = spherical_theta(x, y, z)
     return rho, phi, theta
 
 

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1583,8 +1583,8 @@ class WaveformArray(_FieldArrayWithDefaults):
         parameters.q, parameters.m_p, parameters.m_s, parameters.chi_eff,
         parameters.spin_px, parameters.spin_py, parameters.spin_pz,
         parameters.spin_sx, parameters.spin_sy, parameters.spin_sz,
-        parameters.spin1a, parameters.spin1phi, parameters.spin1theta,
-        parameters.spin2a, parameters.spin2phi, parameters.spin2theta]
+        parameters.spin1_a, parameters.spin1_azmuthal, parameters.spin1_polar,
+        parameters.spin2_a, parameters.spin2_azmuthal, parameters.spin2_polar]
 
     @property
     def m_p(self):
@@ -1688,42 +1688,46 @@ class WaveformArray(_FieldArrayWithDefaults):
         return out
 
     @property
-    def spin1a(self):
+    def spin1_a(self):
         """Returns the dimensionless spin magnitude of mass 1."""
-        out = coordinates.spherical_rho(self.spin1x, self.spin1y, self.spin1z)
+        out = coordinates.cartesian_to_spherical_rho(
+                                    self.spin1x, self.spin1y, self.spin1z)
         return out / self.mass1**2
 
     @property
-    def spin1phi(self):
+    def spin1_azmuthal(self):
         """Returns the azmuthal spin angle of mass 1."""
         # do not need to normalize by mass because it cancels
-        return coordinates.spherical_phi(self.spin1x, self.spin1y)
+        return coordinates.cartesian_to_spherical_azmuthal(
+                                     self.spin1x, self.spin1y)
 
     @property
-    def spin1theta(self):
+    def spin1_polar(self):
         """Returns the polar spin angle of mass 1."""
         # do not need to normalize by mass because it cancels
-        return coordinates.spherical_theta(self.spin1x, self.spin1y,
-                                           self.spin1z)
+        return coordinates.cartesian_to_spherical_polar(
+                                     self.spin1x, self.spin1y, self.spin1z)
 
     @property
-    def spin2a(self):
+    def spin2_a(self):
         """Returns the dimensionless spin magnitude of mass 2."""
-        out = coordinates.spherical_rho(self.spin1x, self.spin1y, self.spin1z)
+        out = coordinates.cartesian_to_spherical_rho(
+                                    self.spin1x, self.spin1y, self.spin1z)
         return out / self.mass2**2
 
     @property
-    def spin2phi(self):
+    def spin2_azmuthal(self):
         """Returns the azmuthal spin angle of mass 2."""
         # do not need to normalize by mass because it cancels
-        return coordinates.spherical_phi(self.spin2x, self.spin2y)
+        return coordinates.cartesian_to_spherical_azmuthal(
+                                     self.spin2x, self.spin2y)
 
     @property
-    def spin2theta(self):
+    def spin2_polar(self):
         """Returns the polar spin angle of mass 2."""
         # do not need to normalize by mass because it cancels
-        return coordinates.spherical_theta(self.spin2x, self.spin2y,
-                                           self.spin2z)
+        return coordinates.cartesian_to_spherical_polar(
+                                     self.spin2x, self.spin2y, self.spin2z)
 
     def det_tc(self, detector):
         """Returns the coalesence time in the given detector."""

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1690,6 +1690,9 @@ class WaveformArray(_FieldArrayWithDefaults):
     @property
     def spin1a(self):
         """Returns the dimensionless spin magnitude of mass 1."""
+        out, _, _ = coordinates.cartesian_to_spherical(self.spin1x,
+                                                       self.spin1y,
+                                                       self.spin1z)
         return out / self.mass1**2
 
 

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -30,6 +30,7 @@ waves.
 
 import os, sys, types, re, copy, numpy, inspect
 from glue.ligolw import types as ligolw_types
+from pycbc import coordinates
 from pycbc.detector import Detector
 from pycbc.waveform import parameters
 
@@ -1580,7 +1581,9 @@ class WaveformArray(_FieldArrayWithDefaults):
     _virtualfields = [parameters.mchirp, parameters.eta, parameters.mtotal,
         parameters.q, parameters.m_p, parameters.m_s, parameters.chi_eff,
         parameters.spin_px, parameters.spin_py, parameters.spin_pz,
-        parameters.spin_sx, parameters.spin_sy, parameters.spin_sz]
+        parameters.spin_sx, parameters.spin_sy, parameters.spin_sz,
+        parameters.spin1_a, parameters.spin1_phi, parameters.spin1_theta,
+        parameters.spin2_a, parameters.spin2_phi, parameters.spin2_theta]
 
 
     @property
@@ -1683,6 +1686,61 @@ class WaveformArray(_FieldArrayWithDefaults):
         mask = self.mass1 < self.mass2
         out[mask] = self.spin1z[mask]
         return out
+
+
+    @property
+    def spin1_a(self):
+        """Returns the dimensionless spin magnitude of mass 1."""
+        out, _, _ = coordinates.cartesian_to_spherical(self.spin1x,
+                                                       self.spin1y,
+                                                       self.spin1z)
+        return a / self.mass1**2
+
+
+    @property
+    def spin1_phi(self):
+        """Returns the azmuthal spin angle of mass 1."""
+        _, out, _ = coordinates.cartesian_to_spherical(self.spin1x,
+                                                       self.spin1y,
+                                                       self.spin1z)
+        return out
+
+
+    @property
+    def spin1_theta(self):
+        """Returns the polar spin angle of mass 1."""
+        _, _, out = coordinates.cartesian_to_spherical(self.spin1x,
+                                                       self.spin1y,
+                                                       self.spin1z)
+        return out
+
+
+    @property
+    def spin2_a(self):
+        """Returns the dimensionless spin magnitude of mass 2."""
+        out, _, _ = coordinates.cartesian_to_spherical(self.spin2x,
+                                                       self.spin2y,
+                                                       self.spin2z)
+        return a / self.mass2**2
+
+
+    @property
+    def spin2_phi(self):
+        """Returns the azmuthal spin angle of mass 2."""
+        _, out, _ = coordinates.cartesian_to_spherical(self.spin2x,
+                                                       self.spin2y,
+                                                       self.spin2z)
+        return out
+
+
+    @property
+    def spin2_theta(self):
+        """Returns the polar spin angle of mass 2."""
+        _, _, out = coordinates.cartesian_to_spherical(self.spin2x,
+                                                       self.spin2y,
+                                                       self.spin2z)
+        return out
+
 
     def det_tc(self, detector):
         """Returns the coalesence time in the given detector."""

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1694,7 +1694,7 @@ class WaveformArray(_FieldArrayWithDefaults):
         out, _, _ = coordinates.cartesian_to_spherical(self.spin1x,
                                                        self.spin1y,
                                                        self.spin1z)
-        return a / self.mass1**2
+        return out / self.mass1**2
 
 
     @property
@@ -1721,7 +1721,7 @@ class WaveformArray(_FieldArrayWithDefaults):
         out, _, _ = coordinates.cartesian_to_spherical(self.spin2x,
                                                        self.spin2y,
                                                        self.spin2z)
-        return a / self.mass2**2
+        return out / self.mass2**2
 
 
     @property

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1690,55 +1690,45 @@ class WaveformArray(_FieldArrayWithDefaults):
     @property
     def spin1a(self):
         """Returns the dimensionless spin magnitude of mass 1."""
-        out, _, _ = coordinates.cartesian_to_spherical(self.spin1x,
-                                                       self.spin1y,
-                                                       self.spin1z)
+        out = coordinates.spherical_rho(self.spin1x, self.spin1y, self.spin1z)
         return out / self.mass1**2
 
 
     @property
     def spin1phi(self):
         """Returns the azmuthal spin angle of mass 1."""
-        _, out, _ = coordinates.cartesian_to_spherical(self.spin1x,
-                                                       self.spin1y,
-                                                       self.spin1z)
-        return out
+        # do not need to normalize by mass because it cancels
+        return coordinates.spherical_phi(self.spin1x, self.spin1y)
 
 
     @property
     def spin1theta(self):
         """Returns the polar spin angle of mass 1."""
-        _, _, out = coordinates.cartesian_to_spherical(self.spin1x,
-                                                       self.spin1y,
-                                                       self.spin1z)
-        return out
+        # do not need to normalize by mass because it cancels
+        return coordinates.spherical_theta(self.spin1x, self.spin1y,
+                                           self.spin1z)
 
 
     @property
     def spin2a(self):
         """Returns the dimensionless spin magnitude of mass 2."""
-        out, _, _ = coordinates.cartesian_to_spherical(self.spin2x,
-                                                       self.spin2y,
-                                                       self.spin2z)
+        out = coordinates.spherical_rho(self.spin1x, self.spin1y, self.spin1z)
         return out / self.mass2**2
 
 
     @property
     def spin2phi(self):
         """Returns the azmuthal spin angle of mass 2."""
-        _, out, _ = coordinates.cartesian_to_spherical(self.spin2x,
-                                                       self.spin2y,
-                                                       self.spin2z)
-        return out
+        # do not need to normalize by mass because it cancels
+        return coordinates.spherical_phi(self.spin2x, self.spin2y)
 
 
     @property
     def spin2theta(self):
         """Returns the polar spin angle of mass 2."""
-        _, _, out = coordinates.cartesian_to_spherical(self.spin2x,
-                                                       self.spin2y,
-                                                       self.spin2z)
-        return out
+        # do not need to normalize by mass because it cancels
+        return coordinates.spherical_theta(self.spin2x, self.spin2y,
+                                           self.spin2z)
 
 
     def det_tc(self, detector):

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1583,8 +1583,8 @@ class WaveformArray(_FieldArrayWithDefaults):
         parameters.q, parameters.m_p, parameters.m_s, parameters.chi_eff,
         parameters.spin_px, parameters.spin_py, parameters.spin_pz,
         parameters.spin_sx, parameters.spin_sy, parameters.spin_sz,
-        parameters.spin1_a, parameters.spin1_azmuthal, parameters.spin1_polar,
-        parameters.spin2_a, parameters.spin2_azmuthal, parameters.spin2_polar]
+        parameters.spin1_a, parameters.spin1_azimuthal, parameters.spin1_polar,
+        parameters.spin2_a, parameters.spin2_azimuthal, parameters.spin2_polar]
 
     @property
     def m_p(self):
@@ -1695,10 +1695,10 @@ class WaveformArray(_FieldArrayWithDefaults):
         return out / self.mass1**2
 
     @property
-    def spin1_azmuthal(self):
-        """Returns the azmuthal spin angle of mass 1."""
+    def spin1_azimuthal(self):
+        """Returns the azimuthal spin angle of mass 1."""
         # do not need to normalize by mass because it cancels
-        return coordinates.cartesian_to_spherical_azmuthal(
+        return coordinates.cartesian_to_spherical_azimuthal(
                                      self.spin1x, self.spin1y)
 
     @property
@@ -1716,10 +1716,10 @@ class WaveformArray(_FieldArrayWithDefaults):
         return out / self.mass2**2
 
     @property
-    def spin2_azmuthal(self):
-        """Returns the azmuthal spin angle of mass 2."""
+    def spin2_azimuthal(self):
+        """Returns the azimuthal spin angle of mass 2."""
         # do not need to normalize by mass because it cancels
-        return coordinates.cartesian_to_spherical_azmuthal(
+        return coordinates.cartesian_to_spherical_azimuthal(
                                      self.spin2x, self.spin2y)
 
     @property

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1578,7 +1578,8 @@ class WaveformArray(_FieldArrayWithDefaults):
     _staticfields = (parameters.cbc_intrinsic_params +
                      parameters.extrinsic_params).dtype_dict
 
-    _virtualfields = [parameters.mchirp, parameters.eta, parameters.mtotal,
+    _virtualfields = [
+        parameters.mchirp, parameters.eta, parameters.mtotal,
         parameters.q, parameters.m_p, parameters.m_s, parameters.chi_eff,
         parameters.spin_px, parameters.spin_py, parameters.spin_pz,
         parameters.spin_sx, parameters.spin_sy, parameters.spin_sz,
@@ -1686,20 +1687,17 @@ class WaveformArray(_FieldArrayWithDefaults):
         out[mask] = self.spin1z[mask]
         return out
 
-
     @property
     def spin1a(self):
         """Returns the dimensionless spin magnitude of mass 1."""
         out = coordinates.spherical_rho(self.spin1x, self.spin1y, self.spin1z)
         return out / self.mass1**2
 
-
     @property
     def spin1phi(self):
         """Returns the azmuthal spin angle of mass 1."""
         # do not need to normalize by mass because it cancels
         return coordinates.spherical_phi(self.spin1x, self.spin1y)
-
 
     @property
     def spin1theta(self):
@@ -1708,13 +1706,11 @@ class WaveformArray(_FieldArrayWithDefaults):
         return coordinates.spherical_theta(self.spin1x, self.spin1y,
                                            self.spin1z)
 
-
     @property
     def spin2a(self):
         """Returns the dimensionless spin magnitude of mass 2."""
         out = coordinates.spherical_rho(self.spin1x, self.spin1y, self.spin1z)
         return out / self.mass2**2
-
 
     @property
     def spin2phi(self):
@@ -1722,14 +1718,12 @@ class WaveformArray(_FieldArrayWithDefaults):
         # do not need to normalize by mass because it cancels
         return coordinates.spherical_phi(self.spin2x, self.spin2y)
 
-
     @property
     def spin2theta(self):
         """Returns the polar spin angle of mass 2."""
         # do not need to normalize by mass because it cancels
         return coordinates.spherical_theta(self.spin2x, self.spin2y,
                                            self.spin2z)
-
 
     def det_tc(self, detector):
         """Returns the coalesence time in the given detector."""

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1582,9 +1582,8 @@ class WaveformArray(_FieldArrayWithDefaults):
         parameters.q, parameters.m_p, parameters.m_s, parameters.chi_eff,
         parameters.spin_px, parameters.spin_py, parameters.spin_pz,
         parameters.spin_sx, parameters.spin_sy, parameters.spin_sz,
-        parameters.spin1_a, parameters.spin1_phi, parameters.spin1_theta,
-        parameters.spin2_a, parameters.spin2_phi, parameters.spin2_theta]
-
+        parameters.spin1a, parameters.spin1phi, parameters.spin1theta,
+        parameters.spin2a, parameters.spin2phi, parameters.spin2theta]
 
     @property
     def m_p(self):
@@ -1689,16 +1688,13 @@ class WaveformArray(_FieldArrayWithDefaults):
 
 
     @property
-    def spin1_a(self):
+    def spin1a(self):
         """Returns the dimensionless spin magnitude of mass 1."""
-        out, _, _ = coordinates.cartesian_to_spherical(self.spin1x,
-                                                       self.spin1y,
-                                                       self.spin1z)
         return out / self.mass1**2
 
 
     @property
-    def spin1_phi(self):
+    def spin1phi(self):
         """Returns the azmuthal spin angle of mass 1."""
         _, out, _ = coordinates.cartesian_to_spherical(self.spin1x,
                                                        self.spin1y,
@@ -1707,7 +1703,7 @@ class WaveformArray(_FieldArrayWithDefaults):
 
 
     @property
-    def spin1_theta(self):
+    def spin1theta(self):
         """Returns the polar spin angle of mass 1."""
         _, _, out = coordinates.cartesian_to_spherical(self.spin1x,
                                                        self.spin1y,
@@ -1716,7 +1712,7 @@ class WaveformArray(_FieldArrayWithDefaults):
 
 
     @property
-    def spin2_a(self):
+    def spin2a(self):
         """Returns the dimensionless spin magnitude of mass 2."""
         out, _, _ = coordinates.cartesian_to_spherical(self.spin2x,
                                                        self.spin2y,
@@ -1725,7 +1721,7 @@ class WaveformArray(_FieldArrayWithDefaults):
 
 
     @property
-    def spin2_phi(self):
+    def spin2phi(self):
         """Returns the azmuthal spin angle of mass 2."""
         _, out, _ = coordinates.cartesian_to_spherical(self.spin2x,
                                                        self.spin2y,
@@ -1734,7 +1730,7 @@ class WaveformArray(_FieldArrayWithDefaults):
 
 
     @property
-    def spin2_theta(self):
+    def spin2theta(self):
         """Returns the polar spin angle of mass 2."""
         _, _, out = coordinates.cartesian_to_spherical(self.spin2x,
                                                        self.spin2y,

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -195,7 +195,7 @@ lambda2 = Parameter("lambda2",
                 dtype=float, default=0., label=r"$\lambda_2$",
                 description="The tidal deformability parameter of object 2.")
 
-# common derived parameters (these are not used for waveform generation)
+# derived parameters (these are not used for waveform generation) for masses
 mchirp = Parameter("mchirp",
                 dtype=float, label=r"$\mathcal{M}~(\mathrm{M}_\odot)$",
                 description="The chirp mass of the binary (in solar masses).")
@@ -214,6 +214,8 @@ m_p = Parameter("m_p",
 m_s = Parameter("m_s",
                 dtype=float, label=r"$m_{\mathrm{sc}}$",
                 description="Mass of the secondary object (in solar masses).")
+
+# derived parameters for component spins
 chi_eff = Parameter("chi_eff",
                 dtype=float, label=r"$\chi_\mathrm{eff}$",
                 description="Effective spin of the binary.")
@@ -241,6 +243,28 @@ spin_sz = Parameter("spin_sz",
                 dtype=float, label=r"$\chi_{\mathrm{sc}\,z}$",
                 description="The z component of the dimensionless spin of the "
                             "secondary object.")
+
+# derived parameters for component spin magnitude and angles
+spin1_a = Parameter("spin1_a",
+                    dtype=float, label=r"$\a_{1}$",
+                    description="The dimensionless spin magnitude "
+                                "$|\vec{s}/m_{1^2}|$.")
+spin2_a = Parameter("spin1_a",
+                    dtype=float, label=r"$\a_{2}$",
+                    description="The dimensionless spin magnitude "
+                                "$|\vec{s}/m_{2^2}|$.")
+spin1_phi = Parameter("spin1_phi",
+                      dtype=float, label=r"$\phi_{\mathrm{spin},1}$",
+                      description="The azmuthal spin angle for mass 1.")
+spin2_phi = Parameter("spin2_phi",
+                      dtype=float, label=r"$\phi_{\mathrm{spin},2}$",
+                      description="The azmuthal spin angle for mass 2.")
+spin1_theta = Parameter("spin1_theta",
+                        dtype=float, label=r"$\theta_{\mathrm{spin},1}$",
+                        description="The polar spin angle for mass 1.")
+spin2_theta = Parameter("spin2_theta",
+                        dtype=float, label=r"$\theta_{\mathrm{spin},2}$",
+                        description="The polar spin angle for mass 2.")
 
 #
 #   Parameters needed for CBC waveform generation

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -248,11 +248,11 @@ spin_sz = Parameter("spin_sz",
 spin1_a = Parameter("spin1_a",
                     dtype=float, label=r"$\a_{1}$",
                     description="The dimensionless spin magnitude "
-                                "$|\vec{s}/m_{1^2}|$.")
+                                "$|\vec{s}/m_{1}^2|$.")
 spin2_a = Parameter("spin1_a",
                     dtype=float, label=r"$\a_{2}$",
                     description="The dimensionless spin magnitude "
-                                "$|\vec{s}/m_{2^2}|$.")
+                                "$|\vec{s}/m_{2}^2|$.")
 spin1_phi = Parameter("spin1_phi",
                       dtype=float, label=r"$\phi_{\mathrm{spin},1}$",
                       description="The azmuthal spin angle for mass 1.")

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -253,12 +253,14 @@ spin2_a = Parameter("spin2_a",
                     dtype=float, label=r"$\a_{2}$",
                     description="The dimensionless spin magnitude "
                                 "$|\vec{s}/m_{2}^2|$.")
-spin1_azmuthal = Parameter("spin1_azmuthal",
-                           dtype=float, label=r"$\theta_1^\mathrm{azmuthal}$",
-                           description="The azmuthal spin angle for mass 1.")
-spin2_azmuthal = Parameter("spin2_azmuthal",
-                           dtype=float, label=r"$\theta_2^\mathrm{azmuthal}$",
-                           description="The azmuthal spin angle for mass 2.")
+spin1_azimuthal = Parameter(
+                      "spin1_azimuthal",
+                      dtype=float, label=r"$\theta_1^\mathrm{azimuthal}$",
+                      description="The azimuthal spin angle for mass 1.")
+spin2_azimuthal = Parameter(
+                      "spin2_azimuthal",
+                      dtype=float, label=r"$\theta_2^\mathrm{azimuthal}$",
+                      description="The azimuthal spin angle for mass 2.")
 spin1_polar = Parameter("spin1_polar",
                         dtype=float, label=r"$\theta_1^\mathrm{polar}$",
                         description="The polar spin angle for mass 1.")

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -249,7 +249,7 @@ spin1a = Parameter("spin1a",
                     dtype=float, label=r"$\a_{1}$",
                     description="The dimensionless spin magnitude "
                                 "$|\vec{s}/m_{1}^2|$.")
-spin2a = Parameter("spin1a",
+spin2a = Parameter("spin2a",
                     dtype=float, label=r"$\a_{2}$",
                     description="The dimensionless spin magnitude "
                                 "$|\vec{s}/m_{2}^2|$.")

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -245,26 +245,27 @@ spin_sz = Parameter("spin_sz",
                             "secondary object.")
 
 # derived parameters for component spin magnitude and angles
-spin1_a = Parameter("spin1_a",
+spin1a = Parameter("spin1a",
                     dtype=float, label=r"$\a_{1}$",
                     description="The dimensionless spin magnitude "
                                 "$|\vec{s}/m_{1}^2|$.")
-spin2_a = Parameter("spin1_a",
+spin2a = Parameter("spin1a",
                     dtype=float, label=r"$\a_{2}$",
                     description="The dimensionless spin magnitude "
                                 "$|\vec{s}/m_{2}^2|$.")
-spin1_phi = Parameter("spin1_phi",
+spin1phi = Parameter("spin1phi",
                       dtype=float, label=r"$\phi_{\mathrm{spin},1}$",
                       description="The azmuthal spin angle for mass 1.")
-spin2_phi = Parameter("spin2_phi",
+spin2phi = Parameter("spin2phi",
                       dtype=float, label=r"$\phi_{\mathrm{spin},2}$",
                       description="The azmuthal spin angle for mass 2.")
-spin1_theta = Parameter("spin1_theta",
+spin1theta = Parameter("spin1theta",
                         dtype=float, label=r"$\theta_{\mathrm{spin},1}$",
                         description="The polar spin angle for mass 1.")
-spin2_theta = Parameter("spin2_theta",
+spin2theta = Parameter("spin2theta",
                         dtype=float, label=r"$\theta_{\mathrm{spin},2}$",
                         description="The polar spin angle for mass 2.")
+
 
 #
 #   Parameters needed for CBC waveform generation

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -246,25 +246,25 @@ spin_sz = Parameter("spin_sz",
 
 # derived parameters for component spin magnitude and angles
 spin1_a = Parameter("spin1_a",
-                   dtype=float, label=r"$\a_{1}$",
-                   description="The dimensionless spin magnitude "
-                               "$|\vec{s}/m_{1}^2|$.")
+                    dtype=float, label=r"$\a_{1}$",
+                    description="The dimensionless spin magnitude "
+                                "$|\vec{s}/m_{1}^2|$.")
 spin2_a = Parameter("spin2_a",
-                   dtype=float, label=r"$\a_{2}$",
-                   description="The dimensionless spin magnitude "
-                               "$|\vec{s}/m_{2}^2|$.")
+                    dtype=float, label=r"$\a_{2}$",
+                    description="The dimensionless spin magnitude "
+                                "$|\vec{s}/m_{2}^2|$.")
 spin1_azmuthal = Parameter("spin1_azmuthal",
-                     dtype=float, label=r"$\theta_1^\mathrm{azmuthal}$",
-                     description="The azmuthal spin angle for mass 1.")
+                           dtype=float, label=r"$\theta_1^\mathrm{azmuthal}$",
+                           description="The azmuthal spin angle for mass 1.")
 spin2_azmuthal = Parameter("spin2_azmuthal",
-                     dtype=float, label=r"$\theta_2^\mathrm{azmuthal}$",
-                     description="The azmuthal spin angle for mass 2.")
+                           dtype=float, label=r"$\theta_2^\mathrm{azmuthal}$",
+                           description="The azmuthal spin angle for mass 2.")
 spin1_polar = Parameter("spin1_polar",
-                       dtype=float, label=r"$\theta_1^\mathrm{polar}$",
-                       description="The polar spin angle for mass 1.")
+                        dtype=float, label=r"$\theta_1^\mathrm{polar}$",
+                        description="The polar spin angle for mass 1.")
 spin2_polar = Parameter("spin2_polar",
-                       dtype=float, label=r"$\theta_2^\mathrm{polar}$",
-                       description="The polar spin angle for mass 2.")
+                        dtype=float, label=r"$\theta_2^\mathrm{polar}$",
+                        description="The polar spin angle for mass 2.")
 
 
 #

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -245,25 +245,25 @@ spin_sz = Parameter("spin_sz",
                             "secondary object.")
 
 # derived parameters for component spin magnitude and angles
-spin1a = Parameter("spin1a",
+spin1_a = Parameter("spin1_a",
                    dtype=float, label=r"$\a_{1}$",
                    description="The dimensionless spin magnitude "
                                "$|\vec{s}/m_{1}^2|$.")
-spin2a = Parameter("spin2a",
+spin2_a = Parameter("spin2_a",
                    dtype=float, label=r"$\a_{2}$",
                    description="The dimensionless spin magnitude "
                                "$|\vec{s}/m_{2}^2|$.")
-spin1phi = Parameter("spin1phi",
-                     dtype=float, label=r"$\phi_{\mathrm{spin},1}$",
+spin1_azmuthal = Parameter("spin1_azmuthal",
+                     dtype=float, label=r"$\theta_1^\mathrm{azmuthal}$",
                      description="The azmuthal spin angle for mass 1.")
-spin2phi = Parameter("spin2phi",
-                     dtype=float, label=r"$\phi_{\mathrm{spin},2}$",
+spin2_azmuthal = Parameter("spin2_azmuthal",
+                     dtype=float, label=r"$\theta_2^\mathrm{azmuthal}$",
                      description="The azmuthal spin angle for mass 2.")
-spin1theta = Parameter("spin1theta",
-                       dtype=float, label=r"$\theta_{\mathrm{spin},1}$",
+spin1_polar = Parameter("spin1_polar",
+                       dtype=float, label=r"$\theta_1^\mathrm{polar}$",
                        description="The polar spin angle for mass 1.")
-spin2theta = Parameter("spin2theta",
-                       dtype=float, label=r"$\theta_{\mathrm{spin},2}$",
+spin2_polar = Parameter("spin2_polar",
+                       dtype=float, label=r"$\theta_2^\mathrm{polar}$",
                        description="The polar spin angle for mass 2.")
 
 

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -246,25 +246,25 @@ spin_sz = Parameter("spin_sz",
 
 # derived parameters for component spin magnitude and angles
 spin1a = Parameter("spin1a",
-                    dtype=float, label=r"$\a_{1}$",
-                    description="The dimensionless spin magnitude "
-                                "$|\vec{s}/m_{1}^2|$.")
+                   dtype=float, label=r"$\a_{1}$",
+                   description="The dimensionless spin magnitude "
+                               "$|\vec{s}/m_{1}^2|$.")
 spin2a = Parameter("spin2a",
-                    dtype=float, label=r"$\a_{2}$",
-                    description="The dimensionless spin magnitude "
-                                "$|\vec{s}/m_{2}^2|$.")
+                   dtype=float, label=r"$\a_{2}$",
+                   description="The dimensionless spin magnitude "
+                               "$|\vec{s}/m_{2}^2|$.")
 spin1phi = Parameter("spin1phi",
-                      dtype=float, label=r"$\phi_{\mathrm{spin},1}$",
-                      description="The azmuthal spin angle for mass 1.")
+                     dtype=float, label=r"$\phi_{\mathrm{spin},1}$",
+                     description="The azmuthal spin angle for mass 1.")
 spin2phi = Parameter("spin2phi",
-                      dtype=float, label=r"$\phi_{\mathrm{spin},2}$",
-                      description="The azmuthal spin angle for mass 2.")
+                     dtype=float, label=r"$\phi_{\mathrm{spin},2}$",
+                     description="The azmuthal spin angle for mass 2.")
 spin1theta = Parameter("spin1theta",
-                        dtype=float, label=r"$\theta_{\mathrm{spin},1}$",
-                        description="The polar spin angle for mass 1.")
+                       dtype=float, label=r"$\theta_{\mathrm{spin},1}$",
+                       description="The polar spin angle for mass 1.")
 spin2theta = Parameter("spin2theta",
-                        dtype=float, label=r"$\theta_{\mathrm{spin},2}$",
-                        description="The polar spin angle for mass 2.")
+                       dtype=float, label=r"$\theta_{\mathrm{spin},2}$",
+                       description="The polar spin angle for mass 2.")
 
 
 #


### PR DESCRIPTION
Adds ``Parameter`` classes for spin magnitude (``spin1a``) and spin angles (``spin1phi``,``spin1theta``) for both component spins. Doesn't add it for primary and secondary masses.

The PR includes them ``WaveformArray`` as well. It uses ``pycbc.coordinates``, which I broke up the Cartesian -> spherical calculations into smaller functions since it would've been overkill for ``WaveformArray``.

Need this PR though just so spin magnitude and angle shows up in the default plotting parameters list.

EDIT:
Example:
```
In [1]: from pycbc import coordinates
__init__: Setting weave cache to /local/cbiwer/5451_python27_compiled/36c77c/36c77c7a0a1f2b2d85b9e22d339418d817f0890a

In [2]: coordinates.cartesian_to_spherical(1,1,1)
Out[2]: (1.7320508075688772, 0.78539816339744828, 0.95531661812450919)

In [3]: from pycbc.io.record import WaveformArray
In [4]: warr = WaveformArray(3, names=["mass1", "mass2", "spin1x", "spin1y", "spin1z"])
In [5]: warr["spin1x"][0] = 1; warr["spin1y"][0] = 1; warr["spin1z"][0] = 1; warr["mass1"][0] = 1.4; warr["mass2"][0] = 1.4

In [6]: warr.spin1apycbc/io/record.py:1694: RuntimeWarning: invalid value encountered in divide
  return out / self.mass1**2
Out[6]: array([ 0.88369939,         nan,         nan])

In [7]: warr.spin1phi
pycbc/coordinates.py:59: RuntimeWarning: invalid value encountered in divide
  return numpy.arctan(y / x)
Out[7]: array([ 0.78539816,         nan,         nan])

In [8]: warr.spin1theta
pycbc/coordinates.py:79: RuntimeWarning: invalid value encountered in divide
  return numpy.arccos(z / spherical_rho(x, y, z))
Out[8]: array([ 0.95531662,         nan,         nan])
```