### PR TITLE
Add note on MacOS installation of m2crypto in install instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -154,7 +154,7 @@ On MacOS using homebrew to install openssl you may need to set the following ext
 
 .. code-block:: bash
 
-   CFLAGS="-I/usr/local/opt/openssl/include -L /usr/local/opt/openssl/lib" SWIG_FEATURES="-cpperraswarn -includeall -I/usr/local/opt/openssl/include/" pip install M2Crypto
+   CFLAGS="-I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib" SWIG_FEATURES="-cpperraswarn -includeall -I/usr/local/opt/openssl/include/" pip install M2Crypto
 
 Once you have these packages installed, you can now install lalsuite following the instructions at:
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -150,6 +150,12 @@ To authenticate with LIGO Data Grid services, you need M2Crypto which you should
 
     SWIG_FEATURES="-cpperraswarn -includeall -I/usr/include/openssl" pip install M2Crypto
 
+On MacOS using homebrew to install openssl you may need to set the following extra environment variables to install M2Crypto:
+
+.. code-block:: bash
+
+   CFLAGS="-I/usr/local/opt/openssl/include -L /usr/local/opt/openssl/lib" SWIG_FEATURES="-cpperraswarn -includeall -I/usr/local/opt/openssl/include/" pip install M2Crypto
+
 Once you have these packages installed, you can now install lalsuite following the instructions at:
 
 .. toctree::


### PR DESCRIPTION
I had some trouble installing on MacOS 10.10 because of openssl and m2crypto. I've just added a line to the install instructions to explain how to solve it.