### PR TITLE
Fix for the X509_USER_PROXY issue with workflow submission

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -408,7 +408,7 @@ chmod 755 debug
 echo pegasus-remove $SUBMIT_DIR/work > stop
 chmod 755 stop
 
-echo > start << EOF
+cat << EOF > start
 #!/bin/bash
 
 if [ -f /tmp/x509up_u`id -u` ] ; then

--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -253,6 +253,9 @@ fi
 grid-proxy-info -exists
 RESULT=$?
 if [ ${RESULT} -eq 0 ] ; then
+  cp /tmp/x509up_u`id -u` /tmp/x509up_u`id -u`.orig
+  grid-proxy-init -valid 72:0 -cert /tmp/x509up_u`id -u`.orig -key /tmp/x509up_u`id -u`.orig
+  rm -f /tmp/x509up_u`id -u`.orig
   grid-proxy-info
 else
   echo "Error: Could not find a valid grid proxy to submit workflow."
@@ -423,6 +426,9 @@ fi
 grid-proxy-info -exists
 RESULT=$?
 if [ ${RESULT} -eq 0 ] ; then
+  cp /tmp/x509up_u`id -u` /tmp/x509up_u`id -u`.orig
+  grid-proxy-init -valid 72:0 -cert /tmp/x509up_u`id -u`.orig -key /tmp/x509up_u`id -u`.orig
+  rm -f /tmp/x509up_u`id -u`.orig
   grid-proxy-info
 else
   echo "Error: Could not find a valid grid proxy to submit workflow."

--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -240,7 +240,25 @@ if [ $NO_CREATE_PROXY == 0 ]; then
   done
   unset X509_USER_PROXY
   ligo-proxy-init $LIGO_USER_NAME || exit 1
+else
+  if [ ! -z ${X509_USER_PROXY} ] ; then
+    if [ -f ${X509_USER_PROXY} ] ; then
+      cp -a ${X509_USER_PROXY} /tmp/x509up_u`id -u`
+      unset X509_USER_PROXY
+    fi
+  fi
 fi
+
+#Check that the proxy is valid
+grid-proxy-info -exists
+RESULT=$?
+if [ ${RESULT} -eq 0 ] ; then
+  grid-proxy-info
+else
+  echo "Error: Could not find a valid grid proxy to submit workflow."
+  exit 1
+fi
+
 
 #Make a directory for the submit files
 SUBMIT_DIR=`mktemp --tmpdir=${LOCAL_PEGASUS_DIR} -d pycbc-tmp.XXXXXXXXXX`
@@ -387,7 +405,35 @@ chmod 755 debug
 echo pegasus-remove $SUBMIT_DIR/work > stop
 chmod 755 stop
 
-echo pegasus-run $SUBMIT_DIR/work > start
+echo > start << EOF
+#!/bin/bash
+
+if [ -f /tmp/x509up_u`id -u` ] ; then
+  unset X509_USER_PROXY
+else
+  if [ ! -z ${X509_USER_PROXY} ] ; then
+    if [ -f ${X509_USER_PROXY} ] ; then
+      cp -a ${X509_USER_PROXY} /tmp/x509up_u`id -u`
+      unset X509_USER_PROXY
+    fi
+  fi
+fi
+
+# Check that the proxy is valid
+grid-proxy-info -exists
+RESULT=$?
+if [ ${RESULT} -eq 0 ] ; then
+  grid-proxy-info
+else
+  echo "Error: Could not find a valid grid proxy to submit workflow."
+  exit 1
+fi
+
+EOF
+echo pegasus-run $SUBMIT_DIR/work >> start
+
+
+
 chmod 755 start
 
 # Copy planning information into workflow directory so it can be displayed on the results page

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -290,9 +290,9 @@ To maintain the documentation under GitHub project pages, see
     build_gh_pages
 
 
-====================================
-Modifying pycbc-glue and pycbc-pylal
-====================================
+====================
+Modifying pycbc-glue
+====================
 
 PyCBC depends on the packages pycbc-glue and pycbc-pylal which are forks of the lalsuite development of these packages. The correct versions are automatically installed by pip as part of the main PyCBC install. If you are developing code in these packages, then you can clone them from GitHib into your virtual environment's source directory and build and install them from there.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -294,11 +294,11 @@ To maintain the documentation under GitHub project pages, see
 Modifying pycbc-glue
 ====================
 
-PyCBC depends on the packages pycbc-glue and pycbc-pylal which are forks of the lalsuite development of these packages. The correct versions are automatically installed by pip as part of the main PyCBC install. If you are developing code in these packages, then you can clone them from GitHib into your virtual environment's source directory and build and install them from there.
+PyCBC depends on the package pycbc-glue which is a fork of the lalsuite packages. The correct version is automatically installed by pip as part of the main PyCBC install. If you are developing code in pycbc-glue, then you can clone them from GitHib into your virtual environment's source directory and build and install them from there.
 
 .. note::
 
-    If you want to develop pycbc-glue and pycbc-pylal, you should follow the instructions to `fork a repository <https://help.github.com/articles/fork-a-repo/>`_ to fork the `ligo-cbc/pycbc-glue <https://github.com/ligo-cbc/pycbc-glue>`_ and `ligo-cbc/pycbc-pylal <https://github.com/ligo-cbc/pycbc-pylal>`_ repositories into your own account.
+    If you want to develop pycbc-glue, you should follow the instructions to `fork a repository <https://help.github.com/articles/fork-a-repo/>`_ to fork the `ligo-cbc/pycbc-glue <https://github.com/ligo-cbc/pycbc-glue>`_ repository into your own account.
 
 You can obtain these repositories in the standard way using git, replacing ``ligo-cbc`` with your GitHub user account name
 
@@ -306,7 +306,6 @@ You can obtain these repositories in the standard way using git, replacing ``lig
 
     cd ${VIRTUAL_ENV}/src
     git clone git@github.com:ligo-cbc/pycbc-glue.git
-    git clone git@github.com:ligo-cbc/pycbc-pylal.git
 
 Once you have the source code cloned, you can run 
 
@@ -314,7 +313,7 @@ Once you have the source code cloned, you can run
 
     python setup.py install
 
-to install each of them into your virtual environment.
+to install pycbc-glue into your virtual environment.
 
 ========================================
 Use of Intel MKL Optimized FFT libraries

--- a/docs/workflow/pycbc_make_coinc_search_workflow.rst
+++ b/docs/workflow/pycbc_make_coinc_search_workflow.rst
@@ -721,13 +721,6 @@ follwing lines to your ``executables.ini`` file::
 Running the workflow
 --------------------
 
-Before running the workflow, a proxy compatible with Xrootd needs to be generated. To generate this proxy run the commands
-::
-
-    ligo-proxy-init albert.einstein
-    cp /tmp/x509up_u`id -u` /tmp/x509up_u`id -u`.orig
-    grid-proxy-init -valid 72:0 -cert /tmp/x509up_u`id -u`.orig -key /tmp/x509up_u`id -u`.orig
-
 Add the following arguments to ``pycbc_submit_dax``::
 
     --no-create-proxy \

--- a/docs/workflow/pycbc_make_coinc_search_workflow.rst
+++ b/docs/workflow/pycbc_make_coinc_search_workflow.rst
@@ -684,17 +684,17 @@ Configuring the workflow
 ------------------------
 
 In order for ``pycbc_inspiral`` to be sent to worker nodes it must be available
-via a remote protocol, either http or gridFTP.  The easiest way to ensure this
-is to include the ``osg_executables.ini``. This file can be downloaded from::
+via a remote protocol, either http or gsiftp. The LDG head nodes run a gridftp
+server that should be able to serve this, or code can obtain the code from the
+web server on ``code.pycbc.phy.syr.edu``. Edit your ``executables.ini`` to 
+specify this path or give the path when you run
+``pycbc_make_coinc_search_workflow``, for example, with the option::
 
-    https://code.pycbc.phy.syr.edu/ligo-cbc/pycbc-software/tree/master
-
-When downloading the ``osg_executables.ini`` make sure that you are obtaining the correct version. The URL/location for the ``osg_executables.ini`` should be added to the list of config files::
-
-    [URL/location for osg_executables.ini] \
+    --config-overrides 'executables:inspiral:gsiftp://server.name/path/to/pycbc_inspiral'
 
 Add the following to the list of ``--config-overrides`` when running ``pycbc_make_coinc_search_workflow``::
      
+    'pegasus_profile-inspiral:pycbc|site:osg' \
     'pegasus_profile-inspiral:hints|execution.site:osg' \
     'pegasus_profile-inspiral:condor|request_memory:1920M' \
     'workflow-main:staging-site:osg=local' \

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -197,7 +197,7 @@ class Executable(pegasus_workflow.Executable):
 
         if exe_url.scheme in ['', 'file']:
             if os.path.isfile(exe_url.path):
-                self.add_pfn(exe_path,site='local')
+                self.add_pfn(exe_path, site='local')
 
                 logging.debug("Using %s executable "
                               "at %s" % (name, exe_url.path))
@@ -209,8 +209,7 @@ class Executable(pegasus_workflow.Executable):
             logging.debug("Using %s executable "
                           "at %s" % (name, exe_path))
             try:
-                value = string.strip(
-                    cp.get('pegasus_profile-%s' % name, 'pycbc|site') )
+                value = cp.get('pegasus_profile-%s' % name, 'pycbc|site')
                 for s in value.split(','):
                     self.add_pfn(exe_path, site=s.strip())
             except:

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -197,7 +197,7 @@ class Executable(pegasus_workflow.Executable):
 
         if exe_url.scheme in ['', 'file']:
             if os.path.isfile(exe_url.path):
-                self.add_pfn(exe_path)
+                self.add_pfn(exe_path,site='local')
 
                 logging.debug("Using %s executable "
                               "at %s" % (name, exe_url.path))
@@ -205,10 +205,18 @@ class Executable(pegasus_workflow.Executable):
                 raise TypeError("Failed to find %s executable " 
                             "at %s" % (name, exe_path))
         else:
-            # Could be http, gsiftp, etc.  Let Pegasus handle it.
+            # Could be http, gsiftp, etc.
             logging.debug("Using %s executable "
                           "at %s" % (name, exe_path))
-            self.add_pfn(exe_path, site='nonlocal')
+            try:
+                value = string.strip(
+                    cp.get('pegasus_profile-%s' % name, 'pycbc|site') )
+                for s in value.split(','):
+                    self.add_pfn(exe_path, site=s.strip())
+            except:
+               # take a guess on the site and see if pegasus can figure it out
+               self.add_pfn(exe_path, site='nonlocal')
+
             self.needs_fetching = True
 
         # Determine the condor universe if we aren't given one 

--- a/pycbc/workflow/pegasus_files/osg-site-template.xml
+++ b/pycbc/workflow/pegasus_files/osg-site-template.xml
@@ -17,3 +17,4 @@
     <profile namespace="condor" key="+OpenScienceGrid">True</profile>
     <profile namespace="env" key="NO_TMPDIR">1</profile>
     <profile namespace="env" key="LAL_DATA_PATH">/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation</profile>
+    <profile namespace="env" key="PEGASUS_HOME" >/usr</profile>


### PR DESCRIPTION
This fixes issue https://github.com/ligo-cbc/pycbc/issues/704 by seeing if the user has a temporarty proxy created by an incoming gsissh session and, if they do, stashing it for use by the workflow.

This also fixes a bug in the way that the ``nonlocal`` site was introduced for OSG jobs and adds an addition ``pegasus_profile`` that can be specified for an executable 
```
[pegasus_profile-inspiral]
pycbc|site = osg
```
to tell pegasus that the URL is valid for a given site.

As a bonus, some documentation fixes.
