### PR TITLE
Add the root workflow name to the sub-workflows

### DIFF
--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -56,8 +56,8 @@ args = parser.parse_args()
 wf.makedir(args.output_dir)
 
 container = wf.Workflow(args, args.workflow_name)
-workflow = wf.Workflow(args, 'main')
-finalize_workflow = wf.Workflow(args, 'finalization')
+workflow = wf.Workflow(args, args.workflow_name + '-main')
+finalize_workflow = wf.Workflow(args, args.workflow_name + '-finalization')
 
 os.chdir(args.output_dir)
 

--- a/bin/workflows/pycbc_make_psd_estimation_workflow
+++ b/bin/workflows/pycbc_make_psd_estimation_workflow
@@ -43,8 +43,8 @@ logging.basicConfig(format='%(asctime)s:%(levelname)s : %(message)s',
                     level=logging.INFO)
 
 container = pycbc.workflow.Workflow(args, args.workflow_name)
-workflow = pycbc.workflow.Workflow(args, 'main')
-finalize_workflow = pycbc.workflow.Workflow(args, 'finalization')
+workflow = pycbc.workflow.Workflow(args, args.workflow_name + '-main')
+finalize_workflow = pycbc.workflow.Workflow(args, args.workflow_name + '-finalization')
 
 pycbc.workflow.makedir(args.output_dir)
 os.chdir(args.output_dir)


### PR DESCRIPTION
The subworkflows are always called ``main`` and ``finalization``, which can get confusing if you have a lot of dashboard tabs open showing different main workflows. This patch adds the name of the parent workflow to the sub-workflows for easier debugging.

@stevereyes01 please can you test this patch and merge if it works for you as well?