### PR TITLE
Make get_slice an instancemethod.

### DIFF
--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -33,54 +33,6 @@ from pycbc.filter import autocorrelation
 #
 # =============================================================================
 #
-#                                   Helper functions
-#
-# =============================================================================
-#
-
-
-def get_slice(fp, thin_start=None, thin_interval=None, thin_end=None):
-    """Formats a slice using the given arguments that can be used to retrieve
-    a thinned array from an InferenceFile.
-
-    Parameters
-    ----------
-    fp : InferenceFile
-        An open inference file. The `burn_in_iterations` and acl will try to
-        be obtained from the file's attributes.
-    thin_start : {None, int}
-        The starting index to use. If None, will try to retrieve the
-        `burn_in_iterations` from the given file. If no `burn_in_iterations`
-        exists, will default to the start of the array.
-    thin_interval : {None, int}
-        The interval to use. If None, will try to retrieve the acl from the
-        given file. If no acl attribute exists, will default to 1.
-    thin_end : {None, int}
-        The end index to use. If None, will retrieve to the end of the array.
-
-    Returns
-    -------
-    slice :
-        The slice needed.
-    """
-    # default is to skip burn in samples
-    if thin_start is None:
-        try:
-            thin_start = fp.burn_in_iterations
-        except KeyError:
-            pass
-    # default is to use stored ACL and accept every i-th sample
-    if thin_interval is None:
-        try:
-            thin_interval = int(numpy.ceil(fp.acl))
-        except KeyError:
-            pass
-    return slice(thin_start, thin_end, thin_interval)
-
-
-#
-# =============================================================================
-#
 #                                   Samplers
 #
 # =============================================================================
@@ -537,8 +489,8 @@ class BaseMCMCSampler(_BaseSampler):
             if thin_end is None:
                 # use the number of current iterations
                 thin_end = fp.niterations
-            get_index = get_slice(fp, thin_start=thin_start, thin_end=thin_end,
-                                  thin_interval=thin_interval)
+            get_index = fp.get_slice(thin_start=thin_start, thin_end=thin_end,
+                                     thin_interval=thin_interval)
 
         # load
         arrays = {}
@@ -719,8 +671,8 @@ class BaseMCMCSampler(_BaseSampler):
             if thin_end is None:
                 # use the number of current iterations
                 thin_end = fp.niterations
-            get_index = get_slice(fp, thin_start=thin_start, thin_end=thin_end,
-                                  thin_interval=thin_interval)
+            get_index = fp.get_slice(thin_start=thin_start, thin_end=thin_end,
+                                     thin_interval=thin_interval)
         acfs = fp['acceptance_fraction'][get_index]
         if iteration is not None:
             acfs = numpy.array([acfs])

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -27,7 +27,7 @@ packages for parameter estimation.
 """
 
 import numpy
-from pycbc.inference.sampler_base import BaseMCMCSampler, get_slice
+from pycbc.inference.sampler_base import BaseMCMCSampler
 from pycbc.io import WaveformArray, FieldArray
 from pycbc.filter import autocorrelation
 
@@ -670,8 +670,8 @@ class EmceePTSampler(BaseMCMCSampler):
             if thin_end is None:
                 # use the number of current iterations
                 thin_end = fp.niterations
-            get_index = get_slice(fp, thin_start=thin_start, thin_end=thin_end,
-                                  thin_interval=thin_interval)
+            get_index = fp.get_slice(thin_start=thin_start, thin_end=thin_end,
+                                     thin_interval=thin_interval)
 
         # load
         arrays = {}

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -26,6 +26,7 @@ inference samplers generate.
 """
 
 import h5py
+import numpy
 from pycbc import pnutils
 from pycbc.waveform import parameters as wfparams
 import pycbc.inference.sampler
@@ -294,4 +295,3 @@ def get_slice(self, thin_start=None, thin_interval=None, thin_end=None):
         except KeyError:
             pass
     return slice(thin_start, thin_end, thin_interval)
-

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -256,3 +256,42 @@ class InferenceFile(h5py.File):
             psd_dim = self.create_dataset(key+"/psds/0",
                                           data=psds[key])
             psd_dim.attrs["delta_f"] = psds[key].delta_f
+
+
+def get_slice(self, thin_start=None, thin_interval=None, thin_end=None):
+    """Formats a slice using the given arguments that can be used to retrieve
+    a thinned array from an InferenceFile.
+
+    Parameters
+    ----------
+    thin_start : {None, int}
+        The starting index to use. If None, will try to retrieve the
+        `burn_in_iterations` from the given file. If no `burn_in_iterations`
+        exists, will default to the start of the array.
+    thin_interval : {None, int}
+        The interval to use. If None, will try to retrieve the acl from the
+        given file. If no acl attribute exists, will default to 1.
+    thin_end : {None, int}
+        The end index to use. If None, will retrieve to the end of the array.
+
+    Returns
+    -------
+    slice :
+        The slice needed.
+    """
+
+    # default is to skip burn in samples
+    if thin_start is None:
+        try:
+            thin_start = self.burn_in_iterations
+        except KeyError:
+            pass
+
+    # default is to use stored ACL and accept every i-th sample
+    if thin_interval is None:
+        try:
+            thin_interval = int(numpy.ceil(self.acl))
+        except KeyError:
+            pass
+    return slice(thin_start, thin_end, thin_interval)
+


### PR DESCRIPTION
This moves ``get_slice`` from the sampler modules and makes it an instance method of ``InferenceFile``. Something like this should be an instance method.

There are also a lot of if-else statements for a single iteration in the chain or a slice. These aren't really different things, ``slice(n, n+1, 1)`` is the same as getting the n-th iteration. We could remove these special cases later and just pass ``thin_start=n, thin_end=n+1, thin_interval=1`` but not for this PR.