### PR TITLE
If datafind returns CVMFS urls then they can also be used on OSG

### DIFF
--- a/docs/workflow/pycbc_make_coinc_search_workflow.rst
+++ b/docs/workflow/pycbc_make_coinc_search_workflow.rst
@@ -714,8 +714,8 @@ follwing lines to your ``executables.ini`` file::
 
     [pegasus_profile-inspiral]
     condor|periodic_hold = (JobStatus == 2) && ((CurrentTime - EnteredCurrentStatus) > (2 * 86400))
-    condor|period_release = (JobStatus == 5) && ( HoldReasonCode == 3 ) && ( NumJobStarts < 5 ) && ((CurrentTime - EnteredCurrentStatus) > (300))
-    condor|period_remove = ( NumJobStarts >= 5 )
+    condor|periodic_release = (JobStatus == 5) && (HoldReasonCode == 3) && (NumJobStarts < 5) && ((CurrentTime - EnteredCurrentStatus) > (300))
+    condor|periodic_remove = (NumJobStarts >= 5)
 
 --------------------
 Running the workflow

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -690,6 +690,14 @@ def convert_cachelist_to_filelist(datafindcache_list):
                     frame.segment, file_url=frame.url, use_tmp_subdirs=True)
             if frame.url.startswith('file://'):
                 currFile.PFN(frame.url, site='local')
+                if frame.url.startswith(
+                    'file:///cvmfs/oasis.opensciencegrid.org/'):
+                    # Datafind returned a URL valid on the osg as well
+                    # so add the additional PFNs to allow OSG access.
+                    currFile.PFN(frame.url, site='osg')
+                    currFile.PFN(frame.url.replace(
+                        'file:///cvmfs/oasis.opensciencegrid.org/',
+                        'root://xrootd-local.unl.edu/user/'), site='osg')
             else:
                 currFile.PFN(frame.url, site='notlocal')
             datafind_filelist.append(currFile)

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -698,6 +698,9 @@ def convert_cachelist_to_filelist(datafindcache_list):
                     currFile.PFN(frame.url.replace(
                         'file:///cvmfs/oasis.opensciencegrid.org/',
                         'root://xrootd-local.unl.edu/user/'), site='osg')
+                    currFile.PFN(frame.url.replace(
+                        'file:///cvmfs/oasis.opensciencegrid.org/',
+                        'gsiftp://red-gridftp.unl.edu/user/'), site='osg')
             else:
                 currFile.PFN(frame.url, site='notlocal')
             datafind_filelist.append(currFile)

--- a/pycbc/workflow/pegasus_files/osg-site-template.xml
+++ b/pycbc/workflow/pegasus_files/osg-site-template.xml
@@ -16,5 +16,5 @@
     <profile namespace="condor" key="when_to_transfer_output">ON_EXIT_OR_EVICT</profile>
     <profile namespace="condor" key="+OpenScienceGrid">True</profile>
     <profile namespace="env" key="NO_TMPDIR">1</profile>
-    <profile namespace="env" key="LAL_DATA_PATH">/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation:/cvmfs/oasis.opensciencegrid.org/ligo/pipeline/pycbc/pycbc/ROM/lal-data/lalsimulation</profile>
+    <profile namespace="env" key="LAL_DATA_PATH">/cvmfs/oasis.opensciencegrid.org/ligo/pipeline/pycbc/pycbc/ROM/lal-data/lalsimulation</profile>
     <profile namespace="env" key="PEGASUS_HOME" >/usr</profile>

--- a/pycbc/workflow/pegasus_files/osg-site-template.xml
+++ b/pycbc/workflow/pegasus_files/osg-site-template.xml
@@ -16,5 +16,5 @@
     <profile namespace="condor" key="when_to_transfer_output">ON_EXIT_OR_EVICT</profile>
     <profile namespace="condor" key="+OpenScienceGrid">True</profile>
     <profile namespace="env" key="NO_TMPDIR">1</profile>
-    <profile namespace="env" key="LAL_DATA_PATH">/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation</profile>
+    <profile namespace="env" key="LAL_DATA_PATH">/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/current/share/lalsimulation:/cvmfs/oasis.opensciencegrid.org/ligo/pipeline/pycbc/pycbc/ROM/lal-data/lalsimulation</profile>
     <profile namespace="env" key="PEGASUS_HOME" >/usr</profile>


### PR DESCRIPTION
If the datafind command returns file URLs that match the string
```
file:///cvmfs/oasis.opensciencegrid.org
```
then these are CVMFS file so they are also available on the OSG. Add additional PFN entries to the DAX to indicate this. These PFNs are ignored if the workflow is not running on OSG. The OSG PFNs are also ignored on the local site.

This doesn't affect command line datafind queries as they don't go through this code path. This removes the need to pass a separate cache file for frames for OSG running.

Also fix a documentation bug that I noticed.