### PR TITLE
base the behavior of --fixed-weave-cache on env. var. FIXED_WEAVE_CACHE

### DIFF
--- a/pycbc/weave.py
+++ b/pycbc/weave.py
@@ -125,7 +125,12 @@ def verify_weave_options(opt, parser):
 
     # Check whether to use a fixed directory for scipy.weave
     if opt.fixed_weave_cache:
-        cache_dir = os.path.join(os.getcwd(),"pycbc_inspiral")
+        if os.environ.get("FIXED_WEAVE_CACHE", None):
+            cache_dir = os.environ["FIXED_WEAVE_CACHE"]
+        elif getattr(sys, 'frozen', False):
+            cache_dir = sys._MEIPASS
+        else:
+            os.path.join(os.getcwd(),"pycbc_inspiral")
         os.environ['PYTHONCOMPILED'] = cache_dir
         logging.debug("fixed_weave_cache: Setting weave cache to %s", cache_dir)
         sys.path = [cache_dir] + sys.path

--- a/pycbc/weave.py
+++ b/pycbc/weave.py
@@ -126,11 +126,6 @@ def verify_weave_options(opt, parser):
     # Check whether to use a fixed directory for scipy.weave
     if opt.fixed_weave_cache:
         cache_dir = os.path.join(os.getcwd(),"pycbc_inspiral")
-        # if running a 'frozen' onefile PyInstaller bundle,
-        # point PYTHONCOMPILED to the bundle directory
-        if getattr(sys, 'frozen', False):
-            if sys._MEIPASS.startswith("/tmp/"):
-                cache_dir = sys._MEIPASS
         os.environ['PYTHONCOMPILED'] = cache_dir
         logging.debug("fixed_weave_cache: Setting weave cache to %s", cache_dir)
         sys.path = [cache_dir] + sys.path


### PR DESCRIPTION
This should fix setting the weave cache location (PYTHONCOMPILED) for all relevant cases (E@H, OSG).