### PR TITLE
remove redundant flag option

### DIFF
--- a/pycbc/types/array_cpu.py
+++ b/pycbc/types/array_cpu.py
@@ -59,7 +59,7 @@ for (int i=0; i<N; i++){
 }
 loc[0] = l;
 """
-code_flags = [WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags
+code_flags = [WEAVE_FLAGS] + omp_flags
 
 
 def abs_arg_max(self):


### PR DESCRIPTION
"WEAVE_FLAGS" already contains the flags listed here, so it was redundant to add them again, and removes the option to set them through the environment. 