### PR TITLE
Hide message that says 'setting weave blah blah'

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -128,7 +128,7 @@ _cache_dir_path = os.path.join(_tmp_dir, _cache_dir_name)
 _cache_dir_path = os.path.join(_cache_dir_path, pycbc_version)
 _cache_dir_path = os.path.join(_cache_dir_path, git_hash)
 if os.environ.get("NO_TMPDIR", None):
-    print >>sys.stderr, "__init__: Skipped creating %s as NO_TEMPDIR is set" % _cache_dir_path
+    logging.info("__init__: Skipped creating %s as NO_TEMPDIR is set" % _cache_dir_path)
 else:
     try: os.makedirs(_cache_dir_path)
     except OSError: pass

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -132,7 +132,7 @@ if os.environ.get("NO_TMPDIR", None):
 else:
     try: os.makedirs(_cache_dir_path)
     except OSError: pass
-    print >>sys.stderr, "__init__: Setting weave cache to %s" % _cache_dir_path
+    logging.info("__init__: Setting weave cache to %s" % _cache_dir_path)
 os.environ['PYTHONCOMPILED'] = _cache_dir_path
 
 # Check for MKL capability


### PR DESCRIPTION
Since some time ago, every time you use pycbc or import pycbc modules in ipython an init message appears saying 'setting weave to...'
This PR hides that message to appear only when verbose option selected.