### PR TITLE
Cache the pip directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
 cache:
   directories:
     - $HOME/inst
+    - $HOME/.cache/pip
 install:
   - travis_retry ./tools/install_travis.sh
 script:


### PR DESCRIPTION
This will speed up the build by caching, e.g. scipy, in the Travis cache. We don't need to re-build these pips unless a new version has been released.

See https://docs.travis-ci.com/user/caching/