### PR TITLE
fixed-weave-cache: if running a 'frozen' 'onefile' PyInstaller bundle,

### DIFF
--- a/pycbc/weave.py
+++ b/pycbc/weave.py
@@ -126,6 +126,11 @@ def verify_weave_options(opt, parser):
     # Check whether to use a fixed directory for scipy.weave
     if opt.fixed_weave_cache:
         cache_dir = os.path.join(os.getcwd(),"pycbc_inspiral")
+        # if running a 'frozen' onefile PyInstaller bundle,
+        # point PYTHONCOMPILED to the bundle directory
+        if getattr(sys, 'frozen', False):
+            if sys._MEIPASS.startswith("/tmp/"):
+                cache_dir = sys._MEIPASS
         os.environ['PYTHONCOMPILED'] = cache_dir
         logging.debug("fixed_weave_cache: Setting weave cache to %s", cache_dir)
         sys.path = [cache_dir] + sys.path


### PR DESCRIPTION
…point PYTHONCOMPILED to the bundle directory

Required for a "onefile" PyInstaller bundle that contains a weave code cache to run, e.g. on OSG
