### PR TITLE
Add the root workflow name to the sub-workflows

### DIFF
--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -56,8 +56,8 @@ args = parser.parse_args()
 wf.makedir(args.output_dir)
 
 container = wf.Workflow(args, args.workflow_name)
-workflow = wf.Workflow(args, 'main')
-finalize_workflow = wf.Workflow(args, 'finalization')
+workflow = wf.Workflow(args, args.workflow_name + '-main')
+finalize_workflow = wf.Workflow(args, args.workflow_name + '-finalization')
 
 os.chdir(args.output_dir)
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -119,7 +119,7 @@ If you are running on a Scientific Linux 6 cluster, you need to install the HDF5
 
     mkdir -p $VIRTUAL_ENV/src
     cd $VIRTUAL_ENV/src
-    pip install nose>=1.0.0
+    pip install "nose>=1.0.0"
     curl https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.12/src/hdf5-1.8.12.tar.gz > hdf5-1.8.12.tar.gz
     tar -zxvf hdf5-1.8.12.tar.gz
     cd hdf5-1.8.12


### PR DESCRIPTION
The subworkflows are always called ``main`` and ``finalization``, which can get confusing if you have a lot of dashboard tabs open showing different main workflows. This patch adds the name of the parent workflow to the sub-workflows for easier debugging.

@stevereyes01 please can you test this patch and merge if it works for you as well?