### PR TITLE
Add ability to use frequency cutoff function

### DIFF
--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -541,6 +541,10 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
             # the kmax of the waveforms may be different than internal kmax
             kmax = min(len(h), self._kmax)
             # whiten the waveform
+            if self._kmin >= kmax:
+                # if the waveform terminates before the filtering low frequency
+                # cutoff, there is nothing to filter, so just go onto the next
+                continue
             h[self._kmin:kmax] *= self._weight[det][self._kmin:kmax]
             lr += (
                 # <h, d>

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -27,6 +27,7 @@ for parameter estimation.
 """
 
 from pycbc import filter
+from pycbc.waveform import NoWaveformError
 from pycbc.types import Array
 import numpy
 
@@ -530,13 +531,15 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
         float
             The value of the log likelihood ratio evaluated at the given point.
         """
-        lr = 0
-        for det,h in self._waveform_generator.generate(*params).items():
+        lr = 0.
+        try:
+            wfs = self._waveform_generator.generate(*params)
+        except NoWaveformError:
+            # if no waveform was generated, just return 0
+            return lr
+        for det,h in wfs.items():
             # the kmax of the waveforms may be different than internal kmax
             kmax = min(len(h), self._kmax)
-            if kmax <= self._kmin:
-                kmax = self._kmin + 2
-                h.resize(kmax)
             # whiten the waveform
             h[self._kmin:kmax] *= self._weight[det][self._kmin:kmax]
             lr += (

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -534,6 +534,9 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
         for det,h in self._waveform_generator.generate(*params).items():
             # the kmax of the waveforms may be different than internal kmax
             kmax = min(len(h), self._kmax)
+            if kmax <= self._kmin:
+                kmax = self._kmin + 2
+                h.resize(kmax)
             # whiten the waveform
             h[self._kmin:kmax] *= self._weight[det][self._kmin:kmax]
             lr += (

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -444,46 +444,46 @@ def get_final_freq(approx, m1, m2, s1z, s2z):
     return _vec_get_final_freq(lalsim_approx, m1, m2, s1z, s2z)
 
 # Dictionary of functions with uniform API taking a 
-# parameter dict indexed on m1, m2, s1z, s2z
+# parameter dict indexed on mass1, mass2, spin1z, spin2z
 named_frequency_cutoffs = {
     # functions depending on the total mass alone
-    "SchwarzISCO": lambda p: f_SchwarzISCO(p["m1"]+p["m2"]),
-    "LightRing"  : lambda p: f_LightRing(p["m1"]+p["m2"]),
-    "ERD"        : lambda p: f_ERD(p["m1"]+p["m2"]),
+    "SchwarzISCO": lambda p: f_SchwarzISCO(p["mass1"]+p["mass2"]),
+    "LightRing"  : lambda p: f_LightRing(p["mass1"]+p["mass2"]),
+    "ERD"        : lambda p: f_ERD(p["mass1"]+p["mass2"]),
     # functions depending on the 2 component masses
-    "BKLISCO"    : lambda p: f_BKLISCO(p["m1"], p["m2"]),
-    "FRD"        : lambda p: f_FRD(p["m1"], p["m2"]),
-    "LRD"        : lambda p: f_LRD(p["m1"], p["m2"]),
+    "BKLISCO"    : lambda p: f_BKLISCO(p["mass1"], p["mass2"]),
+    "FRD"        : lambda p: f_FRD(p["mass1"], p["mass2"]),
+    "LRD"        : lambda p: f_LRD(p["mass1"], p["mass2"]),
     # functions depending on 2 component masses and aligned spins
-    "MECO"       : lambda p: meco_frequency(p["m1"], p["m2"],
-                                              p["s1z"], p["s2z"]),
-    "HybridMECO" : lambda p: hybrid_meco_frequency(p["m1"], p["m2"],
-                                p["s1z"], p["s2z"], qm1=None, qm2=None),
+    "MECO"       : lambda p: meco_frequency(p["mass1"], p["mass2"],
+                                              p["spin1z"], p["spin2z"]),
+    "HybridMECO" : lambda p: hybrid_meco_frequency(
+        p["mass1"], p["mass2"], p["spin1z"], p["spin2z"], qm1=None, qm2=None),
     "IMRPhenomBFinal": lambda p: get_freq("fIMRPhenomBFinal",
-                                              p["m1"], p["m2"],
-                                              p["s1z"], p["s2z"]),
+                                              p["mass1"], p["mass2"],
+                                              p["spin1z"], p["spin2z"]),
     "IMRPhenomCFinal": lambda p: get_freq("fIMRPhenomCFinal",
-                                              p["m1"], p["m2"],
-                                              p["s1z"], p["s2z"]),
+                                              p["mass1"], p["mass2"],
+                                              p["spin1z"], p["spin2z"]),
     "IMRPhenomDPeak": lambda p: get_freq("fIMRPhenomDPeak",
-                                              p["m1"], p["m2"],
-                                              p["s1z"], p["s2z"]),
-    "EOBNRv2RD"   : lambda p: get_freq("fEOBNRv2RD", p["m1"], p["m2"],
-                                              p["s1z"], p["s2z"]),
-    "EOBNRv2HMRD" : lambda p: get_freq("fEOBNRv2HMRD", p["m1"], p["m2"],
-                                              p["s1z"], p["s2z"]),
-    "SEOBNRv1RD"  : lambda p: get_freq("fSEOBNRv1RD",  p["m1"], p["m2"],
-                                              p["s1z"], p["s2z"]),
-    "SEOBNRv1Peak": lambda p: get_freq("fSEOBNRv1Peak", p["m1"], p["m2"],
-                                              p["s1z"], p["s2z"]),
-    "SEOBNRv2RD": lambda p: get_freq("fSEOBNRv2RD", p["m1"], p["m2"],
-                                     p["s1z"], p["s2z"]),
-    "SEOBNRv2Peak": lambda p: get_freq("fSEOBNRv2Peak", p["m1"], p["m2"],
-                                       p["s1z"], p["s2z"]),
-    "SEOBNRv4RD": lambda p: get_freq("fSEOBNRv4RD", p["m1"], p["m2"],
-                                     p["s1z"], p["s2z"]),
-    "SEOBNRv4Peak": lambda p: get_freq("fSEOBNRv4Peak", p["m1"], p["m2"],
-                                       p["s1z"], p["s2z"])
+                                              p["mass1"], p["mass2"],
+                                              p["spin1z"], p["spin2z"]),
+    "EOBNRv2RD"   : lambda p: get_freq("fEOBNRv2RD", p["mass1"], p["mass2"],
+                                              p["spin1z"], p["spin2z"]),
+    "EOBNRv2HMRD" : lambda p: get_freq("fEOBNRv2HMRD", p["mass1"], p["mass2"],
+                                              p["spin1z"], p["spin2z"]),
+    "SEOBNRv1RD"  : lambda p: get_freq("fSEOBNRv1RD",  p["mass1"], p["mass2"],
+                                              p["spin1z"], p["spin2z"]),
+    "SEOBNRv1Peak": lambda p: get_freq("fSEOBNRv1Peak", p["mass1"], p["mass2"],
+                                              p["spin1z"], p["spin2z"]),
+    "SEOBNRv2RD": lambda p: get_freq("fSEOBNRv2RD", p["mass1"], p["mass2"],
+                                     p["spin1z"], p["spin2z"]),
+    "SEOBNRv2Peak": lambda p: get_freq("fSEOBNRv2Peak", p["mass1"], p["mass2"],
+                                       p["spin1z"], p["spin2z"]),
+    "SEOBNRv4RD": lambda p: get_freq("fSEOBNRv4RD", p["mass1"], p["mass2"],
+                                     p["spin1z"], p["spin2z"]),
+    "SEOBNRv4Peak": lambda p: get_freq("fSEOBNRv4Peak", p["mass1"], p["mass2"],
+                                       p["spin1z"], p["spin2z"])
     }
 
 def frequency_cutoff_from_name(name, m1, m2, s1z, s2z):
@@ -920,7 +920,6 @@ def hybrid_meco_velocity(m1, m2, chi1, chi2, qm1=None, qm2=None):
     if qm2 is None:
         qm2 = 1
 
-    # The velocity can only go from 0 to 1.
     # Set bounds at 0.1 to skip v=0 and at the lightring velocity
     chi = (chi1 * m1 + chi2 * m2) / (m1 + m2)
     vmax = kerr_lightring_velocity(chi) - 0.01

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -509,7 +509,7 @@ def frequency_cutoff_from_name(name, m1, m2, s1z, s2z):
     f : float or numpy.array
         Frequency in Hz
     """
-    params = {"m1":m1, "m2":m2, "s1z":s1z, "s2z":s2z}
+    params = {"mass1":m1, "mass2":m2, "spin1z":s1z, "spin2z":s2z}
     return named_frequency_cutoffs[name](params)
 
 def _get_imr_duration(m1, m2, s1z, s2z, f_low, approximant="SEOBNRv4"):

--- a/pycbc/tmpltbank/coord_utils.py
+++ b/pycbc/tmpltbank/coord_utils.py
@@ -656,10 +656,10 @@ def find_max_and_min_frequencies(name, mass_range_params, freqs):
         mass1, mass2, spin1z, spin2z = \
                 get_random_mass(1000000, mass_range_params)
         mass_dict = {}
-        mass_dict['m1'] = mass1
-        mass_dict['m2'] = mass2
-        mass_dict['s1z'] = spin1z
-        mass_dict['s2z'] = spin2z
+        mass_dict['mass1'] = mass1
+        mass_dict['mass2'] = mass2
+        mass_dict['spin1z'] = spin1z
+        mass_dict['spin2z'] = spin2z
         tmp_freqs = cutoff_fns[name](mass_dict)
         upper_f_cutoff = tmp_freqs.max()
         lower_f_cutoff = tmp_freqs.min()

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -289,6 +289,10 @@ f_final = Parameter("f_final",
                 description="The ending frequency of the waveform. The "
                             "default (0) indicates that the choice is made by "
                             "the respective approximant.")
+f_final_func = Parameter("f_final_func",
+                dtype=str, default="", label=None,
+                description="Use the given frequency function to compute f_final "
+                            "based on the parameters of the waveform.")
 f_ref = Parameter("f_ref",
                 dtype=float, default=0, label=r"$f_{\mathrm{ref}}$ (Hz)",
                 description="The reference frequency.")
@@ -430,7 +434,7 @@ common_gen_equal_sampled_params = ParameterList([f_lower]) + \
 
 # the following are parameters needed to generate an FD waveform
 fd_waveform_params = cbc_rframe_params + ParameterList([delta_f]) + \
-    common_gen_equal_sampled_params + ParameterList([f_final])
+    common_gen_equal_sampled_params + ParameterList([f_final, f_final_func])
 
 # the following are parameters needed to generate a TD waveform
 td_waveform_params = cbc_rframe_params + ParameterList([delta_t]) + \

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -450,14 +450,13 @@ def get_fd_waveform(template=None, **kwargs):
             # convert the frequency function to a value
             input_params['f_final'] = pnutils.named_frequency_cutoffs[ffunc](
                 input_params)
+            # if the f_final is < f_lower, raise a NoWaveformError
+            if 'f_final' in input_params and (
+                    input_params['f_lower']+input_params['delta_f']
+                                        >= input_params['f_final']):
+                raise NoWaveformError("cannot generate waveform: f_lower >= f_final")
     except KeyError:
         pass
-
-    # if the f_final is < f_lower, raise a NoWaveformError
-    if 'f_final' in input_params and (
-            input_params['f_lower']+input_params['delta_f']
-            >= input_params['f_final']):
-        raise NoWaveformError("cannot generate waveform: f_lower >= f_final")
 
     return wav_gen[input_params['approximant']](**input_params)
 

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -438,6 +438,23 @@ def get_fd_waveform(template=None, **kwargs):
         if arg not in input_params:
             raise ValueError("Please provide " + str(arg) )
 
+    try:
+        ffunc = input_params.pop('f_final_func')
+        # convert the frequency function to a value
+        input_params['f_final'] = pnutils.named_frequency_cutoffs[ffunc](
+            input_params)
+        # if the f_final is < f_lower, just return zeros
+        if input_params['f_final'] < input_params['f_lower']:
+            kmax = int(2**(numpy.ceil(numpy.log2(
+                input_params['f_lower']/input_params['delta_f'])))+1)
+            hp = FrequencySeries(zeros(kmax, dtype=complex),
+                                 delta_f=input_params['delta_f'])
+            hc = FrequencySeries(zeros(kmax, dtype=complex),
+                                 delta_f=input_params['delta_f'])
+            return hp, hc
+    except KeyError:
+        pass
+
     return wav_gen[input_params['approximant']](**input_params)
 
 get_fd_waveform.__doc__ = get_fd_waveform.__doc__.format(

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -440,20 +440,22 @@ def get_fd_waveform(template=None, **kwargs):
 
     try:
         ffunc = input_params.pop('f_final_func')
-        # convert the frequency function to a value
-        input_params['f_final'] = pnutils.named_frequency_cutoffs[ffunc](
-            input_params)
-        # if the f_final is < f_lower, just return zeros
-        if input_params['f_final'] < input_params['f_lower']:
-            kmax = int(2**(numpy.ceil(numpy.log2(
-                input_params['f_lower']/input_params['delta_f'])))+1)
-            hp = FrequencySeries(zeros(kmax, dtype=complex),
-                                 delta_f=input_params['delta_f'])
-            hc = FrequencySeries(zeros(kmax, dtype=complex),
-                                 delta_f=input_params['delta_f'])
-            return hp, hc
+        if ffunc != '':
+            # convert the frequency function to a value
+            input_params['f_final'] = pnutils.named_frequency_cutoffs[ffunc](
+                input_params)
     except KeyError:
         pass
+
+    # if the f_final is < f_lower, just return zeros
+    if input_params['f_final'] < input_params['f_lower']:
+        kmax = int(2**(numpy.ceil(numpy.log2(
+            input_params['f_lower']/input_params['delta_f'])))+1)
+        hp = FrequencySeries(zeros(kmax, dtype=complex),
+                             delta_f=input_params['delta_f'])
+        hc = FrequencySeries(zeros(kmax, dtype=complex),
+                             delta_f=input_params['delta_f'])
+        return hp, hc
 
     return wav_gen[input_params['approximant']](**input_params)
 

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -886,4 +886,5 @@ __all__ = ["get_td_waveform", "get_fd_waveform", "get_fd_waveform_sequence",
            "waveform_norm_exists", "get_template_amplitude_norm",
            "get_waveform_filter_length_in_time", "get_sgburst_waveform",
            "print_sgburst_approximants", "sgburst_approximants",
-           "td_waveform_to_fd_waveform", "get_two_pol_waveform_filter"]
+           "td_waveform_to_fd_waveform", "get_two_pol_waveform_filter",
+           "NoWaveformError"]

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -455,7 +455,8 @@ def get_fd_waveform(template=None, **kwargs):
 
     # if the f_final is < f_lower, raise a NoWaveformError
     if 'f_final' in input_params and (
-            input_params['f_lower'] >= input_params['f_final']):
+            input_params['f_lower']+input_params['delta_f']
+            >= input_params['f_final']):
         raise NoWaveformError("cannot generate waveform: f_lower >= f_final")
 
     return wav_gen[input_params['approximant']](**input_params)


### PR DESCRIPTION
This patch adds the ability to use a frequency cutoff function when generating waveforms. This is done by adding a new parameter to `parameters.py` called `f_final_func`. If this is specified in the keyword arguments given to `get_fd_waveform`, the final frequency derived on the fly from `pnutils.named_frequency_cutoffs`. In order to get `named_frequency_cutoffs` to work with `get_fd_waveform`, I had to change the names of parameters that are expected in the dictionary from `m1, m2, s1z, s2z` to `mass1, mass2, spin1z, spin2z`. This allows, e.g., `HybridMECO` to be used in PE codes.

One thing I wasn't sure about: it can happen that the final frequency ends up being larger than the lower frequency cutoff that was specified. I don't want this to raise an error, because this can happen in PE runs. Instead, I prefer that a waveform with zeros should be returned. To do this, I'm currently just creating the FrequencySeries with zeros in it in `get_fd_waveform` (see lines 417-424 of `waveform.py` in the patch). I'm not sure if that's the correct thing to do if non-cpu generators are used though. @ahnitz Is this ok? Or would you prefer something else?