### PR TITLE
Encode html and parse append-site-profile properly

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -129,11 +129,23 @@ while true ; do
     -k|--append-site-profile)
       case "$2" in
         "") shift 2 ;;
-        *) APPEND_SITE_PROFILE_ARRAY=(${2//:/ })
+        *) OIFS=${IFS}; IFS=":"
+          APPEND_SITE_PROFILE_ARRAY=`perl -e 'use HTML::Entities; print encode_entities(decode_entities(<STDIN>), "\'\"'\'\''<>()&+" );'` <<< "${2}"
+           read -ra APPEND_SITE_PROFILE_ARRAY <<< "${APPEND_SITE_PROFILE_ARRAY}"
+           IFS=${OIFS}
            APPEND_SITE=${APPEND_SITE_PROFILE_ARRAY[0]}
            APPEND_SITE_NS_KEY=(${APPEND_SITE_PROFILE_ARRAY[1]//\|/ })
-           APPEND_SITE_VALUE=${APPEND_SITE_PROFILE_ARRAY[2]}
-           echo "    <profile namespace=\"${APPEND_SITE_NS_KEY[0]}\" key=\"${APPEND_SITE_NS_KEY[1]}\">${APPEND_SITE_VALUE}</profile>" >> ${APPEND_SITE}-extra-site-properties.xml
+           APPEND_SITE_VALUE=("${APPEND_SITE_PROFILE_ARRAY[@]:2}")
+           /bin/echo -n "    <profile namespace=\"${APPEND_SITE_NS_KEY[0]}\" key=\"${APPEND_SITE_NS_KEY[1]}\">" >> ${APPEND_SITE}-extra-site-properties.xml
+           need_colon=0
+           for i in in "${APPEND_SITE_VALUE[@]}" ; do
+               if [ ${need_colon} -eq 1 ] ; then
+                   /bin/echo -n ":" >> ${APPEND_SITE}-extra-site-properties.xml
+               fi
+               /bin/echo -n "${i}" >> ${APPEND_SITE}-extra-site-properties.xml
+               need_colon=1
+           done
+           echo "</profile>" >> ${APPEND_SITE}-extra-site-properties.xml
         shift 2 ;;
       esac ;;
     -t|--transformation-catalog)
@@ -553,6 +565,7 @@ if [ -e ${DASHBOARD_PATH} ] ; then
     cp ${DASHBOARD_PATH} ${DASHBOARD_COPY}
   fi
 
+  COMMAND_LINE=`perl -e 'use HTML::Entities; print encode_entities(decode_entities(<STDIN>), "\'\"'\'\''<>()&+" );' <<< ${COMMAND_LINE}`
   perl -pi.bak -e "s+PYCBC_SUBMIT_DAX_ARGV+${COMMAND_LINE}+g" ${DASHBOARD_PATH}
   perl -pi.bak -e "s+PEGASUS_DASHBOARD_URL+${DASHBOARD_URL}+g" ${DASHBOARD_PATH}
 fi

--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -v
 # Redirect stdout ( > ) into a named pipe ( >() ) running "tee"
 set -e
 
@@ -129,8 +129,9 @@ while true ; do
     -k|--append-site-profile)
       case "$2" in
         "") shift 2 ;;
-        *) OIFS=${IFS}; IFS=":"
-          APPEND_SITE_PROFILE_ARRAY=`perl -e 'use HTML::Entities; print encode_entities(decode_entities(<STDIN>), "\'\"'\'\''<>()&+" );'` <<< "${2}"
+        *) SITE_PROFILE=${2}
+           APPEND_SITE_PROFILE_ARRAY=`perl -e 'use HTML::Entities; print encode_entities(decode_entities(<STDIN>), "\'\"'\'\''<>()&+" );' <<< ${SITE_PROFILE}`
+           OIFS=${IFS}; IFS=":"
            read -ra APPEND_SITE_PROFILE_ARRAY <<< "${APPEND_SITE_PROFILE_ARRAY}"
            IFS=${OIFS}
            APPEND_SITE=${APPEND_SITE_PROFILE_ARRAY[0]}
@@ -138,7 +139,7 @@ while true ; do
            APPEND_SITE_VALUE=("${APPEND_SITE_PROFILE_ARRAY[@]:2}")
            /bin/echo -n "    <profile namespace=\"${APPEND_SITE_NS_KEY[0]}\" key=\"${APPEND_SITE_NS_KEY[1]}\">" >> ${APPEND_SITE}-extra-site-properties.xml
            need_colon=0
-           for i in in "${APPEND_SITE_VALUE[@]}" ; do
+           for i in "${APPEND_SITE_VALUE[@]}" ; do
                if [ ${need_colon} -eq 1 ] ; then
                    /bin/echo -n ":" >> ${APPEND_SITE}-extra-site-properties.xml
                fi
@@ -146,7 +147,7 @@ while true ; do
                need_colon=1
            done
            echo "</profile>" >> ${APPEND_SITE}-extra-site-properties.xml
-        shift 2 ;;
+           shift 2 ;;
       esac ;;
     -t|--transformation-catalog)
       case "$2" in

--- a/pycbc/workflow/pegasus_files/osg-site-template.xml
+++ b/pycbc/workflow/pegasus_files/osg-site-template.xml
@@ -18,3 +18,5 @@
     <profile namespace="env" key="NO_TMPDIR">1</profile>
     <profile namespace="env" key="LAL_DATA_PATH">/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/8/share/lalsimulation</profile>
     <profile namespace="env" key="PEGASUS_HOME" >/usr</profile>
+    <profile namespace="env" key="PATH">/usr/local/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/sbin</profile>
+


### PR DESCRIPTION
This encodes HTML special characters in the command line properly and also allows correct parsing of the ``--append-site-profile`` argument.