### PR TITLE
Use relative-dir not relative-submit-dir

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -363,9 +363,9 @@ fi
 
 
 if [ $CACHE_FILE == 0 ]; then
-  pegasus-plan --conf ./pegasus-properties.conf -d $DAX_FILE --sites $SITE_LIST $STAGING_SITES -o local --dir $SUBMIT_DIR --cleanup inplace --relative-submit-dir work --cluster label $SUBMIT_DAX 
+  pegasus-plan --conf ./pegasus-properties.conf -d $DAX_FILE --sites $SITE_LIST $STAGING_SITES -o local --dir $SUBMIT_DIR --cleanup inplace --relative-dir work --cluster label $SUBMIT_DAX 
 else
-  pegasus-plan --conf ./pegasus-properties.conf -d $DAX_FILE --sites $SITE_LIST $STAGING_SITES -o local --dir $SUBMIT_DIR --cleanup inplace --cache _reuse.cache --relative-submit-dir work --cluster label $SUBMIT_DAX
+  pegasus-plan --conf ./pegasus-properties.conf -d $DAX_FILE --sites $SITE_LIST $STAGING_SITES -o local --dir $SUBMIT_DIR --cleanup inplace --cache _reuse.cache --relative-dir work --cluster label $SUBMIT_DAX
 fi
 
 echo

--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -363,7 +363,7 @@ fi
 
 
 if [ $CACHE_FILE == 0 ]; then
-  pegasus-plan --conf ./pegasus-properties.conf -d $DAX_FILE --sites $SITE_LIST $STAGING_SITES -o local --dir $SUBMIT_DIR --cleanup inplace --relative-dir work --cluster label $SUBMIT_DAX 
+  pegasus-plan --conf ./pegasus-properties.conf -d $DAX_FILE --sites $SITE_LIST $STAGING_SITES -o local --dir $SUBMIT_DIR --cleanup inplace --relative-dir work --cluster label $SUBMIT_DAX
 else
   pegasus-plan --conf ./pegasus-properties.conf -d $DAX_FILE --sites $SITE_LIST $STAGING_SITES -o local --dir $SUBMIT_DIR --cleanup inplace --cache _reuse.cache --relative-dir work --cluster label $SUBMIT_DAX
 fi


### PR DESCRIPTION
Currently the cleanup operation (basically a rm of the temporary "local-site-scratch" directory) in pycbc_coinc_search_workflow is not working because it is removing the wrong directory. The issue seems to be inconsistent use of relative-dir and relative-submit-dir in pycbc_submit_dax. Therefore the local-site-scratch for the sub-daxes is *not* a sub-directory of the local-site-scratch for the main uberdax.

This is easily fixed with the attached patch. Tested on pegasus 4.6.2 and 4.7.1dev.

I think I have also tracked down the reason why the workflow fails if we do not use "flat" directory layout (`pegasus.dir.staging.mapper=Flat`)in the local-site-scratch directories. I think it is a bug is pegasus 4.7.1dev, so will try to explain this to @vahi in email.