### PR TITLE
Add memory statements for aligned bank

### DIFF
--- a/bin/pycbc_geom_aligned_bank
+++ b/bin/pycbc_geom_aligned_bank
@@ -506,18 +506,26 @@ if opts.threed_lattice:
     cp.set('aligned2dstack', 'threed-lattice', '')
 if opts.random_seed:
     cp.set('aligned2dstack', 'random-seed', str(opts.random_seed))
+cp.add_section('pegasus_profile-aligned2dstack')
+cp.set('pegasus_profile-aligned2dstack', 'condor|request_memory=3000')
 
 # alignedcat
 cp.add_section('alignedbankcat')
 if opts.f_low_column is not None:
     cp.set('alignedbankcat', 'f-low-column', opts.f_low_column)
+cp.add_section('pegasus_profile-alignedbankcat')
+cp.set('pegasus_profile-alignedbankcat', 'condor|request_memory=3000')
 
 # dumptochis
 cp.add_section('dumptochis')
+cp.add_section('pegasus_profile-dumptochis')
+cp.set('pegasus_profile-dumptochis', 'condor|request_memory=3000')
 
 # bank verification
 cp.add_section('bankverify')
 cp.set('bankverify', 'bin-spacing', str(1 - opts.min_match))
+cp.add_section('pegasus_profile-bankverify')
+cp.set('pegasus_profile-bankverify', 'condor|request_memory=3000')
 
 temp_fp = open('temp.ini', 'w')
 cp.write(temp_fp)


### PR DESCRIPTION
Add memory requirements for the pycbc geometric aligned-spin bank generator.

Maybe at some point we should rewrite the aligned-spin workflow so that it just takes a configuration file like normal pycbc workflows. I don't have time for this before O2, so this is the best solution for now.