### PR TITLE
Allow pycbc_generate_hwinj to use --asd-file and --psd-file

### DIFF
--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -200,7 +200,8 @@ _psd.insert_psd_option_group_multi_ifo(parser)
 opts = parser.parse_args()
 
 # verify options are sane
-_strain.verify_strain_options_multi_ifo(opts, parser, opts.instruments)
+if not opts.psd_file and not opts.asd_file:
+    _strain.verify_strain_options_multi_ifo(opts, parser, opts.instruments)
 
 # setup log
 logging_level = logging.DEBUG
@@ -356,7 +357,8 @@ for ifo in opts.instruments:
 
     # get antenna pattern
     f_plus, f_cross = det.antenna_pattern(sim.longitude, sim.latitude,
-                        sim.polarization, sim.geocent_end_time)
+                                          sim.polarization,
+                                          sim.geocent_end_time)
 
     # calculate strain
     logging.info('Calculating strain for %s', ifo)
@@ -366,13 +368,15 @@ for ifo in opts.instruments:
     logging.info('Tapering strain for %s', ifo)
     strain = taper_timeseries(strain, tapermethod=sim.taper)
 
+    logging.info('strain.delta_t %f', strain.delta_t)
+
     # FFT strain
     logging.info('FFT strain for %s', ifo)
     strain_tilde = make_frequency_series(strain)
 
     # interpolate PSD to waveform delta_f
     if psd_dict[ifo].delta_f != strain_tilde.delta_f:
-        logging.info('Interpolating PSD for %s from %.2fHz to %.2fHz',
+        logging.info('Interpolating PSD for %s from %fHz to %fHz',
                      ifo, psd_dict[ifo].delta_f, strain_tilde.delta_f)
         psd_interpolated = _psd.interpolate(
                                     psd_dict[ifo], strain_tilde.delta_f)
@@ -421,12 +425,13 @@ for ifo in opts.instruments:
 
     # get time delay to detector from center of the Earth
     time_delay = det.time_delay_from_earth_center(sim.longitude, sim.latitude,
-                        sim.geocent_end_time)
+                                                  sim.geocent_end_time)
     end_time = sim.geocent_end_time + time_delay
 
     # get antenna pattern
     f_plus, f_cross = det.antenna_pattern(sim.longitude, sim.latitude,
-                        sim.polarization, sim.geocent_end_time)
+                                          sim.polarization,
+                                          sim.geocent_end_time)
 
     # calculate strain
     logging.info('Calculating strain for %s', ifo)
@@ -442,7 +447,7 @@ for ifo in opts.instruments:
 
     # interpolate PSD to waveform delta_f
     if psd_dict[ifo].delta_f != strain_tilde.delta_f:
-        logging.info('Interpolating PSD for %s from %.2fHz to %.2fHz',
+        logging.info('Interpolating PSD for %s from %fHz to %fHz',
                      ifo, psd_dict[ifo].delta_f, strain_tilde.delta_f)
         psd_interpolated = _psd.interpolate(
                                     psd_dict[ifo], strain_tilde.delta_f)

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -371,16 +371,14 @@ for ifo in opts.instruments:
     if psd_dict[ifo].delta_f != strain_tilde.delta_f:
         logging.info('Interpolating PSD for %s from %fHz to %fHz',
                      ifo, psd_dict[ifo].delta_f, strain_tilde.delta_f)
-        psd_interpolated = _psd.interpolate(
+        psd_dict[ifo] = _psd.interpolate(
                                     psd_dict[ifo], strain_tilde.delta_f)
-    else:
-        psd_interpolated = psd_dict[ifo]
 
     # calculate sigma-squared SNR
     logging.info('Calculating sigma for %s', ifo)
     sigma_squared = sigmasq(
                         DYN_RANGE_FAC * strain_tilde,
-                        psd=psd_interpolated,
+                        psd=psd_dict[ifo],
                         low_frequency_cutoff=opts.psd_low_frequency_cutoff,
                         high_frequency_cutoff=f_high)
     logging.info('Sigma integrated from %.3f to %.3fHz for %s is %.3f',
@@ -438,19 +436,10 @@ for ifo in opts.instruments:
     logging.info('FFT strain for '+ifo+'...')
     strain_tilde = make_frequency_series(strain)
 
-    # interpolate PSD to waveform delta_f
-    if psd_dict[ifo].delta_f != strain_tilde.delta_f:
-        logging.info('Interpolating PSD for %s from %fHz to %fHz',
-                     ifo, psd_dict[ifo].delta_f, strain_tilde.delta_f)
-        psd_interpolated = _psd.interpolate(
-                                    psd_dict[ifo], strain_tilde.delta_f)
-    else:
-        psd_interpolated = psd_dict[ifo]
-
     # calculate sigma-squared SNR
     logging.info('Calculating sigma for %s', ifo)
     sigma_squared = sigmasq(DYN_RANGE_FAC * strain_tilde,
-                            psd=psd_interpolated,
+                            psd=psd_dict[ifo],
                             low_frequency_cutoff=opts.psd_low_frequency_cutoff,
                             high_frequency_cutoff=f_high)
     logging.info('Sigma integrated from %.3f to %.3fHz for %s is %.3f',

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -240,8 +240,8 @@ outdoc.appendChild(ligolw.LIGO_LW())
 opts_dict = convert_to_process_params_dict(opts)
 
 # create process table
-proc_id = utils.process.register_to_xmldoc(outdoc,
-                    sys.argv[0], opts_dict,
+proc_id = utils.process.register_to_xmldoc(
+                    outdoc, sys.argv[0], opts_dict,
                     comment="", ifos=[''.join(opts.instruments)],
                     version=glue.git_version.id,
                     cvs_repository=glue.git_version.branch,
@@ -249,7 +249,7 @@ proc_id = utils.process.register_to_xmldoc(outdoc,
 
 # create sim_inspiral table
 sim_table = lsctables.New(lsctables.SimInspiralTable,
-                            columns=lsctables.SimInspiralTable.validcolumns)
+                          columns=lsctables.SimInspiralTable.validcolumns)
 outdoc.childNodes[0].appendChild(sim_table)
 
 # create sim_inspiral row for injection
@@ -284,7 +284,7 @@ name, phase_order = legacy_approximant_name(sim.waveform)
 
 # create sngl_inspiral table
 sngl_table = lsctables.New(lsctables.SnglInspiralTable,
-                            columns=lsctables.SnglInspiralTable.validcolumns)
+                           columns=lsctables.SnglInspiralTable.validcolumns)
 outdoc.childNodes[0].appendChild(sngl_table)
 
 # create sngl_inspiral row for injection
@@ -372,8 +372,8 @@ for ifo in opts.instruments:
 
     # interpolate PSD to waveform delta_f
     if psd_dict[ifo].delta_f != strain_tilde.delta_f:
-        logging.info('Interpolating PSD for %s to %.2fHz',
-                     ifo, strain_tilde.delta_f)
+        logging.info('Interpolating PSD for %s from %.2fHz to %.2fHz',
+                     ifo, psd_dict[ifo].delta_f, strain_tilde.delta_f)
         psd_interpolated = _psd.interpolate(
                                     psd_dict[ifo], strain_tilde.delta_f)
     else:
@@ -442,8 +442,8 @@ for ifo in opts.instruments:
 
     # interpolate PSD to waveform delta_f
     if psd_dict[ifo].delta_f != strain_tilde.delta_f:
-        logging.info('Interpolating PSD for %s to %.2fHz',
-                     ifo, strain_tilde.delta_f)
+        logging.info('Interpolating PSD for %s from %.2fHz to %.2fHz',
+                     ifo, psd_dict[ifo].delta_f, strain_tilde.delta_f)
         psd_interpolated = _psd.interpolate(
                                     psd_dict[ifo], strain_tilde.delta_f)
     else:

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -200,7 +200,7 @@ _psd.insert_psd_option_group_multi_ifo(parser)
 opts = parser.parse_args()
 
 # verify options are sane if using strain options
-if not opts.psd_file and not opts.asd_file:
+if opts.psd_estimation:
     _strain.verify_strain_options_multi_ifo(opts, parser, opts.instruments)
 
 # setup log
@@ -318,7 +318,7 @@ h_cross = pad_timeseries_to_integer_length(h_cross, sample_rate)
 # get strain time series
 # strain is used to estimate a PSD so if user supplies PSD
 # then genreate a zeroNoise TimeSeries to get length, delta_f, etc.
-if opts.psd_file or opts.asd_file:
+if not opts.psd_estimation:
     opts.fake_strain = "zeroNoise"
 strain_dict = _strain.from_cli_multi_ifos(opts, opts.instruments,
                                           dyn_range_fac=DYN_RANGE_FAC)

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -108,74 +108,80 @@ pn_orders = {
 }
 
 # command line usage
-parser = argparse.ArgumentParser(usage='pycbc_generate_hwinj [--options]',
-                  description="Generates a hardware injection waveform using \
-                  a time-domain waveform.")
+parser = argparse.ArgumentParser(
+                  usage=__name__ + ' [--options]',
+                  description="Generates a hardware injection waveform using "
+                              "a time-domain waveform.")
 
 # IFO network options
 parser.add_argument('--network-snr', type=float, required=True,
-                  help='The network SNR of the injection.')
+                    help='The network SNR of the injection.')
 
 # sky location options
 parser.add_argument('--ra', type=float, required=True,
-                  help='The right ascension of the injection in radians.')
+                    help='The right ascension of the injection in radians.')
 parser.add_argument('--dec', type=float, required=True,
-                  help='The declination of the injection in radians.')
+                    help='The declination of the injection in radians.')
 parser.add_argument('--polarization', type=float, required=True,
-                  help='The polarization of the injection in radians.')
+                    help='The polarization of the injection in radians.')
 
 # waveform parameter options
 parser.add_argument('--approximant', type=str, required=True,
-                  choices=td_approximants(),
-                  help='Approximant to use for generating waveform.')
+                    choices=td_approximants(),
+                    help='Approximant to use for generating waveform.')
 parser.add_argument("--order", type=str, default='default',
-                  choices = pn_orders.keys(),
-                  help='The integer half-PN order at which to generate \
-                  the approximant.')
+                    choices = pn_orders.keys(),
+                    help='The integer half-PN order at which to generate '
+                         'the approximant.')
 parser.add_argument('--mass1', type=float, required=True,
-                  help='First mass of the binary in solar masses.')
+                    help='First mass of the binary in solar masses.')
 parser.add_argument('--mass2', type=float, required=True,
-                  help='Second mass of the binary in solar masses.')
+                    help='Second mass of the binary in solar masses.')
 parser.add_argument('--inclination', type=float, required=True,
-                  help='Inclination of the binary in radians.')
+                    help='Inclination of the binary in radians.')
 parser.add_argument('--taper',  required=True,
-                    choices=['TAPER_NONE', 'TAPER_START', 'TAPER_END', 'TAPER_STARTEND'],
+                    choices=['TAPER_NONE', 'TAPER_START',
+                             'TAPER_END', 'TAPER_STARTEND'],
                     help='Taper the wavform before FFT.')
-parser.add_argument('--waveform-low-frequency-cutoff', type=float, required=True,
-                  help='Frequency to begin generating the waveform in Hz.')
+parser.add_argument('--waveform-low-frequency-cutoff', type=float,
+                    required=True,
+                    help='Frequency to begin generating the waveform in Hz.')
 
 # waveform spin parameter options
 parser.add_argument('--spin1z', type=float, default=0.0,
-                  help='(optional) Spin in z direction for mass1.')
+                    help='(optional) Spin in z direction for mass1.')
 parser.add_argument('--spin1y', type=float, default=0.0,
-                  help='(optional) Spin in y direction for mass1.')
+                    help='(optional) Spin in y direction for mass1.')
 parser.add_argument('--spin1x', type=float, default=0.0,
-                  help='(optional) Spin in x direction for mass1.')
+                    help='(optional) Spin in x direction for mass1.')
 parser.add_argument('--spin2z', type=float, default=0.0,
-                  help='(optional) Spin in z direction for mass2.')
+                    help='(optional) Spin in z direction for mass2.')
 parser.add_argument('--spin2y', type=float, default=0.0,
-                  help='(optional) Spin in y direction for mass2.')
+                    help='(optional) Spin in y direction for mass2.')
 parser.add_argument('--spin2x', type=float, default=0.0,
-                  help='(optional) Spin in x direction for mass2.')
+                    help='(optional) Spin in x direction for mass2.')
 
 # Use this for NR injections
 parser.add_argument('--numrel-data', type=str, default='',
-                  help="Location of NR data file if using NR injections.")
+                    help="Location of NR data file if using NR injections.")
 
 # end time options
 parser.add_argument('--geocentric-end-time', type=float, required=True,
-                  help='The geocentric GPS end time of the injection.')
+                    help='The geocentric GPS end time of the injection.')
 
 # data conditioning options
 parser.add_argument('--psd-low-frequency-cutoff', type=float, required=True,
-                  help='Frequency to begin generating the PSD in Hz. This is the start frequency of the SNR calculation.')
+                    help='Frequency to begin generating the PSD in Hz. This '
+                         'is the start frequency of the SNR calculation.')
 parser.add_argument('--psd-high-frequency-cutoff', type=float,
-                  help='(optional) Upper frequency to terminate the SNR calculation. Default will be Nyquist frequency, ie. int(sample_rate/2).')
+                    help='(optional) Upper frequency to terminate the SNR '
+                         'calculation. Default will be Nyquist frequency, '
+                         'ie. int(sample_rate/2).')
 parser.add_argument("--frame-type", type=str, nargs="+",
-                  action=MultiDetOptionAppendAction,
-                  metavar='IFO:FRAME_TYPE',
-                  help='(optional) Replaces frame-files. Use datafind '
-                       'to get the needed frame file(s) of this type.')
+                    action=MultiDetOptionAppendAction,
+                    metavar='IFO:FRAME_TYPE',
+                    help='(optional) Replaces frame-files. Use datafind '
+                         'to get the needed frame file(s) of this type.')
 
 # output options
 parser.add_argument("--tag", type=str, default='hwinjcbc',
@@ -284,7 +290,8 @@ outdoc.childNodes[0].appendChild(sngl_table)
 sngl = _empty_row(lsctables.SnglInspiral)
 sngl.mass1 = opts.mass1
 sngl.mass2 = opts.mass2
-sngl.mchirp, sngl.eta = pnutils.mass1_mass2_to_mchirp_eta(sngl.mass1, sngl.mass2)
+sngl.mchirp, sngl.eta = pnutils.mass1_mass2_to_mchirp_eta(sngl.mass1,
+                                                          sngl.mass2)
 sngl.mtotal = sngl.mass1 + sngl.mass2
 sngl.spin1z = opts.spin1z
 sngl.spin1y = opts.spin1y
@@ -294,9 +301,12 @@ sngl.spin2y = opts.spin2y
 sngl.spin2x = opts.spin2x
 
 # generate waveform
-logging.info('Generating waveform at %.3fMpc beginning at %.3fHz for SNR calculation', sim.distance, opts.psd_low_frequency_cutoff)
-h_plus, h_cross = get_td_waveform(sim, approximant=name, phase_order=phase_order, f_lower=opts.psd_low_frequency_cutoff,
-                      delta_t=1.0/sample_rate)
+logging.info('Generating waveform at %.3fMpc beginning at %.3fHz for '
+             'SNR calculation', sim.distance, opts.psd_low_frequency_cutoff)
+h_plus, h_cross = get_td_waveform(sim, approximant=name,
+                                  phase_order=phase_order,
+                                  f_lower=opts.psd_low_frequency_cutoff,
+                                  delta_t=1.0 / sample_rate)
 
 # zero pad polarizations to get integer second time series
 h_plus = pad_timeseries_to_integer_length(h_plus, sample_rate)
@@ -375,7 +385,8 @@ for ifo in opts.instruments:
                         low_frequency_cutoff=opts.psd_low_frequency_cutoff,
                         high_frequency_cutoff=f_high)
     logging.info('Sigma integrated from %.3f to %.3fHz for %s is %.3f',
-                        opts.psd_low_frequency_cutoff, f_high, ifo, numpy.sqrt(sigma_squared))
+                 opts.psd_low_frequency_cutoff, f_high, ifo,
+                 numpy.sqrt(sigma_squared))
 
     # include sigma in network SNR calculation
     network_snr += sigma_squared
@@ -389,9 +400,12 @@ sim.distance = scale*sim.distance
 network_snr = 0.0
 
 # generate waveform
-logging.info('Generating waveform at %.3fMpc beginning at %.3fHz for SNR calculation', sim.distance, opts.psd_low_frequency_cutoff)
-h_plus, h_cross = get_td_waveform(sim, approximant=name, phase_order=phase_order, f_lower=opts.psd_low_frequency_cutoff,
-                      delta_t=1.0/sample_rate)
+logging.info('Generating waveform at %.3fMpc beginning at %.3fHz for '
+             'SNR calculation', sim.distance, opts.psd_low_frequency_cutoff)
+h_plus, h_cross = get_td_waveform(sim, approximant=name,
+                                  phase_order=phase_order,
+                                  f_lower=opts.psd_low_frequency_cutoff,
+                                  delta_t=1.0 / sample_rate)
 
 # zero pad polarizations to get integer second time series
 h_plus = pad_timeseries_to_integer_length(h_plus, sample_rate)
@@ -440,7 +454,8 @@ for ifo in opts.instruments:
                             low_frequency_cutoff=opts.psd_low_frequency_cutoff,
                             high_frequency_cutoff=f_high)
     logging.info('Sigma integrated from %.3f to %.3fHz for %s is %.3f',
-                        opts.psd_low_frequency_cutoff, f_high, ifo, numpy.sqrt(sigma_squared))
+                 opts.psd_low_frequency_cutoff, f_high, ifo,
+                 numpy.sqrt(sigma_squared))
 
     # populate IFO end time columns
     setattr(sim, ifo[0].lower()+'_end_time', int(end_time))
@@ -461,7 +476,8 @@ for ifo in opts.instruments:
 # sanity check network SNR
 network_snr = numpy.sqrt(network_snr)
 if not abs(opts.network_snr / network_snr) - 1 < 0.1:
-    logging.warn('Exiting because network SNR is %f but requested %s', network_snr, opts.network_snr)
+    logging.warn('Exiting because network SNR is %f but requested %s',
+                 network_snr, opts.network_snr)
     sys.exit()
 else:
     logging.info('Network SNR of injection is %.3f', network_snr)
@@ -487,7 +503,8 @@ prefix = opts.tag + '_' + str(start_time)
 logging.info('Writing XML file')
 xml_filename = prefix + '.xml.gz'
 if os.path.exists(xml_filename):
-    logging.warn('Filename %s already exists and will not be overwritten', xml_filename)
+    logging.warn('Filename %s already exists and will not be overwritten',
+                 xml_filename)
     sys.exit()
 else:
     utils.write_filename(outdoc, xml_filename, gz=xml_filename.endswith('gz'))
@@ -497,7 +514,8 @@ for ifo in opts.instruments:
 
     # create a time series of zeroes to inject waveform into
     initial_array = numpy.zeros(num_samples, dtype=strain.dtype)
-    output = TimeSeries(initial_array, delta_t=1.0/sample_rate, epoch=start_time, dtype=strain.dtype)
+    output = TimeSeries(initial_array, delta_t=1.0 / sample_rate,
+                        epoch=start_time, dtype=strain.dtype)
 
     # inject waveform
     logging.info('Injecting %s waveform into timeseries of zeroes', ifo)
@@ -509,7 +527,8 @@ for ifo in opts.instruments:
 
     # check if filename exists
     if os.path.exists(txt_filename):
-        logging.warn('Filename %s already exists and will not be overwritten', txt_filename)
+        logging.warn('Filename %s already exists and will not be overwritten',
+                     txt_filename)
         sys.exit()
 
     # save waveform as single-column ASCII for awgstream to use

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -199,7 +199,7 @@ _psd.insert_psd_option_group_multi_ifo(parser)
 # parse command line
 opts = parser.parse_args()
 
-# verify options are sane
+# verify options are sane if using strain options
 if not opts.psd_file and not opts.asd_file:
     _strain.verify_strain_options_multi_ifo(opts, parser, opts.instruments)
 
@@ -316,12 +316,12 @@ h_plus = pad_timeseries_to_integer_length(h_plus, sample_rate)
 h_cross = pad_timeseries_to_integer_length(h_cross, sample_rate)
 
 # get strain time series
-# strain is used to estimate a PSD so if user supplies PSD then set to None
-if not opts.psd_file and not opts.asd_file:
-    strain_dict = _strain.from_cli_multi_ifos(opts, opts.instruments,
-                                              dyn_range_fac=DYN_RANGE_FAC)
-else:
-    strain_dict = dict([(ifo, None) for ifo in opts.instruments])
+# strain is used to estimate a PSD so if user supplies PSD
+# then genreate a zeroNoise TimeSeries to get length, delta_f, etc.
+if opts.psd_file or opts.asd_file:
+    opts.fake_strain = "zeroNoise"
+strain_dict = _strain.from_cli_multi_ifos(opts, opts.instruments,
+                                          dyn_range_fac=DYN_RANGE_FAC)
 
 # organize options for multi-IFO PSD
 # if not generating strain then set those related options to None
@@ -330,14 +330,9 @@ length_dict = {}
 delta_f_dict = {}
 low_frequency_cutoff_dict = {}
 for ifo in opts.instruments:
-    if strain_dict[ifo] != None:
-        stilde_dict[ifo] = strain_dict[ifo].to_frequencyseries()
-        length_dict[ifo] = len(stilde_dict[ifo])
-        delta_f_dict[ifo] = stilde_dict[ifo].delta_f
-    else:
-        stilde_dict[ifo] = None
-        length_dict[ifo] = None
-        delta_f_dict[ifo] = None
+    stilde_dict[ifo] = strain_dict[ifo].to_frequencyseries()
+    length_dict[ifo] = len(stilde_dict[ifo])
+    delta_f_dict[ifo] = stilde_dict[ifo].delta_f
     low_frequency_cutoff_dict[ifo] = opts.psd_low_frequency_cutoff
 
 # get PSD

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -360,7 +360,8 @@ for ifo in opts.instruments:
 
     # interpolate PSD to waveform delta_f
     if psd_dict[ifo].delta_f != strain_tilde.delta_f:
-        logging.info('Interpolating PSD for %s', ifo)
+        logging.info('Interpolating PSD for %s to %.2fHz',
+                     ifo, strain_tilde.delta_f)
         psd_interpolated = _psd.interpolate(
                                     psd_dict[ifo], strain_tilde.delta_f)
     else:
@@ -425,7 +426,8 @@ for ifo in opts.instruments:
 
     # interpolate PSD to waveform delta_f
     if psd_dict[ifo].delta_f != strain_tilde.delta_f:
-        logging.info('Interpolating PSD for %s', ifo)
+        logging.info('Interpolating PSD for %s to %.2fHz',
+                     ifo, strain_tilde.delta_f)
         psd_interpolated = _psd.interpolate(
                                     psd_dict[ifo], strain_tilde.delta_f)
     else:

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -368,8 +368,6 @@ for ifo in opts.instruments:
     logging.info('Tapering strain for %s', ifo)
     strain = taper_timeseries(strain, tapermethod=sim.taper)
 
-    logging.info('strain.delta_t %f', strain.delta_t)
-
     # FFT strain
     logging.info('FFT strain for %s', ifo)
     strain_tilde = make_frequency_series(strain)

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -202,6 +202,11 @@ opts = parser.parse_args()
 # verify options are sane if using strain options
 if opts.psd_estimation:
     _strain.verify_strain_options_multi_ifo(opts, parser, opts.instruments)
+if not opts.psd_estimation and (opts.frame_files or opts.frame_type
+                            or opts.frame_cache or opts.fake_strain):
+    raise KeyError("Must use --psd-estimation with frame options"
+                   "(--frame-files, --frame-type, --frame-cache, "
+                   "and --fake-strain).")
 
 # setup log
 logging_level = logging.DEBUG

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -314,7 +314,7 @@ low_frequency_cutoff_dict = {}
 for ifo in opts.instruments:
     stilde_dict[ifo] = strain_dict[ifo].to_frequencyseries()
     length_dict[ifo] = len(stilde_dict[ifo])
-    delta_f_dict[ifo] = stilde_dict[ifo].delta_f
+    delta_f_dict[ifo] = h_plus.delta_f
     low_frequency_cutoff_dict[ifo] = opts.psd_low_frequency_cutoff
 
 # get PSD
@@ -348,10 +348,21 @@ for ifo in opts.instruments:
     logging.info('FFT strain for %s', ifo)
     strain_tilde = make_frequency_series(strain)
 
+    # interpolate PSD to waveform delta_f
+    if psd_dict[ifo].delta_f != strain_tilde.delta_f:
+        logging.info('Interpolating PSD for %s', ifo)
+        psd_interpolated = _psd.interpolate(
+                                    psd_dict[ifo], strain_tilde.delta_f)
+    else:
+        psd_interpolated = psd_dict[ifo]
+
     # calculate sigma-squared SNR
     logging.info('Calculating sigma for %s', ifo)
-    sigma_squared = sigmasq(DYN_RANGE_FAC * strain_tilde, psd=psd_dict[ifo],
-                        low_frequency_cutoff=opts.psd_low_frequency_cutoff, high_frequency_cutoff=f_high)
+    sigma_squared = sigmasq(
+                        DYN_RANGE_FAC * strain_tilde,
+                        psd=psd_interpolated,
+                        low_frequency_cutoff=opts.psd_low_frequency_cutoff,
+                        high_frequency_cutoff=f_high)
     logging.info('Sigma integrated from %.3f to %.3fHz for %s is %.3f',
                         opts.psd_low_frequency_cutoff, f_high, ifo, numpy.sqrt(sigma_squared))
 
@@ -402,10 +413,20 @@ for ifo in opts.instruments:
     logging.info('FFT strain for '+ifo+'...')
     strain_tilde = make_frequency_series(strain)
 
+    # interpolate PSD to waveform delta_f
+    if psd_dict[ifo].delta_f != strain_tilde.delta_f:
+        logging.info('Interpolating PSD for %s', ifo)
+        psd_interpolated = _psd.interpolate(
+                                    psd_dict[ifo], strain_tilde.delta_f)
+    else:
+        psd_interpolated = psd_dict[ifo]
+
     # calculate sigma-squared SNR
     logging.info('Calculating sigma for %s', ifo)
-    sigma_squared = sigmasq(DYN_RANGE_FAC * strain_tilde, psd=psd_dict[ifo],
-                        low_frequency_cutoff=opts.psd_low_frequency_cutoff, high_frequency_cutoff=f_high)
+    sigma_squared = sigmasq(DYN_RANGE_FAC * strain_tilde,
+                            psd=psd_interpolated,
+                            low_frequency_cutoff=opts.psd_low_frequency_cutoff,
+                            high_frequency_cutoff=f_high)
     logging.info('Sigma integrated from %.3f to %.3fHz for %s is %.3f',
                         opts.psd_low_frequency_cutoff, f_high, ifo, numpy.sqrt(sigma_squared))
 

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -303,18 +303,28 @@ h_plus = pad_timeseries_to_integer_length(h_plus, sample_rate)
 h_cross = pad_timeseries_to_integer_length(h_cross, sample_rate)
 
 # get strain time series
-strain_dict = _strain.from_cli_multi_ifos(opts, opts.instruments,
-                                         dyn_range_fac=DYN_RANGE_FAC)
+# strain is used to estimate a PSD so if user supplies PSD then set to None
+if not opts.asd_file or not opts.psd_file:
+    strain_dict = _strain.from_cli_multi_ifos(opts, opts.instruments,
+                                              dyn_range_fac=DYN_RANGE_FAC)
+else:
+    strain_dict = dict([(ifo, None) for ifo in opts.instruments])
 
-# organize options from multi-IFO PSD
+# organize options for multi-IFO PSD
+# if not generating strain then set those related options to None
 stilde_dict = {}
 length_dict = {}
 delta_f_dict = {}
 low_frequency_cutoff_dict = {}
 for ifo in opts.instruments:
-    stilde_dict[ifo] = strain_dict[ifo].to_frequencyseries()
-    length_dict[ifo] = len(stilde_dict[ifo])
-    delta_f_dict[ifo] = h_plus.delta_f
+    if strain_dict[ifo] != None:
+        stilde_dict[ifo] = strain_dict[ifo].to_frequencyseries()
+        length_dict[ifo] = len(stilde_dict[ifo])
+        delta_f_dict[ifo] = stilde_dict[ifo].delta_f
+    else:
+        stilde_dict[ifo] = None
+        length_dict[ifo] = None
+        delta_f_dict[ifo] = None
     low_frequency_cutoff_dict[ifo] = opts.psd_low_frequency_cutoff
 
 # get PSD

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -81,7 +81,8 @@ def pad_timeseries_to_integer_length(timeseries, sample_rate):
     one more sample than the start zero padding.
     '''
 
-    # calculate how many sample points needed to pad to get integer second time series
+    # calculate how many sample points needed to pad to get
+    # integer second time series
     remainder = sample_rate - len(timeseries) % sample_rate
     start_pad = int(remainder / 2)
     end_pad = int(remainder - start_pad)
@@ -92,7 +93,8 @@ def pad_timeseries_to_integer_length(timeseries, sample_rate):
 
     # pad waveform with arrays of zeroes
     initial_array = numpy.concatenate([start_array,timeseries,end_array])
-    return TimeSeries(initial_array, delta_t=timeseries.delta_t, epoch=timeseries.start_time, dtype=timeseries.dtype)
+    return TimeSeries(initial_array, delta_t=timeseries.delta_t,
+                      epoch=timeseries.start_time, dtype=timeseries.dtype)
 
 # map order integer to a string that can be parsed by lalsimulation
 pn_orders = {

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -317,7 +317,7 @@ h_cross = pad_timeseries_to_integer_length(h_cross, sample_rate)
 
 # get strain time series
 # strain is used to estimate a PSD so if user supplies PSD then set to None
-if not opts.asd_file or not opts.psd_file:
+if not opts.psd_file and not opts.asd_file:
     strain_dict = _strain.from_cli_multi_ifos(opts, opts.instruments,
                                               dyn_range_fac=DYN_RANGE_FAC)
 else:


### PR DESCRIPTION
Alternative to #1252. If this is merged we can close #1252.

The problem is when using a ASD/PSD file with ``pycbc_generate_hwinj`` it will still try and generate strain using the ``strain`` module. It only needs the strain to generate the PSD so its kind of worthless to keep this step in there if using ``opts.psd_file`` or ``opts.asd_file``.

This PR:
  * Skips strain reading if ``opts.psd_file`` or ``opts.asd_file`` are set.
  * Add interpolation to the waveform's ``delta_f`` if ASD/PSD files happen to be something different.
  * Also have to remove the verify strain options because if ASD/PSD file are given, then user shouldn't be required to set something like ``--fake-strain zeroNoise``.

I got carried away and changed a lot of stuff to PEP-8 as well. So I'll point out that the interpolation is at line 400 of the PR. And bypassing the strain options if ``opts.psd_file`` or ``opts.asd_file`` happens at lines 202 and 321.

Tested with the following command using ASD file:
```
pycbc_generate_hwinj --network-snr 18 --ra 4.2 --dec -0.6 --polarization 0.0 --approximant SEOBNRv2 --order pseudoFourPN --mass1 1.4 --mass2 1.4 --inclination 0.4 --taper TAPER_START --waveform-low-frequency-cutoff 40.0  --spin1x 0 --spin2x 0 --spin1y 0 --spin2y 0 --spin1z 0 --spin2z 0 --geocentric-end-time $(lalapps_tconvert now) --psd-low-frequency-cutoff 40 --instruments H1 L1 --gps-start-time $[ $(lalapps_tconvert now) - 1000 ] --gps-end-time $[$(lalapps_tconvert now) + 100 ] --strain-high-pass 30 --pad-data 10 --sample-rate H1:16384 L1:16384 --channel-name H1:GDS-CALIB_STRAIN L1:GDS-CALIB_STRAIN --asd-file H1:O2projections_H1.txt L1:O2projections_L1.txt
```

And estimating from data:
```
#! /bin/bash

GEOCENT_END_TIME=1126257416
GPS_START_TIME=1126256416
GPS_END_TIME=$((${GPS_START_TIME} + 2048))

IFO=H1
FRAME_TYPE=H1_HOFT_C00
CHANNEL_NAME=GDS-CALIB_STRAIN

SAMPLE_RATE=16384

pycbc_generate_hwinj --instruments ${IFO} \
    --waveform-low-frequency-cutoff 10 \
    --geocentric-end-time ${GEOCENT_END_TIME} \
    --gps-start-time ${GPS_START_TIME} \
    --gps-end-time ${GPS_END_TIME} \
    --frame-type ${IFO}:${FRAME_TYPE} \
    --channel-name ${IFO}:${CHANNEL_NAME} \
    --approximant SEOBNRv2 \
    --order pseudoFourPN \
    --mass1 1.4 \
    --mass2 1.4 \
    --inclination 1.0472 \
    --polarization 0.0 \
    --ra 0.0 \
    --dec 0.0 \
    --taper TAPER_START \
    --network-snr 18.424 \
    --spin1z 0.0 \
    --spin2z 0.0 \
    --psd-low-frequency-cutoff 30.0 \
    --sample-rate ${IFO}:${SAMPLE_RATE} \
    --pad-data 8 \
    --strain-high-pass 30.0 \
    --psd-estimation median \
    --psd-segment-length 16 \
    --psd-segment-stride 8
```