### PR TITLE
Added code to determine optimal orientation for a detector at a given GPS time

### DIFF
--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -40,6 +40,8 @@ class Detector(object):
         self.frDetector =  lalsimulation.DetectorPrefixToLALDetector(self.name)
         self.response = self.frDetector.response
         self.location = self.frDetector.location
+        self.latitude = self.frDetector.vertexLatitudeRadians
+        self.longitude = self.frDetector.vertexLongitudeRadians
 
     def light_travel_time_to_detector(self, det):
         """ Return the light travel time from this detector
@@ -80,6 +82,13 @@ class Detector(object):
                 h_lal.data.data, delta_t=h_lal.deltaT, epoch=h_lal.epoch,
                 dtype=np.float64, copy=False)
 
+    def optimal_orientation(self, t_gps):
+        """Return the optimal orientation in right ascension and declination 
+           for a given GPS time.
+        """
+        ra = self.longitude + (lal.GreenwichMeanSiderealTime(t_gps) % (2*np.pi))
+        dec = self.latitude
+        return ra, dec
 
 def overhead_antenna_pattern(right_ascension, declination, polarization):
     """Return the detector response where (0, 0) indicates an overhead source. 

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -40,8 +40,8 @@ class Detector(object):
         self.frDetector =  lalsimulation.DetectorPrefixToLALDetector(self.name)
         self.response = self.frDetector.response
         self.location = self.frDetector.location
-        self.latitude = self.frDetector.vertexLatitudeRadians
-        self.longitude = self.frDetector.vertexLongitudeRadians
+        self.latitude = self.frDetector.frDetector.vertexLatitudeRadians
+        self.longitude = self.frDetector.frDetector.vertexLongitudeRadians
 
     def light_travel_time_to_detector(self, det):
         """ Return the light travel time from this detector

--- a/pycbc/detector.py
+++ b/pycbc/detector.py
@@ -83,7 +83,7 @@ class Detector(object):
                 dtype=np.float64, copy=False)
 
     def optimal_orientation(self, t_gps):
-        """Return the optimal orientation in right ascension and declination 
+        """Return the optimal orientation in right ascension and declination
            for a given GPS time.
         """
         ra = self.longitude + (lal.GreenwichMeanSiderealTime(t_gps) % (2*np.pi))


### PR DESCRIPTION
This piggybacks off of the current usage of the lal detector class to get the latitude and longitude of each detector. The optimal orientation is computed by adjusting the longitude based on the Greenwich Mean Sidereal Time. This can be verified using the `time_delay_to_earth_center` function. At optimal orientation, a signal should reach a detector on the surface of the Earth 21 ms before it reaches the center of the Earth.

Example usage and output:
```
In [1]: import pycbc.detector as det
In [2]: llo = det.Detector('L1')

In [3]: llo.latitude
Out[3]: 0.53342313506

In [4]: llo.longitude
Out[4]: -1.58430937078

In [5]: ra, dec = llo.optimal_orientation(1162598417)

In [6]: llo.time_delay_from_earth_center(ra,dec,1162598417)
Out[6]: -0.021256732778422018
```