### PR TITLE
pycbc_banksim: variable low-frequency cutoff and cleanup

### DIFF
--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -14,20 +14,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-
-#
-# =============================================================================
-#
-#                                   Preamble
-#
-# =============================================================================
-#
-from time import time
-
-start = time()
-elapsed_time = lambda: time()-start
-
 import sys
+import logging
 from numpy import complex64, float32
 from argparse import ArgumentParser
 from glue.ligolw import utils as ligolw_utils
@@ -162,35 +150,64 @@ aprs = sorted(list(set(td_approximants() + fd_approximants())))
 
 #File output Settings
 parser = ArgumentParser()
-parser.add_argument("--match-file", dest="out_file", help="file to output match results", metavar="FILE")
-parser.add_argument("--verbose", action='store_true', default=False, help="Print verbose statements")
+parser.add_argument("--match-file", dest="out_file", metavar="FILE",
+                    help="file to output match results")
+parser.add_argument("--verbose", action='store_true', default=False,
+                    help="Print verbose statements")
 
 #Template Settings
-parser.add_argument("--template-file", dest="bank_file", help="SimInspiral or SnglInspiral XML file containing the template parameters", metavar="FILE")
-parser.add_argument("--total-mass-divide", type=float, help="Total mass to switch from --template-approximant to --highmass-approximant.")
-parser.add_argument("--highmass-approximant", help="Waveform approximant for highmass templates.", choices=aprs)
-parser.add_argument("--template-approximant", help="Waveform approximant for templates", choices=aprs)
-parser.add_argument("--template-phase-order", help="PN order to use for the template phase", default=-1, type=int)
-parser.add_argument("--template-amplitude-order", help="PN order to use for the template amplitude", default=-1, type=int)
-parser.add_argument("--template-spin-order", help="PN order to use for the template spin terms", default=-1, type=int)
-parser.add_argument("--template-start-frequency", help="Starting frequency for templates [Hz]", type=float)
-parser.add_argument("--template-sample-rate", help="Sample rate for templates [Hz]", type=float)
+parser.add_argument("--template-file", dest="bank_file", metavar="FILE",
+                    help="SimInspiral or SnglInspiral XML file containing the "
+                         "template parameters")
+parser.add_argument("--total-mass-divide", type=float,
+                    help="Total mass to switch from --template-approximant to "
+                         "--highmass-approximant.")
+parser.add_argument("--highmass-approximant", choices=aprs,
+                    help="Waveform approximant for highmass templates.")
+parser.add_argument("--template-approximant", choices=aprs,
+                    help="Waveform approximant for templates")
+parser.add_argument("--template-phase-order", default=-1, type=int,
+                    help="PN order to use for the template phase")
+parser.add_argument("--template-amplitude-order", default=-1, type=int,
+                    help="PN order to use for the template amplitude")
+parser.add_argument("--template-spin-order", default=-1, type=int,
+                    help="PN order to use for the template spin terms")
+parser.add_argument("--template-start-frequency", type=float,
+                    help="Starting frequency for templates [Hz]")
+parser.add_argument("--template-sample-rate", type=float,
+                    help="Sample rate for templates [Hz]")
 
 #Signal Settings
-parser.add_argument("--signal-file", dest="sim_file", help="SimInspiral or SnglInspiral XML file containing the signal parameters", metavar="FILE")
-parser.add_argument("--signal-approximant", help="Waveform approximant for signals", choices=aprs)
-parser.add_argument("--signal-phase-order", help="PN order to use for the signal phase", default=-1, type=int)
-parser.add_argument("--signal-spin-order", help="PN order to use for the signal spin terms", default=-1, type=int)
-parser.add_argument("--signal-amplitude-order", help="PN order to use for the signal amplitude", default=-1, type=int)
-parser.add_argument("--signal-start-frequency", help="Starting frequency for signals [Hz]", type=float)
-parser.add_argument("--signal-sample-rate", help="Sample rate for signals [Hz]", type=float)
-parser.add_argument("--use-sky-location", help="Inject into a theoretical detector at the celestial North pole of a non-rotating Earth rather than overhead", action='store_true')
+parser.add_argument("--signal-file", dest="sim_file", metavar="FILE",
+                    help="SimInspiral or SnglInspiral XML file containing the "
+                         "signal parameters")
+parser.add_argument("--signal-approximant", choices=aprs,
+                    help="Waveform approximant for signals")
+parser.add_argument("--signal-phase-order", default=-1, type=int,
+                    help="PN order to use for the signal phase")
+parser.add_argument("--signal-spin-order", default=-1, type=int,
+                    help="PN order to use for the signal spin terms")
+parser.add_argument("--signal-amplitude-order", default=-1, type=int,
+                    help="PN order to use for the signal amplitude")
+parser.add_argument("--signal-start-frequency", type=float,
+                    help="Starting frequency for signals [Hz]")
+parser.add_argument("--signal-sample-rate", type=float,
+                    help="Sample rate for signals [Hz]")
+parser.add_argument("--use-sky-location", action='store_true',
+                    help="Inject into a theoretical detector at the celestial "
+                         "North pole of a non-rotating Earth rather than overhead")
 
 #Filtering Settings
-parser.add_argument('--filter-low-frequency-cutoff', metavar='FREQ', help='low frequency cutoff of matched filter', type=float)
-parser.add_argument('--filter-high-freq-cutoff-isco-factor', metavar='FLOAT', help='High frequency cutoff of matched filter as a fraction of the injection\'s ISCO', type=float)
-parser.add_argument("--filter-sample-rate", help="Filter sample rate [Hz]", type=float)
-parser.add_argument("--filter-signal-length", help="Length of signal for filtering, shoud be longer than all waveforms and include some padding", type=int)
+parser.add_argument('--filter-low-frequency-cutoff', metavar='FREQ', type=float,
+                    help='low frequency cutoff of matched filter')
+parser.add_argument('--filter-high-freq-cutoff-isco-factor', metavar='FLOAT',
+                    type=float, help="High frequency cutoff of matched filter "
+                                     "as a fraction of the injection's ISCO")
+parser.add_argument("--filter-sample-rate", type=float,
+                    help="Filter sample rate [Hz]")
+parser.add_argument("--filter-signal-length", type=int,
+                    help="Length of signal for filtering, shoud be longer "
+                         "than all waveforms and include some padding")
 
 # add PSD options
 pycbc.psd.insert_psd_option_group(parser, output=False)
@@ -203,8 +220,24 @@ pycbc.scheme.insert_processing_option_group(parser)
 pycbc.fft.insert_fft_option_group(parser)
 
 #Restricted maximization
-parser.add_argument("--mchirp-window", type=str, metavar="FRACTION", help="Ignore templates whose chirp mass deviates from signal's one more than given fraction. Provide two comma separated numbers to have different bounds above and below the signal's, with below bound listed first.")
+parser.add_argument("--mchirp-window", type=str, metavar="FRACTION",
+                    help="Ignore templates whose chirp mass deviates from "
+                         "signal's one more than given fraction. Provide two "
+                         "comma separated numbers to have different bounds "
+                         "above and below the signal's, with below bound "
+                         "listed first.")
 options = parser.parse_args()
+
+pycbc.init_logging(options.verbose)
+
+pycbc.psd.verify_psd_options(options, parser)
+
+if options.psd_estimation:
+    pycbc.strain.verify_strain_options(options, parser)
+
+if options.total_mass_divide and options.highmass_approximant is None:
+    parser.error("You must provide a highmass-approximant if you want total-mass-divide.")
+
 #Split mchirp_window depending on whether it contains a comma
 mchirp_list = True if ',' in options.mchirp_window else False
 if mchirp_list:
@@ -213,15 +246,6 @@ if mchirp_list:
 else:
      mchirp_window_equal = float(options.mchirp_window)
 
-
-template_sample_rate = options.filter_sample_rate
-signal_sample_rate = options.filter_sample_rate
-
-pycbc.psd.verify_psd_options(options, parser)
-
-if options.psd_estimation:
-    pycbc.strain.verify_strain_options(options, parser)
-
 # If we are going to use h(t) to estimate a PSD we need h(t)
 if options.psd_estimation:
     logging.info("Obtaining h(t) for PSD generation")
@@ -229,57 +253,45 @@ if options.psd_estimation:
 else:
     strain = None
 
-if options.total_mass_divide and options.highmass_approximant is None:
-    parser.error("You must provide a highmass-approximant if you want total-mass-divide.")
-
-if options.template_sample_rate:
-    template_sample_rate = options.template_sample_rate
-
-if options.signal_sample_rate:
-    signal_sample_rate = options.signal_sample_rate
+template_sample_rate = options.template_sample_rate or options.filter_sample_rate
+signal_sample_rate = options.signal_sample_rate or options.filter_sample_rate
 
 ctx = pycbc.scheme.from_cli(options)
 
-if options.verbose:
-  print "Options read and verified, beginning banksim at %fs" %(elapsed_time())
-
-# Load in the template bank file
-indoc = ligolw_utils.load_filename(options.bank_file, False, contenthandler=mycontenthandler)
+logging.info('Reading template bank')
+indoc = ligolw_utils.load_filename(options.bank_file, False,
+                                   contenthandler=mycontenthandler)
 try :
     template_table = table.get_table(indoc, lsctables.SnglInspiralTable.tableName) 
 except ValueError:
     template_table = table.get_table(indoc, lsctables.SimInspiralTable.tableName)
+logging.info("  %d templates", len(template_table))
 
-# Load in the simulation list
-indoc = ligolw_utils.load_filename(options.sim_file, False, contenthandler=mycontenthandler)
+logging.info('Reading simulation list')
+indoc = ligolw_utils.load_filename(options.sim_file, False,
+                                   contenthandler=mycontenthandler)
 try:
     signal_table = table.get_table(indoc, lsctables.SimInspiralTable.tableName) 
 except ValueError:
     signal_table = table.get_table(indoc, lsctables.SnglInspiralTable.tableName)
+logging.info("  %d signal waveforms", len(signal_table))
 
-if options.verbose:
-  print "Bank and simulation files read at %fs" %(elapsed_time())
-  print "Number of Signal Waveforms: ",len(signal_table)
-  print "Number of Templates       : ",len(template_table)
-  print "Matches will be written to " + options.out_file
-  print "Recovered templates will be written to " + options.out_file+".found"
+logging.info("Matches will be written to %s", options.out_file)
 
 filter_N = int(options.filter_signal_length * options.filter_sample_rate)
 filter_n = filter_N / 2 + 1
 filter_delta_f = 1.0 / float(options.filter_signal_length)
 
-if options.verbose:
-  print("Reading and Interpolating PSD")
-psd = pycbc.psd.from_cli(options, filter_n,  
-                         filter_delta_f, options.filter_low_frequency_cutoff, strain=strain,
-                         dyn_range_factor=pycbc.DYN_RANGE_FAC, precision='single')
-
-if options.verbose:
-  print("PSD interpolated at %fs" %(elapsed_time()))
-  print("Pregenerating Signals")
+logging.info("Reading and Interpolating PSD")
+psd = pycbc.psd.from_cli(options, filter_n, filter_delta_f,
+                         options.filter_low_frequency_cutoff, strain=strain,
+                         dyn_range_factor=pycbc.DYN_RANGE_FAC,
+                         precision='single')
   
 with ctx: 
     pycbc.fft.from_cli(options)
+
+    logging.info("Pregenerating Signals")
 
     signals = []
     index = 0 
@@ -290,14 +302,14 @@ with ctx:
         if not options.use_sky_location:
             signal_params.latitude = 0.
             signal_params.longitude = 0.
-        stilde = get_waveform(options.signal_approximant, 
-                      options.signal_phase_order, 
-                      options.signal_amplitude_order, 
-                      options.signal_spin_order,
-                      signal_params, 
-                      options.signal_start_frequency, 
-                      signal_sample_rate, 
-                      filter_N, options.filter_sample_rate)
+        stilde = get_waveform(options.signal_approximant,
+                              options.signal_phase_order,
+                              options.signal_amplitude_order,
+                              options.signal_spin_order,
+                              signal_params,
+                              options.signal_start_frequency,
+                              signal_sample_rate,
+                              filter_N, options.filter_sample_rate)
         if options.filter_high_freq_cutoff_isco_factor is not None:
             high_freq_cutoff = options.filter_high_freq_cutoff_isco_factor \
                     * f_SchwarzISCO(signal_params.mass1 + signal_params.mass2)
@@ -307,20 +319,16 @@ with ctx:
                 low_frequency_cutoff=options.filter_low_frequency_cutoff,
                 high_frequency_cutoff=high_freq_cutoff)
         stilde /= psd
-        signals.append((stilde, s_norm, [], signal_params,
-                        high_freq_cutoff))
+        signals.append((stilde, s_norm, [], signal_params, high_freq_cutoff))
 
-    if options.verbose:
-      print
-      print("Signals pregenerated at %fs" %(elapsed_time()))
-      print("Calculating Overlaps")
+    logging.info("Calculating Overlaps")
 
     index = 0 
     # Calculate the overlaps
     for template_params in template_table:
         index += 1
         if options.verbose:
-          update_progress(float(index)/len(template_table))
+            update_progress(float(index)/len(template_table))
         h_norm = htilde = None
         for stilde, s_norm, matches, signal_params, signal_high_freq_cutoff in signals:
             # Check if we need to look at this
@@ -366,10 +374,7 @@ with ctx:
                     high_frequency_cutoff=signal_high_freq_cutoff)
             matches.append(o)
 
-if options.verbose:
-  print
-  print("Overlaps finished at %fs" %(elapsed_time()))
-  print("Determining maximum overlaps and outputting results")
+logging.info("Determining maximum overlaps and outputting results")
 
 # Find the maximum overlap in the bank and output to a file
 with open(options.out_file, "w") as fout:

--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -355,10 +355,9 @@ with ctx:
         h_norm = htilde = None
         for stilde, s_norm, matches, signal_params, signal_high_freq_cutoff in signals:
             # Check if we need to look at this
-            if stilde is None:
+            if stilde is None or \
+                    outside_mchirp_window(template_params, signal_params):
                 matches.append(0)
-                continue
-            if outside_mchirp_window(template_params, signal_params):
                 continue
 
             # Generate htilde if we haven't already done so

--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -272,8 +272,14 @@ if options.psd_estimation:
 else:
     strain = None
 
-template_sample_rate = options.template_sample_rate or options.filter_sample_rate
-signal_sample_rate = options.signal_sample_rate or options.filter_sample_rate
+if options.template_sample_rate is not None:
+    template_sample_rate = options.template_sample_rate
+else:
+    template_sample_rate = options.filter_sample_rate
+if options.signal_sample_rate is not None:
+    signal_sample_rate = options.signal_sample_rate
+else:
+    signal_sample_rate = options.filter_sample_rate
 
 ctx = pycbc.scheme.from_cli(options)
 

--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -14,6 +14,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+"""Calculate the fitting factors of simulated signals with a template bank."""
+
 import sys
 import logging
 from numpy import complex64, float32
@@ -36,9 +38,10 @@ import pycbc.psd, pycbc.scheme, pycbc.fft, pycbc.strain
 from pycbc.detector import overhead_antenna_pattern as generate_fplus_fcross
 
 def update_progress(progress):
-    print '\r\r[{0}] {1:.2%}'.format('#'*(int(progress*100)/2)+' '*(50-int(progress*100)/2), progress),
-    if progress == 100:
-        print "Done"
+    bar = '#' * (int(progress*100)/2) + ' ' * (50-int(progress*100)/2)
+    print '[{0}] {1:.2%}\r\r'.format(bar, progress),
+    if progress == 1:
+        print('Done' + ' ' * 70)
     sys.stdout.flush()
 
 ## Remove the need for these functions ########################################
@@ -125,26 +128,6 @@ def get_waveform(approximant, phase_order, amplitude_order, spin_order,
 
     return make_padded_frequency_series(hvec, filter_N)
 
-# returns true if template_mchirp is more than w*signal_mchirp above or below signal_mchirp
-def outside_mchirp_window(template, signal, w):
-    template_mchirp, et = mass1_mass2_to_mchirp_eta(template.mass1,
-                                                    template.mass2)
-    signal_mchirp, et = mass1_mass2_to_mchirp_eta(signal.mass1, signal.mass2)
-    return abs(signal_mchirp - template_mchirp) > (w * signal_mchirp)
-
-# returns true if template_mchirp is more than w*signal_mchirp above signal_mchirp
-def above_mchirp_window(template, signal, w):
-    template_mchirp, et = mass1_mass2_to_mchirp_eta(template.mass1,
-                                                    template.mass2)
-    signal_mchirp, et = mass1_mass2_to_mchirp_eta(signal.mass1, signal.mass2)
-    return template_mchirp - signal_mchirp > (w * signal_mchirp)
-
-# returns true if template_mchirp is more than w*signal_mchirp below signal_mchirp
-def below_mchirp_window(template, signal, w):
-    template_mchirp, et = mass1_mass2_to_mchirp_eta(template.mass1,
-                                                    template.mass2)
-    signal_mchirp, et = mass1_mass2_to_mchirp_eta(signal.mass1, signal.mass2)
-    return signal_mchirp - template_mchirp > (w * signal_mchirp)
 
 def filter_low_freq_cutoff(options, template_params):
     """Parse CLI options related to the filter low-frequency cutoff, do basic
@@ -163,22 +146,22 @@ def filter_low_freq_cutoff(options, template_params):
 aprs = sorted(list(set(td_approximants() + fd_approximants())))
 
 #File output Settings
-parser = ArgumentParser()
+parser = ArgumentParser(description=__doc__)
 parser.add_argument("--match-file", dest="out_file", metavar="FILE",
-                    help="file to output match results")
+                    required=True, help="File to output match results")
 parser.add_argument("--verbose", action='store_true', default=False,
                     help="Print verbose statements")
 
 #Template Settings
 parser.add_argument("--template-file", dest="bank_file", metavar="FILE",
-                    help="SimInspiral or SnglInspiral XML file containing the "
-                         "template parameters")
+                    required=True, help="SimInspiral or SnglInspiral XML file "
+                                        "containing the template parameters")
 parser.add_argument("--total-mass-divide", type=float,
                     help="Total mass to switch from --template-approximant to "
                          "--highmass-approximant.")
 parser.add_argument("--highmass-approximant", choices=aprs,
                     help="Waveform approximant for highmass templates.")
-parser.add_argument("--template-approximant", choices=aprs,
+parser.add_argument("--template-approximant", choices=aprs, required=True,
                     help="Waveform approximant for templates")
 parser.add_argument("--template-phase-order", default=-1, type=int,
                     help="PN order to use for the template phase")
@@ -193,9 +176,9 @@ parser.add_argument("--template-sample-rate", type=float,
 
 #Signal Settings
 parser.add_argument("--signal-file", dest="sim_file", metavar="FILE",
-                    help="SimInspiral or SnglInspiral XML file containing the "
-                         "signal parameters")
-parser.add_argument("--signal-approximant", choices=aprs,
+                    required=True, help="SimInspiral or SnglInspiral XML file "
+                                        "containing the signal parameters")
+parser.add_argument("--signal-approximant", choices=aprs, required=True,
                     help="Waveform approximant for signals")
 parser.add_argument("--signal-phase-order", default=-1, type=int,
                     help="PN order to use for the signal phase")
@@ -213,19 +196,20 @@ parser.add_argument("--use-sky-location", action='store_true',
 
 #Filtering Settings
 parser.add_argument('--filter-low-frequency-cutoff', metavar='FREQ', type=float,
-                    help='low frequency cutoff of matched filter')
+                    required=True, help='low frequency cutoff of matched filter')
 parser.add_argument('--filter-low-freq-cutoff-column', metavar='NAME', type=str,
-                    help='If given, use a per-template low-frequency cutoff'
+                    help='If given, use a per-template low-frequency cutoff '
                          'from column NAME of the template table instead of '
-                         'the value given via --filter-low-frequency-cutoff.'
+                         'the value given via --filter-low-frequency-cutoff. '
                          'Signals are still normalized using '
-                         '--filter-low-frequency-cutoff.')
+                         '--filter-low-frequency-cutoff and the value in '
+                         'column NAME must be larger than or equal to it.')
 parser.add_argument('--filter-high-freq-cutoff-isco-factor', metavar='FLOAT',
                     type=float, help="High frequency cutoff of matched filter "
                                      "as a fraction of the injection's ISCO")
-parser.add_argument("--filter-sample-rate", type=float,
+parser.add_argument("--filter-sample-rate", type=float, required=True,
                     help="Filter sample rate [Hz]")
-parser.add_argument("--filter-signal-length", type=int,
+parser.add_argument("--filter-signal-length", type=int, required=True,
                     help="Length of signal for filtering, shoud be longer "
                          "than all waveforms and include some padding")
 
@@ -258,13 +242,28 @@ if options.psd_estimation:
 if options.total_mass_divide and options.highmass_approximant is None:
     parser.error("You must provide a highmass-approximant if you want total-mass-divide.")
 
-#Split mchirp_window depending on whether it contains a comma
-mchirp_list = True if ',' in options.mchirp_window else False
-if mchirp_list:
-     mchirp_window_lower = float(options.mchirp_window.split(",")[0])
-     mchirp_window_upper = float(options.mchirp_window.split(",")[1])
+if options.mchirp_window is None:
+    def outside_mchirp_window(template, signal):
+        return False
+elif ',' in options.mchirp_window:
+    # asymmetric chirp mass window
+    mchirp_window_lower = float(options.mchirp_window.split(",")[0])
+    mchirp_window_upper = float(options.mchirp_window.split(",")[1])
+    def outside_mchirp_window(template, signal):
+        template_mchirp, _ = mass1_mass2_to_mchirp_eta(template.mass1,
+                                                       template.mass2)
+        signal_mchirp, _ = mass1_mass2_to_mchirp_eta(signal.mass1, signal.mass2)
+        delta = (template_mchirp - signal_mchirp) / signal_mchirp
+        return delta > mchirp_window_upper or -delta > mchirp_window_lower
 else:
-     mchirp_window_equal = float(options.mchirp_window)
+    # symmetric chirp mass window
+    mchirp_window = float(options.mchirp_window)
+    def outside_mchirp_window(template, signal):
+        template_mchirp, _ = mass1_mass2_to_mchirp_eta(template.mass1,
+                                                       template.mass2)
+        signal_mchirp, _ = mass1_mass2_to_mchirp_eta(signal.mass1, signal.mass2)
+        return abs(signal_mchirp - template_mchirp) > \
+                (mchirp_window * signal_mchirp)
 
 # If we are going to use h(t) to estimate a PSD we need h(t)
 if options.psd_estimation:
@@ -316,7 +315,7 @@ with ctx:
     signals = []
     for index, signal_params in enumerate(signal_table):
         if options.verbose:
-            update_progress(float(index)/len(signal_table))
+            update_progress(float(index+1)/len(signal_table))
         if not options.use_sky_location:
             signal_params.latitude = 0.
             signal_params.longitude = 0.
@@ -343,27 +342,17 @@ with ctx:
 
     for index, template_params in enumerate(template_table):
         if options.verbose:
-            update_progress(float(index)/len(template_table))
+            update_progress(float(index+1)/len(template_table))
+
+        f_lower = filter_low_freq_cutoff(options, template_params)
+
         h_norm = htilde = None
         for stilde, s_norm, matches, signal_params, signal_high_freq_cutoff in signals:
             # Check if we need to look at this
             if stilde is None:
                 matches.append(0)
                 continue
-            # Don't look if outside mchirp_window_equal range
-            elif mchirp_list is False and outside_mchirp_window(
-                    template_params, signal_params, mchirp_window_equal):
-                matches.append(0)
-                continue
-            # Don't look if below mchirp_window_lower range
-            elif mchirp_list is True and below_mchirp_window(
-                    template_params, signal_params, mchirp_window_lower):
-                matches.append(0)
-                continue
-            # Don't look if above mchirp_window_upper range
-            elif mchirp_list is True and above_mchirp_window(
-                    template_params, signal_params, mchirp_window_upper):
-                matches.append(0)
+            if outside_mchirp_window(template_params, signal_params):
                 continue
 
             # Generate htilde if we haven't already done so
@@ -379,8 +368,6 @@ with ctx:
                                       options.template_start_frequency,
                                       template_sample_rate,
                                       filter_N, options.filter_sample_rate)
-
-            f_lower = filter_low_freq_cutoff(options, template_params)
 
             h_norm = sigmasq(htilde, psd=psd, low_frequency_cutoff=f_lower,
                              high_frequency_cutoff=signal_high_freq_cutoff)

--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -146,6 +146,20 @@ def below_mchirp_window(template, signal, w):
     signal_mchirp, et = mass1_mass2_to_mchirp_eta(signal.mass1, signal.mass2)
     return signal_mchirp - template_mchirp > (w * signal_mchirp)
 
+def filter_low_freq_cutoff(options, template_params):
+    """Parse CLI options related to the filter low-frequency cutoff, do basic
+    sanity checks and return the cutoff."""
+    if options.filter_low_freq_cutoff_column:
+        f_lower = getattr(template_params, options.filter_low_freq_cutoff_column)
+    else:
+        f_lower = options.filter_low_frequency_cutoff
+    if f_lower < options.template_start_frequency or \
+            f_lower < options.signal_start_frequency or \
+            f_lower < options.filter_low_frequency_cutoff:
+        raise ValueError('Invalid low-frequency cutoff %f' % f_lower)
+    return f_lower
+
+
 aprs = sorted(list(set(td_approximants() + fd_approximants())))
 
 #File output Settings
@@ -200,6 +214,12 @@ parser.add_argument("--use-sky-location", action='store_true',
 #Filtering Settings
 parser.add_argument('--filter-low-frequency-cutoff', metavar='FREQ', type=float,
                     help='low frequency cutoff of matched filter')
+parser.add_argument('--filter-low-freq-cutoff-column', metavar='NAME', type=str,
+                    help='If given, use a per-template low-frequency cutoff'
+                         'from column NAME of the template table instead of '
+                         'the value given via --filter-low-frequency-cutoff.'
+                         'Signals are still normalized using '
+                         '--filter-low-frequency-cutoff.')
 parser.add_argument('--filter-high-freq-cutoff-isco-factor', metavar='FLOAT',
                     type=float, help="High frequency cutoff of matched filter "
                                      "as a fraction of the injection's ISCO")
@@ -294,9 +314,7 @@ with ctx:
     logging.info("Pregenerating Signals")
 
     signals = []
-    index = 0 
-    for signal_params in signal_table:
-        index += 1
+    for index, signal_params in enumerate(signal_table):
         if options.verbose:
             update_progress(float(index)/len(signal_table))
         if not options.use_sky_location:
@@ -315,18 +333,15 @@ with ctx:
                     * f_SchwarzISCO(signal_params.mass1 + signal_params.mass2)
         else:
             high_freq_cutoff = None
-        s_norm = sigmasq(stilde, psd=psd, 
-                low_frequency_cutoff=options.filter_low_frequency_cutoff,
-                high_frequency_cutoff=high_freq_cutoff)
+        s_norm = sigmasq(stilde, psd=psd,
+                         low_frequency_cutoff=options.filter_low_frequency_cutoff,
+                         high_frequency_cutoff=high_freq_cutoff)
         stilde /= psd
         signals.append((stilde, s_norm, [], signal_params, high_freq_cutoff))
 
     logging.info("Calculating Overlaps")
 
-    index = 0 
-    # Calculate the overlaps
-    for template_params in template_table:
-        index += 1
+    for index, template_params in enumerate(template_table):
         if options.verbose:
             update_progress(float(index)/len(template_table))
         h_norm = htilde = None
@@ -355,7 +370,7 @@ with ctx:
             if htilde is None:
                 this_approximant = options.template_approximant
                 if options.total_mass_divide is not None and (template_params.mass1+template_params.mass2) >= options.total_mass_divide:
-                        this_approximant = options.highmass_approximant
+                    this_approximant = options.highmass_approximant
                 htilde = get_waveform(this_approximant,
                                       options.template_phase_order,
                                       options.template_amplitude_order,
@@ -364,14 +379,15 @@ with ctx:
                                       options.template_start_frequency,
                                       template_sample_rate,
                                       filter_N, options.filter_sample_rate)
-            
-            h_norm = sigmasq(htilde, psd=psd,
-                    low_frequency_cutoff=options.filter_low_frequency_cutoff,
-                    high_frequency_cutoff=signal_high_freq_cutoff)
+
+            f_lower = filter_low_freq_cutoff(options, template_params)
+
+            h_norm = sigmasq(htilde, psd=psd, low_frequency_cutoff=f_lower,
+                             high_frequency_cutoff=signal_high_freq_cutoff)
 
             o, i = match(htilde, stilde, v1_norm=h_norm, v2_norm=s_norm,
-                    low_frequency_cutoff=options.filter_low_frequency_cutoff,
-                    high_frequency_cutoff=signal_high_freq_cutoff)
+                         low_frequency_cutoff=f_lower,
+                         high_frequency_cutoff=signal_high_freq_cutoff)
             matches.append(o)
 
 logging.info("Determining maximum overlaps and outputting results")


### PR DESCRIPTION
This is a change to `pycbc_banksim` which enables picking up the per-template low-frequency cutoff from a given column in the template table.

I also moved print statements to the logging module, added some `required=True` to the CLI and simplified/cleaned up the code a bit.

I did some basic checks against an old banksim I had lying around, but please let me run this on the variable-flow bank before merging.