### PR TITLE
Allow exemption for pegasus-profile section

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -563,6 +563,11 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
         """
         # Loop over the sections in the ini file
         for section in self.sections():
+            # [pegasus_profile] specially is allowed to be overriden by
+            # sub-sections
+            if section == 'pegasus_profile':
+                continue
+
             # Loop over the sections again
             for section2 in self.sections():
                 # Check if any are subsections of section


### PR DESCRIPTION
@ahnitz The recent change to add a pegasus_profile section broke the workflow because it doesn't obey the "no duplicate options in subsections" rule.

In this case I think it is best to allow a specific exemption. Maybe we should consider allowing options to be overridden at some point.