### PR TITLE
Use TD waveforms in inference

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -242,11 +242,12 @@ with ctx:
     generator_function = select_waveform_generator(static_args["approximant"])
 
     # construct class that will generate waveforms
-    generator = waveform.FDomainDetFrameGenerator(generator_function,
-                        epoch=stilde_dict.values()[0].epoch,
-                        variable_args=variable_args,
-                        detectors=opts.instruments,
-                        delta_f=delta_f_dict.values()[0], **static_args)
+    generator = waveform.FDomainDetFrameGenerator(
+                       generator_function, epoch=stilde_dict.values()[0].epoch,
+                       variable_args=variable_args, detectors=opts.instruments,
+                       delta_f=delta_f_dict.values()[0],
+                       delta_t=strain_dict.values()[0].delta_t,
+                       **static_args)
 
     # construct class that will return the natural logarithm of likelihood
     likelihood = inference.likelihood_evaluators[opts.likelihood_evaluator](

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -29,6 +29,7 @@ import functools
 import waveform
 import ringdown
 from pycbc import coordinates
+from pycbc import filter
 from pycbc.waveform import parameters
 from pycbc.waveform.utils import apply_fd_time_shift
 from pycbc.detector import Detector
@@ -525,6 +526,8 @@ class FDomainDetFrameGenerator(object):
         rfparams = dict([(param, self.current_params[param])
             for param in self.rframe_generator.variable_args])
         hp, hc = self.rframe_generator.generate_from_kwargs(**rfparams)
+        hp = filter.make_frequency_series(hp)
+        hc = filter.make_frequency_series(hc)
         hp._epoch = hc._epoch = self._epoch
         h = {}
         if 'tc' in self.current_params:


### PR DESCRIPTION
With a couple changes its possible to use TD waveforms in ``pycbc_inference``. Basically pass the ``delta_t`` option to the generator and then FFT after generation. If a FD waveform is used, then ``make_frequency_series`` waveform just returns the input.