### PR TITLE
Code for adding more options for parameter space and frequency space interpolation for SEOBNRv2-ROMs

### DIFF
--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -40,50 +40,74 @@ from pycbc import filter
 
 parser = argparse.ArgumentParser(description=__description__)
 parser.add_argument("--bank-file", type=str,
-                help="Bank hdf file to load.")
+                    help="Bank hdf file to load.")
 parser.add_argument("--output", type=str,
-                help="The hdf file to save the templates and compressed "
-                     "waveforms to.")
+                    help="The hdf file to save the templates and compressed "
+                    "waveforms to.")
 parser.add_argument("--low-frequency-cutoff", type=float, required=True,
-                help="The low frequency cutoff to use for generating "
-                     "the waveforms (Hz)")
+                    help="The low frequency cutoff to use for generating "
+                    "the waveforms (Hz)")
 # add approximant arg
 pycbc.waveform.bank.add_approximant_arg(parser)
 parser.add_argument("--sample-rate", type=int, required=True,
-                help="Half this value sets the maximum frequency of the "
-                     "compressed waveforms.")
+                    help="Half this value sets the maximum frequency of the "
+                    "compressed waveforms.")
 parser.add_argument("--tmplt-index", nargs=2, type=int, default=None,
-                help="Only generate compressed waveforms for the given "
-                     "indices in the bank file. Must provide both a start "
-                     "and a stop index. Default is to compress all of the "
-                     "templates in the bank file.")
+                    help="Only generate compressed waveforms for the given "
+                    "indices in the bank file. Must provide both a start "
+                    "and a stop index. Default is to compress all of the "
+                    "templates in the bank file.")
+parser.add_argument("--ROM-parameter-space-interpolation", type=str,
+                    choices=["linear_compression", "partial_ROM_compression"],
+                    default="linear_compression",
+                    help="The method used to get the amplitude and phase"
+                    "interpolants and the corressponding amplitude and"
+                    "phase frequency points for the SEOBNRv2_ROM waveforms"
+                    "in the template bank. Choices are 'linear_compression'"
+                    "which would calculate the interpolants and frequency"
+                    "points in the compress_waveform function in compress.py,"
+                    "OR 'partial_rom_compression' which would call the"
+                    "LAL code for SEOBNRv2_ROM from the partial_compress_rom"
+                    "function of compress.py to get the interpolants and"
+                    "the frequency points")
 parser.add_argument("--compression-algorithm", type=str, required=True,
-                choices=compress.compression_algorithms.keys(),
-                help="The compression algorithm to use for selecting "
-                     "frequency points.")
+                    choices=compress.compression_algorithms.keys(),
+                    help="The compression algorithm to use for selecting "
+                    "frequency points for all TaylorF2 templates and"
+                    "SEOBNRv2_ROM templates when"
+                    " --ROM-parameter-space-interpolation is "
+                    "'linear_compression'. This would select a common "
+                    "set of frequency points for both amplitude "
+                    "and phase interpolants")
 parser.add_argument("--t-pad", type=float, default=0.001,
-                help="The minimum duration used for t(f) in seconds. The "
-                     "inverse of this gives the maximum frequency step that "
-                     "will be used in the compressed waveforms. Default is "
-                     "0.001.")
+                    help="The minimum duration used for t(f) in seconds. The "
+                    "inverse of this gives the maximum frequency step that "
+                    "will be used in the compressed waveforms. Default is "
+                    "0.001.")
 parser.add_argument("--tolerance", type=float, default=0.001,
-                help="The maximum mismatch to allow between the interpolated "
-                     "waveform must and the full waveform. Points will be "
-                     "added to the compressed waveform until its "
-                     "interpolation has a mismatch <= this value. Default is "
-                     "0.001.")
-parser.add_argument("--interpolation", type=str, default="linear",
-                help="The interpolation to use for decompressing the "
-                     "waveforms for checking tolerance. Options are 'linear', "
-                     "or any interpolation recognized by scipy's interp1d "
-                     "kind argument. Default is linear.")
+                    help="The maximum mismatch to allow between the "
+                    "interpolated waveform and the full waveform. Points"
+                    "will be added to the compressed waveform until its "
+                    "interpolation has a mismatch <= this value."
+                    " Default is 0.001.")
+parser.add_argument("--interpolation", type=str,
+                    default="inline_linear",
+                    help="The interpolation to use for decompressing the "
+                    "waveforms for checking tolerance. Options are "
+                    "'inline_linear', which assumes that the "
+                    "frequency samples of the amplitude and phase "
+                    "interpolants are the same, or any interpolation "
+                    "recognized by scipy's interp1d kind argument, which "
+                    "allows the frequency interpolant samples to be "
+                    "different for the amplitude and phase. "
+                    "Default is inline_linear.")
 parser.add_argument("--precision", type=str, choices=["double", "single"],
-                default="double",
-                help="What precision to generate and store the waveforms with;"
-                     " default is double.")
+                    default="double",
+                    help="What precision to generate and store the"
+                    "waveforms with; default is double.")
 parser.add_argument("--force", action="store_true", default=False,
                     help="Overwrite the given hdf file if it exists. "
-                         "Otherwise, an error is raised.")
+                    "Otherwise, an error is raised.")
 parser.add_argument("--verbose", action="store_true", default=False)
 
 
@@ -105,7 +129,7 @@ else:
     dtype = numpy.complex128
 # we'll just use dummy values for N, df for now
 bank = waveform.FilterBank(args.bank_file, 5, 0.25, fmin, dtype,
-    approximant=args.approximant)
+                           approximant=args.approximant)
 templates = bank.table
 if args.tmplt_index is not None:
     imin, imax = args.tmplt_index
@@ -128,7 +152,6 @@ output = bank.write_to_hdf(args.output, force=args.force,
 
 # get the compressed sample points for each template
 logging.info("getting compressed amplitude and phase")
-mismatches = numpy.zeros(imax-imin, dtype=float)
 for ii in range(imin, imax):
     # update the N, df to use based on this waveform
     N = int(args.sample_rate*seg_lens[ii-imin])
@@ -136,7 +159,7 @@ for ii in range(imin, imax):
     bank.delta_f = df
     bank.N = N
     bank.filter_length = N/2 + 1
-    # We'll budge the waveform starting frequency down by 1df to ensure 
+    # We'll budge the waveform starting frequency down by 1df to ensure
     # the first point is correct
     bank.f_lower = fmin-df
     bank.kmin = int(bank.f_lower / df)
@@ -146,23 +169,57 @@ for ii in range(imin, imax):
     htilde = bank[ii-imin]
     tmplt = bank.table[ii-imin]
     kmax = htilde.end_idx
-    
-    # get the compressed sample points
-    if args.compression_algorithm == 'mchirp':
-        sample_points = compress.mchirp_compression(tmplt.mass1, tmplt.mass2,
-            fmin, (kmax-1)*df, min_seglen=args.t_pad, df_multiple=df).astype(
-            real_same_precision_as(htilde))
-    elif args.compression_algorithm == 'spa':
-        sample_points = compress.spa_compression(htilde, fmin, (kmax-1)*df,
-            min_seglen=args.t_pad).astype(real_same_precision_as(htilde))
+
+    mtotal = tmplt.mass1 + tmplt.mass2
+    # Call the appropriate function in compress.py to get the compressed
+    # amplitude and phase frequency points and decompress them in
+    # frequency space :
+
+    # If template is SEOBNRv2_ROM perform linear_compression or
+    # partial_ROM_compression as per user input
+    if mtotal >= 4:
+        if args.ROM_parameter_space_interpolation == 'linear_compression':
+            if args.compression_algorithm == 'mchirp':
+                sample_points = compress.mchirp_compression(
+                    tmplt.mass1, tmplt.mass2, fmin, (kmax-1)*df,
+                    min_seglen=args.t_pad,
+                    df_multiple=df).astype(real_same_precision_as(htilde))
+            elif args.compression_algorithm == 'spa':
+                sample_points = compress.spa_compression(
+                    htilde, fmin, (kmax-1)*df, min_seglen=
+                    args.t_pad).astype(real_same_precision_as(htilde))
+            else:
+                raise ValueError("unrecognized compression algorithm %s" %(
+                             args.compression_algorithm))
+
+            hcompressed = compress.compress_waveform(
+                    htilde, sample_points, args.tolerance,
+                    args.interpolation, decomp_scratch=decomp_scratch)
+
+        elif args.ROM_parameter_space_interpolation == 'partial_ROM_compression':
+            hcompressed = compress.partial_compress_rom( htilde, tmplt.mass1,
+                tmplt.mass2, tmplt.spin1z, tmplt.spin2z, df, fmin,
+                (kmax-1)*df, args.interpolation)
+
+    # if template is a SPAtmplt waveform perform linear_compression
     else:
-        raise ValueError("unrecognized compression algorithm %s" %(
-            args.compression_algorithm))
-            
-    # compress
-    hcompressed = compress.compress_waveform(
-        htilde, sample_points, args.tolerance, args.interpolation,
-        decomp_scratch=decomp_scratch)
+        if args.compression_algorithm == 'mchirp':
+            sample_points = compress.mchirp_compression(
+                tmplt.mass1, tmplt.mass2, fmin, (kmax-1)*df,
+                min_seglen=args.t_pad,
+                df_multiple=df).astype(real_same_precision_as(htilde))
+        elif args.compression_algorithm == 'spa':
+            sample_points = compress.spa_compression(
+                htilde, fmin, (kmax-1)*df, min_seglen=
+                args.t_pad).astype(real_same_precision_as(htilde))
+        else:
+            raise ValueError("unrecognized compression algorithm %s" %(
+                             args.compression_algorithm))
+
+        hcompressed = compress.compress_waveform(
+                    htilde, sample_points, args.tolerance,
+                    args.interpolation, decomp_scratch=decomp_scratch)
+
 
     # save results
     hcompressed.write_to_hdf(output, tmplt.template_hash)

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -57,20 +57,17 @@ parser.add_argument("--tmplt-index", nargs=2, type=int, default=None,
                     "indices in the bank file. Must provide both a start "
                     "and a stop index. Default is to compress all of the "
                     "templates in the bank file.")
-parser.add_argument("--compression-algorithm", nargs='*', type=str,
-                    required=True,
-                    choices=compress.compression_algorithms.keys(),
-                    help="Specify the waveform model and compression"
-                    "algorithm to use for selecting frequency points"
-                    "for TaylorF2 templates and SEOBNRv2_ROM templates."
-                    "This would be used to select sets of frequency"
-                    "points for amplitude and phase interpolants. Either"
-                    "specify different algorithms for the TaylorF2 and"
-                    "SEOBNRv2_ROM or specify a common compression"
-                    "algorithm compatible with both. For example"
-                    "partial_rom_compression works only for the ROMs."
-                    "Look at compress.compression_algorithms.keys()"
-                    "for the available options")
+parser.add_argument("--compression-algorithm", nargs='+', type=str,
+                    required=True, metavar="ALGORITHM[:APPRX]",
+                    help="Specify the compression algorithm to use for "
+                    "selecting frequency points for amplitude and phase "
+                    "interpolants for generating waveforms. Choices are "
+                    "{}.format(', '.join(compress.compression_algorithms.keys())) ."
+                    "To use an algorithm with a specific approximant, "
+                    "add the approximant name preceded by a colon after "
+                    "the algorithm name;  e.g., 'spa:TaylorF2'. In this "
+                    "case, specify an algorithm for every approximant "
+                    "that the bank taken as input contains. ")
 parser.add_argument("--t-pad", type=float, default=0.001,
                     help="The minimum duration used for t(f) in seconds. The "
                     "inverse of this gives the maximum frequency step that "
@@ -78,10 +75,10 @@ parser.add_argument("--t-pad", type=float, default=0.001,
                     "0.001.")
 parser.add_argument("--tolerance", type=float, default=0.001,
                     help="The maximum mismatch to allow between the "
-                    "interpolated waveform and the full waveform. Points"
+                    "interpolated waveform and the full waveform. Points "
                     "will be added to the compressed waveform until its "
-                    "interpolation has a mismatch <= this value."
-                    " Default is 0.001.")
+                    "interpolation has a mismatch <= this value. "
+                    "Default is 0.001.")
 parser.add_argument("--interpolation", type=str,
                     default="inline_linear",
                     help="The interpolation to use for decompressing the "
@@ -95,7 +92,7 @@ parser.add_argument("--interpolation", type=str,
                     "Default is inline_linear.")
 parser.add_argument("--precision", type=str, choices=["double", "single"],
                     default="double",
-                    help="What precision to generate and store the"
+                    help="What precision to generate and store the "
                     "waveforms with; default is double.")
 parser.add_argument("--force", action="store_true", default=False,
                     help="Overwrite the given hdf file if it exists. "
@@ -109,19 +106,13 @@ pycbc.init_logging(args.verbose)
 
 num_compression_algorithms = len(args.compression_algorithm)
 
-if num_compression_algorithms == 1:
-    compression_type = args.compression_algorithm[0]
-    if compression_type is 'partial_compress_rom':
-        raise ValueError("""partial_compress_rom cannot be used as a
-                         compression algorithm for TaylorF2 waveforms.
-                         Specify a different compression algorithm
-                         compatible with TaylorF2 and
-                         SEOBNRv2_ROM_DoubleSpin.""")
-
-elif num_compression_algorithms == 2:
-    compression_type_approximant1, compression_type_approximant2 = args.compression_algorithm
-    compression_type1, approximant1 = compression_type_approximant1.split(':')
-    compression_type2, approximant2 = compression_type_approximant2.split(':')
+# If the number of arguments taken in by compression_algorithm is
+# more than 1, create a dictionary to store the entries, mapping
+# the approximants to the compression algorithms.
+if num_compression_algorithms > 1:
+    compression_algorithm_dict = {k:v for k,v in (x.split(':')for x in args.compression_algorithm) }
+    algorithms = compression_algorithm_dict.keys()
+    approximants = compression_algorithm_dict.values()
 
 fmin = args.low_frequency_cutoff
 fmax = args.sample_rate/2.
@@ -179,17 +170,30 @@ for ii in range(imin, imax):
     tmplt = bank.table[ii-imin]
     kmax = htilde.end_idx
     tmplt_approximant = htilde.approximant
-    if num_compression_algorithms == 2:
-        if tmplt_approximant == approximant1:
-            compression_type = compression_type1
-        if tmplt_approximant == approximant2:
-            compression_type = compression_type2
+    # If the number of arguments entered for compression_algorithm is 1
+    # the same algorithm is expected to be used for all kinds of
+    # approximants in the bank. If multiple ALGORITHM:APPROX have been
+    # entered in compression_algorithm, pass the approximant for htilde
+    # to the dictionary created before and find the corressponding
+    # compression algorithm.
+    if num_compression_algorithms == 1 :
+        compression_type = args.compression_algorithm[0]
+    else :
+        if tmplt_approximant not in approximants :
+            raise ValueError("""A compression algorithm for the %s
+                             templates in the bank needs to be provided
+                             as input.""" %(tmplt_approximant))
+        compression_type = algorithms[approximants.index(tmplt_approximant)]
+
+    if compression_type == 'partial_compress_rom' and tmplt_approximant != 'SEOBNRv2_ROM_DoubleSpin' :
+        raise ValueError("""The compression algorithm partial_compress_rom
+                         works only for SEOBNRv2_ROM_DoubleSpin templates.
+                         Please enter a valid compression algorithm for
+                         %s templates.""" %(tmplt_approximant))
     # Call the appropriate function in compress.py to get the compressed
     # amplitude and phase frequency points and decompress them in
     # frequency space :
 
-    # If template is SEOBNRv2_ROM perform linear_compression or
-    # partial_ROM_compression as per user input
     if compression_type == 'mchirp':
         sample_points = compress.mchirp_compression(
             tmplt.mass1, tmplt.mass2, fmin, (kmax-1)*df,

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -65,9 +65,10 @@ parser.add_argument("--compression-algorithm", nargs='+', type=str,
                     "{}.format(', '.join(compress.compression_algorithms.keys())) ."
                     "To use an algorithm with a specific approximant, "
                     "add the approximant name preceded by a colon after "
-                    "the algorithm name;  e.g., 'spa:TaylorF2'. In this "
-                    "case, specify an algorithm for every approximant "
-                    "that the bank taken as input contains. ")
+                    "the algorithm name. In this case, specify an "
+                    "algorithm for every approximant that the bank "
+                    "taken as input contains; e.g., "
+                    "'spa:TaylorF2' 'partial_compress_rom:SEOBNRv2_ROM_DoubleSpin' .")
 parser.add_argument("--t-pad", type=float, default=0.001,
                     help="The minimum duration used for t(f) in seconds. The "
                     "inverse of this gives the maximum frequency step that "
@@ -190,10 +191,10 @@ for ii in range(imin, imax):
                          works only for SEOBNRv2_ROM_DoubleSpin templates.
                          Please enter a valid compression algorithm for
                          %s templates.""" %(tmplt_approximant))
+    
     # Call the appropriate function in compress.py to get the compressed
     # amplitude and phase frequency points and decompress them in
     # frequency space :
-
     if compression_type == 'mchirp':
         sample_points = compress.mchirp_compression(
             tmplt.mass1, tmplt.mass2, fmin, (kmax-1)*df,

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -57,28 +57,20 @@ parser.add_argument("--tmplt-index", nargs=2, type=int, default=None,
                     "indices in the bank file. Must provide both a start "
                     "and a stop index. Default is to compress all of the "
                     "templates in the bank file.")
-parser.add_argument("--ROM-parameter-space-interpolation", type=str,
-                    choices=["linear_compression", "partial_ROM_compression"],
-                    default="linear_compression",
-                    help="The method used to get the amplitude and phase"
-                    "interpolants and the corressponding amplitude and"
-                    "phase frequency points for the SEOBNRv2_ROM waveforms"
-                    "in the template bank. Choices are 'linear_compression'"
-                    "which would calculate the interpolants and frequency"
-                    "points in the compress_waveform function in compress.py,"
-                    "OR 'partial_rom_compression' which would call the"
-                    "LAL code for SEOBNRv2_ROM from the partial_compress_rom"
-                    "function of compress.py to get the interpolants and"
-                    "the frequency points")
-parser.add_argument("--compression-algorithm", type=str, required=True,
+parser.add_argument("--compression-algorithm", nargs='*', type=str,
+                    required=True,
                     choices=compress.compression_algorithms.keys(),
-                    help="The compression algorithm to use for selecting "
-                    "frequency points for all TaylorF2 templates and"
-                    "SEOBNRv2_ROM templates when"
-                    " --ROM-parameter-space-interpolation is "
-                    "'linear_compression'. This would select a common "
-                    "set of frequency points for both amplitude "
-                    "and phase interpolants")
+                    help="Specify the waveform model and compression"
+                    "algorithm to use for selecting frequency points"
+                    "for TaylorF2 templates and SEOBNRv2_ROM templates."
+                    "This would be used to select sets of frequency"
+                    "points for amplitude and phase interpolants. Either"
+                    "specify different algorithms for the TaylorF2 and"
+                    "SEOBNRv2_ROM or specify a common compression"
+                    "algorithm compatible with both. For example"
+                    "partial_rom_compression works only for the ROMs."
+                    "Look at compress.compression_algorithms.keys()"
+                    "for the available options")
 parser.add_argument("--t-pad", type=float, default=0.001,
                     help="The minimum duration used for t(f) in seconds. The "
                     "inverse of this gives the maximum frequency step that "
@@ -115,20 +107,37 @@ args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)
 
+num_compression_algorithms = len(args.compression_algorithm)
+
+if num_compression_algorithms == 1:
+    compression_type = args.compression_algorithm[0]
+    if compression_type is 'partial_compress_rom':
+        raise ValueError("""partial_compress_rom cannot be used as a
+                         compression algorithm for TaylorF2 waveforms.
+                         Specify a different compression algorithm
+                         compatible with TaylorF2 and
+                         SEOBNRv2_ROM_DoubleSpin.""")
+
+elif num_compression_algorithms == 2:
+    compression_type_approximant1, compression_type_approximant2 = args.compression_algorithm
+    compression_type1, approximant1 = compression_type_approximant1.split(':')
+    compression_type2, approximant2 = compression_type_approximant2.split(':')
+
 fmin = args.low_frequency_cutoff
 fmax = args.sample_rate/2.
 
 # load the bank
 logging.info("loading bank")
 # set the dtype to use
-# FIXME: there really should be a function in pycbc.types that provides this
-# mapping
+# FIXME: there really should be a function in pycbc.types that provides
+#this mapping
 if args.precision == "single":
     dtype = numpy.complex64
 else:
     dtype = numpy.complex128
 # we'll just use dummy values for N, df for now
-bank = waveform.FilterBank(args.bank_file, 5, 0.25, fmin, dtype,
+bank = waveform.FilterBank(args.bank_file, 5, 0.25, dtype,
+                           low_frequency_cutoff=fmin,
                            approximant=args.approximant)
 templates = bank.table
 if args.tmplt_index is not None:
@@ -169,57 +178,40 @@ for ii in range(imin, imax):
     htilde = bank[ii-imin]
     tmplt = bank.table[ii-imin]
     kmax = htilde.end_idx
-
-    mtotal = tmplt.mass1 + tmplt.mass2
+    tmplt_approximant = htilde.approximant
+    if num_compression_algorithms == 2:
+        if tmplt_approximant == approximant1:
+            compression_type = compression_type1
+        if tmplt_approximant == approximant2:
+            compression_type = compression_type2
     # Call the appropriate function in compress.py to get the compressed
     # amplitude and phase frequency points and decompress them in
     # frequency space :
 
     # If template is SEOBNRv2_ROM perform linear_compression or
     # partial_ROM_compression as per user input
-    if mtotal >= 4:
-        if args.ROM_parameter_space_interpolation == 'linear_compression':
-            if args.compression_algorithm == 'mchirp':
-                sample_points = compress.mchirp_compression(
-                    tmplt.mass1, tmplt.mass2, fmin, (kmax-1)*df,
-                    min_seglen=args.t_pad,
-                    df_multiple=df).astype(real_same_precision_as(htilde))
-            elif args.compression_algorithm == 'spa':
-                sample_points = compress.spa_compression(
-                    htilde, fmin, (kmax-1)*df, min_seglen=
-                    args.t_pad).astype(real_same_precision_as(htilde))
-            else:
-                raise ValueError("unrecognized compression algorithm %s" %(
-                                 args.compression_algorithm))
-
-            hcompressed = compress.compress_waveform(
-                    htilde, sample_points, args.tolerance,
-                    args.interpolation, decomp_scratch=decomp_scratch)
-
-        elif args.ROM_parameter_space_interpolation == 'partial_ROM_compression':
-            hcompressed = compress.partial_compress_rom( htilde, tmplt.mass1,
-                tmplt.mass2, tmplt.spin1z, tmplt.spin2z, df, fmin,
-                (kmax-1)*df, args.interpolation)
-
-    # if template is a SPAtmplt waveform perform linear_compression
-    else:
-        if args.compression_algorithm == 'mchirp':
-            sample_points = compress.mchirp_compression(
-                tmplt.mass1, tmplt.mass2, fmin, (kmax-1)*df,
-                min_seglen=args.t_pad,
-                df_multiple=df).astype(real_same_precision_as(htilde))
-        elif args.compression_algorithm == 'spa':
-            sample_points = compress.spa_compression(
-                htilde, fmin, (kmax-1)*df, min_seglen=
-                args.t_pad).astype(real_same_precision_as(htilde))
-        else:
-            raise ValueError("unrecognized compression algorithm %s" %(
-                             args.compression_algorithm))
-
+    if compression_type == 'mchirp':
+        sample_points = compress.mchirp_compression(
+            tmplt.mass1, tmplt.mass2, fmin, (kmax-1)*df,
+            min_seglen=args.t_pad,
+            df_multiple=df).astype(real_same_precision_as(htilde))
         hcompressed = compress.compress_waveform(
-                    htilde, sample_points, args.tolerance,
-                    args.interpolation, decomp_scratch=decomp_scratch)
-
+            htilde, sample_points, args.tolerance, args.interpolation,
+            decomp_scratch=decomp_scratch)
+    elif compression_type == 'spa':
+        sample_points = compress.spa_compression(
+            htilde, fmin, (kmax-1)*df, min_seglen=
+            args.t_pad).astype(real_same_precision_as(htilde))
+        hcompressed = compress.compress_waveform(
+            htilde, sample_points, args.tolerance, args.interpolation,
+            decomp_scratch=decomp_scratch)
+    elif compression_type == 'partial_compress_rom':
+        hcompressed = compress.partial_rom_compression(
+            htilde, tmplt.mass1, tmplt.mass2, tmplt.spin1z, tmplt.spin2z,
+            df, fmin, (kmax-1)*df, args.interpolation)
+    else:
+        raise ValueError("unrecognized compression algorithm %s" %(
+                         args.compression_algorithm))
 
     # save results
     hcompressed.write_to_hdf(output, tmplt.template_hash)

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -148,7 +148,7 @@ seg_lens = 4*numpy.array([max(4./args.sample_rate,
 # generate output file
 logging.info("writing template info to output")
 output = bank.write_to_hdf(args.output, force=args.force,
-    skip_fields='template_duration')
+                           skip_fields='template_duration')
 
 # get the compressed sample points for each template
 logging.info("getting compressed amplitude and phase")
@@ -190,7 +190,7 @@ for ii in range(imin, imax):
                     args.t_pad).astype(real_same_precision_as(htilde))
             else:
                 raise ValueError("unrecognized compression algorithm %s" %(
-                             args.compression_algorithm))
+                                 args.compression_algorithm))
 
             hcompressed = compress.compress_waveform(
                     htilde, sample_points, args.tolerance,

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -26,19 +26,21 @@ domain waveforms.
 import lalsimulation, lal, numpy, logging, h5py
 from pycbc import pnutils, filter
 from pycbc.opt import omp_libs, omp_flags
-from pycbc import WEAVE_FLAGS
+from pycbc import WEAVE_FLAGS, DYN_RANGE_FAC
 from scipy.weave import inline
 from scipy import interpolate
+from scipy.interpolate import splrep
 from pycbc.types import FrequencySeries, zeros, complex_same_precision_as, real_same_precision_as
 from pycbc.waveform import utils
 
 def rough_time_estimate(m1, m2, flow, fudge_length=1.1, fudge_min=0.02):
     """ A very rough estimate of the duration of the waveform.
 
-    An estimate of the waveform duration starting from flow. This is intended
-    to be fast but not necessarily accurate. It should be an overestimate of
-    the length. It is derived from a simplification of the 0PN post-newtonian
-    terms and includes a fudge factor for possible ringdown, etc.
+    An estimate of the waveform duration starting from flow. This is
+    intended to be fast but not necessarily accurate. It should be an
+    overestimate of the length. It is derived from a simplification of
+    the 0PN post-newtonian terms and includes a fudge factor for possible
+    ringdown, etc.
 
     Parameters
     ----------
@@ -66,7 +68,7 @@ def rough_time_estimate(m1, m2, flow, fudge_length=1.1, fudge_min=0.02):
         (numpy.pi * msun * flow) **  (8.0 / 3.0)
 
     # fudge factoriness
-    return .022 if t < 0 else (t + fudge_min) * fudge_length 
+    return .022 if t < 0 else (t + fudge_min) * fudge_length
 
 def mchirp_compression(m1, m2, fmin, fmax, min_seglen=0.02, df_multiple=None):
     """Return the frequencies needed to compress a waveform with the given
@@ -85,9 +87,9 @@ def mchirp_compression(m1, m2, fmin, fmax, min_seglen=0.02, df_multiple=None):
     min_seglen : float
         The inverse of this gives the maximum frequency step that is used.
     df_multiple : {None, float}
-        Make the compressed sampling frequencies a multiple of the given value.
-        If None provided, the returned sample points can have any floating
-        point value.
+        Make the compressed sampling frequencies a multiple of the given
+        value. If None provided, the returned sample points can have any
+        floating point value.
 
     Returns
     -------
@@ -167,8 +169,8 @@ def _vecdiff(htilde, hinterp, fmin, fmax):
                           normalized=False))
 
 def vecdiff(htilde, hinterp, sample_points):
-    """Computes a statistic indicating between which sample points a waveform
-    and the interpolated waveform differ the most.
+    """Computes a statistic indicating between which sample points a
+    waveform and the interpolated waveform differ the most.
     """
     vecdiffs = numpy.zeros(sample_points.size-1, dtype=float)
     for kk,thisf in enumerate(sample_points[:-1]):
@@ -178,35 +180,36 @@ def vecdiff(htilde, hinterp, sample_points):
 
 def compress_waveform(htilde, sample_points, tolerance, interpolation,
         decomp_scratch=None):
-    """Retrieves the amplitude and phase at the desired sample points, and adds
-    frequency points in order to ensure that the interpolated waveform
-    has a mismatch with the full waveform that is <= the desired tolerance. The
-    mismatch is computed by finding 1-overlap between `htilde` and the
-    decompressed waveform; no maximimization over phase/time is done, nor is
-    any PSD used.
-    
+    """Retrieves the amplitude and phase at the desired sample points,
+    and adds frequency points in order to ensure that the interpolated
+    waveform has a mismatch with the full waveform that is <= the desired
+    tolerance. The mismatch is computed by finding 1-overlap between
+    `htilde` and the decompressed waveform; no maximimization over
+    phase/time is done, nor is any PSD used.
+
     .. note::
-        The decompressed waveform is only garaunteed to have a true mismatch
-        <= the tolerance for the given `interpolation` and for no PSD.
-        However, since no maximization over time/phase is performed when
-        adding points, the actual mismatch between the decompressed waveform
-        and `htilde` is better than the tolerance, using no PSD. Using a PSD
-        does increase the mismatch, and can lead to mismatches > than the
-        desired tolerance, but typically by only a factor of a few worse.
+        The decompressed waveform is only garaunteed to have a true
+        mismatch <= the tolerance for the given `interpolation` and for
+        no PSD. However, since no maximization over time/phase is
+        performed when adding points, the actual mismatch between the
+        decompressed waveform and `htilde` is better than the tolerance,
+        using no PSD. Using a PSD does increase the mismatch, and can
+        lead to mismatches > than the desired tolerance, but typically
+        by only a factor of a few worse.
 
     Parameters
     ----------
     htilde : FrequencySeries
         The waveform to compress.
     sample_points : array
-        The frequencies at which to store the amplitude and phase. More points
-        may be added to this, depending on the desired tolerance.
+        The frequencies at which to store the amplitude and phase. More
+        points may be added to this, depending on the desired tolerance.
     tolerance : float
         The maximum mismatch to allow between a decompressed waveform and
         `htilde`.
     interpolation : str
-        The interpolation to use for decompressing the waveform when computing
-        overlaps.
+        The interpolation to use for decompressing the waveform when
+        computing overlaps.
     decomp_scratch : {None, FrequencySeries}
         Optionally provide scratch space for decompressing the waveform. The
         provided frequency series must have the same `delta_f` and length
@@ -231,17 +234,17 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
         outdf = None
     out = decomp_scratch
     hdecomp = fd_decompress(comp_amp, comp_phase, sample_points,
-        out=decomp_scratch, df=outdf, f_lower=fmin,
-        interpolation=interpolation)
+                            out=decomp_scratch, df=outdf, f_lower=fmin,
+                            interpolation=interpolation)
     mismatch = 1. - filter.overlap(hdecomp, htilde, low_frequency_cutoff=fmin)
     if mismatch > tolerance:
-        # we'll need the difference in the waveforms as a function of frequency
+        # we'll need the difference in the waveforms as a function of
+        # frequency
         vecdiffs = vecdiff(htilde, hdecomp, sample_points)
-
     # We will find where in the frequency series the interpolated waveform
     # has the smallest overlap with the full waveform, add a sample point
     # there, and re-interpolate. We repeat this until the overall mismatch
-    # is > than the desired tolerance 
+    # is > than the desired tolerance
     added_points = []
     while mismatch > tolerance:
         minpt = vecdiffs.argmax()
@@ -260,23 +263,90 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
         comp_phase = phase.take(sample_index)
         # update the vecdiffs and mismatch
         hdecomp = fd_decompress(comp_amp, comp_phase, sample_points,
-            out=decomp_scratch, df=outdf, f_lower=fmin,
-            interpolation=interpolation)
+                                out=decomp_scratch, df=outdf, 
+                                f_lower=fmin, interpolation=interpolation)
         new_vecdiffs = numpy.zeros(vecdiffs.size+1)
         new_vecdiffs[:minpt] = vecdiffs[:minpt]
         new_vecdiffs[minpt+2:] = vecdiffs[minpt+1:]
         new_vecdiffs[minpt:minpt+2] = vecdiff(htilde, hdecomp,
-            sample_points[minpt:minpt+2])
+                                              sample_points[minpt:minpt+2])
         vecdiffs = new_vecdiffs
         mismatch = 1. - filter.overlap(hdecomp, htilde,
-            low_frequency_cutoff=fmin)
+                                       low_frequency_cutoff=fmin)
         added_points.append(addidx)
     logging.info("mismatch: %f, N points: %i (%i added)" %(mismatch,
-        len(comp_amp), len(added_points)))
-    
-    return CompressedWaveform(sample_points, comp_amp, comp_phase,
-                interpolation=interpolation, tolerance=tolerance,
-                mismatch=mismatch)
+                 len(comp_amp), len(added_points)))
+    return CompressedWaveform(comp_amp, comp_phase, sample_points,
+                              interpolation=interpolation,
+                              mismatch=mismatch, tolerance=tolerance)
+
+def partial_compress_rom(htilde, mass1, mass2, chi1, chi2, deltaF, fLow,
+                         fHigh, interpolation):
+    phiRef = 0
+    fRef = 0
+    # a suitable value for distance is provided for now
+    distance = float((1.0e6 * lal.PC_SI)/DYN_RANGE_FAC)
+    inclination = 0
+    # Convert the component masses from solar mass units to kg, because
+    # the function in the SEOBNRv2_ROM LAL code reads in masses in SI units
+    m1SI = mass1 * lal.MSUN_SI
+    m2SI = mass2 * lal.MSUN_SI
+    # Get the amplitude and phase interpolants and amplitude and phase
+    # frequency points from the SEOBNRv2_ROM LAL code
+    amp_interp_points, amp_freq_points, phase_interp_points, phase_freq_points = lalsimulation.SimIMRSEOBNRv2ROMDoubleSpinAmpPhaseInterpolants(
+            phiRef, deltaF, fLow, fHigh, fRef, distance, inclination,
+            m1SI, m2SI, float(chi1), float(chi2) )
+    amp_freq_points = numpy.asarray(amp_freq_points.data,
+                                    dtype=numpy.float32)
+    phase_freq_points = numpy.asarray(phase_freq_points.data,
+                                      dtype=numpy.float32)
+    amp_interp_points = numpy.asarray(amp_interp_points.data,
+                                      dtype=numpy.float32)
+    phase_interp_points = numpy.asarray(phase_interp_points.data,
+                                        dtype=numpy.float32)
+
+    Mtot = mass1+mass2
+    Mtot_sec = float(Mtot*lal.MTSUN_SI)
+    # The LAL code returns the frequency points in geometric units.
+    # Converting them into Hz by diving them by total mass of binary in
+    # secs
+    amp_freq_points = amp_freq_points/Mtot_sec
+    phase_freq_points = phase_freq_points/Mtot_sec
+    fmin_interp = max(amp_freq_points.min(), phase_freq_points.min())
+    fmax_interp = min(amp_freq_points.max(), phase_freq_points.max())
+    # Decompress the waveform in frequency space
+    hdecomp = fd_decompress(amp_interp_points, phase_interp_points,
+			    phase_freq_points, amp_freq_points, out=None,
+			    df=deltaF, f_lower=fmin_interp,
+                            interpolation=interpolation)
+    # Calculate the highest frequency point in the frequency series for
+    # the full decompresssed SEOBNRv2_ROM waveform (htilde) and the the
+    # highest frequency point in the frequency series partially
+    # decompressed SEOBNRv2_ROM waveform (hdecomp)
+    fmax_hdecomp = numpy.amax(hdecomp.sample_frequencies.numpy())
+    fmax_htilde = numpy.amax(htilde.sample_frequencies.numpy())
+    # Calculate the minimum of the highest frequency points for the two
+    # waveforms which would be used as a high_frequency_cutoff while
+    # calculating the mismatch between the two
+    high_frequency_cutoff = min(fmax_hdecomp, fmax_htilde)
+    # Calculate the mismatch between the two waveforms :
+    # The low_frequency_cutoff is the lower frequency point taken as user
+    # input in 'pycbc_compress_bank' for generating 'htilde'. The lengths
+    # of hdecomp and htilde are not the same. Therefore a
+    # high_frequency_cutoff which lies in the range of freqencies for
+    # htilde and hdecomp is provided and is calculated as described above.
+    # The mismatch is calculated for the length of the waveforms between
+    # the low_frequency_cutoff and high_frequency_cutoff.
+    mismatch = 1. - filter.overlap(abs(hdecomp), abs(htilde),
+                                   low_frequency_cutoff=fLow,
+                                   high_frequency_cutoff=high_frequency_cutoff)
+    logging.info("""mismatch: %.10f, for low_frequency_cutoff = %.1f and
+                 high_frequency_cutoff = %.1f"""%(mismatch, fLow,
+                 high_frequency_cutoff))
+    return CompressedWaveform(amp_interp_points, phase_interp_points,
+                              phase_freq_points, amp_freq_points,
+                              interpolation=interpolation,
+                              mismatch=mismatch)
 
 
 _linear_decompress_code = r"""
@@ -310,7 +380,7 @@ _linear_decompress_code = r"""
     double* outptr = (double*) h;
 
     // for keeping track of where in the output frequencies we are
-    int findex, next_sfindex, kmax; 
+    int findex, next_sfindex, kmax;
 
     // variables for computing the interpolation
     double df = (double) delta_f;
@@ -379,7 +449,7 @@ _linear_decompress_code = r"""
             // for the next update_interval steps, compute h by incrementing
             // the last h
             kmax = findex + update_interval;
-            if (kmax > next_sfindex) 
+            if (kmax > next_sfindex)
                 kmax = next_sfindex;
             while (findex < kmax){
                 incrh_re = h_re * dphi_re - h_im * dphi_im;
@@ -423,8 +493,9 @@ _real_dtypes = {
     'double': numpy.float64
 }
 
-def fd_decompress(amp, phase, sample_frequencies, out=None, df=None,
-        f_lower=None, interpolation='linear'):
+def fd_decompress(amp, phase, sample_frequencies,
+                  amp_sample_frequencies=None, out=None, df=None,
+                  f_lower=None, interpolation='inline_linear'):
     """Decompresses an FD waveform using the given amplitude, phase, and the
     frequencies at which they are sampled at.
 
@@ -434,22 +505,31 @@ def fd_decompress(amp, phase, sample_frequencies, out=None, df=None,
         The amplitude of the waveform at the sample frequencies.
     phase : array
         The phase of the waveform at the sample frequencies.
+    amp_sample_frequencies : array
+        This is set to None by default. But if specified, is used for
+        the frequency (in Hz) of the waveform for the amplitude.
     sample_frequencies : array
-        The frequency (in Hz) of the waveform at the sample frequencies.
+        This is used used for frequency (in Hz) of the waveform for both 
+        amplitude and phase. But if amp_sample_frequencies is specified,
+        this is used only for frequency of the waveform for phase. 
     out : {None, FrequencySeries}
         The output array to save the decompressed waveform to. If this contains
-        slots for frequencies > the maximum frequency in sample_frequencies,
-        the rest of the values are zeroed. If not provided, must provide a df.
+        slots for frequencies > the maximum frequency in the interpolant
+        frequency arrays, the rest of the values are zeroed. If not provided,
+        must provide a df.
     df : {None, float}
         The frequency step to use for the decompressed waveform. Must be
         provided if out is None.
     f_lower : {None, float}
         The frequency to start the decompression at. If None, will use whatever
-        the lowest frequency is in sample_frequencies. All values at
-        frequencies less than this will be 0 in the decompressed waveform.
-    interpolation : {'linear', str}
+        the lowest frequency is of the interpolants in amplitude and phase.
+        All values at frequencies less than this will be 0 in the decompressed
+        waveform.
+    interpolation : {'linear_same_freq_points', str}
         The interpolation to use for the amplitude and phase. Default is
-        'linear'. If 'linear' a custom interpolater is used. Otherwise,
+        'linear_same_freq_points'. If 'linear_same_freq_points' a custom
+        interpolater is used that assumes that the the frequency samples of
+        the amplitude and phase interpolants are exactly the same. Otherwise,
         ``scipy.interpolate.interp1d`` is used; for other options, see
         possible values for that function's ``kind`` argument.
 
@@ -460,17 +540,31 @@ def fd_decompress(amp, phase, sample_frequencies, out=None, df=None,
         FrequencySeries with the decompressed waveform.
     """
     precision = _precision_map[sample_frequencies.dtype.name]
-    if _precision_map[amp.dtype.name] != precision or \
-            _precision_map[phase.dtype.name] != precision:
-        raise ValueError("amp, phase, and sample_points must all have the "
-            "same precision")
+    if amp_sample_frequencies == None:
+    	if _precision_map[amp.dtype.name] != precision or \
+    		_precision_map[phase.dtype.name] != precision:
+            raise ValueError("amp, phase, and sample_frequencies must"
+                            " all have the same precision")
+        f_min = sample_frequencies.min()
+        f_max = sample_frequencies.max()
+
+    else:
+    	if _precision_map[amp.dtype.name] != precision or \
+       	     _precision_map[phase.dtype.name] != precision or \
+                _precision_map[amp_sample_frequencies.dtype.name] != precision:
+    	    raise ValueError("amp, phase, amp_sample_frequencies, and"
+                             "sample_frequencies must all have the same"
+                             "precision")
+        f_min = max([amp_sample_frequencies.min(),sample_frequencies.min()])
+        f_max = min([amp_sample_frequencies.max(),sample_frequencies.max()])
+
     if out is None:
         if df is None:
             raise ValueError("Either provide output memory or a df")
-        hlen = int(numpy.ceil(sample_frequencies.max()/df+1))
+        hlen = int(numpy.ceil(f_max/df+1))
         out = FrequencySeries(numpy.zeros(hlen,
-            dtype=_complex_dtypes[precision]), copy=False,
-            delta_f=df)
+                              dtype=_complex_dtypes[precision]),
+                              copy=False, delta_f=df)
     else:
         # check for precision compatibility
         if out.precision == 'double' and precision == 'single':
@@ -479,14 +573,20 @@ def fd_decompress(amp, phase, sample_frequencies, out=None, df=None,
         hlen = len(out)
     if f_lower is None:
         imin = 0
-        f_lower = sample_frequencies[0]
+	f_lower = f_min
     else:
-        if f_lower >= sample_frequencies.max():
-            raise ValueError("f_lower is > than the maximum sample frequency")
-        imin = int(numpy.searchsorted(sample_frequencies, f_lower))
+	if f_lower >= f_max:
+            raise ValueError("f_lower is greater than the maximum "
+                             "sample frequency of the interpolants")
     start_index = int(numpy.floor(f_lower/df))
     # interpolate the amplitude and the phase
-    if interpolation == "linear":
+    if interpolation == "inline_linear":
+        if amp_sample_frequencies != None:
+           raise ValueError("for inline_linear decompression"
+                            "amp_sample_frequencies should be set to"
+                            "None as it should be the same as"
+                            "sample_frequencies")
+        imin = int(numpy.searchsorted(sample_frequencies, f_lower))
         if precision == 'single':
             code = _linear_decompress_code32
         else:
@@ -498,17 +598,20 @@ def fd_decompress(amp, phase, sample_frequencies, out=None, df=None,
         inline(code, ['h', 'hlen', 'sflen', 'delta_f', 'sample_frequencies',
                       'amp', 'phase', 'start_index', 'imin'],
                extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] +\
-                                  omp_flags,
-               libraries=omp_libs)
+               omp_flags, libraries=omp_libs) 
     else:
+        if amp_sample_frequencies == None:
+                amp_sample_frequencies = sample_frequencies
         # use scipy for fancier interpolation
         outfreq = out.sample_frequencies.numpy()
-        amp_interp = interpolate.interp1d(sample_frequencies.numpy(),
-            amp.numpy(), kind=interpolation, bounds_error=False, fill_value=0.,
-            assume_sorted=True)
-        phase_interp = interpolate.interp1d(sample_frequencies.numpy(),
-            phase.numpy(), kind=interpolation, bounds_error=False,
-            fill_value=0., assume_sorted=True)
+        amp_interp = interpolate.interp1d(
+                        amp_sample_frequencies, amp, kind=interpolation,
+                        bounds_error=False, fill_value=0.,
+                        assume_sorted=True)
+        phase_interp = interpolate.interp1d(
+                        sample_frequencies, phase, kind=interpolation,
+                        bounds_error=False, fill_value=0.,
+                        assume_sorted=True)
         A = amp_interp(outfreq)
         phi = phase_interp(outfreq)
         out.data[:] = A*numpy.cos(phi) + (1j)*A*numpy.sin(phi)
@@ -517,38 +620,65 @@ def fd_decompress(amp, phase, sample_frequencies, out=None, df=None,
 
 class CompressedWaveform(object):
     """Class that stores information about a compressed waveform.
-    
+
     Parameters
     ----------
-    sample_points : {array, h5py.Dataset}
-        The frequency points at which the compressed waveform is sampled.
     amplitude : {array, h5py.Dataset}
         The amplitude of the waveform at the given `sample_points`.
     phase : {array, h5py.Dataset}
         The phase of the waveform at the given `sample_points`.
+    freq_points : {array, h5py.Dataset}
+        The frequency points at which the amplitude and phase of the
+        compressed waveform is sampled if amplitude_freq_points is not
+        specified. If amplitude_freq_points is specified, this would
+        store only the phase frequency points.
+    amplitude_freq_points : {array, h5py.Dataset}
+        The frequency points at which the amplitude of the compressed
+        waveform is sampled.
     interpolation : {None, str}
         The interpolation that was used when compressing the waveform for
-        computing tolerance. This is also the default interpolation used when
-        decompressing; see `decompress` for details.
+        computing tolerance. This is also the default interpolation used
+        when decompressing; see `decompress` for details.
     tolerance : {None, float}
         The tolerance that was used when compressing the waveform.
     mismatch : {None, float}
-        The actual mismatch between the decompressed waveform (using the given
-        `interpolation`) and the full waveform.
+        The actual mismatch between the decompressed waveform (using the
+        given `interpolation`) and the full waveform.
     load_to_memory : {True, bool}
-        If `sample_points`, `amplitude`, and/or `phase` is an hdf dataset, they
-        will be cached in memory the first time they are accessed. Default is
-        True.
+        If `sample_points`, `amplitude`, and/or `phase` is an hdf dataset,
+        they will be cached in memory the first time they are accessed.
+        Default is True.
 
     Attributes
     ----------
-    sample_points
-    amplitude
-    phase
+    amplitude : array
+        The amplitude of the waveform at the `freq_points` or
+        `amplitude_freq_points` as the case may be.
+        This is always returned as an array, even if the stored
+        `amplitude` is an hdf dataset. If `load_to_memory` is True
+        and the stored points are an hdf dataset, the `amplitude` will
+        be cached in memory the first time this attribute is accessed.
+    phase : array
+        The phase of the waveform at the `freq_points`. This is
+        always returned as an array; the same logic as for `amplitude`
+        is used to determine whether or not to cache in memory.
+    freq_points : array
+        The frequencies at which the amplitude and phase of the
+        compressed waveform is sampled if `amplitude_freq_points` is not
+        specified. If `amplitude_freq_points` is specified, this would
+        store only the phase frequency points. This is always returned
+        as an array; the same logic as for `amplitude`
+        is used to determine whether or not to cache in memory.
+    amplitude_freq_points : array
+        The frequencies at which the amplitude of the compressed waveform is
+        sampled. This always returned as an array, the same logic as for
+        `amplitude` is used to determine whether or not to cache in
+        memory.
     load_to_memory : bool
-        Whether or not to load `sample_points`/`amplitude`/`phase` into memory
-        the first time they are accessed, if they are hdf datasets. Can be
-        set directly to toggle this behavior.
+        Whether or not to load `freq_points`/`amplitude_freq_points`/
+        `amplitude`/`phase` into memory the first time they are accessed,
+        if they are hdf datasets.
+        Can be set directly to toggle this behavior.
     interpolation : str
         The interpolation that was used when compressing the waveform, for
         checking the mismatch. Also the default interpolation used when
@@ -558,21 +688,38 @@ class CompressedWaveform(object):
     mismatch : {None, float}
         The mismatch between the decompressed waveform and the original
         waveform.
+
+    Methods
+    -------
+    decompress :
+        Decompresses the waveform to the desired sampling.
+    write_to_hdf :
+        Writes the compressed waveform to an open hdf file.
+    clear_cache :
+        Clears the in-memory cache used to hold the
+        `amplitude_freq_points`/`freq_points`/`amplitude`/`phase`;
+        only relevant if `load_to_memory` is True.
+
+    Class Methods
+    -------------
+    from_hdf :
+        Loads a compressed waveform from the given open hdf file.
     """
-    
-    def __init__(self, sample_points, amplitude, phase,
-            interpolation=None, tolerance=None, mismatch=None,
-            load_to_memory=True):
-        self._sample_points = sample_points
+
+    def __init__(self, amplitude, phase, freq_points,
+                 amplitude_freq_points=None, interpolation=None,
+                 tolerance=None, mismatch=None, load_to_memory=True):
         self._amplitude = amplitude
         self._phase = phase
+        self._freq_points = freq_points
+        self._amplitude_freq_points = amplitude_freq_points
         self._cache = {}
         self.load_to_memory = load_to_memory
-        # if sample points, amplitude, and/or phase are hdf datasets,
+        # if frequency points, amplitude, and/or phase are hdf datasets,
         # save their filenames
         self._filenames = {}
         self._groupnames = {}
-        for arrname in ['sample_points', 'amplitude', 'phase']:
+        for arrname in ['freq_points', 'amplitude_freq_points', 'amplitude', 'phase']:
             try:
                 fname = getattr(self, '_{}'.format(arrname)).file.filename
                 gname = getattr(self, '_{}'.format(arrname)).name
@@ -606,94 +753,72 @@ class CompressedWaveform(object):
 
     @property
     def amplitude(self):
-        """The amplitude of the waveform at the `sample_points`.
-
-        This is always returned as an array; the same logic as for
-        `sample_points` is used to determine whether or not to cache in
-        memory.
-
-        Returns
-        -------
-        amplitude : Array
-        """
         return self._get('amplitude')
 
     @property
     def phase(self):
-        """The phase of the waveform as the `sample_points`.
-
-        This is always returned as an array; the same logic as for
-        `sample_points` returned as an array; the same logic as for
-        `sample_points` is used to determine whether or not to cache in
-        memory.
-
-        Returns
-        -------
-        phase : Array
-        """
         return self._get('phase')
 
     @property
-    def sample_points(self):
-        """The frequencies at which the compressed waveform is sampled.
+    def freq_points(self):
+        return self._get('freq_points')
 
-        This is
-        always returned as an array, even if the stored `sample_points` is an
-        hdf dataset. If `load_to_memory` is True and the stored points are
-        an hdf dataset, the `sample_points` will cached in memory the first
-        time this attribute is accessed.
-
-        Returns
-        -------
-        sample_points : Array
-        """
-        return self._get('sample_points')
+    @property
+    def amplitude_freq_points(self):
+        return self._get('amplitude_freq_points')
 
     def clear_cache(self):
-        """Clear self's cache of amplitude, phase, and sample_points."""
+        """Clear self's cache of amplitude, phase, and sample points."""
         self._cache.clear()
 
     def decompress(self, out=None, df=None, f_lower=None, interpolation=None):
         """Decompress self.
-        
+
         Parameters
         ----------
         out : {None, FrequencySeries}
-            Write the decompressed waveform to the given frequency series. The
-            decompressed waveform will have the same `delta_f` as `out`.
+            Write the decompressed waveform to the given frequency series.
+            The decompressed waveform will have the same `delta_f` as `out`.
             Either this or `df` must be provided.
         df : {None, float}
             Decompress the waveform such that its `delta_f` has the given
             value. Either this or `out` must be provided.
         f_lower : {None, float}
-            The starting frequency at which to decompress the waveform. Cannot
-            be less than the minimum frequency in `sample_points`. If `None`
-            provided, will default to the minimum frequency in `sample_points`.
-        interpolation : {None, str}
-            The interpolation to use for decompressing the waveform. If `None`
-            provided, will default to `self.interpolation`.
+            The starting frequency at which to decompress the waveform.
+            Cannot be less than the minimum frequency of either
+            `amplitude_freq_points` or `freq_points`. If `None`
+            provided, will default to the minimum frequency available.
+        interpolation : {interpolation, str}
+            The interpolation to use for decompressing the waveform. If
+            `None` provided, will default to `self.interpolation`.
 
         Returns
         -------
         FrequencySeries
             The decompressed waveform.
         """
-        if f_lower is None:
-            # use the minimum of the samlpe points
-            f_lower = self.sample_points.min()
         if interpolation is None:
             interpolation = self.interpolation
-        return fd_decompress(self.amplitude, self.phase, self.sample_points,
-            out=out, df=df, f_lower=f_lower, interpolation=interpolation)
+        return fd_decompress(self.amplitude, self.phase,
+                             self.freq_points,
+                             self.amplitude_freq_points,
+                             out=out, df=df, f_lower=f_lower,
+                             interpolation=interpolation)
 
     def write_to_hdf(self, fp, template_hash, root=None):
         """Write the compressed waveform to the given hdf file handler.
 
         The waveform is written to:
         `fp['[{root}/]compressed_waveforms/{template_hash}/{param}']`,
-        where `param` is the `sample_points`, `amplitude`, and `phase`. The
-        `interpolation`, `tolerance`, and `mismatch` are saved to the group's
-        attributes.
+        where `param` is the `amplitude_freq_points`, `freq_points`,
+        `amplitude`, and `phase`. If the frequency points for amplitude
+        interpolants and phase interpolants are the same, write only the
+        one set of frequency points set to the hdf file, which would be
+        `freq_points`. If the frequency points for amplitude interpolants
+        and phase interpolants are different, write both of those sets,
+        represented by `amplitude_freq_points` and `freq_points` to the
+        hdf file. The `interpolation`, `tolerance`, and `mismatch` are
+        saved to the group's attributes.
 
         Parameters
         ----------
@@ -702,29 +827,35 @@ class CompressedWaveform(object):
         template_hash : {hash, int, str}
             A hash, int, or string to map the template to the waveform.
         root : {None, str}
-            Put the `compressed_waveforms` group in the given directory in the
-            hdf file. If `None`, `compressed_waveforms` will be the root
-            directory.
+            Put the `compressed_waveforms` group in the given directory
+            in the hdf file. If `None`, `compressed_waveforms` will be
+            the root directory.
         """
         if root is None:
             root = ''
         else:
             root = '%s/'%(root)
         group = '%scompressed_waveforms/%s' %(root, str(template_hash))
-        for param in ['amplitude', 'phase', 'sample_points']:
-            fp['%s/%s' %(group, param)] = self._get(param)
+        if self.amplitude_freq_points is None:
+            for param in ['amplitude', 'phase', 'freq_points']:
+                fp['%s/%s' %(group, param)] = self._get(param)
+            fp[group].attrs['tolerance'] = self.tolerance
+        else:
+            for param in ['amplitude', 'phase', 'amplitude_freq_points',
+                          'freq_points']:
+                fp['%s/%s' %(group, param)] = self._get(param)
         fp[group].attrs['mismatch'] = self.mismatch
         fp[group].attrs['interpolation'] = self.interpolation
-        fp[group].attrs['tolerance'] = self.tolerance
 
     @classmethod
     def from_hdf(cls, fp, template_hash, root=None, load_to_memory=True,
-            load_now=False):
+                 load_now=False):
         """Load a compressed waveform from the given hdf file handler.
 
         The waveform is retrieved from:
         `fp['[{root}/]compressed_waveforms/{template_hash}/{param}']`,
-        where `param` is the `sample_points`, `amplitude`, and `phase`.
+        where `param` is the `amplitude_freq_points`, `freq_points`,
+        `amplitude`, and `phase`.
 
         Parameters
         ----------
@@ -740,7 +871,8 @@ class CompressedWaveform(object):
             Set the `load_to_memory` attribute to the given value in the
             returned instance.
         load_now : {False, bool}
-            Immediately load the `sample_points`/`amplitude`/`phase` to memory.
+            Immediately load the `amplitude_freq_points`/`freq_points`
+            /`amplitude`/`phase` to memory.
 
 
         Returns
@@ -753,16 +885,30 @@ class CompressedWaveform(object):
         else:
             root = '%s/'%(root)
         group = '%scompressed_waveforms/%s' %(root, str(template_hash))
-        sample_points = fp[group]['sample_points']
-        amp = fp[group]['amplitude']
-        phase = fp[group]['phase']
-        if load_now:
-            sample_points = sample_points[:]
-            amp = amp[:]
-            phase = phase[:]
-        return cls(sample_points, amp, phase,
-            interpolation=fp[group].attrs['interpolation'],
-            tolerance=fp[group].attrs['tolerance'],
-            mismatch=fp[group].attrs['mismatch'],
-            load_to_memory=load_to_memory)
+        if 'amplitude_freq_points' in fp[group] :
+            amp_sample_frequencies = fp[group]['amplitude_freq_points']
+            sample_frequencies = fp[group]['freq_points']
+            amp = fp[group]['amplitude']
+            phase = fp[group]['phase']
+            tolerance = None
+            if load_now:
+                amp_sample_frequencies = amp_sample_frequencies[:]
+                sample_frequencies = sample_frequencies[:]
+                amp = amp[:]
+                phase = phase[:]
+        else :
+            amp_sample_frequencies = None
+            sample_frequencies = fp[group]['freq_points']
+            amp = fp[group]['amplitude']
+            phase = fp[group]['phase']
+            tolerance = fp[group].attrs['tolerance']
+            if load_now:
+                sample_frequencies = sample_frequencies[:]
+                amp = amp[:]
+                phase = phase[:]
+        return cls(amp, phase, sample_frequencies, amp_sample_frequencies,
+                   interpolation=fp[group].attrs['interpolation'],
+                   tolerance=tolerance,
+                   mismatch=fp[group].attrs['mismatch'],
+                   load_to_memory=load_to_memory)
 

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -349,7 +349,8 @@ def partial_rom_compression(htilde, mass1, mass2, chi1, chi2, deltaF, fLow,
     fmin_interp = max(amp_freq_points.min(), phase_freq_points.min())
     fmax_interp = min(amp_freq_points.max(), phase_freq_points.max())
 
-    # Perform the frequency space interpolation to get the decompressed waveform                        hdecomp = fd_decompress(amp_interp_points, phase_interp_points,
+    # Perform the frequency space interpolation to get the decompressed waveform
+    hdecomp = fd_decompress(amp_interp_points, phase_interp_points,
                             phase_freq_points, amp_freq_points, out=None,
                             df=deltaF, f_lower=fmin_interp,
                             interpolation=interpolation)
@@ -965,6 +966,7 @@ class CompressedWaveform(object):
             if load_now:
                 sample_frequencies = sample_frequencies[:]
                 amp = amp[:]
+                phase = phase[:]
         return cls(amp, phase, sample_frequencies, amp_sample_frequencies,
                    interpolation=fp[group].attrs['interpolation'],
                    tolerance=tolerance,

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -30,7 +30,7 @@ from pycbc import WEAVE_FLAGS, DYN_RANGE_FAC
 from scipy.weave import inline
 from scipy import interpolate
 from scipy.interpolate import splrep
-from pycbc.types import FrequencySeries, zeros, real_same_precision_as
+from pycbc.types import FrequencySeries, real_same_precision_as
 from pycbc.waveform import utils
 
 def rough_time_estimate(m1, m2, flow, fudge_length=1.1, fudge_min=0.02):
@@ -347,7 +347,6 @@ def partial_rom_compression(htilde, mass1, mass2, chi1, chi2, deltaF, fLow,
     amp_freq_points = amp_freq_points/Mtot_sec
     phase_freq_points = phase_freq_points/Mtot_sec
     fmin_interp = max(amp_freq_points.min(), phase_freq_points.min())
-    fmax_interp = min(amp_freq_points.max(), phase_freq_points.max())
 
     # Perform the frequency space interpolation to get the decompressed waveform
     hdecomp = fd_decompress(amp_interp_points, phase_interp_points,
@@ -383,7 +382,7 @@ def partial_rom_compression(htilde, mass1, mass2, chi1, chi2, deltaF, fLow,
     # Calculated the match and then the mismatch between htilde and
     # hdecomp
     match, _ = filter.match(hdecomp_cut, htilde_cut, low_frequency_cutoff=fLow, high_frequency_cutoff=high_frequency_cutoff)
-    logging.info("match=%.10f"%match)
+    logging.info("match=%.10f", match)
     mismatch = 1.0-match
     logging.info("mismatch: %.10f, for low_frequency_cutoff = %.1f and high_frequency_cutoff = %.1f", \
                  mismatch, fLow, high_frequency_cutoff)

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -30,7 +30,7 @@ from pycbc import WEAVE_FLAGS, DYN_RANGE_FAC
 from scipy.weave import inline
 from scipy import interpolate
 from scipy.interpolate import splrep
-from pycbc.types import FrequencySeries, zeros, complex_same_precision_as, real_same_precision_as
+from pycbc.types import FrequencySeries, zeros, real_same_precision_as
 from pycbc.waveform import utils
 
 def rough_time_estimate(m1, m2, flow, fudge_length=1.1, fudge_min=0.02):
@@ -282,7 +282,9 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
 
 def partial_compress_rom(htilde, mass1, mass2, chi1, chi2, deltaF, fLow,
                          fHigh, interpolation):
-    """Retrieves the amplitude and phase interpolants, and amplitude and
+    """
+
+    Retrieves the amplitude and phase interpolants, and amplitude and
     phase frequency sample points from the SEOBNRv2_ROM LAL code, and
     and calls fd_decompress to perform the interpolation in frequency
     space using various interpolation methods offered by scipy, to get
@@ -350,11 +352,10 @@ def partial_compress_rom(htilde, mass1, mass2, chi1, chi2, deltaF, fLow,
     amp_freq_points = amp_freq_points/Mtot_sec
     phase_freq_points = phase_freq_points/Mtot_sec
     fmin_interp = max(amp_freq_points.min(), phase_freq_points.min())
-    fmax_interp = min(amp_freq_points.max(), phase_freq_points.max())
     # Decompress the waveform in frequency space
     hdecomp = fd_decompress(amp_interp_points, phase_interp_points,
-			    phase_freq_points, amp_freq_points, out=None,
-			    df=deltaF, f_lower=fmin_interp,
+                            phase_freq_points, amp_freq_points, out=None,
+                            df=deltaF, f_lower=fmin_interp,
                             interpolation=interpolation)
     # Calculate the highest frequency point in the frequency series for
     # the full decompresssed SEOBNRv2_ROM waveform (htilde) and the the
@@ -377,8 +378,8 @@ def partial_compress_rom(htilde, mass1, mass2, chi1, chi2, deltaF, fLow,
     mismatch = 1. - filter.overlap(abs(hdecomp), abs(htilde),
                                    low_frequency_cutoff=fLow,
                                    high_frequency_cutoff=high_frequency_cutoff)
-    logging.info("mismatch: %.10f, for low_frequency_cutoff = %.1f and high_frequency_cutoff = %.1f" % \
-                 (mismatch, fLow, high_frequency_cutoff))
+    logging.info("mismatch: %.10f, for low_frequency_cutoff = %.1f and high_frequency_cutoff = %.1f", \
+                 mismatch, fLow, high_frequency_cutoff)
     return CompressedWaveform(amp_interp_points, phase_interp_points,
                               phase_freq_points, amp_freq_points,
                               interpolation=interpolation,
@@ -532,8 +533,10 @@ _real_dtypes = {
 def fd_decompress(amp, phase, sample_frequencies,
                   amp_sample_frequencies=None, out=None, df=None,
                   f_lower=None, interpolation='inline_linear'):
-    """Decompresses an FD waveform using the given amplitude, phase, and the
-    frequencies at which they are sampled at.
+    """Decompresses an FD waveform in frequency space.
+
+    The decompression of the waveform is done using the given amplitude,
+    phase, and the frequencies at which they are sampled at.
 
     Parameters
     ----------
@@ -541,13 +544,13 @@ def fd_decompress(amp, phase, sample_frequencies,
         The amplitude of the waveform at the sample frequencies.
     phase : array
         The phase of the waveform at the sample frequencies.
-    amp_sample_frequencies : array
-        This is set to None by default. But if specified, is used for
-        the frequency (in Hz) of the waveform for the amplitude.
     sample_frequencies : array
         This is used used for frequency (in Hz) of the waveform for both
         amplitude and phase. But if amp_sample_frequencies is specified,
         this is used only for frequency of the waveform for phase.
+    amp_sample_frequencies : array
+        This is set to None by default. But if specified, is used for
+        the frequency (in Hz) of the waveform for the amplitude.
     out : {None, FrequencySeries}
         The output array to save the decompressed waveform to. If this contains
         slots for frequencies > the maximum frequency in the interpolant
@@ -577,18 +580,18 @@ def fd_decompress(amp, phase, sample_frequencies,
     """
     precision = _precision_map[sample_frequencies.dtype.name]
     if amp_sample_frequencies is None:
-    	if _precision_map[amp.dtype.name] != precision or \
-    		_precision_map[phase.dtype.name] != precision:
+        if _precision_map[amp.dtype.name] != precision or \
+                _precision_map[phase.dtype.name] != precision:
             raise ValueError("amp, phase, and sample_frequencies must"
                             " all have the same precision")
         f_min = sample_frequencies.min()
         f_max = sample_frequencies.max()
 
     else:
-    	if _precision_map[amp.dtype.name] != precision or \
-       	     _precision_map[phase.dtype.name] != precision or \
+        if _precision_map[amp.dtype.name] != precision or \
+             _precision_map[phase.dtype.name] != precision or \
                 _precision_map[amp_sample_frequencies.dtype.name] != precision:
-    	    raise ValueError("amp, phase, amp_sample_frequencies, and"
+            raise ValueError("amp, phase, amp_sample_frequencies, and"
                              "sample_frequencies must all have the same"
                              "precision")
         f_min = max([amp_sample_frequencies.min(),sample_frequencies.min()])
@@ -609,9 +612,9 @@ def fd_decompress(amp, phase, sample_frequencies,
         hlen = len(out)
     if f_lower is None:
         imin = 0
-	f_lower = f_min
+        f_lower = f_min
     else:
-	if f_lower >= f_max:
+        if f_lower >= f_max:
             raise ValueError("f_lower is greater than the maximum "
                              "sample frequency of the interpolants")
     start_index = int(numpy.floor(f_lower/df))

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -680,9 +680,10 @@ class CompressedWaveform(object):
     Parameters
     ----------
     amplitude : {array, h5py.Dataset}
-        The amplitude of the waveform at the given `sample_points`.
+        The amplitude of the waveform at the `freq_points` or 
+        `amplitude_freq_points` depending on the case.
     phase : {array, h5py.Dataset}
-        The phase of the waveform at the given `sample_points`.
+        The phase of the waveform at the `freq_points`.
     freq_points : {array, h5py.Dataset}
         The frequency points at which the amplitude and phase of the
         compressed waveform is sampled if amplitude_freq_points is not
@@ -701,9 +702,9 @@ class CompressedWaveform(object):
         The actual mismatch between the decompressed waveform (using the
         given `interpolation`) and the full waveform.
     load_to_memory : {True, bool}
-        If `sample_points`, `amplitude`, and/or `phase` is an hdf dataset,
-        they will be cached in memory the first time they are accessed.
-        Default is True.
+        If `freq_points`, `amplitude_freq_points`, `amplitude`, and/or
+        `phase` is an hdf dataset, they will be cached in memory the
+        first time they are accessed. Default is True.
 
     Attributes
     ----------

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -394,11 +394,7 @@ def partial_rom_compression(htilde, mass1, mass2, chi1, chi2, deltaF, fLow,
 compression_algorithms = {
         'mchirp': mchirp_compression,
         'spa': spa_compression,
-        'partial_compress_rom:SEOBNRv2_ROM_DoubleSpin' : partial_rom_compression,
-        'spa:TaylorF2' : spa_compression,
-        'spa:SEOBNRv2_ROM_DoubleSpin' : spa_compression,
-        'mchirp:TaylorF2' : mchirp_compression,
-        'mchirp:SEOBNRv2_ROM_DoubleSpin' : mchirp_compression
+        'partial_compress_rom': partial_rom_compression,
         }
 
 _linear_decompress_code = r"""

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -263,7 +263,7 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
         comp_phase = phase.take(sample_index)
         # update the vecdiffs and mismatch
         hdecomp = fd_decompress(comp_amp, comp_phase, sample_points,
-                                out=decomp_scratch, df=outdf, 
+                                out=decomp_scratch, df=outdf,
                                 f_lower=fmin, interpolation=interpolation)
         new_vecdiffs = numpy.zeros(vecdiffs.size+1)
         new_vecdiffs[:minpt] = vecdiffs[:minpt]
@@ -509,9 +509,9 @@ def fd_decompress(amp, phase, sample_frequencies,
         This is set to None by default. But if specified, is used for
         the frequency (in Hz) of the waveform for the amplitude.
     sample_frequencies : array
-        This is used used for frequency (in Hz) of the waveform for both 
+        This is used used for frequency (in Hz) of the waveform for both
         amplitude and phase. But if amp_sample_frequencies is specified,
-        this is used only for frequency of the waveform for phase. 
+        this is used only for frequency of the waveform for phase.
     out : {None, FrequencySeries}
         The output array to save the decompressed waveform to. If this contains
         slots for frequencies > the maximum frequency in the interpolant
@@ -598,7 +598,7 @@ def fd_decompress(amp, phase, sample_frequencies,
         inline(code, ['h', 'hlen', 'sflen', 'delta_f', 'sample_frequencies',
                       'amp', 'phase', 'start_index', 'imin'],
                extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] +\
-               omp_flags, libraries=omp_libs) 
+               omp_flags, libraries=omp_libs)
     else:
         if amp_sample_frequencies == None:
                 amp_sample_frequencies = sample_frequencies

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -317,7 +317,6 @@ def partial_compress_rom(htilde, mass1, mass2, chi1, chi2, deltaF, fLow,
     CompressedWaveform
         The compressed waveform data; see `CompressedWaveform` for details.
     """
-
     # Orbital phase at reference frequency
     phiRef = 0
     # Reference frequency
@@ -378,9 +377,8 @@ def partial_compress_rom(htilde, mass1, mass2, chi1, chi2, deltaF, fLow,
     mismatch = 1. - filter.overlap(abs(hdecomp), abs(htilde),
                                    low_frequency_cutoff=fLow,
                                    high_frequency_cutoff=high_frequency_cutoff)
-    logging.info("mismatch: %.10f, for low_frequency_cutoff = %.1f and
-                 high_frequency_cutoff = %.1f"%(mismatch, fLow,
-                 high_frequency_cutoff))
+    logging.info("mismatch: %.10f, for low_frequency_cutoff = %.1f and high_frequency_cutoff = %.1f" % \
+                 (mismatch, fLow, high_frequency_cutoff))
     return CompressedWaveform(amp_interp_points, phase_interp_points,
                               phase_freq_points, amp_freq_points,
                               interpolation=interpolation,


### PR DESCRIPTION
* @cdcapano @duncan-brown I've added the new algorithm  ```partial_compress_rom``` for doing the parameter space interpolation in the SEOBNRv2_ROM LAL code and importing the amplitude and phase interpolants from there. The function will then call ```fd_decompress``` to do the frequency space interpolation. This function would require a modification in the LAL code too so that it allows an access to the amplitude and frequency interpolants directly. See https://bugs.ligo.org/redmine/issues/4825 . 

* I've added a new command line argument in ```pycbc_compress_bank``` called ```--ROM-parameter-space-interpolation``` which would which would take in options ```linear_compression``` or ```partial_ROM_compression``` to decide the process of ROM compression.

* I've added modifications in ```compress.py``` so that it supports handling and storing two separate set of frequency points for amplitude and phase when doing the new partial ROM compression and deals with one set of frequency points for the spa compression. This takes into consideration the changes requested in https://github.com/ligo-cbc/pycbc/pull/1185 .

@cdcapano could you please take a look at this?

