### PR TITLE
Display what parameters are input and output for pycbc.waveform.generator functions

### DIFF
--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -37,6 +37,8 @@ import lal as _lal
 #
 #   Pregenerator functions for generator
 #
+
+
 def add_attrs(**func_attrs):
     """ Decorator for adding attributes to a function.
     """

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -28,6 +28,7 @@ This modules provides classes for generating waveforms.
 import functools
 import waveform
 import ringdown
+from pycbc.waveform import parameters
 from pycbc.waveform.utils import apply_fd_time_shift
 from pycbc.detector import Detector
 from pycbc import pnutils
@@ -36,8 +37,26 @@ import lal as _lal
 #
 #   Pregenerator functions for generator
 #
+def add_attrs(**func_attrs):
+    """ Decorator for adding attributes to a function.
+    """
+    def add_attr_decorator(fn):
+        # wraps is a decorator for updating the attributes of the
+        # wrapping function to those of the original function
+        # ie. __name__, __doc__, and __module__ will point to the
+        # original function instead of the wrapped function
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            return fn(*args, **kwargs)
+        # update with attributes
+        for attr, value in func_attrs.iteritems():
+            setattr(wrapper, attr, value)
+        return wrapper
+    return add_attr_decorator
 
 
+@add_attrs(input_params=[parameters.mchirp, parameters.eta],
+           output_params=[parameters.mass1, parameters.mass2])
 def generator_mchirp_eta_to_mass1_mass2(generator):
     """Converts mchirp and eta in `current_params`, to mass1 and mass2.
     """
@@ -48,6 +67,8 @@ def generator_mchirp_eta_to_mass1_mass2(generator):
     generator.current_params['mass2'] = m2
 
 
+@add_attrs(input_params=[parameters.mtotal, parameters.eta],
+           output_params=[parameters.mass1, parameters.mass2])
 def generator_mtotal_eta_to_mass1_mass2(generator):
     """Converts mtotal and eta in `current_params`, to mass1 and mass2.
     """
@@ -58,6 +79,8 @@ def generator_mtotal_eta_to_mass1_mass2(generator):
     generator.current_params['mass2'] = m2
 
 
+@add_attrs(input_params=[parameters.mchirp, parameters.q],
+           output_params=[parameters.mass1, parameters.mass2])
 def generator_mchirp_q_to_mass1_mass2(generator):
     """Converts mchirp and q in `current_params`, to mass1 and mass2.
     """


### PR DESCRIPTION
So this uses a decorator to display what the input parameters and output parameters for the functions at the top of ``pycbc.waveform.generators``.

This is the sort of literal implementation from Collin's description in #1108:
>>  @ahnitz has suggested that we make it so that each function "advertises" the parameters it takes in and what it converts them to.

Though an alternatively would to have these functions become classes (kind of silly since they'll not have instances) with a ``staticmethod`` and ``input_params``/``output_params`` as attributes. If you'd prefer this way let me know and I'll change the PR.
EDIT: Though I think we'l just end up with the same pickling problem we're trying to avoid with these functions.

Anyways could use the superset operation between these lists and a list of the generator's parameters to figure out what function needs to be called.

EDIT:
Example:
```
In [2]: generator_mchirp_eta_to_mass1_mass2.input_params
Out[2]: ['mchirp', 'eta']

In [3]: generator_mchirp_eta_to_mass1_mass2.output_params
Out[3]: ['mass1', 'mass2']
```