### PR TITLE
Read the template start frequency from the template bank

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -270,10 +270,10 @@ with ctx:
   
     logging.info("Read in template bank")
     bank = waveform.FilterBank(opt.bank_file, flen, delta_f,
-                    low_frequency_cutoff=flow,
-                    dtype=complex64, phase_order=opt.order,
-                    taper=opt.taper_template, approximant=opt.approximant,
-                    out=template_mem, max_template_length=opt.max_template_length)
+        low_frequency_cutoff=None if opt.enable_bank_start_frequency else flow,
+        dtype=complex64, phase_order=opt.order,
+        taper=opt.taper_template, approximant=opt.approximant,
+        out=template_mem, max_template_length=opt.max_template_length)
 
     ntemplates = len(bank)
     nfilters = 0

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -45,6 +45,9 @@ parser.add_argument("--newsnr-threshold", type=float, metavar='THRESHOLD',
                     help="Cut triggers with NewSNR less than THRESHOLD")
 parser.add_argument("--low-frequency-cutoff", type=float,
                   help="The low frequency cutoff to use for filtering (Hz)")
+parser.add_argument("--enable-bank-start-frequency", action='store_true',
+                  help="Read the starting frequency of template waveforms"
+                       " from the template bank.")
 parser.add_argument("--max-template-length", type=float,
                   help="The maximum length of a template is seconds. The "
                        "starting frequency of the template is modified to "

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -267,7 +267,8 @@ with ctx:
   
     logging.info("Read in template bank")
     bank = waveform.FilterBank(opt.bank_file, flen, delta_f,
-                    flow, dtype=complex64, phase_order=opt.order,
+                    low_frequency_cutoff=flow,
+                    dtype=complex64, phase_order=opt.order,
                     taper=opt.taper_template, approximant=opt.approximant,
                     out=template_mem, max_template_length=opt.max_template_length)
 

--- a/pycbc/vetoes/bank_chisq.py
+++ b/pycbc/vetoes/bank_chisq.py
@@ -183,8 +183,8 @@ class SingleDetBankVeto(object):
             logging.info("Read in bank veto template bank")
             bank_veto_bank = FilterBank(bank_file,
                     self.seg_len_freq,
-                    self.delta_f, f_low,
-                    dtype=self.cdtype,
+                    self.delta_f, self.cdtype,
+                    low_frequency_cutoff=f_low,
                     approximant=approximant, **kwds)
 
             self.filters = list(bank_veto_bank)

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -702,7 +702,7 @@ class FilterBank(TemplateBank):
         htilde._sigmasq = {}
         return htilde
 
-def find_variable_start_frequency(approximant, parameters, f_start, max_length, 
+def find_variable_start_frequency(approximant, parameters, f_start, max_length,
                                   delta_f = 1):
     """ Find a frequency value above the starting frequency that results in a
     waveform shorter than max_length.

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -596,6 +596,8 @@ class LiveFilterBank(TemplateBank):
         htilde.params = self.table[index]
         htilde.chirp_length = template_duration
         htilde.length_in_time = ttotal
+        htilde.approximant = approximant
+        htilde.end_frequency = f_end
 
         # Add sigmasq as a method of this instance
         htilde.sigmasq = types.MethodType(sigma_cached, htilde)
@@ -623,7 +625,6 @@ class FilterBank(TemplateBank):
         self.N = (filter_length - 1 ) * 2
         self.delta_t = 1.0 / (self.N * self.delta_f)
         self.filter_length = filter_length
-        self.kmin = int(f_lower / delta_f)
         self.max_template_length = max_template_length
 
         super(FilterBank, self).__init__(filename, approximant=approximant,
@@ -645,13 +646,13 @@ class FilterBank(TemplateBank):
             f_end = (self.filter_length-1) * self.delta_f
 
         # Find the start frequency, if variable
-        if self.max_template_length is not None:
+        if self.f_lower is None:
+            f_low = self.table[index].f_lower
+        elif self.max_template_length is not None:
             f_low = find_variable_start_frequency(approximant,
                                                   self.table[index],
                                                   self.f_lower,
                                                   self.max_template_length)
-        elif self.f_lower is None:
-            f_low = self.table[index].f_lower
         else:
             f_low = self.f_lower
 
@@ -686,6 +687,8 @@ class FilterBank(TemplateBank):
         htilde.params = self.table[index]
         htilde.chirp_length = template_duration
         htilde.length_in_time = ttotal
+        htilde.approximant = approximant
+        htilde.end_frequency = f_end
 
         # Add sigmasq as a method of this instance
         htilde.sigmasq = types.MethodType(sigma_cached, htilde)
@@ -721,7 +724,6 @@ class FilterBankSkyMax(TemplateBank):
         self.N = (filter_length - 1 ) * 2
         self.delta_t = 1.0 / (self.N * self.delta_f)
         self.filter_length = filter_length
-        self.kmin = int(f_lower / delta_f)
         self.max_template_length = max_template_length
 
         super(FilterBankSkyMax, self).__init__(filename, parameters=parameters,


### PR DESCRIPTION
This updates pycbc inspiral (FilterBank) to read the start frequency of templates from the template bank. If an xml file is used the 'alpha6' column is used. If an hdf file, the 'f_lower' column is used. An explicity '--enable-bank-start-frequency' option needs to be given to pycbc_inspiral to enable this functionality. This will override all other options such as (--max-template-length). 
