### PR TITLE
pass errors through faithsim

### DIFF
--- a/bin/pycbc_faithsim
+++ b/bin/pycbc_faithsim
@@ -247,8 +247,8 @@ with ctx:
             s1s.append(s1)
             s2s.append(s2)
         except Exception as e:
-            logging.info("Unable to generate waveforms")
-            logging.info("Error: %s, %s", str(type(e)), str(e))
+            logging.warning("Unable to generate waveforms")
+            logging.warning("Error: %s, %s", str(type(e)), str(e))
             matches.append(-1)
             overlaps.append(-1)
             time_offsets.append(-1)

--- a/bin/pycbc_faithsim
+++ b/bin/pycbc_faithsim
@@ -246,8 +246,9 @@ with ctx:
             time_offsets.append(i * 1./options.filter_sample_rate)
             s1s.append(s1)
             s2s.append(s2)
-        except:
+        except Exception as e:
             logging.info("Unable to generate waveforms")
+            logging.info("Error: %s, %s", str(type(e)), str(e))
             matches.append(-1)
             overlaps.append(-1)
             time_offsets.append(-1)


### PR DESCRIPTION
This will report errors when verbose mode is enabled that occur when trying to generating a waveform.