### PR TITLE
Add pregenerate function for spherical to Cartesian spin coordinates

### DIFF
--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -263,7 +263,7 @@ class BaseCBCGenerator(BaseGenerator):
         unused_args = all_args.difference(params_used) \
                               .difference(all_waveform_input_args)
         if len(unused_args):
-            raise ValueError("The following args are not used: %s"
+            raise ValueError("The following args are not being used: %s"
                              % unused_args)
 
 

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -28,6 +28,7 @@ This modules provides classes for generating waveforms.
 import functools
 import waveform
 import ringdown
+from pycbc import coordinates
 from pycbc.waveform import parameters
 from pycbc.waveform.utils import apply_fd_time_shift
 from pycbc.detector import Detector
@@ -93,9 +94,10 @@ def generator_mchirp_q_to_mass1_mass2(generator):
     generator.current_params['mass2'] = m2
 
 
-@add_attrs(input_params=[parmeters.spin1_a, parmeters.spin2_a,
-	                 parmeters.spin1_azimuthal, parmeters.spin2_azimuthal,
-			 parmeters.spin1_polar, parmeters.spin2_polar],
+@add_attrs(input_params=[parameters.spin1_a, parameters.spin2_a,
+	                 parameters.spin1_azimuthal,
+			 parameters.spin2_azimuthal,
+			 parameters.spin1_polar, parameters.spin2_polar],
            output_params=[parameters.spin1x, parameters.spin2x,
 		          parameters.spin1y, parameters.spin2y,
 			  parameters.spin1z, parameters.spin2z])
@@ -108,17 +110,17 @@ def generator_spin_spherical_to_spin_cartesian(generator):
 			           * generator.current_params["mass1"]**2,
 		                   generator.current_params["spin1_azimuthal"],
                                    generator.current_params["spin1_polar"])
-    self.current_params["spin1x"] = x
-    self.current_params["spin1y"] = y
-    self.current_params["spin1z"] = z
+    generator.current_params["spin1x"] = x
+    generator.current_params["spin1y"] = y
+    generator.current_params["spin1z"] = z
     x, y, z = coordinates.spherical_to_cartesian(
                                    generator.current_params["spin2_a"] \
                                    * generator.current_params["mass2"]**2,
                                    generator.current_params["spin2_azimuthal"],
                                    generator.current_params["spin2_polar"])
-    self.current_params["spin2x"] = x
-    self.current_params["spin2y"] = y
-    self.current_params["spin2z"] = z
+    generator.current_params["spin2x"] = x
+    generator.current_params["spin2y"] = y
+    generator.current_params["spin2z"] = z
 
 
 # a list of all generator functions

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -177,12 +177,11 @@ class BaseGenerator(object):
         self.current_params.update(kwargs)
         return self._generate_from_current()
 
-
     def _add_pregenerate(self, func):
-	""" Adds a function that will be called by the generator function
-	before waveform generation.
-	"""
-	self._pregenerate_functions.append(func)
+        """ Adds a function that will be called by the generator function
+        before waveform generation.
+        """
+        self._pregenerate_functions.append(func)
 
 
     def _postgenerate(self, res):
@@ -196,7 +195,7 @@ class BaseGenerator(object):
         the waveform generator function.
         """
         def dostuff(self):
-	    for func in self._pregenerate_functions:
+            for func in self._pregenerate_functions:
                 func(self)
             res = generate_func(self)
             return self._postgenerate(res)
@@ -218,10 +217,10 @@ class BaseCBCGenerator(BaseGenerator):
             variable_args=variable_args, **frozen_params)
         # decorate the generator function with a list of functions that convert
 	# parameters to those used by the waveform generation interface
-	all_args = set(self.frozen_params.keys() + list(self.variable_args))
+        all_args = set(self.frozen_params.keys() + list(self.variable_args))
         # compare a set of all args of the generator to the input parameters
-	# of the functions that do conversions and adds to list of pregenerate
-	# functions if it is needed
+        # of the functions that do conversions and adds to list of pregenerate
+        # functions if it is needed
         for func in generator_functions:
             if set(func.input_params).issubset(all_args):
                 self._add_pregenerate(func)

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -93,11 +93,40 @@ def generator_mchirp_q_to_mass1_mass2(generator):
     generator.current_params['mass2'] = m2
 
 
+@add_attrs(input_params=[parmeters.spin1_a, parmeters.spin2_a,
+	                 parmeters.spin1_azimuthal, parmeters.spin2_azimuthal,
+			 parmeters.spin1_polar, parmeters.spin2_polar],
+           output_params=[parameters.spin1x, parameters.spin2x,
+		          parameters.spin1y, parameters.spin2y,
+			  parameters.spin1z, parameters.spin2z])
+def generator_spin_spherical_to_spin_cartesian(generator):
+    """Converts spherical spin magnitude and angles in `current_params`,
+    to cartesian component spins.
+    """
+    x, y, z = coordinates.spherical_to_cartesian(
+		                   generator.current_params["spin1_a"] \
+			           * generator.current_params["mass1"]**2,
+		                   generator.current_params["spin1_azimuthal"],
+                                   generator.current_params["spin1_polar"])
+    self.current_params["spin1x"] = x
+    self.current_params["spin1y"] = y
+    self.current_params["spin1z"] = z
+    x, y, z = coordinates.spherical_to_cartesian(
+                                   generator.current_params["spin2_a"] \
+                                   * generator.current_params["mass2"]**2,
+                                   generator.current_params["spin2_azimuthal"],
+                                   generator.current_params["spin2_polar"])
+    self.current_params["spin2x"] = x
+    self.current_params["spin2y"] = y
+    self.current_params["spin2z"] = z
+
+
 # a list of all generator functions
 generator_functions = [
     generator_mchirp_eta_to_mass1_mass2,
     generator_mtotal_eta_to_mass1_mass2,
     generator_mchirp_q_to_mass1_mass2,
+    generator_spin_spherical_to_spin_cartesian,
 ]
 
 #

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -95,20 +95,20 @@ def generator_mchirp_q_to_mass1_mass2(generator):
 
 
 @add_attrs(input_params=[parameters.spin1_a, parameters.spin2_a,
-	                 parameters.spin1_azimuthal,
-			 parameters.spin2_azimuthal,
-			 parameters.spin1_polar, parameters.spin2_polar],
+                         parameters.spin1_azimuthal,
+                         parameters.spin2_azimuthal,
+                         parameters.spin1_polar, parameters.spin2_polar],
            output_params=[parameters.spin1x, parameters.spin2x,
-		          parameters.spin1y, parameters.spin2y,
-			  parameters.spin1z, parameters.spin2z])
+                          parameters.spin1y, parameters.spin2y,
+                          parameters.spin1z, parameters.spin2z])
 def generator_spin_spherical_to_spin_cartesian(generator):
     """Converts spherical spin magnitude and angles in `current_params`,
     to cartesian component spins.
     """
     x, y, z = coordinates.spherical_to_cartesian(
-		                   generator.current_params["spin1_a"] \
-			           * generator.current_params["mass1"]**2,
-		                   generator.current_params["spin1_azimuthal"],
+                                   generator.current_params["spin1_a"] \
+                                   * generator.current_params["mass1"]**2,
+                                   generator.current_params["spin1_azimuthal"],
                                    generator.current_params["spin1_polar"])
     generator.current_params["spin1x"] = x
     generator.current_params["spin1y"] = y

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -93,6 +93,13 @@ def generator_mchirp_q_to_mass1_mass2(generator):
     generator.current_params['mass2'] = m2
 
 
+# a list of all generator functions
+generator_functions = [
+    generator_mchirp_eta_to_mass1_mass2,
+    generator_mtotal_eta_to_mass1_mass2,
+    generator_mchirp_q_to_mass1_mass2,
+]
+
 #
 #   Generator for CBC waveforms
 #
@@ -147,6 +154,7 @@ class BaseGenerator(object):
         # we'll keep a dictionary of the current parameters for fast
         # generation
         self.current_params = frozen_params.copy()
+        self._pregenerate_functions = []
 
     @property
     def static_args(self):
@@ -168,11 +176,12 @@ class BaseGenerator(object):
         self.current_params.update(kwargs)
         return self._generate_from_current()
 
-    def _pregenerate(self, option):
-        """Allows the current parameters to be manipulated before calling
-        the waveform generator.
-        """
-        pass
+
+    def _add_pregenerate(self, func):
+	""" Adds a function that will be called with _pregenerate.
+	"""
+	self._pregenerate_functions.append(func)
+
 
     def _postgenerate(self, res):
         """Allows the waveform returned by the generator function to be
@@ -185,7 +194,8 @@ class BaseGenerator(object):
         the waveform generator function.
         """
         def dostuff(self):
-            self._pregenerate(self)
+	    for func in self._pregenerate_functions:
+                func(self)
             res = generate_func(self)
             return self._postgenerate(res)
         return dostuff
@@ -204,20 +214,15 @@ class BaseCBCGenerator(BaseGenerator):
     def __init__(self, generator, variable_args=(), **frozen_params):
         super(BaseCBCGenerator, self).__init__(generator,
             variable_args=variable_args, **frozen_params)
-        # if m1 and m2 are not parameters, decorate the generator function
-        # to convert the used mass parameters to m1, m2
-        all_args = self.frozen_params.keys() + list(self.variable_args)
-        if 'mass1' not in all_args or 'mass2' not in all_args:
-            # set the decorator to the appropriate converter
-            if 'mchirp' in all_args and 'eta' in all_args:
-                self._pregenerate = generator_mchirp_eta_to_mass1_mass2
-            elif 'mtotal' in all_args and 'eta' in all_args:
-                self._pregenerate = generator_mtotal_eta_to_mass1_mass2
-            elif 'mchirp' in all_args and 'q' in all_args:
-                self._pregenerate = generator_mchirp_q_to_mass1_mass2
-            else:
-                raise ValueError("if not specifying mass1, mass2, must either use "
-                    "(mchirp, eta) or (mtotal, eta)")
+        # decorate the generator function with a list of functions that convert
+	# parameters to those used by the waveform generation interface
+	all_args = set(self.frozen_params.keys() + list(self.variable_args))
+        # compare a set of all args of the generator to the input parameters
+	# of the functions that do conversions and adds to list of pregenerate
+	# functions if it is needed
+        for func in generator_functions:
+            if set(func.input_params).issubset(all_args):
+                self._add_pregenerate(func)
 
 
 class FDomainCBCGenerator(BaseCBCGenerator):

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -252,9 +252,19 @@ class BaseCBCGenerator(BaseGenerator):
         # compare a set of all args of the generator to the input parameters
         # of the functions that do conversions and adds to list of pregenerate
         # functions if it is needed
+        params_used = set([])
         for func in generator_functions:
             if set(func.input_params).issubset(all_args):
                 self._add_pregenerate(func)
+                params_used.update(func.input_params)
+        # check that there are no unused parameters
+        all_waveform_input_args = set(parameters.td_waveform_params +
+                                      parameters.fd_waveform_params)
+        unused_args = all_args.difference(params_used) \
+                              .difference(all_waveform_input_args)
+        if len(unused_args):
+            raise ValueError("The following args are not used: %s"
+                             % unused_args)
 
 
 class FDomainCBCGenerator(BaseCBCGenerator):

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -106,16 +106,16 @@ def generator_spin_spherical_to_spin_cartesian(generator):
     to cartesian component spins.
     """
     x, y, z = coordinates.spherical_to_cartesian(
-                                   generator.current_params["spin1_a"]
-                                   * generator.current_params["mass1"]**2,
+                                   generator.current_params["spin1_a"] *
+                                   generator.current_params["mass1"]**2,
                                    generator.current_params["spin1_azimuthal"],
                                    generator.current_params["spin1_polar"])
     generator.current_params["spin1x"] = x
     generator.current_params["spin1y"] = y
     generator.current_params["spin1z"] = z
     x, y, z = coordinates.spherical_to_cartesian(
-                                   generator.current_params["spin2_a"]
-                                   * generator.current_params["mass2"]**2,
+                                   generator.current_params["spin2_a"] *
+                                   generator.current_params["mass2"]**2,
                                    generator.current_params["spin2_azimuthal"],
                                    generator.current_params["spin2_polar"])
     generator.current_params["spin2x"] = x

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -106,7 +106,7 @@ def generator_spin_spherical_to_spin_cartesian(generator):
     to cartesian component spins.
     """
     x, y, z = coordinates.spherical_to_cartesian(
-                                   generator.current_params["spin1_a"] \
+                                   generator.current_params["spin1_a"]
                                    * generator.current_params["mass1"]**2,
                                    generator.current_params["spin1_azimuthal"],
                                    generator.current_params["spin1_polar"])
@@ -114,7 +114,7 @@ def generator_spin_spherical_to_spin_cartesian(generator):
     generator.current_params["spin1y"] = y
     generator.current_params["spin1z"] = z
     x, y, z = coordinates.spherical_to_cartesian(
-                                   generator.current_params["spin2_a"] \
+                                   generator.current_params["spin2_a"]
                                    * generator.current_params["mass2"]**2,
                                    generator.current_params["spin2_azimuthal"],
                                    generator.current_params["spin2_polar"])

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -154,6 +154,7 @@ class BaseGenerator(object):
         # we'll keep a dictionary of the current parameters for fast
         # generation
         self.current_params = frozen_params.copy()
+        # keep a list of functions to call before waveform generation
         self._pregenerate_functions = []
 
     @property
@@ -178,7 +179,8 @@ class BaseGenerator(object):
 
 
     def _add_pregenerate(self, func):
-	""" Adds a function that will be called with _pregenerate.
+	""" Adds a function that will be called by the generator function
+	before waveform generation.
 	"""
 	self._pregenerate_functions.append(func)
 

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -216,7 +216,7 @@ class BaseCBCGenerator(BaseGenerator):
         super(BaseCBCGenerator, self).__init__(generator,
             variable_args=variable_args, **frozen_params)
         # decorate the generator function with a list of functions that convert
-	# parameters to those used by the waveform generation interface
+        # parameters to those used by the waveform generation interface
         all_args = set(self.frozen_params.keys() + list(self.variable_args))
         # compare a set of all args of the generator to the input parameters
         # of the functions that do conversions and adds to list of pregenerate


### PR DESCRIPTION
Depends on #1134.

Adds function to ``generator_functions`` that converts between spherical to Cartesian coordinates for generators.

There's a case where if someone is missing an argument then it generates the waveform without the options, hence the WIP tag. This should be fixed in this PR for the spin function. This doesn't affect any of the mass generator functions because ``mass1`` and ``mass2`` are required and the user would get an error. Mainly making a PR now to show that I've worked on this, will push fix.

Eg. of case missing ``spin2_polar`` that doesn't give an error:
```
from pycbc import waveform
generator = waveform.FDomainCBCGenerator(variable_args=['mchirp', 'q', 'spin1_a', 'spin1_azimuthal', 'spin1_polar', 'spin2_a', 'spin2_azimuthal'], delta_f=1./32, f_lower=30., approximant='IMRPhenomP')
generator.generate(1, 1, 0.5, 0.1, 0.1, 0.5, 0.1)
```