### PR TITLE
Fix local-site-scratch variable

### DIFF
--- a/pycbc/workflow/pegasus_files/pegasus-properties.conf
+++ b/pycbc/workflow/pegasus_files/pegasus-properties.conf
@@ -31,6 +31,8 @@ pegasus.catalog.replica.dax.asrc=true
 # as determined from the planner options. This replicated the
 # behavior from Pegasus 4.6.x and is needed until we switch to
 # hashed sub-directories in the submit directory
+# Same for local-site-scratch
 pegasus.dir.submit.mapper=Flat
+pegasus.dir.staging.mapper=Flat
 
 pegasus.metrics.app=ligo-pycbc


### PR DESCRIPTION
For #1151 I think @duncan-brown changed the wrong setting. I think this is the right one to change. I think our workflows *will* run with pegasus.dir.submit.mapper set to its default value. But as an advanced user, a disadvantage to that is it may slow down debugging if I have to search for relevant submit files.