### PR TITLE
Documentation correction for pycbc_make_inference_workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ To download and install PyCBC follow the instructions at
 [![PyPI version](https://badge.fury.io/py/pycbc.svg)](http://badge.fury.io/py/pycbc)
 [![Build Status](https://travis-ci.org/ligo-cbc/pycbc.svg?branch=master)](https://travis-ci.org/ligo-cbc/pycbc)
 [![Code Health](https://landscape.io/github/ligo-cbc/pycbc/master/landscape.svg?style=flat)](https://landscape.io/github/ligo-cbc/pycbc/master)
+
+
+TESTING!
+this change has been made to test git communicaiont (161021:6:00p)

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ To download and install PyCBC follow the instructions at
 
 
 TESTING!
-this change has been made to test git communicaiont (161021:6:00p)
+this change has been made to test git communication (161021:6:00p)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,3 @@ To download and install PyCBC follow the instructions at
 [![Build Status](https://travis-ci.org/ligo-cbc/pycbc.svg?branch=master)](https://travis-ci.org/ligo-cbc/pycbc)
 [![Code Health](https://landscape.io/github/ligo-cbc/pycbc/master/landscape.svg?style=flat)](https://landscape.io/github/ligo-cbc/pycbc/master)
 
-
-TESTING!
-this change has been made to test git communication (161021:6:00p)

--- a/README.md
+++ b/README.md
@@ -17,4 +17,3 @@ To download and install PyCBC follow the instructions at
 [![PyPI version](https://badge.fury.io/py/pycbc.svg)](http://badge.fury.io/py/pycbc)
 [![Build Status](https://travis-ci.org/ligo-cbc/pycbc.svg?branch=master)](https://travis-ci.org/ligo-cbc/pycbc)
 [![Code Health](https://landscape.io/github/ligo-cbc/pycbc/master/landscape.svg?style=flat)](https://landscape.io/github/ligo-cbc/pycbc/master)
-

--- a/docs/workflow/pycbc_make_inference_workflow.rst
+++ b/docs/workflow/pycbc_make_inference_workflow.rst
@@ -171,7 +171,7 @@ You will also need a configuration file with sections that tells ``pycbc_inferen
 
 A simple configuration file for parameter estimation on the ringdown is::
 
-    [variable-args]
+    [variable_args]
     ; parameters to vary in inference sampler
     tc =
     f_0 =
@@ -284,6 +284,8 @@ Else you can run from a specific GPS end time with the ``--gps-end-time`` option
                            inference:psd-end-time:$((${GPS_END_TIME}+1748))
 
 Where ``${GPS_END_TIME}`` is the GPS end time of the trigger.
+
+For the CBC example above add the environment variable ``GPS_END_TIME=1126259462`` and include ``--output-map output.map`` as an argument for ``pycbc_make_inference_workflow``. 
 
 =============================
 Plan and execute the workflow

--- a/docs/workflow/pycbc_make_inference_workflow.rst
+++ b/docs/workflow/pycbc_make_inference_workflow.rst
@@ -139,8 +139,8 @@ You will also need a configuration file with sections that tells ``pycbc_inferen
     [prior-mass2]
     ; how to construct prior distribution
     name = uniform
-    min-mass1 = 10.
-    max-mass1 = 80.
+    min-mass2 = 10.
+    max-mass2 = 80.
 
     [prior-distance]
     ; how to construct prior distribution

--- a/docs/workflow/pycbc_make_inference_workflow.rst
+++ b/docs/workflow/pycbc_make_inference_workflow.rst
@@ -285,7 +285,7 @@ Else you can run from a specific GPS end time with the ``--gps-end-time`` option
 
 Where ``${GPS_END_TIME}`` is the GPS end time of the trigger.
 
-For the CBC example above add the environment variable ``GPS_END_TIME=1126259462`` and include ``--output-map output.map`` as an argument for ``pycbc_make_inference_workflow``. 
+For the CBC example above define the environment variables ``GPS_END_TIME=1126259462`` and ``OUTPUT_MAP_PATH=output.map``. 
 
 =============================
 Plan and execute the workflow


### PR DESCRIPTION
Example Inference file now references mass2 in the [prior-mass2] section instead of mass1.