### PR TITLE
Add corner to install required.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'mpld3>=0.3git',
                       'pyRXP>=2.1.0',
                       'pycbc-glue>=0.9.8',
-                      'kombine>=0.8.0',
+                      'kombine',
                       'emcee>=2.2.0',
                       'corner>=2.0.1',
                       #'scikit-learn>=0.17.0',  # travis does not like scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,9 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'mpld3>=0.3git',
                       'pyRXP>=2.1.0',
                       'pycbc-glue>=0.9.8',
-                      'kombine',
+                      'kombine>=0.8.0',
                       'emcee>=2.2.0',
+                      'corner>=2.0.1',
                       #'scikit-learn>=0.17.0',  # travis does not like scikit-learn
                       ]
 links = ['https://github.com/ligo-cbc/mpld3/tarball/master#egg=mpld3-0.3git']


### PR DESCRIPTION
This PR is in response to #1016.

If people are not okay with adding corner to the required for install list they should say so, @ahnitz @cdcapano.

I personally don't care if I have to do ``pip install corner``, this is just a fix for #1016. But we should either do something like this PR or just close #1016 (I guess we could update the install docs with a ``pip install corner`` command in this case).