### PR TITLE
Default to N chisq bins in case of NaN

### DIFF
--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -17,7 +17,7 @@
 """ Calculate the SNR and CHISQ timeseries for either a chosen template, or 
 a specific Nth loudest coincident event.
 """
-import sys, logging, argparse, numpy, itertools, pycbc, h5py, warnings
+import sys, logging, argparse, numpy, itertools, pycbc, h5py
 from pycbc import vetoes, psd, waveform, version, strain, scheme, fft, filter
 from pycbc.io import WaveformArray
 from pycbc import events
@@ -300,11 +300,11 @@ with ctx:
         chisq_bins = int(vetoes.SingleDetPowerChisq.parse_option(parse_row,
             opt.chisq_bins))
     except ValueError:
-        if ops.default_chisq_bins:
+        if opt.default_chisq_bins:
             chisq_bins = ops.default_chisq_bins
-            warnings.warn(
+            logging.warning(
                 "Unable to compute chisq bins: defaulting to %d bins" % 
-                chisq_bins, RuntimeWarning)
+                chisq_bins )
         else:
             raise ValueError("invalid number of chisq bins")
 

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -299,11 +299,13 @@ with ctx:
     try:
         chisq_bins = int(vetoes.SingleDetPowerChisq.parse_option(parse_row,
             opt.chisq_bins))
+        if chisq_bins < 2:
+            raise ValueError
     except ValueError:
         if opt.default_chisq_bins:
             chisq_bins = ops.default_chisq_bins
             logging.warning(
-                "Unable to compute chisq bins: defaulting to %d bins" % 
+                "Number of chisq bins is less than 2 or NaN: defaulting to %d bins" % 
                 chisq_bins )
         else:
             raise ValueError("invalid number of chisq bins")

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -17,7 +17,7 @@
 """ Calculate the SNR and CHISQ timeseries for either a chosen template, or 
 a specific Nth loudest coincident event.
 """
-import sys, logging, argparse, numpy, itertools, pycbc, h5py
+import sys, logging, argparse, numpy, itertools, pycbc, h5py, warnings
 from pycbc import vetoes, psd, waveform, version, strain, scheme, fft, filter
 from pycbc.io import WaveformArray
 from pycbc import events
@@ -293,8 +293,15 @@ with ctx:
     parse_row.params = t()
     for param in row.fieldnames:
         setattr(parse_row.params, param, row[param][0])
-    chisq_bins = int(vetoes.SingleDetPowerChisq.parse_option(parse_row,
-                                                               opt.chisq_bins))
+
+    try:
+        chisq_bins = int(vetoes.SingleDetPowerChisq.parse_option(parse_row,
+           opt.chisq_bins))
+    except ValueError:
+        warnings.warn(
+            "Unable to compute chisq bins: defaulting to three bins",
+            RuntimeWarning )
+        chisq_bins = 3
 
     f['template'] = template.numpy()                  
     snrs, chisqs = [], []  

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -300,9 +300,12 @@ with ctx:
         opt.chisq_bins)
     if chisq_bins_float.isnan() or (int(chisq_bins_float) < 
                                     opt.minimum_chisq_bins): 
-        chisq_bins = opt.minimum_chisq_bins
-        logging.warning( "Number of chisq bins is less than minimum or is NaN."
-                         + (" Using %d bins." % opt.minimum_chisq_bins) )
+        if opt.minimum_chisq_bins:
+            chisq_bins = opt.minimum_chisq_bins
+            logging.warning( "Number of chisq bins is less than minimum or is NaN."
+                            + (" Using %d bins." % opt.minimum_chisq_bins) )
+        else:
+            raise ValueError("Chisq bins is NaN and no default minimum set.")
     else:
         chisq_bins = int(chisq_bins_float)
 

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -94,6 +94,8 @@ parser.add_argument("--low-frequency-cutoff", type=float,
                   help="The low frequency cutoff to use for filtering (Hz)")
 parser.add_argument("--chisq-bins", default="0", type=str, help=
                     "Number of frequency bins to use for power chisq.")
+parser.add_argument("--default-chisq-bins", default="0", type=int, help=
+                    "If the chisq bin formula fails, default to this number.")
 parser.add_argument("--trigger-time", type=float, default=0,
                   help="The central time of the trigger to use.")
 parser.add_argument("--use-params-of-closest-injection", action="store_true",
@@ -296,12 +298,15 @@ with ctx:
 
     try:
         chisq_bins = int(vetoes.SingleDetPowerChisq.parse_option(parse_row,
-           opt.chisq_bins))
+            opt.chisq_bins))
     except ValueError:
-        warnings.warn(
-            "Unable to compute chisq bins: defaulting to three bins",
-            RuntimeWarning )
-        chisq_bins = 3
+        if ops.default_chisq_bins:
+            chisq_bins = ops.default_chisq_bins
+            warnings.warn(
+                "Unable to compute chisq bins: defaulting to %d bins" % 
+                chisq_bins, RuntimeWarning)
+        else:
+            raise ValueError("invalid number of chisq bins")
 
     f['template'] = template.numpy()                  
     snrs, chisqs = [], []  

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -305,7 +305,8 @@ with ctx:
             logging.warning( "Number of chisq bins is less than minimum or is NaN."
                             + (" Using %d bins." % opt.minimum_chisq_bins) )
         else:
-            raise ValueError("Chisq bins is NaN and no default minimum set.")
+            raise ValueError(
+                "Chisq bins is NaN or negative and no minimum is set.")
     else:
         chisq_bins = int(chisq_bins_float)
 

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -94,7 +94,7 @@ parser.add_argument("--low-frequency-cutoff", type=float,
                   help="The low frequency cutoff to use for filtering (Hz)")
 parser.add_argument("--chisq-bins", default="0", type=str, help=
                     "Number of frequency bins to use for power chisq.")
-parser.add_argument("--default-chisq-bins", default="0", type=int, help=
+parser.add_argument("--minimum-chisq-bins", default=0, type=int, help=
                     "If the chisq bin formula fails, default to this number.")
 parser.add_argument("--trigger-time", type=float, default=0,
                   help="The central time of the trigger to use.")
@@ -296,19 +296,15 @@ with ctx:
     for param in row.fieldnames:
         setattr(parse_row.params, param, row[param][0])
 
-    try:
-        chisq_bins = int(vetoes.SingleDetPowerChisq.parse_option(parse_row,
-            opt.chisq_bins))
-        if chisq_bins < 2:
-            raise ValueError
-    except ValueError:
-        if opt.default_chisq_bins:
-            chisq_bins = ops.default_chisq_bins
-            logging.warning(
-                "Number of chisq bins is less than 2 or NaN: defaulting to %d bins" % 
-                chisq_bins )
-        else:
-            raise ValueError("invalid number of chisq bins")
+    chisq_bins_float = vetoes.SingleDetPowerChisq.parse_option(parse_row,
+        opt.chisq_bins)
+    if chisq_bins_float.isnan() or (int(chisq_bins_float) < 
+                                    opt.minimum_chisq_bins): 
+        chisq_bins = opt.minimum_chisq_bins
+        logging.warning( "Number of chisq bins is less than minimum or is NaN."
+                         + (" Using %d bins." % opt.minimum_chisq_bins) )
+    else:
+        chisq_bins = int(chisq_bins_float)
 
     f['template'] = template.numpy()                  
     snrs, chisqs = [], []  


### PR DESCRIPTION
This fixes https://github.com/ligo-cbc/pycbc/issues/1214 including @tdent's suggestion of having a default in the command line.

This only affects ``pycbc_single_template`` as this should raise a ``ValueError`` in e.g. ``pycbc_inspiral``.

I set this to 10 in the ER10 ini file based on @titodalcanton's suggestion

https://code.pycbc.phy.syr.edu/ligo-cbc/pycbc-config/commit/d46087faa2713ad6ac4ae2a280e3c824569e16bf