### PR TITLE
Add ability to gate data to pycbc inference

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -55,6 +55,7 @@ def select_waveform_generator(approximant):
     else:
         raise ValueError("%s is not a valid approximant."%approximant)
 
+
 def convert_liststring_to_list(lstring):
     """ Checks if an argument of the configuration file is a string of a list
     and returns the corresponding list (of strings)
@@ -64,14 +65,15 @@ def convert_liststring_to_list(lstring):
                       for n in range(len(lstring[1:-1].split(',')))]
     return lvalue
 
-def gates_from_cli(opts):
-    """Parses the --gate option into something understandable by
+
+def _gates_from_cli(opts, gate_opt):
+    """Parses the given `gate_opt` into something understandable by
     `strain.gate_data`.
     """
     gates = {}
-    if opts.gate is None:
+    if getattr(opts, gate_opt) is None:
         return gates
-    for gate in opts.gate:
+    for gate in getattr(opts, gate_opt):
         try:
             ifo, central_time, half_dur, taper_dur = gate.split(':')
             central_time = float(central_time)
@@ -86,16 +88,76 @@ def gates_from_cli(opts):
             gates[ifo] = [(central_time, half_dur, taper_dur)]
     return gates
 
-def apply_gates(stilde_dict, gates):
+
+def gates_from_cli(opts):
+    """Parses the --gate option into something understandable by
+    `strain.gate_data`.
+    """
+    return _gates_from_cli(opts, 'gate')
+
+
+def psd_gates_from_cli(opts):
+    """Parses the --psd-gate option into something understandable by
+    `strain.gate_data`.
+    """
+    return _gates_from_cli(opts, 'psd_gate')
+
+
+def apply_gates_to_td(strain_dict, gates):
     """Applies the given dictionary of gates to the given dictionary of
     strain.
+
+    Parameters
+    ----------
+    strain_dict : dict
+        Dictionary of time-domain strain, keyed by the ifos.
+    gates : dict
+        Dictionary of gates. Keys should be the ifo to apply the data to,
+        values are a tuple giving the central time of the gate, the half
+        duration, and the taper duration.
+
+    Returns
+    -------
+    dict
+        Dictionary of time-domain strain with the gates applied.
     """
-    strain_dict = {}
+    # copy data to new dictionary
+    outdict = dict(zip(strain_dict.items()))
     for ifo in gates:
-        thisstrain = stilde_dict[ifo].to_timeseries()
-        strain_dict[ifo] = strain.gate_data(thisstrain, gates[ifo])
-        stilde_dict[ifo] = strain_dict[ifo].to_frequencyseries()
-    return stilde_dict, strain_dict
+        outdict[ifo] = strain.gate_data(outdict[ifo], gates[ifo])
+    return outdict
+
+
+def apply_gates_to_fd(stilde_dict, gates):
+    """Applies the given dictionary of gates to the given dictionary of
+    strain in the frequency domain.
+
+    Gates are applied by IFFT-ing the strain data to the time domain, applying
+    the gate, then FFT-ing back to the frequency domain.
+
+    Parameters
+    ----------
+    stilde_dict : dict
+        Dictionary of frequency-domain strain, keyed by the ifos.
+    gates : dict
+        Dictionary of gates. Keys should be the ifo to apply the data to,
+        values are a tuple giving the central time of the gate, the half
+        duration, and the taper duration.
+
+    Returns
+    -------
+    dict
+        Dictionary of frequency-domain strain with the gates applied.
+    """
+    # copy data to new dictionary
+    outdict = dict(zip(stilde_dict.items()))
+    # create a time-domin strain dictionary to apply the gates to
+    strain_dict = dict([outdict[ifo].to_timeseries() for ifo in gates])
+    # apply gates and fft back to the frequency domain
+    for ifo,d in apply_gates_to_td(strain_dict):
+        outdict[ifo] = d.to_frequencyseries()
+    return outdict
+
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
@@ -120,6 +182,16 @@ parser.add_argument("--gate", nargs="+", type=str,
                     metavar="IFO:CENTRALTIME:HALFDUR:TAPERDUR",
                     help="Apply one or more gates to the data before "
                          "filtering.")
+parser.add_argument("--gate-overwhitened", action="store_true", default=False,
+                    help="Overwhiten data first, then apply the gates "
+                         "specified in --gate. Overwhitening allows for "
+                         "sharper tapers to be used, since lines are not "
+                         "blurred.")
+parser.add_argument("--psd-gate", nargs="+", type=str,
+                    metavar="IFO:CENTRALTIME:HALFDUR:TAPERDUR",
+                    help="Apply one or more gates to the data used for "
+                         "computing the PSD. Gates are applied prior to "
+                         "FFT-ing the data for PSD estimation.")
 
 # add inference options
 parser.add_argument("--likelihood-evaluator", required=True,
@@ -208,9 +280,17 @@ fft.fftw.set_measure_level(0)
 ctx = scheme.from_cli(opts)
 fft.from_cli(opts)
 
+# get gates to apply
+gates = gates_from_cli(opts)
+psd_gates = psd_gates_from_cli(opts)
+
 # get strain time series
 strain_dict = strain.from_cli_multi_ifos(opts, opts.instruments,
                                          precision="double")
+# apply gates if not waiting to overwhiten
+if not opts.gate_overwhitened:
+    strain_dict = apply_gates_to_td(strain_dict, gates)
+
 # get strain time series to use for PSD estimation
 # if user has not given the PSD time options then use same data as analysis
 if opts.psd_start_time and opts.psd_end_time:
@@ -221,7 +301,7 @@ if opts.psd_start_time and opts.psd_end_time:
     psd_strain_dict = strain.from_cli_multi_ifos(psd_opts, opts.instruments,
                                                 precision="double")
     # apply any gates
-    # psd_strain_dict = apply_gates(psd_strain_dict, gates)
+    psd_strain_dict = apply_gates_to_td(psd_strain_dict, psd_gates)
 
 elif opts.psd_start_time or opts.psd_end_time:
     raise ValueError("Must give --psd-start-time and --psd-end-time")
@@ -248,16 +328,13 @@ with ctx:
                                low_frequency_cutoff_dict, opts.instruments,
                                strain_dict=psd_strain_dict, precision="double")
 
-    # apply any gates
-    if opts.gate is not None: 
+    # apply any gates to overwhitened data, if desired
+    if opts.gate_overwhitened and opts.gate is not None:
         logging.info("Applying gates to overwhitend data")
         # overwhiten the data
         for ifo in stilde_dict:
             stilde_dict[ifo] /= psd_dict[ifo]
-        # apply the gates
-        gates = gates_from_cli(opts)
-        stilde_dict, whstrain_dict = apply_gates(stilde_dict, gates)
-        strain_dict.update(whstrain_dict)
+        stilde_dict = apply_gates_to_fd(stilde_dict, gates)
         # unwhiten the data for the likelihood generator
         for ifo in stilde_dict:
             stilde_dict[ifo] *= psd_dict[ifo]

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -222,13 +222,14 @@ parser.add_argument("--force", action="store_true", default=False,
                          "Otherwise, an OSError is raised.")
 parser.add_argument("--save-strain", action="store_true", default=False,
                     help="Save the conditioned strain time series to the "
-                         "output file. This is done after all gates have "
-                         "been applied.")
+                         "output file. If gate-overwhitened, this is done "
+                         "before all gates have been applied.")
 parser.add_argument("--save-stilde", action="store_true", default=False,
                     help="Save the conditioned strain frequency series to "
-                         "the output file.")
-parser.add_argument("--save-psds", action="store_true", default=False,
-                    help="Save the psds to the output file.")
+                         "the output file. This is done after all gates have "
+                         "been applied.")
+parser.add_argument("--save-psd", action="store_true", default=False,
+                    help="Save the psd of each ifo to the output file.")
 parser.add_argument("--checkpoint-interval", type=int, default=None,
                     help="Number of iterations to take before saving new "
                          "samples to file.")
@@ -343,7 +344,7 @@ with ctx:
             stilde_dict[ifo] *= psd_dict[ifo]
 
     # save PSD
-    if opts.save_psds:
+    if opts.save_psd:
         # apply dynamic range factor for saving PSDs since
         # plotting code expects it
         logging.info("Saving PSDs")
@@ -353,7 +354,7 @@ with ctx:
                                         psd_dict[key] * pycbc.DYN_RANGE_FAC**2,
                                         delta_f=psd_dict[key].delta_f)
         with InferenceFile(opts.output_file, "a") as fp:
-            fp.write_psds(psds=psd_dyn_dict,
+            fp.write_psd(psds=psd_dyn_dict,
                           low_frequency_cutoff=low_frequency_cutoff_dict)
 
     # save stilde

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -18,9 +18,11 @@
 """ Runs a sampler to find the posterior distributions.
 """
 
+import os
 import argparse
 import logging
 import numpy
+import pycbc
 import pycbc.opt
 import pycbc.weave
 import random
@@ -62,6 +64,39 @@ def convert_liststring_to_list(lstring):
                       for n in range(len(lstring[1:-1].split(',')))]
     return lvalue
 
+def gates_from_cli(opts):
+    """Parses the --gate option into something understandable by
+    `strain.gate_data`.
+    """
+    gates = {}
+    if opts.gate is None:
+        return gates
+    for gate in opts.gate:
+        try:
+            ifo, central_time, half_dur, taper_dur = gate.split(':')
+            central_time = float(central_time)
+            half_dur = float(half_dur)
+            taper_dur = float(taper_dur)
+        except ValueError:
+            raise ValueError("--gate {} not formatted correctly; ".format(
+                gate) + "see help")
+        try:
+            gates[ifo].append((central_time, half_dur, taper_dur))
+        except KeyError:
+            gates[ifo] = [(central_time, half_dur, taper_dur)]
+    return gates
+
+def apply_gates(stilde_dict, gates):
+    """Applies the given dictionary of gates to the given dictionary of
+    strain.
+    """
+    strain_dict = {}
+    for ifo in gates:
+        thisstrain = stilde_dict[ifo].to_timeseries()
+        strain_dict[ifo] = strain.gate_data(thisstrain, gates[ifo])
+        stilde_dict[ifo] = strain_dict[ifo].to_frequencyseries()
+    return stilde_dict, strain_dict
+
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
                                  description=__doc__)
@@ -81,6 +116,10 @@ parser.add_argument("--psd-start-time", type=float, default=None,
 parser.add_argument("--psd-end-time", type=float, default=None,
                     help="End time to use for PSD estimation if different "
                          "from analysis.")
+parser.add_argument("--gate", nargs="+", type=str,
+                    metavar="IFO:CENTRALTIME:HALFDUR:TAPERDUR",
+                    help="Apply one or more gates to the data before "
+                         "filtering.")
 
 # add inference options
 parser.add_argument("--likelihood-evaluator", required=True,
@@ -105,13 +144,25 @@ parser.add_argument("--config-overrides", type=str, nargs="+", default=None,
 # output options
 parser.add_argument("--output-file", type=str, required=True,
                     help="Output file path.")
+parser.add_argument("--force", action="store_true", default=False,
+                    help="If the output-file already exists, overwrite it. "
+                         "Otherwise, an OSError is raised.")
+parser.add_argument("--save-strain", action="store_true", default=False,
+                    help="Save the conditioned strain time series to the "
+                         "output file. This is done after all gates have "
+                         "been applied.")
+parser.add_argument("--save-stilde", action="store_true", default=False,
+                    help="Save the conditioned strain frequency series to "
+                         "the output file.")
+parser.add_argument("--save-psds", action="store_true", default=False,
+                    help="Save the psds to the output file.")
 parser.add_argument("--checkpoint-interval", type=int, default=None,
                     help="Number of iterations to take before saving new "
                          "samples to file.")
 parser.add_argument("--checkpoint-fast", action="store_true",
                     help="Do not calculate derived data (eg. ACL or evidence) "
                          "after each checkpoint. Calculate them at the end.")
-
+ 
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="Print logging messages.")
@@ -135,6 +186,14 @@ scheme.verify_processing_options(opts, parser)
 #strain.verify_strain_options(opts, parser)
 pycbc.weave.verify_weave_options(opts, parser)
 
+# check for the output file
+if os.path.exists(opts.output_file) and not opts.force:
+    raise OSError("output-file already exists; use --force if you wish to "
+                  "overwrite it.")
+# create the file for adding to
+fp = InferenceFile(opts.output_file, "w")
+fp.close()
+
 # setup log
 pycbc.init_logging(opts.verbose)
 
@@ -152,7 +211,6 @@ fft.from_cli(opts)
 # get strain time series
 strain_dict = strain.from_cli_multi_ifos(opts, opts.instruments,
                                          precision="double")
-
 # get strain time series to use for PSD estimation
 # if user has not given the PSD time options then use same data as analysis
 if opts.psd_start_time and opts.psd_end_time:
@@ -162,6 +220,9 @@ if opts.psd_start_time and opts.psd_end_time:
     psd_opts.gps_end_time = psd_opts.psd_end_time
     psd_strain_dict = strain.from_cli_multi_ifos(psd_opts, opts.instruments,
                                                 precision="double")
+    # apply any gates
+    # psd_strain_dict = apply_gates(psd_strain_dict, gates)
+
 elif opts.psd_start_time or opts.psd_end_time:
     raise ValueError("Must give --psd-start-time and --psd-end-time")
 else:
@@ -187,18 +248,43 @@ with ctx:
                                low_frequency_cutoff_dict, opts.instruments,
                                strain_dict=psd_strain_dict, precision="double")
 
-    # apply dynamic range factor for saving PSDs since plotting code expects it
-    logging.info("Saving PSDs")
-    psd_dyn_dict = {}
-    for key,val in psd_dict.iteritems():
-         psd_dyn_dict[key] = types.FrequencySeries(
-                                        psd_dict[key] * pycbc.DYN_RANGE_FAC**2,
-                                        delta_f=psd_dict[key].delta_f)
+    # apply any gates
+    if opts.gate is not None: 
+        logging.info("Applying gates to overwhitend data")
+        # overwhiten the data
+        for ifo in stilde_dict:
+            stilde_dict[ifo] /= psd_dict[ifo]
+        # apply the gates
+        gates = gates_from_cli(opts)
+        stilde_dict, whstrain_dict = apply_gates(stilde_dict, gates)
+        strain_dict.update(whstrain_dict)
+        # unwhiten the data for the likelihood generator
+        for ifo in stilde_dict:
+            stilde_dict[ifo] *= psd_dict[ifo]
 
     # save PSD
-    with InferenceFile(opts.output_file, "w") as fp:
-        fp.write_psds(psds=psd_dyn_dict,
-                      low_frequency_cutoff=low_frequency_cutoff_dict)
+    if opts.save_psds:
+        # apply dynamic range factor for saving PSDs since
+        # plotting code expects it
+        logging.info("Saving PSDs")
+        psd_dyn_dict = {}
+        for key,val in psd_dict.iteritems():
+             psd_dyn_dict[key] = types.FrequencySeries(
+                                        psd_dict[key] * pycbc.DYN_RANGE_FAC**2,
+                                        delta_f=psd_dict[key].delta_f)
+        with InferenceFile(opts.output_file, "a") as fp:
+            fp.write_psds(psds=psd_dyn_dict,
+                          low_frequency_cutoff=low_frequency_cutoff_dict)
+
+    # save stilde
+    if opts.save_stilde:
+        with InferenceFile(opts.output_file, "a") as fp:
+            fp.write_stilde(stilde_dict)
+
+    # save strain if desired
+    if opts.save_strain:
+        with InferenceFile(opts.output_file, "a") as fp:
+            fp.write_strain(strain_dict)
 
     # read configuration file
     logging.info("Reading configuration file")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -122,8 +122,9 @@ def apply_gates_to_td(strain_dict, gates):
         Dictionary of time-domain strain with the gates applied.
     """
     # copy data to new dictionary
-    outdict = dict(zip(strain_dict.items()))
+    outdict = dict(strain_dict.items())
     for ifo in gates:
+        logging.info("Gating {} strain".format(ifo))
         outdict[ifo] = strain.gate_data(outdict[ifo], gates[ifo])
     return outdict
 
@@ -150,11 +151,11 @@ def apply_gates_to_fd(stilde_dict, gates):
         Dictionary of frequency-domain strain with the gates applied.
     """
     # copy data to new dictionary
-    outdict = dict(zip(stilde_dict.items()))
+    outdict = dict(stilde_dict.items())
     # create a time-domin strain dictionary to apply the gates to
-    strain_dict = dict([outdict[ifo].to_timeseries() for ifo in gates])
+    strain_dict = dict([[ifo, outdict[ifo].to_timeseries()] for ifo in gates])
     # apply gates and fft back to the frequency domain
-    for ifo,d in apply_gates_to_td(strain_dict):
+    for ifo,d in apply_gates_to_td(strain_dict, gates).items():
         outdict[ifo] = d.to_frequencyseries()
     return outdict
 
@@ -289,6 +290,7 @@ strain_dict = strain.from_cli_multi_ifos(opts, opts.instruments,
                                          precision="double")
 # apply gates if not waiting to overwhiten
 if not opts.gate_overwhitened:
+    logging.info("Applying gates to strain data")
     strain_dict = apply_gates_to_td(strain_dict, gates)
 
 # get strain time series to use for PSD estimation
@@ -301,6 +303,7 @@ if opts.psd_start_time and opts.psd_end_time:
     psd_strain_dict = strain.from_cli_multi_ifos(psd_opts, opts.instruments,
                                                 precision="double")
     # apply any gates
+    logging.info("Applying gates to PSD data")
     psd_strain_dict = apply_gates_to_td(psd_strain_dict, psd_gates)
 
 elif opts.psd_start_time or opts.psd_end_time:
@@ -330,13 +333,13 @@ with ctx:
 
     # apply any gates to overwhitened data, if desired
     if opts.gate_overwhitened and opts.gate is not None:
-        logging.info("Applying gates to overwhitend data")
+        logging.info("Applying gates to overwhitened data")
         # overwhiten the data
-        for ifo in stilde_dict:
+        for ifo in gates:
             stilde_dict[ifo] /= psd_dict[ifo]
         stilde_dict = apply_gates_to_fd(stilde_dict, gates)
         # unwhiten the data for the likelihood generator
-        for ifo in stilde_dict:
+        for ifo in gates:
             stilde_dict[ifo] *= psd_dict[ifo]
 
     # save PSD

--- a/docs/workflow/pycbc_make_inference_workflow.rst
+++ b/docs/workflow/pycbc_make_inference_workflow.rst
@@ -69,6 +69,7 @@ A simple workflow configuration file::
     likelihood-evaluator = gaussian
     nwalkers = 500
     niterations = 100000
+    save-psd =
 
     [pegasus_profile-inference]
     ; pegasus profile for inference nodes

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -241,6 +241,34 @@ class InferenceFile(h5py.File):
                 return parameter
         return label
 
+    def write_strain(self, strain_dict):
+        """Writes strain for each IFO to file.
+
+        Parameters
+        -----------
+        strain : {dict, FrequencySeries}
+            A dict of FrequencySeries where the key is the IFO.
+        """
+        group = "{ifo}/strain"
+        for ifo,strain in strain_dict.items():
+            self[group.format(ifo=ifo)] = strain
+            self[group.format(ifo=ifo)].attrs['delta_t'] = strain.delta_t
+            self[group.format(ifo=ifo)].attrs['start_time'] = float(strain.start_time)
+
+    def write_stilde(self, stilde_dict):
+        """Writes stilde for each IFO to file.
+
+        Parameters
+        -----------
+        stilde : {dict, FrequencySeries}
+            A dict of FrequencySeries where the key is the IFO.
+        """
+        group = "{ifo}/stilde"
+        for ifo,stilde in stilde_dict.items():
+            self[group.format(ifo=ifo)] = stilde
+            self[group.format(ifo=ifo)].attrs['delta_f'] = stilde.delta_f
+            self[group.format(ifo=ifo)].attrs['epoch'] = float(stilde.epoch)
+
     def write_psds(self, psds, low_frequency_cutoff):
         """ Writes PSD for each IFO to file.
 

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -269,8 +269,8 @@ class InferenceFile(h5py.File):
             self[group.format(ifo=ifo)].attrs['delta_f'] = stilde.delta_f
             self[group.format(ifo=ifo)].attrs['epoch'] = float(stilde.epoch)
 
-    def write_psds(self, psds, low_frequency_cutoff):
-        """ Writes PSD for each IFO to file.
+    def write_psd(self, psds, low_frequency_cutoff):
+        """Writes PSD for each IFO to file.
 
         Parameters
         -----------


### PR DESCRIPTION
This adds options to `pycbc_inference` to gate segments of data before analyzing. Both the data to be analyzed and the data used for PSD estimation may be gated. The data may be gated either before FFT-ing or after being overwhitened. I've found that doing the latter allows you to use a steep taper without incuring a bunch of noise. This is useful in case a significant signal occurs close to a glitch. It's also needed for the testing the area theorem paper, as we gate away the merger when doing PE on the insprial. Right now the gates are passed in by command line options. It's not very pretty. Not sure of a better way to do it though.

This patch also adds command line options to save the strain, PSD, and frequency domain strain to the output file. These are saved in similar groups as the PSD is currently. This means that the PSD will no longer be saved by default.

Finally, this patch makes it so that an error will be raised if the output file already exists. This can be overridden with the `--force` command. I added this after accidentally blowing away a result file that took several hours to generate.