### PR TITLE
Force backwards compatibility for submit directory layout

### DIFF
--- a/pycbc/workflow/pegasus_files/pegasus-properties.conf
+++ b/pycbc/workflow/pegasus_files/pegasus-properties.conf
@@ -27,4 +27,10 @@ pegasus.catalog.site.file=site-catalog.xml
 pegasus.catalog.replica.cache.asrc=true
 pegasus.catalog.replica.dax.asrc=true
 
+# placing all the job submit files in the submit directory
+# as determined from the planner options. This replicated the
+# behavior from Pegasus 4.6.x and is needed until we switch to
+# hashed sub-directories in the submit directory
+pegasus.dir.submit.mapper=Flat
+
 pegasus.metrics.app=ligo-pycbc


### PR DESCRIPTION
Pegasus 4.7 uses a new hierarchical layout of the submit directories. However, this breaks our workflows as we don't give full paths to sub-daxes in the workflow. At some point we should fix this, but the workaround for now is to tell Pegasus 4.7 to use the same directory layout as 4.6.