### PR TITLE
fail status if channel cannot be read

### DIFF
--- a/pycbc/frame.py
+++ b/pycbc/frame.py
@@ -732,8 +732,8 @@ class StatusBuffer(DataBuffer):
         if self.increment_update_cache:
             self.update_cache_by_increment(blocksize)
 
-        ts = DataBuffer.advance(self, blocksize)
-        if ts is not None:
+        try:
+            ts = DataBuffer.advance(self, blocksize)
             return self.check_valid(ts)
-        else:
+        except RuntimeError:
             return False

--- a/pycbc/frame.py
+++ b/pycbc/frame.py
@@ -732,4 +732,8 @@ class StatusBuffer(DataBuffer):
         if self.increment_update_cache:
             self.update_cache_by_increment(blocksize)
 
-        return self.check_valid(DataBuffer.advance(self, blocksize))
+        ts = DataBuffer.advance(self, blocksize)
+        if ts is not None:
+            return self.check_valid(ts)
+        else:
+            return False


### PR DESCRIPTION
If the state vector channel can't be read but the hoft could, let's just treat that as a failure and return a failed status indicator. 