### PR TITLE
Use set operations to add a list of functions to call before waveform generation in Generators

### DIFF
--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -177,12 +177,11 @@ class BaseGenerator(object):
         self.current_params.update(kwargs)
         return self._generate_from_current()
 
-
     def _add_pregenerate(self, func):
-	""" Adds a function that will be called by the generator function
-	before waveform generation.
-	"""
-	self._pregenerate_functions.append(func)
+        """ Adds a function that will be called by the generator function
+        before waveform generation.
+        """
+        self._pregenerate_functions.append(func)
 
 
     def _postgenerate(self, res):
@@ -196,7 +195,7 @@ class BaseGenerator(object):
         the waveform generator function.
         """
         def dostuff(self):
-	    for func in self._pregenerate_functions:
+            for func in self._pregenerate_functions:
                 func(self)
             res = generate_func(self)
             return self._postgenerate(res)
@@ -218,10 +217,10 @@ class BaseCBCGenerator(BaseGenerator):
             variable_args=variable_args, **frozen_params)
         # decorate the generator function with a list of functions that convert
 	# parameters to those used by the waveform generation interface
-	all_args = set(self.frozen_params.keys() + list(self.variable_args))
+        all_args = set(self.frozen_params.keys() + list(self.variable_args))
         # compare a set of all args of the generator to the input parameters
-	# of the functions that do conversions and adds to list of pregenerate
-	# functions if it is needed
+        # of the functions that do conversions and adds to list of pregenerate
+        # functions if it is needed
         for func in generator_functions:
             if set(func.input_params).issubset(all_args):
                 self._add_pregenerate(func)

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -93,6 +93,13 @@ def generator_mchirp_q_to_mass1_mass2(generator):
     generator.current_params['mass2'] = m2
 
 
+# a list of all generator functions
+generator_functions = [
+    generator_mchirp_eta_to_mass1_mass2,
+    generator_mtotal_eta_to_mass1_mass2,
+    generator_mchirp_q_to_mass1_mass2,
+]
+
 #
 #   Generator for CBC waveforms
 #
@@ -147,6 +154,7 @@ class BaseGenerator(object):
         # we'll keep a dictionary of the current parameters for fast
         # generation
         self.current_params = frozen_params.copy()
+        self._pregenerate_functions = []
 
     @property
     def static_args(self):
@@ -168,11 +176,12 @@ class BaseGenerator(object):
         self.current_params.update(kwargs)
         return self._generate_from_current()
 
-    def _pregenerate(self, option):
-        """Allows the current parameters to be manipulated before calling
-        the waveform generator.
-        """
-        pass
+
+    def _add_pregenerate(self, func):
+	""" Adds a function that will be called with _pregenerate.
+	"""
+	self._pregenerate_functions.append(func)
+
 
     def _postgenerate(self, res):
         """Allows the waveform returned by the generator function to be
@@ -185,7 +194,8 @@ class BaseGenerator(object):
         the waveform generator function.
         """
         def dostuff(self):
-            self._pregenerate(self)
+	    for func in self._pregenerate_functions:
+                func(self)
             res = generate_func(self)
             return self._postgenerate(res)
         return dostuff
@@ -204,20 +214,15 @@ class BaseCBCGenerator(BaseGenerator):
     def __init__(self, generator, variable_args=(), **frozen_params):
         super(BaseCBCGenerator, self).__init__(generator,
             variable_args=variable_args, **frozen_params)
-        # if m1 and m2 are not parameters, decorate the generator function
-        # to convert the used mass parameters to m1, m2
-        all_args = self.frozen_params.keys() + list(self.variable_args)
-        if 'mass1' not in all_args or 'mass2' not in all_args:
-            # set the decorator to the appropriate converter
-            if 'mchirp' in all_args and 'eta' in all_args:
-                self._pregenerate = generator_mchirp_eta_to_mass1_mass2
-            elif 'mtotal' in all_args and 'eta' in all_args:
-                self._pregenerate = generator_mtotal_eta_to_mass1_mass2
-            elif 'mchirp' in all_args and 'q' in all_args:
-                self._pregenerate = generator_mchirp_q_to_mass1_mass2
-            else:
-                raise ValueError("if not specifying mass1, mass2, must either use "
-                    "(mchirp, eta) or (mtotal, eta)")
+        # decorate the generator function with a list of functions that convert
+	# parameters to those used by the waveform generation interface
+	all_args = set(self.frozen_params.keys() + list(self.variable_args))
+        # compare a set of all args of the generator to the input parameters
+	# of the functions that do conversions and adds to list of pregenerate
+	# functions if it is needed
+        for func in generator_functions:
+            if set(func.input_params).issubset(all_args):
+                self._add_pregenerate(func)
 
 
 class FDomainCBCGenerator(BaseCBCGenerator):

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -154,6 +154,7 @@ class BaseGenerator(object):
         # we'll keep a dictionary of the current parameters for fast
         # generation
         self.current_params = frozen_params.copy()
+        # keep a list of functions to call before waveform generation
         self._pregenerate_functions = []
 
     @property
@@ -178,7 +179,8 @@ class BaseGenerator(object):
 
 
     def _add_pregenerate(self, func):
-	""" Adds a function that will be called with _pregenerate.
+	""" Adds a function that will be called by the generator function
+	before waveform generation.
 	"""
 	self._pregenerate_functions.append(func)
 

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -216,7 +216,7 @@ class BaseCBCGenerator(BaseGenerator):
         super(BaseCBCGenerator, self).__init__(generator,
             variable_args=variable_args, **frozen_params)
         # decorate the generator function with a list of functions that convert
-	# parameters to those used by the waveform generation interface
+        # parameters to those used by the waveform generation interface
         all_args = set(self.frozen_params.keys() + list(self.variable_args))
         # compare a set of all args of the generator to the input parameters
         # of the functions that do conversions and adds to list of pregenerate


### PR DESCRIPTION
Adds a ``self._pregenerate_functions`` attribute for keeping track of a list of functions to call before waveform generation with ``generators.py`` module.

Also replaces ``self._pregenerate`` with ``self._add_pregenerate`` that updates the list.

Then in the decorator (``_gdecorator``) iterate over these functions and call them before waveform generation.

Python ``set`` operations are used to decide what functions are needed.

Example:
```
In [2]: generator = waveform.FDomainCBCGenerator(variable_args=['mchirp', 'q'], delta_f=1./32, f_lower=30., approximant='TaylorF2')
In [3]: generator.generate(7, 4)
```