### PR TITLE
Implementing injection-filter-rejector in PyCBC

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_mergetrigs
+++ b/bin/hdfcoinc/pycbc_coinc_mergetrigs
@@ -67,6 +67,7 @@ logging.info('reading the metadata from the files')
 start = numpy.array([], dtype=numpy.float64)
 end = numpy.array([], dtype=numpy.float64)
 tpc = numpy.array([], dtype=numpy.float64)
+frpc = numpy.array([], dtype=numpy.float64)
 stf = numpy.array([], dtype=numpy.float64)
 gating = {}
 for filename in args.trigger_files:
@@ -77,6 +78,8 @@ for filename in args.trigger_files:
 
     if 'templates_per_core' in ifo_data['search'].keys():
         tpc = numpy.append(tpc, ifo_data['search/templates_per_core'][:])
+    if 'filter_rate_per_core' in ifo_data['search'].keys():
+        frpc = numpy.append(frpc, ifo_data['search/filter_rate_per_core'][:])
     if 'setup_time_fraction' in ifo_data['search'].keys():
         stf = numpy.append(stf, ifo_data['search/setup_time_fraction'][:])
 
@@ -94,6 +97,8 @@ f['%s/search/start_time' % ifo], f['%s/search/end_time' % ifo] = start, end
 
 if len(tpc) > 0:
     f['%s/search/templates_per_core' % ifo] = tpc
+if len(frpc) > 0:
+    f['%s/search/filter_rate_per_core' % ifo] = frpc
 if len(stf) > 0:
     f['%s/search/setup_time_fraction' % ifo] = stf
 

--- a/bin/hdfcoinc/pycbc_plot_throughput
+++ b/bin/hdfcoinc/pycbc_plot_throughput
@@ -4,7 +4,7 @@ import argparse
 import logging
 import h5py
 import numpy as np
-import matplotlib
+import matplotlib; matplotlib.use('Agg')
 import pylab as pl
 from pycbc.results.color import ifo_color
 import pycbc.version

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -25,6 +25,7 @@ from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, complex64
 import pycbc.fft.fftw, pycbc.version
 import pycbc.opt
 import pycbc.weave
+import pycbc.inject
 import time
 
 tstart = time.time()
@@ -140,11 +141,6 @@ parser.add_argument("--keep-loudest-interval", type=float,
 parser.add_argument("--keep-loudest-num", type=int,
                     help="Number of triggers to keep from each maximization interval")
 parser.add_argument("--gpu-callback-method", default='none')
-parser.add_argument("--threshold-template-filtering", type= float)
-
-
-
-
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -154,6 +150,7 @@ scheme.insert_processing_option_group(parser)
 fft.insert_fft_option_group(parser)
 pycbc.opt.insert_optimization_option_group(parser)
 pycbc.weave.insert_weave_option_group(parser)
+pycbc.inject.insert_injfilterrejector_option_group(parser)
 
 opt = parser.parse_args()
 
@@ -168,8 +165,10 @@ pycbc.weave.verify_weave_options(opt, parser)
 
 pycbc.init_logging(opt.verbose)
 
+inj_filter_rejector = pycbc.inject.InjFilterRejector.from_cli(opt)
 ctx = scheme.from_cli(opt)
-gwstrain = strain.from_cli(opt, DYN_RANGE_FAC)
+gwstrain = strain.from_cli(opt, dyn_range_fac=DYN_RANGE_FAC,
+                           inj_filter_rejector=inj_filter_rejector)
 strain_segments = strain.StrainSegments.from_cli(opt, gwstrain)
       
 
@@ -272,33 +271,47 @@ with ctx:
                     taper=opt.taper_template, approximant=opt.approximant,
                     out=template_mem, max_template_length=opt.max_template_length)
 
-    if opt.injection_file is not None and \
-            opt.threshold_template_filtering is not None:
-        logging.info("Template Bank Size Before Cut: %s", len(bank))
-        bank.table = bank.template_thinning(gwstrain.injections.table,
-                                            opt.threshold_template_filtering)
-        logging.info("Template Bank Size After Cut: %s", len(bank))
-      
     ntemplates = len(bank)
+    nfilters = 0
+
+    logging.info("Full template bank size: %s", ntemplates)
+    bank.template_thinning(inj_filter_rejector)
+    if not len(bank) == ntemplates:
+        logging.info("Template bank size after thinning: %s", len(bank))
+
     tsetup = time.time() - tstart
 
     # Note: in the class-based approach used now, 'template' is not explicitly used
     # within the loop.  Rather, the iteration simply fills the memory specifed in
     # the 'template_mem' argument to MatchedFilterControl with the next template
     # from the bank.
-    for t_num, template in enumerate(bank):
-        event_mgr.new_template(tmplt=template.params, sigmasq=template.sigmasq(segments[0].psd))
-
-        if opt.cluster_method == "window":
-            cluster_window = int(opt.cluster_window * gwstrain.sample_rate)
-        if opt.cluster_method == "template":
-            cluster_window = int(template.chirp_length * gwstrain.sample_rate)
-
+    for t_num in xrange(len(bank)):
+        tmplt_generated = False
 
         for s_num, stilde in enumerate(segments):
+            # Filter check checks the 'inj_filter_rejector' options to
+            # determine whether
+            # to filter this template/segment if injections are present.
+            if not inj_filter_rejector.template_segment_checker(
+                    bank, t_num, stilde, opt.gps_start_time):
+                continue
+            if not tmplt_generated:
+                template = bank[t_num]
+                event_mgr.new_template(tmplt=template.params,
+                    sigmasq=template.sigmasq(segments[0].psd))
+                tmplt_generated = True
+
+            if opt.cluster_method == "window":
+                cluster_window = int(opt.cluster_window * gwstrain.sample_rate)
+            if opt.cluster_method == "template":
+                cluster_window = \
+                    int(template.chirp_length * gwstrain.sample_rate)
+
+
             logging.info("Filtering template %d/%d segment %d/%d" %
                          (t_num + 1, len(bank), s_num + 1, len(segments)))
 
+            nfilters = nfilters + 1
             snr, norm, corr, idx, snrv = \
                matched_filter.matched_filter_and_cluster(s_num, template.sigmasq(stilde.psd), cluster_window)
 
@@ -362,7 +375,7 @@ if opt.maximization_interval:
 
 tstop = time.time()
 run_time = tstop - tstart
-event_mgr.save_performance(ncores, ntemplates, run_time, tsetup)
+event_mgr.save_performance(ncores, nfilters, ntemplates, run_time, tsetup)
 
 logging.info("Writing out triggers")
 event_mgr.write_events(opt.output)

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -373,13 +373,15 @@ class EventManager(object):
             if not os.path.exists(path) and path is not None:
                 os.makedirs(path)
 
-    def save_performance(self, ncores, ntemplates, run_time, setup_time):
+    def save_performance(self, ncores, nfilters, ntemplates, run_time,
+                         setup_time):
         """
         Calls variables from pycbc_inspiral to be used in a timing calculation
         """
         self.run_time = run_time
         self.setup_time = setup_time
         self.ncores = ncores
+        self.nfilters = nfilters
         self.ntemplates = ntemplates
         self.write_performance = True
 
@@ -480,8 +482,11 @@ class EventManager(object):
             self.analysis_time = search_end_time - search_start_time
             time_ratio = numpy.array([float(self.analysis_time) / float(self.run_time)])
             temps_per_core = float(self.ntemplates) / float(self.ncores)
+            filters_per_core = float(self.nfilters) / float(self.ncores)
             f['search/templates_per_core'] = \
                 numpy.array([float(temps_per_core) * float(time_ratio)])
+            f['search/filter_rate_per_core'] = \
+                numpy.array([filters_per_core / float(self.run_time)])
             f['search/setup_time_fraction'] = \
                 numpy.array([float(self.setup_time) / float(self.run_time)])
 

--- a/pycbc/inject/__init__.py
+++ b/pycbc/inject/__init__.py
@@ -1,0 +1,2 @@
+from pycbc.inject.injfilterrejector import *
+from pycbc.inject.inject import *

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -130,7 +130,7 @@ class InjectionSet(object):
         TypeError
             For invalid types of `strain`.
         """
-        if not strain.dtype in (float32, float64):
+        if strain.dtype not in (float32, float64):
             raise TypeError("Strain dtype must be float32 or float64, not " \
                     + str(strain.dtype))
 
@@ -166,7 +166,7 @@ class InjectionSet(object):
             signal = self.make_strain_from_inj_object(inj, strain.delta_t,
                      detector_name, f_lower=f_l, distance_scale=distance_scale)
             if float(signal.start_time) > t1:
-               continue
+                continue
             
             signal = signal.astype(strain.dtype)
             signal_lal = signal.lal()
@@ -306,7 +306,7 @@ class SGBurstInjectionSet(object):
         TypeError
             For invalid types of `strain`.
         """
-        if not strain.dtype in (float32, float64):
+        if strain.dtype not in (float32, float64):
             raise TypeError("Strain dtype must be float32 or float64, not " \
                     + str(strain.dtype))
 
@@ -328,7 +328,7 @@ class SGBurstInjectionSet(object):
             polarization = 0.0
             start_time = end_time - 2 * inj_length
             if end_time < t0 or start_time > t1:
-               continue
+                continue
 
             # compute the waveform time series
             hp, hc = sim.SimBurstSineGaussian(float(inj.q),
@@ -339,7 +339,7 @@ class SGBurstInjectionSet(object):
             hp._epoch += float(end_time)
             hc._epoch += float(end_time)
             if float(hp.start_time) > t1:
-               continue
+                continue
 
             # compute the detector response, taper it if requested
             # and add it to the strain

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -23,8 +23,7 @@
 #
 # =============================================================================
 #
-"""This module provides utilities for injecting signals into data
-"""
+"""This module provides utilities for injecting signals into data"""
 
 import numpy as np
 import lal
@@ -50,7 +49,7 @@ class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
 lsctables.use_in(LIGOLWContentHandler)
 
 def legacy_approximant_name(apx):
-    """ Convert the old style xml approximant name to a name
+    """Convert the old style xml approximant name to a name
     and phase_order. Alex: I hate this function. Please delet this when we
     use Collin's new tables.
     """
@@ -65,6 +64,7 @@ def legacy_approximant_name(apx):
     
 
 class InjectionSet(object):
+
     """Manages sets of injections: reads injections from LIGOLW XML files
     and injects them into time series.
 
@@ -79,6 +79,7 @@ class InjectionSet(object):
     indoc
     table
     """
+
     def __init__(self, sim_file, **kwds):
         self.indoc = ligolw_utils.load_filename(
             sim_file, False, contenthandler=LIGOLWContentHandler)
@@ -129,7 +130,6 @@ class InjectionSet(object):
         TypeError
             For invalid types of `strain`.
         """
-
         if not strain.dtype in (float32, float64):
             raise TypeError("Strain dtype must be float32 or float64, not " \
                     + str(strain.dtype))
@@ -146,7 +146,6 @@ class InjectionSet(object):
         if simulation_ids:
             injections = [inj for inj in injections \
                           if inj.simulation_id in simulation_ids]
-        l= 0
         injection_parameters = []
         for inj in injections:
             if f_lower is None:
@@ -243,11 +242,11 @@ class InjectionSet(object):
         
         
     def end_times(self):
-        """ Return the end times of all injections
-        """
+        """Return the end times of all injections"""
         return [inj.get_time_geocent() for inj in self.table]      
     
 class SGBurstInjectionSet(object):
+
     """Manages sets of sine-Gaussian burst injections: reads injections
     from LIGOLW XML files and injects them into time series.
 
@@ -307,7 +306,6 @@ class SGBurstInjectionSet(object):
         TypeError
             For invalid types of `strain`.
         """
-
         if not strain.dtype in (float32, float64):
             raise TypeError("Strain dtype must be float32 or float64, not " \
                     + str(strain.dtype))
@@ -352,6 +350,7 @@ class SGBurstInjectionSet(object):
         strain.data[:] = lalstrain.data.data[:]
 
 class RingdownInjectionSet(object):
+
     """Manages a ringdown injection: reads injection from hdf file
     and injects it into time series.
 
@@ -392,7 +391,6 @@ class RingdownInjectionSet(object):
         TypeError
             For invalid types of `strain`.
         """
-
         if strain.dtype not in (float32, float64):
             raise TypeError("Strain dtype must be float32 or float64, not " \
                     + str(strain.dtype))

--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -84,8 +84,7 @@ _injfilterer_flower_help = \
 
 
 def insert_injfilterrejector_option_group(parser):
-    """ Add options for injfilterrejector to executable.
-    """
+    """Add options for injfilterrejector to executable."""
     injfilterrejector_group = \
         parser.add_argument_group(_injfilterrejector_group_help)
     curr_arg = "--injection-filter-rejector-chirp-time-window"
@@ -109,14 +108,18 @@ def insert_injfilterrejector_option_group(parser):
 
 
 class InjFilterRejector(object):
+
+    """Class for holding parameters for using injection/template pre-filtering.
+
+    This class is responsible for identifying where a matched-filter operation
+    between templates and data is unncessary because the injections contained
+    in the data will not match well with the given template.
     """
-    Class for holding parameters for using injection/template pre-filtering.
-    """
+
     def __init__(self, injection_file, chirp_time_window,
                  match_threshold, f_lower, coarsematch_deltaf=1.,
                  coarsematch_fmax=256, seg_buffer=10):
-        """ Initialise InjFilterRejector instance.
-        """
+        """Initialise InjFilterRejector instance."""
         # Determine if InjFilterRejector is to be enabled
         if injection_file is None or injection_file == 'False' or\
                 (chirp_time_window is None and match_threshold is None):
@@ -143,9 +146,7 @@ class InjFilterRejector(object):
 
     @classmethod
     def from_cli(cls, opt):
-        """
-        Initialize an InjFilterRejector instance from command-line options.
-        """
+        """Create an InjFilterRejector instance from command-line options."""
         injection_file = opt.injection_file
         chirp_time_window = \
             opt.injection_filter_rejector_chirp_time_window
@@ -167,9 +168,7 @@ class InjFilterRejector(object):
                    seg_buffer=seg_buffer)
 
     def generate_short_inj_from_inj(self, inj_waveform, simulation_id):
-        """
-        Generate and a store a truncated representation of inj_waveform.
-        """
+        """Generate and a store a truncated representation of inj_waveform."""
         if not self.enabled:
             # Do nothing!
             return
@@ -203,7 +202,7 @@ class InjFilterRejector(object):
         self.short_injections[simulation_id] = new_inj
 
     def template_segment_checker(self, bank, t_num, segment, start_time):
-        """ Test if injections in segment are worth filtering with template.
+        """Test if injections in segment are worth filtering with template.
 
         Using the current template, current segment, and injections within that
         segment. Test if the injections and sufficiently "similar" to any of
@@ -303,7 +302,7 @@ class InjFilterRejector(object):
             for inj_idx, inj in enumerate(self.injection_params.table):
                 end_time = inj.geocent_end_time + \
                     1E-9 * inj.geocent_end_time_ns
-                if end_time > seg_end_time or end_time < seg_start_time:
+                if not(seg_start_time < end_time < seg_end_time):
                     continue
                 curr_inj = self.short_injections[inj.simulation_id]
                 o, i = match(htilde, curr_inj, psd=red_psd,

--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -31,55 +31,61 @@ from pycbc.pnutils import nearest_larger_binary_number
 from pycbc.pnutils import mass1_mass2_to_tau0_tau3
 from pycbc.types import FrequencySeries, zeros
 
-_injfilterrejector_group_help = ("Options that, if injections are present in "
-    "this run, are responsible for performing pre-checks between injections "
-    "in the data being filtered and the current search template to determine "
-    "if the template has any chance of actually detecting the injection. "
-    "The parameters of this test are given by the various options below. "
-    "The --injection-filter-rejector-chirp-time-window and "
-    "--injection-filter-rejector-match-threshold options need to be provided "
-    "if those tests are desired. Other options will take default values "
-    "unless overriden. More details on these options follow.")
+_injfilterrejector_group_help = \
+    ("Options that, if injections are present in "
+     "this run, are responsible for performing pre-checks between injections "
+     "in the data being filtered and the current search template to determine "
+     "if the template has any chance of actually detecting the injection. "
+     "The parameters of this test are given by the various options below. "
+     "The --injection-filter-rejector-chirp-time-window and "
+     "--injection-filter-rejector-match-threshold options need to be provided "
+     "if those tests are desired. Other options will take default values "
+     "unless overriden. More details on these options follow.")
 
-_injfilterer_cthresh_help = ("If this value is not None and an "
-    "injection file is given then we will calculate the difference in "
-    "chirp time (tau_0) between the template and each injection in the "
-    "analysis segment. If the difference is greate than this threshold for "
-    "all injections then filtering is not performed. By default this will "
-    "be None.")
-_injfilterer_mthresh_help = ("If this value is not None and an "
-    "injection file is provided then we will calculate a 'coarse match' "
-    "between the template and each injection in the analysis segment. If the "
-    "match is less than this threshold for all injections then filtering is "
-    "not performed. Parameters for the 'coarse match' follow. By default this "
-    "value will be None.")
-_injfilterer_deltaf_help = ("If injections are present "
-    "and a match threshold is "
-    "provided, this option specifies the frequency spacing that will be used "
-    "for injections, templates and PSD when computing the 'coarse match'. "
-    "Templates will be generated directly with this spacing. The PSD and "
-    "injections will be resampled.")
-_injfilterer_fmax_help = ("If injections are present and "
-    "a match threshold is "
-    "provided, this option specifies the maximum frequency that will be used "
-    "for injections, templates and PSD when computing the 'coarse match'. "
-    "Templates will be generated directly with this max frequency. The PSD "
-    "and injections' frequency series will be truncated.")
-_injfilterer_buffer_help = ("If injections are present and "
-    "either a match "
-    "threshold or a chirp-time window is given, we will determine if "
-    "injections are 'in' the specified analysis chunk by using the end times. "
-    "If this value is non-zero the analysis chunk is extended on both sides "
-    "by this amount before determining if injections are within the given "
-    "window.")
-_injfilterer_flower_help = ("If injections are present and "
-    "either a match "
-    "threshold or a chirp-time window is given, this value is used to set "
-    "the lower frequency for determine chirp times or for calculating "
-    "matches. If this value is None the lower frequency used for the full "
-    "matched-filter is used. Otherwise this value is used.")
+_injfilterer_cthresh_help = \
+    ("If this value is not None and an "
+     "injection file is given then we will calculate the difference in "
+     "chirp time (tau_0) between the template and each injection in the "
+     "analysis segment. If the difference is greate than this threshold for "
+     "all injections then filtering is not performed. By default this will "
+     "be None.")
+_injfilterer_mthresh_help = \
+    ("If this value is not None and an "
+     "injection file is provided then we will calculate a 'coarse match' "
+     "between the template and each injection in the analysis segment. If the "
+     "match is less than this threshold for all injections then filtering is "
+     "not performed. Parameters for the 'coarse match' follow. By default this "
+     "value will be None.")
+_injfilterer_deltaf_help = \
+    ("If injections are present and a match threshold is "
+     "provided, this option specifies the frequency spacing that will be used "
+     "for injections, templates and PSD when computing the 'coarse match'. "
+     "Templates will be generated directly with this spacing. The PSD and "
+     "injections will be resampled.")
+_injfilterer_fmax_help = \
+    ("If injections are present and a match threshold is "
+     "provided, this option specifies the maximum frequency that will be used "
+     "for injections, templates and PSD when computing the 'coarse match'. "
+     "Templates will be generated directly with this max frequency. The PSD "
+     "and injections' frequency series will be truncated.")
+_injfilterer_buffer_help = \
+    ("If injections are present and either a match "
+     "threshold or a chirp-time window is given, we will determine if "
+     "injections are 'in' the specified analysis chunk by using the end times. "
+     "If this value is non-zero the analysis chunk is extended on both sides "
+     "by this amount before determining if injections are within the given "
+     "window.")
+_injfilterer_flower_help = \
+    ("If injections are present and either a match "
+     "threshold or a chirp-time window is given, this value is used to set "
+     "the lower frequency for determine chirp times or for calculating "
+     "matches. If this value is None the lower frequency used for the full "
+     "matched-filter is used. Otherwise this value is used.")
+
 
 def insert_injfilterrejector_option_group(parser):
+    """ Add options for injfilterrejector to executable.
+    """
     injfilterrejector_group = \
         parser.add_argument_group(_injfilterrejector_group_help)
     curr_arg = "--injection-filter-rejector-chirp-time-window"
@@ -113,7 +119,7 @@ class InjFilterRejector(object):
         """
         # Determine if InjFilterRejector is to be enabled
         if injection_file is None or injection_file == 'False' or\
-            (chirp_time_window is None and match_threshold is None):
+                (chirp_time_window is None and match_threshold is None):
             self.enabled = False
             return
         else:
@@ -167,7 +173,7 @@ class InjFilterRejector(object):
         if not self.enabled:
             # Do nothing!
             return
-        if self.short_injections.has_key(simulation_id):
+        if simulation_id in self.short_injections:
             err_msg = "An injection with simulation id "
             err_msg += str(simulation_id)
             err_msg += " has already been added. This suggests "
@@ -243,7 +249,7 @@ class InjFilterRejector(object):
             for inj_idx, inj in enumerate(self.injection_params.table):
                 end_time = inj.geocent_end_time + \
                     1E-9 * inj.geocent_end_time_ns
-                if end_time > seg_end_time or end_time < seg_start_time:
+                if not(seg_start_time <= end_time <= seg_end_time):
                     continue
                 tau0_inj, tau3_inj = \
                     mass1_mass2_to_tau0_tau3(inj.mass1, inj.mass2,
@@ -259,7 +265,7 @@ class InjFilterRejector(object):
         if self.match_threshold:
             if self._short_template_mem is None:
                 # Set the memory for the short templates
-                wav_len = 1 + int(self.coarsematch_fmax / \
+                wav_len = 1 + int(self.coarsematch_fmax /
                                   self.coarsematch_deltaf)
                 self._short_template_mem = zeros(wav_len, dtype=np.complex64)
 
@@ -280,7 +286,7 @@ class InjFilterRejector(object):
             if not t_num == self._short_template_id:
                 # Set the memory for the short templates if unset
                 if self._short_template_mem is None:
-                    wav_len = 1 + int(self.coarsematch_fmax / \
+                    wav_len = 1 + int(self.coarsematch_fmax /
                                       self.coarsematch_deltaf)
                     self._short_template_mem = zeros(wav_len,
                                                      dtype=np.complex64)

--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -1,0 +1,311 @@
+# Copyright (C) 2013 Ian Harry
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Generals
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This module contains functions to filter injections with only useful templates.
+
+This module implements a set of checks to test for each segment and template
+combination whether injections contained within the segment are sufficiently
+"similar" to the template to require a matched-filter. There are a few ways of
+testing the "similarity" of templates and injections.
+ * A chirp time threshold rejects templates if chirp time difference is large
+ * A coarse match threshold rejects templates if a coarse overlap is small
+"""
+
+import numpy as np
+from pycbc import DYN_RANGE_FAC
+from pycbc.filter import match
+from pycbc.pnutils import nearest_larger_binary_number
+from pycbc.pnutils import mass1_mass2_to_tau0_tau3
+from pycbc.types import FrequencySeries, zeros
+
+_injfilterrejector_group_help = ("Options that, if injections are present in "
+    "this run, are responsible for performing pre-checks between injections "
+    "in the data being filtered and the current search template to determine "
+    "if the template has any chance of actually detecting the injection. "
+    "The parameters of this test are given by the various options below. "
+    "The --injection-filter-rejector-chirp-time-window and "
+    "--injection-filter-rejector-match-threshold options need to be provided "
+    "if those tests are desired. Other options will take default values "
+    "unless overriden. More details on these options follow.")
+
+_injfilterer_cthresh_help = ("If this value is not None and an "
+    "injection file is given then we will calculate the difference in "
+    "chirp time (tau_0) between the template and each injection in the "
+    "analysis segment. If the difference is greate than this threshold for "
+    "all injections then filtering is not performed. By default this will "
+    "be None.")
+_injfilterer_mthresh_help = ("If this value is not None and an "
+    "injection file is provided then we will calculate a 'coarse match' "
+    "between the template and each injection in the analysis segment. If the "
+    "match is less than this threshold for all injections then filtering is "
+    "not performed. Parameters for the 'coarse match' follow. By default this "
+    "value will be None.")
+_injfilterer_deltaf_help = ("If injections are present "
+    "and a match threshold is "
+    "provided, this option specifies the frequency spacing that will be used "
+    "for injections, templates and PSD when computing the 'coarse match'. "
+    "Templates will be generated directly with this spacing. The PSD and "
+    "injections will be resampled.")
+_injfilterer_fmax_help = ("If injections are present and "
+    "a match threshold is "
+    "provided, this option specifies the maximum frequency that will be used "
+    "for injections, templates and PSD when computing the 'coarse match'. "
+    "Templates will be generated directly with this max frequency. The PSD "
+    "and injections' frequency series will be truncated.")
+_injfilterer_buffer_help = ("If injections are present and "
+    "either a match "
+    "threshold or a chirp-time window is given, we will determine if "
+    "injections are 'in' the specified analysis chunk by using the end times. "
+    "If this value is non-zero the analysis chunk is extended on both sides "
+    "by this amount before determining if injections are within the given "
+    "window.")
+_injfilterer_flower_help = ("If injections are present and "
+    "either a match "
+    "threshold or a chirp-time window is given, this value is used to set "
+    "the lower frequency for determine chirp times or for calculating "
+    "matches. If this value is None the lower frequency used for the full "
+    "matched-filter is used. Otherwise this value is used.")
+
+def insert_injfilterrejector_option_group(parser):
+    injfilterrejector_group = \
+        parser.add_argument_group(_injfilterrejector_group_help)
+    curr_arg = "--injection-filter-rejector-chirp-time-window"
+    injfilterrejector_group.add_argument(curr_arg, type=float, default=None,
+                                         help=_injfilterer_cthresh_help)
+    curr_arg = "--injection-filter-rejector-match-threshold"
+    injfilterrejector_group.add_argument(curr_arg, type=float, default=None,
+                                         help=_injfilterer_mthresh_help)
+    curr_arg = "--injection-filter-rejector-coarsematch-deltaf"
+    injfilterrejector_group.add_argument(curr_arg, type=float, default=1.,
+                                         help=_injfilterer_deltaf_help)
+    curr_arg = "--injection-filter-rejector-coarsematch-fmax"
+    injfilterrejector_group.add_argument(curr_arg, type=float, default=256.,
+                                         help=_injfilterer_fmax_help)
+    curr_arg = "--injection-filter-rejector-seg-buffer"
+    injfilterrejector_group.add_argument(curr_arg, type=int, default=10,
+                                         help=_injfilterer_buffer_help)
+    curr_arg = "--injection-filter-rejector-f-lower"
+    injfilterrejector_group.add_argument(curr_arg, type=int, default=None,
+                                         help=_injfilterer_flower_help)
+
+
+class InjFilterRejector(object):
+    """
+    Class for holding parameters for using injection/template pre-filtering.
+    """
+    def __init__(self, injection_file, chirp_time_window,
+                 match_threshold, f_lower, coarsematch_deltaf=1.,
+                 coarsematch_fmax=256, seg_buffer=10):
+        """ Initialise InjFilterRejector instance.
+        """
+        # Determine if InjFilterRejector is to be enabled
+        if injection_file is None or injection_file == 'False' or\
+            (chirp_time_window is None and match_threshold is None):
+            self.enabled = False
+            return
+        else:
+            self.enabled = True
+
+        # Store parameters
+        self.chirp_time_window = chirp_time_window
+        self.match_threshold = match_threshold
+        self.coarsematch_deltaf = coarsematch_deltaf
+        self.coarsematch_fmax = coarsematch_fmax
+        self.seg_buffer = seg_buffer
+        self.f_lower = f_lower
+        assert(self.f_lower is not None)
+
+        # Variables for storing arrays (reduced injections, memory
+        # for templates, reduced PSDs ...)
+        self.short_injections = {}
+        self._short_template_mem = None
+        self._short_psd_storage = {}
+        self._short_template_id = None
+
+    @classmethod
+    def from_cli(cls, opt):
+        """
+        Initialize an InjFilterRejector instance from command-line options.
+        """
+        injection_file = opt.injection_file
+        chirp_time_window = \
+            opt.injection_filter_rejector_chirp_time_window
+        match_threshold = opt.injection_filter_rejector_match_threshold
+        coarsematch_deltaf = opt.injection_filter_rejector_coarsematch_deltaf
+        coarsematch_fmax = opt.injection_filter_rejector_coarsematch_fmax
+        seg_buffer = opt.injection_filter_rejector_seg_buffer
+        if opt.injection_filter_rejector_f_lower is not None:
+            f_lower = opt.injection_filter_rejector_f_lower
+        else:
+            # NOTE: Uses main low-frequency cutoff as default option. This may
+            #       need some editing if using this in multi_inspiral, which I
+            #       leave for future work, or if this is being used in another
+            #       code which doesn't have --low-frequency-cutoff
+            f_lower = opt.low_frequency_cutoff
+        return cls(injection_file, chirp_time_window, match_threshold,
+                   f_lower, coarsematch_deltaf=coarsematch_deltaf,
+                   coarsematch_fmax=coarsematch_fmax,
+                   seg_buffer=seg_buffer)
+
+    def generate_short_inj_from_inj(self, inj_waveform, simulation_id):
+        """
+        Generate and a store a truncated representation of inj_waveform.
+        """
+        if not self.enabled:
+            # Do nothing!
+            return
+        if self.short_injections.has_key(simulation_id):
+            err_msg = "An injection with simulation id "
+            err_msg += str(simulation_id)
+            err_msg += " has already been added. This suggests "
+            err_msg += "that your injection file contains injections with "
+            err_msg += "duplicate simulation_ids. This is not allowed."
+            raise ValueError(err_msg)
+        curr_length = len(inj_waveform)
+        new_length = int(nearest_larger_binary_number(curr_length))
+        # Don't want length less than 1/delta_f
+        while new_length * inj_waveform.delta_t < 1./self.coarsematch_deltaf:
+            new_length = new_length * 2
+        inj_waveform.resize(new_length)
+        inj_tilde = inj_waveform.to_frequencyseries()
+        # Dynamic range is important here!
+        inj_tilde_np = inj_tilde.numpy() * DYN_RANGE_FAC
+        delta_f = inj_tilde.get_delta_f()
+        new_freq_len = int(self.coarsematch_fmax / delta_f + 1)
+        # This shouldn't be a problem if injections are generated at
+        # 16384 Hz ... It is only a problem of injection sample rate
+        # gives a lower Nyquist than the trunc_f_max. If this error is
+        # ever raised one could consider zero-padding the injection.
+        assert(new_freq_len <= len(inj_tilde))
+        df_ratio = int(self.coarsematch_deltaf/delta_f)
+        inj_tilde_np = inj_tilde_np[:new_freq_len:df_ratio]
+        new_inj = FrequencySeries(inj_tilde_np, dtype=np.complex64,
+                                  delta_f=self.coarsematch_deltaf)
+        self.short_injections[simulation_id] = new_inj
+
+    def template_segment_checker(self, bank, t_num, segment, start_time):
+        """ Test if injections in segment are worth filtering with template.
+
+        Using the current template, current segment, and injections within that
+        segment. Test if the injections and sufficiently "similar" to any of
+        the injections to justify actually performing a matched-filter call.
+        Ther are two parts to this test: First we check if the chirp time of
+        the template is within a provided window of any of the injections. If
+        not then stop here, it is not worth filtering this template, segment
+        combination for this injection set. If this check passes we compute a
+        match between a coarse representation of the template and a coarse
+        representation of each of the injections. If that match is above a
+        user-provided value for any of the injections then filtering can
+        proceed. This is currently only available if using frequency-domain
+        templates.
+
+        Parameters
+        -----------
+        FIXME
+
+        Returns
+        --------
+        FIXME
+        """
+        if not self.enabled:
+            # If disabled, always filter (ie. return True)
+            return True
+
+        # Get times covered by segment analyze
+        sample_rate = 2. * (len(segment) - 1) * segment.delta_f
+        cum_ind = segment.cumulative_index
+        diff = segment.analyze.stop - segment.analyze.start
+        seg_start_time = cum_ind / sample_rate + start_time
+        seg_end_time = (cum_ind + diff) / sample_rate + start_time
+        # And add buffer
+        seg_start_time = seg_start_time - self.seg_buffer
+        seg_end_time = seg_end_time + self.seg_buffer
+
+        # Chirp time test
+        if self.chirp_time_window is not None:
+            m1 = bank.table[t_num]['mass1']
+            m2 = bank.table[t_num]['mass2']
+            tau0_temp, tau3_temp = mass1_mass2_to_tau0_tau3(m1, m2,
+                                                            self.f_lower)
+            for inj_idx, inj in enumerate(self.injection_params.table):
+                end_time = inj.geocent_end_time + \
+                    1E-9 * inj.geocent_end_time_ns
+                if end_time > seg_end_time or end_time < seg_start_time:
+                    continue
+                tau0_inj, tau3_inj = \
+                    mass1_mass2_to_tau0_tau3(inj.mass1, inj.mass2,
+                                             self.f_lower)
+                tau_diff = abs(tau0_temp - tau0_inj)
+                if tau_diff <= self.chirp_time_window:
+                    break
+            else:
+                # Get's here if all injections are outside chirp-time window
+                return False
+
+        # Coarse match test
+        if self.match_threshold:
+            if self._short_template_mem is None:
+                # Set the memory for the short templates
+                wav_len = 1 + int(self.coarsematch_fmax / \
+                                  self.coarsematch_deltaf)
+                self._short_template_mem = zeros(wav_len, dtype=np.complex64)
+
+            # Set the current short PSD to red_psd
+            try:
+                red_psd = self._short_psd_storage[id(segment.psd)]
+            except KeyError:
+                # PSD doesn't exist yet, so make it!
+                curr_psd = segment.psd.numpy()
+                step_size = int(self.coarsematch_deltaf / segment.psd.delta_f)
+                max_idx = int(self.coarsematch_fmax / segment.psd.delta_f) + 1
+                red_psd_data = curr_psd[:max_idx:step_size]
+                red_psd = FrequencySeries(red_psd_data, copy=False,
+                                          delta_f=self.coarsematch_deltaf)
+                self._short_psd_storage[id(curr_psd)] = red_psd
+
+            # Set htilde to be the current short template
+            if not t_num == self._short_template_id:
+                # Set the memory for the short templates if unset
+                if self._short_template_mem is None:
+                    wav_len = 1 + int(self.coarsematch_fmax / \
+                                      self.coarsematch_deltaf)
+                    self._short_template_mem = zeros(wav_len,
+                                                     dtype=np.complex64)
+                # Generate short waveform
+                htilde = bank.generate_with_delta_f_and_max_freq(
+                    t_num, self.coarsematch_fmax, self.coarsematch_deltaf,
+                    low_frequency_cutoff=self.f_lower,
+                    cached_mem=self._short_template_mem)
+                self._short_template_id = t_num
+                self._short_template_wav = htilde
+            else:
+                htilde = self._short_template_wav
+
+            for inj_idx, inj in enumerate(self.injection_params.table):
+                end_time = inj.geocent_end_time + \
+                    1E-9 * inj.geocent_end_time_ns
+                if end_time > seg_end_time or end_time < seg_start_time:
+                    continue
+                curr_inj = self.short_injections[inj.simulation_id]
+                o, i = match(htilde, curr_inj, psd=red_psd,
+                             low_frequency_cutoff=self.f_lower)
+                if o > self.match_threshold:
+                    break
+            else:
+                # Get's here if all injections are outside match threshold
+                return False
+
+        return True

--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -243,14 +243,13 @@ class InjFilterRejector(object):
         if self.chirp_time_window is not None:
             m1 = bank.table[t_num]['mass1']
             m2 = bank.table[t_num]['mass2']
-            tau0_temp, tau3_temp = mass1_mass2_to_tau0_tau3(m1, m2,
-                                                            self.f_lower)
-            for inj_idx, inj in enumerate(self.injection_params.table):
+            tau0_temp, _ = mass1_mass2_to_tau0_tau3(m1, m2, self.f_lower)
+            for inj in self.injection_params.table:
                 end_time = inj.geocent_end_time + \
                     1E-9 * inj.geocent_end_time_ns
                 if not(seg_start_time <= end_time <= seg_end_time):
                     continue
-                tau0_inj, tau3_inj = \
+                tau0_inj, _ = \
                     mass1_mass2_to_tau0_tau3(inj.mass1, inj.mass2,
                                              self.f_lower)
                 tau_diff = abs(tau0_temp - tau0_inj)
@@ -305,7 +304,7 @@ class InjFilterRejector(object):
                 if not(seg_start_time < end_time < seg_end_time):
                     continue
                 curr_inj = self.short_injections[inj.simulation_id]
-                o, i = match(htilde, curr_inj, psd=red_psd,
+                o, _ = match(htilde, curr_inj, psd=red_psd,
                              low_frequency_cutoff=self.f_lower)
                 if o > self.match_threshold:
                     break

--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -298,7 +298,7 @@ class InjFilterRejector(object):
             else:
                 htilde = self._short_template_wav
 
-            for inj_idx, inj in enumerate(self.injection_params.table):
+            for inj in self.injection_params.table:
                 end_time = inj.geocent_end_time + \
                     1E-9 * inj.geocent_end_time_ns
                 if not(seg_start_time < end_time < seg_end_time):

--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -54,8 +54,8 @@ _injfilterer_mthresh_help = \
      "injection file is provided then we will calculate a 'coarse match' "
      "between the template and each injection in the analysis segment. If the "
      "match is less than this threshold for all injections then filtering is "
-     "not performed. Parameters for the 'coarse match' follow. By default this "
-     "value will be None.")
+     "not performed. Parameters for the 'coarse match' follow. By default "
+     "this value will be None.")
 _injfilterer_deltaf_help = \
     ("If injections are present and a match threshold is "
      "provided, this option specifies the frequency spacing that will be used "
@@ -71,10 +71,10 @@ _injfilterer_fmax_help = \
 _injfilterer_buffer_help = \
     ("If injections are present and either a match "
      "threshold or a chirp-time window is given, we will determine if "
-     "injections are 'in' the specified analysis chunk by using the end times. "
-     "If this value is non-zero the analysis chunk is extended on both sides "
-     "by this amount before determining if injections are within the given "
-     "window.")
+     "injections are 'in' the specified analysis chunk by using the end "
+     "times. If this value is non-zero the analysis chunk is extended on both "
+     "sides by this amount before determining if injections are within the "
+     "given window.")
 _injfilterer_flower_help = \
     ("If injections are present and either a match "
      "threshold or a chirp-time window is given, this value is used to set "

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -205,7 +205,6 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
     strain : TimeSeries
         The time series containing the conditioned strain data.
     """
-
     gating_info = {}
 
     if opt.frame_cache or opt.frame_files or opt.frame_type:

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -243,9 +243,10 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         if opt.injection_file:
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
-            injections = injector.apply(strain, opt.channel_name[0:2],
-                distance_scale=opt.injection_scale_factor,
-                inj_filter_rejector=inj_filter_rejector)
+            injections = \
+                injector.apply(strain, opt.channel_name[0:2],
+                               distance_scale=opt.injection_scale_factor,
+                               inj_filter_rejector=inj_filter_rejector)
 
         if opt.sgburst_injection_file:
             logging.info("Applying sine-Gaussian burst injections")
@@ -333,9 +334,10 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         if opt.injection_file:
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
-            injections = injector.apply(strain, opt.channel_name[0:2],        
-                distance_scale=opt.injection_scale_factor,
-                inj_filter_rejector=inj_filter_rejector)
+            injections = \
+                injector.apply(strain, opt.channel_name[0:2],        
+                               distance_scale=opt.injection_scale_factor,
+                               inj_filter_rejector=inj_filter_rejector)
 
         if opt.sgburst_injection_file:
             logging.info("Applying sine-Gaussian burst injections")

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -181,7 +181,8 @@ def detect_loud_glitches(strain, psd_duration=4., psd_stride=2.,
              for idx in indices[cluster_idx]]
     return times
 
-def from_cli(opt, dyn_range_fac=1, precision='single'):  
+def from_cli(opt, dyn_range_fac=1, precision='single',
+             inj_filter_rejector=None):
     """Parses the CLI options related to strain data reading and conditioning.
     Parameters
     ----------
@@ -193,6 +194,11 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
 
     dyn_range_fac: {float, 1}, optional
         A large constant to reduce the dynamic range of the strain.
+    inj_filter_rejector: InjFilterRejector instance; optional, default=None
+        If given send the InjFilterRejector instance to the inject module so
+        that it can store a reduced representation of injections if
+        necessary.
+
     Returns
     -------
     strain : TimeSeries
@@ -200,6 +206,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
     """
 
     gating_info = {}
+
     if opt.frame_cache or opt.frame_files or opt.frame_type:
         if opt.frame_cache:
             frame_source = opt.frame_cache
@@ -235,8 +242,9 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
         if opt.injection_file:
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
-            injections = injector.apply(strain, opt.channel_name[0:2],        
-                             distance_scale=opt.injection_scale_factor)
+            injections = injector.apply(strain, opt.channel_name[0:2],
+                             distance_scale=opt.injection_scale_factor,
+                             inj_filter_rejector=inj_filter_rejector)
 
         if opt.sgburst_injection_file:
             logging.info("Applying sine-Gaussian burst injections")
@@ -325,7 +333,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
             injections = injector.apply(strain, opt.channel_name[0:2],        
-                             distance_scale=opt.injection_scale_factor)
+                             distance_scale=opt.injection_scale_factor,
+                             inj_filter_rejector=inj_filter_rejector)
 
         if opt.sgburst_injection_file:
             logging.info("Applying sine-Gaussian burst injections")
@@ -342,9 +351,6 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
             logging.info("Converting to float32")
             strain = (dyn_range_fac * strain).astype(pycbc.types.float32)
 
-    if opt.injection_file:
-        strain.injections = injections
-
     if opt.taper_data:
         logging.info("Tapering data")
         # Use auto-gating stuff for this, a one-sided gate is a taper
@@ -354,8 +360,10 @@ def from_cli(opt, dyn_range_fac=1, precision='single'):
                              pd_taper_window) )
         gate_data(strain, gate_params)
 
-
+    if opt.injection_file:
+        strain.injections = injections
     strain.gating_info = gating_info
+
     return strain  
 
 def from_cli_single_ifo(opt, ifo, **kwargs):
@@ -971,6 +979,10 @@ class StrainSegments(object):
         segment_group.add_argument("--segment-end-pad", type=int,
                           help="The time in seconds to ignore at the "
                                "end of each segment in seconds.")
+        segment_group.add_argument("--allow-zero-padding", action='store_true',
+                                   help="Allow for zero padding of data to "
+                                        "analyze requested times, if needed.")
+        # Injection optimization options
         segment_group.add_argument("--filter-inj-only", action='store_true',
                           help="Analyze only segments that contain an injection.")
         segment_group.add_argument("--injection-window", default=None,
@@ -982,9 +994,6 @@ class StrainSegments(object):
                           filter at full rate where needed. NOTE: Reverts to
                           full analysis if two injections are in the same
                           segment.""")
-        segment_group.add_argument("--allow-zero-padding", action='store_true',
-                          help="Allow for zero padding of data to analyze "
-                          "requested times, if needed.")
 
 
     @classmethod
@@ -1037,11 +1046,12 @@ class StrainSegments(object):
                     nargs='+', action=MultiDetOptionAction, metavar='IFO:TIME',
                     help="The time in seconds to ignore at the "
                          "end of each segment in seconds.")
-        segment_group.add_argument("--filter-inj-only", action='store_true',
-                    help="Analyze only segments that contain an injection.")
         segment_group.add_argument("--allow-zero-padding", action='store_true',
                           help="Allow for zero padding of data to analyze "
                           "requested times, if needed.")
+        segment_group.add_argument("--filter-inj-only", action='store_true',
+                                   help="Analyze only segments that contain "
+                                        "an injection.")
 
     required_opts_list = ['--segment-length',
                    '--segment-start-pad',

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -335,7 +335,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
             injections = \
-                injector.apply(strain, opt.channel_name[0:2],        
+                injector.apply(strain, opt.channel_name[0:2],
                                distance_scale=opt.injection_scale_factor,
                                inj_filter_rejector=inj_filter_rejector)
 

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -181,6 +181,7 @@ def detect_loud_glitches(strain, psd_duration=4., psd_stride=2.,
              for idx in indices[cluster_idx]]
     return times
 
+
 def from_cli(opt, dyn_range_fac=1, precision='single',
              inj_filter_rejector=None):
     """Parses the CLI options related to strain data reading and conditioning.
@@ -243,8 +244,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
             injections = injector.apply(strain, opt.channel_name[0:2],
-                             distance_scale=opt.injection_scale_factor,
-                             inj_filter_rejector=inj_filter_rejector)
+                distance_scale=opt.injection_scale_factor,
+                inj_filter_rejector=inj_filter_rejector)
 
         if opt.sgburst_injection_file:
             logging.info("Applying sine-Gaussian burst injections")
@@ -333,8 +334,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             logging.info("Applying injections")
             injector = InjectionSet(opt.injection_file)
             injections = injector.apply(strain, opt.channel_name[0:2],        
-                             distance_scale=opt.injection_scale_factor,
-                             inj_filter_rejector=inj_filter_rejector)
+                distance_scale=opt.injection_scale_factor,
+                inj_filter_rejector=inj_filter_rejector)
 
         if opt.sgburst_injection_file:
             logging.info("Applying sine-Gaussian burst injections")

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -401,7 +401,7 @@ class TemplateBank(object):
     def generate_with_delta_f_and_max_freq(self, t_num, max_freq, delta_f,
                                            low_frequency_cutoff=None,
                                            cached_mem=None):
-        """ Generate the template with index t_num using custom length."""
+        """Generate the template with index t_num using custom length."""
         approximant = self.approximant(t_num)
         # Don't want to use INTERP waveforms in here
         if approximant.endswith('_INTERP'):
@@ -421,7 +421,7 @@ class TemplateBank(object):
         return htilde
 
     def template_thinning(self, inj_filter_rejector):
-        """ Remove templates from bank that are far from all injections."""
+        """Remove templates from bank that are far from all injections."""
         if not inj_filter_rejector.enabled or \
                 inj_filter_rejector.chirp_time_window is None:
             # Do nothing!

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -401,8 +401,7 @@ class TemplateBank(object):
     def generate_with_delta_f_and_max_freq(self, t_num, max_freq, delta_f,
                                            low_frequency_cutoff=None,
                                            cached_mem=None):
-        """ Generate the template with index t_num using custom length.
-        """
+        """ Generate the template with index t_num using custom length."""
         approximant = self.approximant(t_num)
         # Don't want to use INTERP waveforms in here
         if approximant.endswith('_INTERP'):
@@ -422,6 +421,7 @@ class TemplateBank(object):
         return htilde
 
     def template_thinning(self, inj_filter_rejector):
+        """ Remove templates from bank that are far from all injections."""
         if not inj_filter_rejector.enabled or \
                 inj_filter_rejector.chirp_time_window is None:
             # Do nothing!
@@ -433,12 +433,11 @@ class TemplateBank(object):
         m1= self.table['mass1']
         m2= self.table['mass2']
         thinning_bank = []
-        tau0_temp, tau3_temp = pycbc.pnutils.mass1_mass2_to_tau0_tau3(m1, m2,
-                                                                      fref)
+        tau0_temp, _ = pycbc.pnutils.mass1_mass2_to_tau0_tau3(m1, m2, fref)
         indices = []
             
         for inj in injection_parameters:
-            tau0_inj, tau3_inj = \
+            tau0_inj, _ = \
                 pycbc.pnutils.mass1_mass2_to_tau0_tau3(inj.mass1, inj.mass2,
                                                        fref)
             inj_indices = np.where(abs(tau0_temp - tau0_inj) <= threshold)[0]

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -30,14 +30,15 @@ import numpy
 import logging
 import os.path
 import h5py
-import pycbc.waveform
-import pycbc.waveform.compress
-from pycbc.types import zeros
-from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
-from pycbc import DYN_RANGE_FAC
-import pycbc.io
 from copy import copy
 import numpy as np
+from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
+import pycbc.waveform
+import pycbc.pnutils
+import pycbc.waveform.compress
+from pycbc import DYN_RANGE_FAC
+from pycbc.types import zeros
+import pycbc.io
 
 def sigma_cached(self, psd):
     """ Cache sigma calculate for use in tandem with the FilterBank class
@@ -397,24 +398,55 @@ class TemplateBank(object):
     def __len__(self):
         return len(self.table)
 
-    def template_thinning(self, injection_parameters, threshold):
-        from pycbc.pnutils import mass1_mass2_to_tau0_tau3
+    def generate_with_delta_f_and_max_freq(self, t_num, max_freq, delta_f,
+                                           low_frequency_cutoff=None,
+                                           cached_mem=None):
+        """ Generate the template with index t_num using custom length.
+        """
+        approximant = self.approximant(t_num)
+        # Don't want to use INTERP waveforms in here
+        if approximant.endswith('_INTERP'):
+            approximant = approximant.replace('_INTERP', '')
+        # Using SPAtmplt here is bad as the stored cbrt and logv get
+        # recalculated as we change delta_f values. Fall back to TaylorF2
+        # in lalsimulation.
+        if approximant == 'SPAtmplt':
+            approximant = 'TaylorF2'
+        if cached_mem is None:
+            wav_len = int(max_freq / delta_f) + 1
+            cached_mem = zeros(wav_len, dtype=numpy.complex64)
+        htilde = pycbc.waveform.get_waveform_filter(
+            cached_mem, self.table[t_num], approximant=approximant,
+            f_lower=low_frequency_cutoff, f_final=max_freq, delta_f=delta_f,
+            distance=1./DYN_RANGE_FAC, delta_t=1./(2.*max_freq))
+        return htilde
+
+    def template_thinning(self, inj_filter_rejector):
+        if not inj_filter_rejector.enabled or \
+                inj_filter_rejector.chirp_time_window is None:
+            # Do nothing!
+            return
+
+        injection_parameters = inj_filter_rejector.injection_params.table
+        fref = inj_filter_rejector.f_lower
+        threshold = inj_filter_rejector.chirp_time_window
         m1= self.table['mass1']
         m2= self.table['mass2']
         thinning_bank = []
-        fref = 30
-        tau0_temp, tau3_temp= pycbc.pnutils.mass1_mass2_to_tau0_tau3(m1, m2, fref)
+        tau0_temp, tau3_temp = pycbc.pnutils.mass1_mass2_to_tau0_tau3(m1, m2,
+                                                                      fref)
         indices = []
             
         for inj in injection_parameters:
-            tau0_inj, tau3_inj= pycbc.pnutils.mass1_mass2_to_tau0_tau3(inj.mass1, inj.mass2, fref)    
+            tau0_inj, tau3_inj = \
+                pycbc.pnutils.mass1_mass2_to_tau0_tau3(inj.mass1, inj.mass2,
+                                                       fref)
             inj_indices = np.where(abs(tau0_temp - tau0_inj) <= threshold)[0]
             indices.append(inj_indices)
             indices_combined = np.concatenate(indices)
 
         indices_unique= np.unique(indices_combined)
-        restricted= self.table[indices_unique]
-        return restricted 
+        self.table = self.table[indices_unique]
 
 class LiveFilterBank(TemplateBank):
     def __init__(self, filename, f_lower, sample_rate, minimum_buffer,

--- a/setup.py
+++ b/setup.py
@@ -488,6 +488,7 @@ setup (
                'pycbc.results',
                'pycbc.io',
                'pycbc.inference',
+               'pycbc.inject',
                ],
      package_data = {'pycbc.workflow': find_package_data('pycbc/workflow'), 
 	             'pycbc.results': find_package_data('pycbc/results'),


### PR DESCRIPTION
These are the changes to implement injfilterrejector in PyCBC. The basic idea is that 'injfilterrejector' is used to determine whether to filter a segment against a template based on the parameters of the template and any injections made into the segment.

There are currently two tests in injfilterrejector (though one could add more). A chirp-time test, as previously implemented, and a coarse-match test. Using both together speeds up injection runs by over an order of magnitude in tests I've done.

I'm running through some final checks with this version of the code now, to compare with and without injfilterrejector, but I wanted to post the PR now to deal with any comments or code-quality issues. By default injfilterrejector is not enabled, and if no injections are present it does nothing. Therefore to use this in O2 would require a few additional options ... But the resulting speedup might suggest that we would want to tune a few more settings to decrease start-up cost relative to cost doing matched-filtering.
