### PR TITLE
Add more detail to throughput plots

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_throughput
+++ b/bin/hdfcoinc/pycbc_plot_throughput
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
 import argparse
+import logging
 import h5py
-from matplotlib import use
-use('Agg')
-from matplotlib import pyplot as pl
+import numpy as np
+import matplotlib; matplotlib.use('Agg')
+import pylab as pl
 from pycbc.results.color import ifo_color
 import pycbc.version
 
@@ -18,18 +19,45 @@ parser.add_argument('--output-file', required=True,
                     help='Destination file for the plot.')
 args = parser.parse_args()
 
-fig, ax = pl.subplots(1, 1, figsize=(10,5))
+fig, (ax1, ax2, ax3) = pl.subplots(3,1,figsize=(10,10))
 
 for pa in args.input_file:
     f = h5py.File(pa, 'r')
     ifo = f.keys()[0]
     if 'templates_per_core' in f['%s/search' % ifo].keys():
         tpc = f['%s/search/templates_per_core' % ifo][:]
+    else:
+        tpc = None
+    if 'filter_rate_per_core' in f['%s/search' % ifo].keys():
+        fpc = f['%s/search/filter_rate_per_core' % ifo][:]
+    else:
+        fpc = None
+    if 'setup_time_fraction' in f['%s/search' % ifo].keys():
+        stf = f['%s/search/setup_time_fraction' % ifo][:]
+    else:
+        stf = None
+    if tpc is not None:
         label = str(ifo) + ': Mean average - ' + str(tpc.mean())
-        ax.hist(tpc, 100, color=ifo_color(ifo), alpha=0.65, label=label)
-        ax.set_xlabel('Templates per Core')
-        ax.legend(loc='upper right')
-        ax.grid(True)
+        ax1.hist(tpc, 100, color=ifo_color(ifo), alpha = 0.65, label = label)
+        #ax1.set_title('Templates per Core')
+        ax1.set_xlabel('Templates per Core')
+        ax1.legend(loc = 'upper right')
+        ax1.grid(True)
+    if fpc is not None:
+        label = str(ifo) + ': Mean average - ' + str(fpc.mean())
+        ax2.hist(fpc, 100, color=ifo_color(ifo), alpha = 0.65, label = label)
+        #ax2.set_title('Filter rate per core')
+        ax2.set_xlabel('Filter rate per core (# FFTs per second per core)')
+        ax2.legend(loc = 'upper right')
+        ax2.grid(True)
+    if stf is not None:
+        label = str(ifo) + ': Mean average - ' + str(stf.mean())
+        ax3.hist(stf, 100, color=ifo_color(ifo), alpha = 0.65, label = label)
+        #ax2.set_title('Filter rate per core')
+        ax3.set_xlabel('Fraction of time doing setup operations')
+        ax3.legend(loc = 'upper right')
+        ax3.grid(True)
 
+fig.tight_layout()
 fig.savefig(str(args.output_file))
 


### PR DESCRIPTION
@josh-willis, some more information about throughput has been added in recent patches, but has not yet made it into the plotting scripts. Here I propose some changes to the throughput plots to add some more details onto the review pages. An example of this on a test workflow is here:

https://galahad.aei.mpg.de/~spxiwh/LVC/aLIGO/O1/analyses/inj_cutter/injcutter_debugging/run7/8._workflow/8.01_throughput/
