### PR TITLE
Code for splitting a given compressed template bank into smaller banks in hdf5 format

### DIFF
--- a/bin/pycbc_hdf5_splitbank
+++ b/bin/pycbc_hdf5_splitbank
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2016  Soumi De
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+The code reads in a compressed template bank and splits it up into
+smaller banks where the number of smaller banks is a user input
+"""
+
+import argparse
+import h5py
+import logging
+import pycbc, pycbc.version
+from pycbc.waveform import bank
+__author__  = "Soumi De <soumi.de@ligo.org>"
+__version__ = pycbc.version.git_verbose_msg
+__date__    = pycbc.version.date
+__program__ = "pycbc_hdf5_splitbank"
+
+
+parser = argparse.ArgumentParser(description=__doc__[1:])
+parser.add_argument("--bank-file", type=str,
+                    help="Bank hdf file to load.")
+parser.add_argument('--templates-per-bank',
+                    help='number of templates in the output banks', type=int)
+parser.add_argument("--number-of-banks", type=int,
+                    help="Number of banks")
+parser.add_argument("--output-filenames", nargs='*', default=None,
+                    action="store",
+                    help="""Directly specify the names of the output
+                    files. The number of files specified here will
+                    dictate how to split the bank. It will be split
+                    equally between all specified files.""")
+parser.add_argument("--output-prefix", default=None,
+                    help="""Prefix to add to the output template bank names,
+                    for example 'sub-bank'. The output file names would
+                    become args.output_prefix#.hdf""")
+parser.add_argument("--force", action="store_true", default=False,
+                    help="Overwrite the given hdf file if it exists. "
+                         "Otherwise, an error is raised.")
+parser.add_argument("--verbose", action="store_true", default=False)
+
+
+args = parser.parse_args()
+
+pycbc.init_logging(args.verbose)
+
+logging.info("loading bank")
+
+tmplt_bank = bank.TemplateBank(args.bank_file)
+
+templates = tmplt_bank.table
+
+if args.output_filenames and args.output_prefix:
+    errMsg="""Either supply specific filenames for all output files via
+    args.output_filenames or supply a common prefix for all output files
+    via args.output_prefix. Cannot supply both"""
+    parser.error(errMsg)
+
+# If an array of filenames
+if args.output_filenames:
+    args.number_of_banks = len(args.output_filenames)
+
+# Split the templates in the bank taken as input into the smaller banks
+
+# If the number of output banks is taken as input calculate the number
+# of templates to be stored per bank
+if args.number_of_banks:
+    num_files = args.number_of_banks
+    num_per_file = int(templates[:].size/num_files)
+
+# If the number of templates per bank is taken as input calculate the
+# number of output banks
+elif args.templates_per_bank:
+    num_per_file = args.templates_per_bank
+    num_files = int(templates[:].size / num_per_file)
+
+for ii in range(num_files):
+    start_idx = ii * num_per_file
+    # The output banks are assigned a fixed length equal to the number
+    # of templates per bank requested by the user or calculated earlier
+    # in the code except for the last bank in which the remaining
+    # templates, if any, are put.
+    if ( ii == (num_files-1)):
+        end_idx = templates[:].size
+    else:
+        end_idx = (ii + 1) * num_per_file
+
+    # Assign a name to the h5py output file to store the ii'th smaller bank
+    if args.output_filenames:
+        outname = output_filenames[ii]
+    elif args.output_prefix:
+        outname = args.output_prefix + str(ii) + '.hdf'
+    else:
+        errMsg = """Cannot resolve the process of assigning names to
+                output files. output-filenames or an output-prefix
+                should be taken as input."""
+
+    # Generate the hdf5 output file for the ii'th sub-bank, which would
+    # be a slice of the input template bank having a start index and
+    # end index as calculated above
+    output = tmplt_bank.write_to_hdf(outname, start_idx, end_idx,
+                                     force=args.force, skip_fields='template_duration')

--- a/bin/pycbc_hdf5_splitbank
+++ b/bin/pycbc_hdf5_splitbank
@@ -35,20 +35,27 @@ __program__ = "pycbc_hdf5_splitbank"
 parser = argparse.ArgumentParser(description=__doc__[1:])
 parser.add_argument("--bank-file", type=str,
                     help="Bank hdf file to load.")
-parser.add_argument('--templates-per-bank',
-                    help='number of templates in the output banks', type=int)
+parser.add_argument('--templates-per-bank', type = int,
+                    help="This specifies the number of templates in "
+                    "each of the output sub-banks. Either specify this "
+                    "or --number-of-banks, as one of them is used to "
+                    "calculate the other in the code. Do not supply "
+                    "both.")
 parser.add_argument("--number-of-banks", type=int,
-                    help="Number of banks")
+                    help="This specifies the number of output sub-banks."
+                    "Either specify this or --templates-per-bank, as one"
+                    "of them is used to calculate the other in the code." 
+                    "Do not supply both.")
 parser.add_argument("--output-filenames", nargs='*', default=None,
                     action="store",
-                    help="""Directly specify the names of the output
-                    files. The number of files specified here will
-                    dictate how to split the bank. It will be split
-                    equally between all specified files.""")
+                    help="Directly specify the names of the output files."
+                    "The number of files specified here will dictate "
+                    "how to split the bank. It will be split equally "
+                    "between all specified files.")
 parser.add_argument("--output-prefix", default=None,
-                    help="""Prefix to add to the output template bank names,
-                    for example 'sub-bank'. The output file names would
-                    become args.output_prefix#.hdf""")
+                    help="Prefix to add to the output template bank names,"
+                    "for example 'sub-bank'. The output file names would"
+                    "become args.output_prefix.hdf")
 parser.add_argument("--force", action="store_true", default=False,
                     help="Overwrite the given hdf file if it exists. "
                          "Otherwise, an error is raised.")
@@ -68,7 +75,14 @@ templates = tmplt_bank.table
 if args.output_filenames and args.output_prefix:
     errMsg="""Either supply specific filenames for all output files via
     args.output_filenames or supply a common prefix for all output files
-    via args.output_prefix. Cannot supply both"""
+    via args.output_prefix. Cannot supply both."""
+    parser.error(errMsg)
+
+if args.templates_per_bank and args.number_of_banks:
+    errMsg="""Either request a --templates-per-bank which would be used 
+    to calculate the number of sub-banks to be generated or request
+    --number-of-banks which would be used to calculate the number of 
+    templates to be put in each sub-bank. Cannot supply both. """
     parser.error(errMsg)
 
 # If an array of filenames
@@ -89,6 +103,14 @@ elif args.templates_per_bank:
     num_per_file = args.templates_per_bank
     num_files = int(templates[:].size / num_per_file)
 
+else:
+    errMsg = """Either one of the options --templates-per-bank or 
+    --number-of-banks should be requested to generate the output 
+    sub-banks."""
+    parser.error(errMsg)
+
+# Generate sub-banks
+logging.info("Generating the output sub-banks")
 for ii in range(num_files):
     start_idx = ii * num_per_file
     # The output banks are assigned a fixed length equal to the number
@@ -107,11 +129,16 @@ for ii in range(num_files):
         outname = args.output_prefix + str(ii) + '.hdf'
     else:
         errMsg = """Cannot resolve the process of assigning names to
-                output files. output-filenames or an output-prefix
+                output files. --output-filenames or --output-prefix
                 should be taken as input."""
+        raise ValueError(errMsg)
 
     # Generate the hdf5 output file for the ii'th sub-bank, which would
     # be a slice of the input template bank having a start index and
     # end index as calculated above
     output = tmplt_bank.write_to_hdf(outname, start_idx, end_idx,
-                                     force=args.force, skip_fields='template_duration')
+                                     force=args.force, 
+                                     skip_fields='template_duration')
+    output.close()
+
+logging.info("finished")

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -333,13 +333,20 @@ class TemplateBank(object):
                          for p in fields])])
         self.table = self.table.add_fields(template_hash, 'template_hash')
 
-    def write_to_hdf(self, filename, start_index, stop_index, force=False, skip_fields=None):
+    def write_to_hdf(self, filename, start_index=None, stop_index=None,
+                     force=False, skip_fields=None):
         """Writes self to the given hdf file.
 
         Parameters
         ----------
         filename : str
             The name of the file to write to. Must end in '.hdf'.
+        start_index : If a specific slice of the template bank is to be 
+            written to the hdf file, this would specify the index of the
+            first template in the slice
+        stop_index : If a specific slice of the template bank is to be 
+            written to the hdf file, this would specify the index of the
+            last template in the slice
         force : {False, bool}
             If the file already exists, it will be overwritten if True.
             Otherwise, an OSError is raised if the file exists.

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -255,7 +255,7 @@ class TemplateBank(object):
 
             # inclination stored in xml alpha3 column
             names = list(self.table.dtype.names)
-            names = tuple([n if n != 'alpha3' 
+            names = tuple([n if n != 'alpha3'
                           else 'inclination' for n in names])
             self.table.dtype.names = names
 
@@ -387,7 +387,7 @@ class TemplateBank(object):
         from pycbc.waveform.waveform import props
 
         return pycbc.waveform.get_waveform_end_frequency(
-                                self.table[index], 
+                                self.table[index],
                                 approximant=self.approximant(index),
                                 **self.extra_args)
 
@@ -585,7 +585,7 @@ class LiveFilterBank(TemplateBank):
         htilde.sigmasq = types.MethodType(sigma_cached, htilde)
         htilde._sigmasq = {}
 
-        htilde.id = self.id_from_hash(hash((htilde.params.mass1, 
+        htilde.id = self.id_from_hash(hash((htilde.params.mass1,
                                       htilde.params.mass2,
                                       htilde.params.spin1z,
                                       htilde.params.spin2z)))

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -341,10 +341,10 @@ class TemplateBank(object):
         ----------
         filename : str
             The name of the file to write to. Must end in '.hdf'.
-        start_index : If a specific slice of the template bank is to be 
+        start_index : If a specific slice of the template bank is to be
             written to the hdf file, this would specify the index of the
             first template in the slice
-        stop_index : If a specific slice of the template bank is to be 
+        stop_index : If a specific slice of the template bank is to be
             written to the hdf file, this would specify the index of the
             last template in the slice
         force : {False, bool}

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -682,6 +682,7 @@ class FilterBank(TemplateBank):
         htilde._sigmasq = {}
         return htilde
 
+
 def find_variable_start_frequency(approximant, parameters, f_start, max_length,
                                   delta_f = 1):
     """ Find a frequency value above the starting frequency that results in a

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -53,19 +53,19 @@ def sigma_cached(self, psd):
         if pycbc.waveform.waveform_norm_exists(self.approximant):
             if not hasattr(psd, 'sigmasq_vec'):
                 psd.sigmasq_vec = {}
-            
+
             if self.approximant not in psd.sigmasq_vec:
                 psd.sigmasq_vec[self.approximant] = pycbc.waveform.get_waveform_filter_norm(
                      self.approximant, psd, len(psd), psd.delta_f, self.f_lower)
-    
-            if not hasattr(self, 'sigma_scale'):                
+
+            if not hasattr(self, 'sigma_scale'):
                 # Get an amplitude normalization (mass dependant constant norm)
                 amp_norm = pycbc.waveform.get_template_amplitude_norm(
                                      self.params, approximant=self.approximant)
                 amp_norm = 1 if amp_norm is None else amp_norm
                 self.sigma_scale = (DYN_RANGE_FAC * amp_norm) ** 2.0
-                
-                
+
+
             self._sigmasq[key] = psd.sigmasq_vec[self.approximant][self.end_idx] * self.sigma_scale
 
         else:
@@ -75,13 +75,13 @@ def sigma_cached(self, psd):
                 kmin, kmax = get_cutoff_indices(self.f_lower, self.end_frequency, self.delta_f, N)
                 self.sslice = slice(kmin, kmax)
                 self.sigma_view = self[self.sslice].squared_norm() * 4.0 * self.delta_f
-        
+
             if not hasattr(psd, 'invsqrt'):
                 psd.invsqrt = 1.0 / psd[self.sslice]
-                
-            return self.sigma_view.inner(psd.invsqrt)                 
+
+            return self.sigma_view.inner(psd.invsqrt)
     return self._sigmasq[key]
-    
+
 # dummy class needed for loading LIGOLW files
 class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
     pass
@@ -171,8 +171,8 @@ def parse_approximant_arg(approximant_arg, warray):
         the warray.
     """
     return warray.parse_boolargs(boolargs_from_apprxstr(approximant_arg))[0]
-        
-                       
+
+
 class TemplateBank(object):
     """Class to provide some basic helper functions and information
     about elements of a template bank.
@@ -255,7 +255,7 @@ class TemplateBank(object):
 
             # inclination stored in xml alpha3 column
             names = list(self.table.dtype.names)
-            names = tuple([n if n != 'alpha3' else 'inclination' for n in names]) 
+            names = tuple([n if n != 'alpha3' else 'inclination' for n in names])
             self.table.dtype.names = names
 
         elif ext.endswith('hdf'):
@@ -276,7 +276,7 @@ class TemplateBank(object):
                 parameters = fileparams
             common_fields = list(pycbc.io.WaveformArray(1,
                 names=parameters).fieldnames)
-            add_fields = list(set(parameters) & 
+            add_fields = list(set(parameters) &
                 (set(fileparams) - set(common_fields)))
             # load
             dtype = []
@@ -316,7 +316,7 @@ class TemplateBank(object):
         return self.table.fieldnames
 
     def ensure_hash(self):
-        """Ensure that there is a correctly populated template_hash 
+        """Ensure that there is a correctly populated template_hash
         if it doesnt not already exist.
         """
         fields = self.table.fieldnames
@@ -330,12 +330,12 @@ class TemplateBank(object):
 
         fields = [f for f in hash_fields if f in fields]
         template_hash = numpy.array([hash(v) for v in zip(*[self.table[p]
-                         for p in fields])]) 
+                         for p in fields])])
         self.table = self.table.add_fields(template_hash, 'template_hash')
 
-    def write_to_hdf(self, filename, force=False, skip_fields=None):
+    def write_to_hdf(self, filename, start_index, stop_index, force=False, skip_fields=None):
         """Writes self to the given hdf file.
-        
+
         Parameters
         ----------
         filename : str
@@ -364,11 +364,12 @@ class TemplateBank(object):
             parameters = [p for p in parameters if p not in skip_fields]
         # save the parameters
         f.attrs['parameters'] = parameters
+        write_tbl = self.table[start_index:stop_index]
         for p in parameters:
-            f[p] = self.table[p]
+            f[p] = write_tbl[p]
         if self.compressed_waveforms is not None:
-            for tmplt_hash, compwf in self.compressed_waveforms.items():
-                compwf.write_to_hdf(f, tmplt_hash) 
+            for tmplt_hash in write_tbl.template_hash:
+                self.compressed_waveforms[tmplt_hash].write_to_hdf(f, tmplt_hash)
         return f
 
     def end_frequency(self, index):
@@ -378,7 +379,7 @@ class TemplateBank(object):
 
         return pycbc.waveform.get_waveform_end_frequency(self.table[index],
                               approximant=self.approximant(index),
-                              **self.extra_args)      
+                              **self.extra_args)
 
     def parse_approximant(self, approximant):
         """Parses the given approximant argument, returning the approximant to
@@ -435,7 +436,7 @@ class TemplateBank(object):
         thinning_bank = []
         tau0_temp, _ = pycbc.pnutils.mass1_mass2_to_tau0_tau3(m1, m2, fref)
         indices = []
-            
+
         for inj in injection_parameters:
             tau0_inj, _ = \
                 pycbc.pnutils.mass1_mass2_to_tau0_tau3(inj.mass1, inj.mass2,
@@ -450,7 +451,7 @@ class TemplateBank(object):
 class LiveFilterBank(TemplateBank):
     def __init__(self, filename, f_lower, sample_rate, minimum_buffer,
                        approximant=None, increment=8, parameters=None,
-                       load_compressed=True, load_compressed_now=False, 
+                       load_compressed=True, load_compressed_now=False,
                        **kwds):
 
         self.increment = increment
@@ -465,7 +466,7 @@ class LiveFilterBank(TemplateBank):
 
         if not hasattr(self.table, 'template_duration'):
             self.table = self.table.add_fields(numpy.zeros(len(self.table),
-                                     dtype=numpy.float32), 'template_duration') 
+                                     dtype=numpy.float32), 'template_duration')
 
         from pycbc.pnutils import mass1_mass2_to_mchirp_eta
         self.table.sort(order='mchirp')
@@ -506,13 +507,13 @@ class LiveFilterBank(TemplateBank):
         ----------
         hash : int
             Value of the template hash
-    
+
         Returns
         --------
         index : int
             The ordered index that this template has in the template bank.
-        """   
-        return self.hash_lookup[hash_value]        
+        """
+        return self.hash_lookup[hash_value]
 
     def __getitem__(self, index):
         if isinstance(index, slice):
@@ -524,11 +525,11 @@ class LiveFilterBank(TemplateBank):
         # Determine the length of time of the filter, rounded up to
         # nearest power of two
         min_buffer = .5 + self.minimum_buffer
-    
+
         from pycbc.waveform.waveform import props
         p = props(self.table[index])
         p.pop('approximant')
-        buff_size = pycbc.waveform.get_waveform_filter_length_in_time(approximant, f_lower=self.f_lower, 
+        buff_size = pycbc.waveform.get_waveform_filter_length_in_time(approximant, f_lower=self.f_lower,
                                                                       **p)
         tlen = self.round_up((buff_size + min_buffer) * self.sample_rate)
         flen = tlen / 2 + 1
@@ -549,7 +550,7 @@ class LiveFilterBank(TemplateBank):
             **self.extra_args)
 
         # If available, record the total duration (which may
-        # include ringdown) and the duration up to merger since they will be 
+        # include ringdown) and the duration up to merger since they will be
         # erased by the type conversion below.
         ttotal = template_duration = -1
         if hasattr(htilde, 'length_in_time'):
@@ -557,7 +558,7 @@ class LiveFilterBank(TemplateBank):
         if hasattr(htilde, 'chirp_length'):
                 template_duration = htilde.chirp_length
 
-        self.table[index].template_duration = template_duration        
+        self.table[index].template_duration = template_duration
 
         htilde = htilde.astype(numpy.complex64)
         htilde.f_lower = self.f_lower
@@ -567,12 +568,12 @@ class LiveFilterBank(TemplateBank):
         htilde.approximant = approximant
         htilde.chirp_length = template_duration
         htilde.length_in_time = ttotal
-        
+
         # Add sigmasq as a method of this instance
         htilde.sigmasq = types.MethodType(sigma_cached, htilde)
         htilde._sigmasq = {}
 
-        htilde.id = self.id_from_hash(hash((htilde.params.mass1, htilde.params.mass2, 
+        htilde.id = self.id_from_hash(hash((htilde.params.mass1, htilde.params.mass2,
                           htilde.params.spin1z, htilde.params.spin2z)))
         return htilde
 
@@ -580,7 +581,7 @@ class FilterBank(TemplateBank):
     def __init__(self, filename, filter_length, delta_f, f_lower, dtype,
                  out=None, max_template_length=None,
                  approximant=None, parameters=None,
-                 load_compressed=True, load_compressed_now=False, 
+                 load_compressed=True, load_compressed_now=False,
                  **kwds):
         self.out = out
         self.dtype = dtype
@@ -643,7 +644,7 @@ class FilterBank(TemplateBank):
             **self.extra_args)
 
         # If available, record the total duration (which may
-        # include ringdown) and the duration up to merger since they will be 
+        # include ringdown) and the duration up to merger since they will be
         # erased by the type conversion below.
         ttotal = template_duration = None
         if hasattr(htilde, 'length_in_time'):
@@ -651,7 +652,7 @@ class FilterBank(TemplateBank):
         if hasattr(htilde, 'chirp_length'):
                 template_duration = htilde.chirp_length
 
-        self.table[index].template_duration = template_duration        
+        self.table[index].template_duration = template_duration
 
         htilde = htilde.astype(self.dtype)
         htilde.f_lower = self.f_lower
@@ -661,17 +662,17 @@ class FilterBank(TemplateBank):
         htilde.approximant = approximant
         htilde.chirp_length = template_duration
         htilde.length_in_time = ttotal
-        
+
         # Add sigmasq as a method of this instance
         htilde.sigmasq = types.MethodType(sigma_cached, htilde)
         htilde._sigmasq = {}
         return htilde
 
-       
 
-def find_variable_start_frequency(approximant, parameters, f_start, max_length, 
+
+def find_variable_start_frequency(approximant, parameters, f_start, max_length,
                                   delta_f = 1):
-    """ Find a frequency value above the starting frequency that results in a 
+    """ Find a frequency value above the starting frequency that results in a
     waveform shorter than max_length.
     """
     l = max_length + 1
@@ -687,7 +688,7 @@ class FilterBankSkyMax(TemplateBank):
     def __init__(self, filename, filter_length, delta_f, f_lower,
                  dtype, out_plus=None, out_cross=None,
                  max_template_length=None, parameters=None,
-                 load_compressed=True, load_compressed_now=False, 
+                 load_compressed=True, load_compressed_now=False,
                  **kwds):
         self.out_plus = out_plus
         self.out_cross = out_cross
@@ -713,7 +714,7 @@ class FilterBankSkyMax(TemplateBank):
                 rdtype = numpy.float64
             self.table = self.table.add_fields(numpy.zeros(len(self.table),
                                      dtype=rdtype),
-                                     'template_duration') 
+                                     'template_duration')
 
     def __getitem__(self, index):
         # Make new memory for templates if we aren't given output memory

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -255,7 +255,8 @@ class TemplateBank(object):
 
             # inclination stored in xml alpha3 column
             names = list(self.table.dtype.names)
-            names = tuple([n if n != 'alpha3' else 'inclination' for n in names])
+            names = tuple([n if n != 'alpha3' 
+                          else 'inclination' for n in names])
             self.table.dtype.names = names
 
         elif ext.endswith('hdf'):
@@ -330,7 +331,7 @@ class TemplateBank(object):
 
         fields = [f for f in hash_fields if f in fields]
         template_hash = numpy.array([hash(v) for v in zip(*[self.table[p]
-                         for p in fields])])
+                                    for p in fields])])
         self.table = self.table.add_fields(template_hash, 'template_hash')
 
     def write_to_hdf(self, filename, start_index=None, stop_index=None,
@@ -376,7 +377,8 @@ class TemplateBank(object):
             f[p] = write_tbl[p]
         if self.compressed_waveforms is not None:
             for tmplt_hash in write_tbl.template_hash:
-                self.compressed_waveforms[tmplt_hash].write_to_hdf(f, tmplt_hash)
+                self.compressed_waveforms[tmplt_hash].write_to_hdf(
+                                                        f, tmplt_hash)
         return f
 
     def end_frequency(self, index):
@@ -384,9 +386,10 @@ class TemplateBank(object):
         """
         from pycbc.waveform.waveform import props
 
-        return pycbc.waveform.get_waveform_end_frequency(self.table[index],
-                              approximant=self.approximant(index),
-                              **self.extra_args)
+        return pycbc.waveform.get_waveform_end_frequency(
+                                self.table[index], 
+                                approximant=self.approximant(index),
+                                **self.extra_args)
 
     def parse_approximant(self, approximant):
         """Parses the given approximant argument, returning the approximant to
@@ -457,9 +460,9 @@ class TemplateBank(object):
 
 class LiveFilterBank(TemplateBank):
     def __init__(self, filename, f_lower, sample_rate, minimum_buffer,
-                       approximant=None, increment=8, parameters=None,
-                       load_compressed=True, load_compressed_now=False,
-                       **kwds):
+                 approximant=None, increment=8, parameters=None,
+                 load_compressed=True, load_compressed_now=False,
+                 **kwds):
 
         self.increment = increment
         self.f_lower = f_lower
@@ -473,7 +476,8 @@ class LiveFilterBank(TemplateBank):
 
         if not hasattr(self.table, 'template_duration'):
             self.table = self.table.add_fields(numpy.zeros(len(self.table),
-                                     dtype=numpy.float32), 'template_duration')
+                                               dtype=numpy.float32),
+                                               'template_duration')
 
         from pycbc.pnutils import mass1_mass2_to_mchirp_eta
         self.table.sort(order='mchirp')
@@ -536,8 +540,9 @@ class LiveFilterBank(TemplateBank):
         from pycbc.waveform.waveform import props
         p = props(self.table[index])
         p.pop('approximant')
-        buff_size = pycbc.waveform.get_waveform_filter_length_in_time(approximant, f_lower=self.f_lower,
-                                                                      **p)
+        buff_size = pycbc.waveform.get_waveform_filter_length_in_time(
+                                    approximant, f_lower=self.f_lower,
+                                    **p)
         tlen = self.round_up((buff_size + min_buffer) * self.sample_rate)
         flen = tlen / 2 + 1
 
@@ -580,8 +585,10 @@ class LiveFilterBank(TemplateBank):
         htilde.sigmasq = types.MethodType(sigma_cached, htilde)
         htilde._sigmasq = {}
 
-        htilde.id = self.id_from_hash(hash((htilde.params.mass1, htilde.params.mass2,
-                          htilde.params.spin1z, htilde.params.spin2z)))
+        htilde.id = self.id_from_hash(hash((htilde.params.mass1, 
+                                      htilde.params.mass2,
+                                      htilde.params.spin1z,
+                                      htilde.params.spin2z)))
         return htilde
 
 class FilterBank(TemplateBank):
@@ -675,8 +682,6 @@ class FilterBank(TemplateBank):
         htilde._sigmasq = {}
         return htilde
 
-
-
 def find_variable_start_frequency(approximant, parameters, f_start, max_length,
                                   delta_f = 1):
     """ Find a frequency value above the starting frequency that results in a
@@ -720,8 +725,8 @@ class FilterBankSkyMax(TemplateBank):
             else:
                 rdtype = numpy.float64
             self.table = self.table.add_fields(numpy.zeros(len(self.table),
-                                     dtype=rdtype),
-                                     'template_duration')
+                                               dtype=rdtype),
+                                               'template_duration')
 
     def __getitem__(self, index):
         # Make new memory for templates if we aren't given output memory


### PR DESCRIPTION
This PR adds an executable ```pycbc_hdf5_splitbank``` in ```pycbc/bin``` and modifies ```pycbc/waveform/bank.py```. @cdcapano Thanks for your comments on my last PR for the splitbank code. I closed that PR because I messed up it's commit history. This PR is a replacement of that one. I've added the changes you had suggested in this PR.

pycbc_hdf5_splitbank :
* The arguments are similar to pycbc_splitbank.
* The code reads in an input template bank and splits it into smaller banks where the number of output banks is a user input.
* The output banks are in hdf5 format.

Modifications in bank.py:
* Changes made to the ```write_to_hdf``` function in the ```TemplateBank``` class to produce a hdf5 file in which a subset of the template bank would be written 
* Removed white spaces

