### PR TITLE
allow profile to be overriden

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -256,7 +256,7 @@ class Executable(pegasus_workflow.Executable):
 
             value = string.strip(cp.get(sec, opt))
             key = opt.split('|')[1]
-            self.add_profile(namespace, key, value)
+            self.add_profile(namespace, key, value, force=True)
 
             # Remove if Pegasus can apply this hint in the TC
             if namespace == 'hints' and key == 'execution.site':

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -91,14 +91,18 @@ class Executable(ProfileShortcuts):
     def insert_into_dax(self, dax):
         dax.addExecutable(self._dax_executable)
         
-    def add_profile(self, namespace, key, value):
+    def add_profile(self, namespace, key, value, force=False):
         """ Add profile information to this executable
         """
         try:
             entry = dax.Profile(namespace, key, value)
             self._dax_executable.addProfile(entry)  
         except dax.DuplicateError:
-            pass
+            if force:
+                # Replace with the new key
+                self._dax_executable.removeProfile(entry)
+                self._dax_executable.addProfile(entry)
+        
  
 class Node(ProfileShortcuts):    
     def __init__(self, executable):
@@ -209,14 +213,17 @@ class Node(ProfileShortcuts):
         return fil
 
     # functions to describe properties of this node
-    def add_profile(self, namespace, key, value):
+    def add_profile(self, namespace, key, value, force=False):
         """ Add profile information to this node at the DAX level
         """
         try:
             entry = dax.Profile(namespace, key, value)
             self._dax_node.addProfile(entry)
         except dax.DuplicateError:
-            pass    
+            if force:
+                # Replace with the new key
+                self._dax_node.removeProfile(entry)
+                self._dax_node.addProfile(entry)
         
     def _finalize(self):
         args = self._args + self._options


### PR DESCRIPTION
I said I would right a patch for this, and so I have. Unfortunately, I haven't had the chance to test this, so if someone is able to quickly, that would be helpful. 

This patch allows global profile information to be overriden by subsequent profile calls. This means that we can set a global minimum memory request in the [pegasus_profile] section and still have executables respect subsequent [pegasus_profile-exe] sections. 