### PR TITLE
Add spin magnitude and angles to generators.

### DIFF
--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -263,8 +263,8 @@ class BaseCBCGenerator(BaseGenerator):
         unused_args = all_args.difference(params_used) \
                               .difference(all_waveform_input_args)
         if len(unused_args):
-            raise ValueError("The following args are not being used: %s"
-                             % unused_args)
+            raise ValueError("The following args are not being used: "
+                             "{opts}".format(opts=unused_args))
 
 
 class FDomainCBCGenerator(BaseCBCGenerator):


### PR DESCRIPTION
Resubmission of #1135.

Includes a check that if user provides an inappropriate set of options then it displays what args are not being used as an error. This is to keep people from thinking that are generating a waveform with the ``_pregenerate`` functions when they provide the wrong inputs. Eg. missing ``spin2_polar`` option:
```
In [1]: from pycbc import waveform
In [3]: generator = waveform.FDomainCBCGenerator(variable_args=['spin1_a', 'spin1_azimuthal', 'spin1_polar', 'spin2_a', 'spin2_azimuthal'], delta_f=1./32, f_lower=30., q=1, mchirp=2, approximant='IMRPhenomP')
ValueError: The following args are not being used: set(['spin1_a', 'spin1_polar', 'spin1_azimuthal', 'spin2_a', 'spin2_azimuthal'])
```

Also allows spin magnitude and angles to be used with generators.