### PR TITLE
Make output of Gaussian.rvs a record array.

### DIFF
--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -984,7 +984,6 @@ class Gaussian(_BoundedDist):
             corresponding to the given parameter. Otherwise, the array will
             have an element for each parameter in self's params.
         """
-
         # make record array
         if param is not None:
             dtype = [(param, float)]

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -994,7 +994,7 @@ class Gaussian(_BoundedDist):
 
         # draw samples
         params = [param] if param is not None else self._params
-        for i,param in enumerate(params):
+        for param in params:
             sigma = numpy.sqrt(self._var[param])
             vals[param] = scipy.stats.truncnorm.rvs(
                               (self._bounds[param][0]-self._mean[param])/sigma,

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -966,7 +966,7 @@ class Gaussian(_BoundedDist):
     __call__ = logpdf
 
     def rvs(self, size=1, param=None):
-        """Gives a set of random values drawn from this distribution.
+        """ Gives a set of random values drawn from this distribution.
 
         Parameters
         ----------

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -984,14 +984,23 @@ class Gaussian(_BoundedDist):
             corresponding to the given parameter. Otherwise, the array will
             have an element for each parameter in self's params.
         """
+
+        # make record array
+        if param is not None:
+            dtype = [(param, float)]
+        else:
+            dtype = [(p, float) for p in self.params]
+        vals = numpy.zeros(size, dtype=dtype)
+
+        # draw samples
         params = [param] if param is not None else self._params
-        vals = numpy.zeros(shape=(size,len(params)))
         for i,param in enumerate(params):
             sigma = numpy.sqrt(self._var[param])
-            vals[:,i] = scipy.stats.truncnorm.rvs(
+            vals[param] = scipy.stats.truncnorm.rvs(
                               (self._bounds[param][0]-self._mean[param])/sigma,
                               (self._bounds[param][1]-self._mean[param])/sigma,
                               loc=self._mean[param], scale=sigma, size=size)
+
         return vals
 
     @classmethod


### PR DESCRIPTION
This addresses Steven's comment in #1168 about the output of ``Guassian.rvs`` and ``Uniform.rvs`` matching. It is now a record array.

Eg.:
```
In [1]: from pycbc.inference import distributions

In [3]: d = distributions.Gaussian(mass2=(0.5, 1.5, 1.2, 0.15*0.15))

In [4]: vals = d.rvs(2)

In [7]: vals["mass2"]
Out[7]: array([ 1.26055343,  1.36612598])
```