### PR TITLE
geom_aligned_bank: fix syntax error from #1144

### DIFF
--- a/bin/pycbc_geom_aligned_bank
+++ b/bin/pycbc_geom_aligned_bank
@@ -507,25 +507,25 @@ if opts.threed_lattice:
 if opts.random_seed:
     cp.set('aligned2dstack', 'random-seed', str(opts.random_seed))
 cp.add_section('pegasus_profile-aligned2dstack')
-cp.set('pegasus_profile-aligned2dstack', 'condor|request_memory=3000')
+cp.set('pegasus_profile-aligned2dstack', 'condor|request_memory', '3000')
 
 # alignedcat
 cp.add_section('alignedbankcat')
 if opts.f_low_column is not None:
     cp.set('alignedbankcat', 'f-low-column', opts.f_low_column)
 cp.add_section('pegasus_profile-alignedbankcat')
-cp.set('pegasus_profile-alignedbankcat', 'condor|request_memory=3000')
+cp.set('pegasus_profile-alignedbankcat', 'condor|request_memory', '3000')
 
 # dumptochis
 cp.add_section('dumptochis')
 cp.add_section('pegasus_profile-dumptochis')
-cp.set('pegasus_profile-dumptochis', 'condor|request_memory=3000')
+cp.set('pegasus_profile-dumptochis', 'condor|request_memory', '3000')
 
 # bank verification
 cp.add_section('bankverify')
 cp.set('bankverify', 'bin-spacing', str(1 - opts.min_match))
 cp.add_section('pegasus_profile-bankverify')
-cp.set('pegasus_profile-bankverify', 'condor|request_memory=3000')
+cp.set('pegasus_profile-bankverify', 'condor|request_memory', '3000')
 
 temp_fp = open('temp.ini', 'w')
 cp.write(temp_fp)


### PR DESCRIPTION
Current code leads to Condor errors:
```
[...]
11/10/16 17:23:27 From submit:
11/10/16 17:23:27 From submit: ERROR: Parse error in expression:
11/10/16 17:23:27 From submit:  RequestMemory = 3000 = None
11/10/16 17:23:27 From submit:  ^^^
11/10/16 17:23:27 From submit: Error in submit file file
11/10/16 17:23:27 From submit: Failed to parse the job ClassAd. This may reflect a problem with your submit file syntax.
[...]
```