### PR TITLE
Documentation fix: SEOBNRv4 ROM requires LAL to have HDF5

### DIFF
--- a/docs/install_lalsuite.rst
+++ b/docs/install_lalsuite.rst
@@ -60,7 +60,7 @@ From the top-level lalsuite directory, you can use the master configure script t
 .. code-block:: bash
 
     ./00boot 
-    ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-swig-python --disable-lalstochastic --disable-lalxml --disable-lalinference --disable-laldetchar --disable-lalapps --with-hdf5=no
+    ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-swig-python --disable-lalstochastic --disable-lalxml --disable-lalinference --disable-laldetchar --disable-lalapps
 
 Next make the software and install it. If you are on a multicore machine, you
 can speed this up by running ``make -j N`` where ``N`` is the number of


### PR DESCRIPTION
Drop the ``--with-hdf5=no`` from the lalsuite configure instructions in the install documentation.