### PR TITLE
Ability to save low-frequency cutoff into bank XML files

### DIFF
--- a/bin/pycbc_aligned_bank_cat
+++ b/bin/pycbc_aligned_bank_cat
@@ -58,6 +58,9 @@ parser.add_argument("-i", "--input-glob",
 parser.add_argument("-I", "--input-files", nargs='+',
                     help="Explicit list of input files.")
 parser.add_argument("-o", "--output-file",  help="Output file name")
+parser.add_argument('--f-low-column', type=str, metavar='NAME',
+                    help='If given, store the lower frequency cutoff into '
+                         'column NAME of the single-inspiral table.')
 parser.add_argument("-m", "--metadata-file", metavar="METADATA_FILE",
                   help="XML file containing the process and process_params "
                   "tables that the aligned_bank code was run with.")

--- a/bin/pycbc_geom_aligned_bank
+++ b/bin/pycbc_geom_aligned_bank
@@ -509,6 +509,8 @@ if opts.random_seed:
 
 # alignedcat
 cp.add_section('alignedbankcat')
+if opts.f_low_column is not None:
+    cp.set('alignedbankcat', 'f-low-column', opts.f_low_column)
 
 # dumptochis
 cp.add_section('dumptochis')

--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -358,6 +358,12 @@ def output_sngl_inspiral_table(outputFile, tempBank, metricParams,
                     ethincaParams.cutoff,
                     sngl.mass1, sngl.mass2, sngl.spin1z, sngl.spin2z)
 
+    # set per-template low-frequency cutoff
+    if 'f_low_column' in optDict and 'f_low' in optDict and \
+            optDict['f_low_column'] is not None:
+        for sngl in sngl_inspiral_table:
+            setattr(sngl, optDict['f_low_column'], optDict['f_low'])
+
     outdoc.childNodes[0].appendChild(sngl_inspiral_table)
 
     # get times to put in search summary table

--- a/pycbc/tmpltbank/option_utils.py
+++ b/pycbc/tmpltbank/option_utils.py
@@ -129,6 +129,9 @@ def insert_base_bank_options(parser):
     parser.add_argument(
             '-O', '--output-file', required=True,
             help="Output file name. Required.")
+    parser.add_argument('--f-low-column', type=str, metavar='NAME',
+                        help='If given, store the lower frequency cutoff into '
+                             'column NAME of the single-inspiral table.')
 
 def insert_metric_calculation_options(parser):
     """


### PR DESCRIPTION
This is needed for the uberbank workflow to produce a consistent bank when the variable cutoff is used in sbank. Tested with `pycbc_geom_nonspinbank`.