### PR TITLE
Minor bug fixes for OSG running

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -266,10 +266,15 @@ fi
 grid-proxy-info -exists
 RESULT=$?
 if [ ${RESULT} -eq 0 ] ; then
-  cp /tmp/x509up_u`id -u` /tmp/x509up_u`id -u`.orig
-  grid-proxy-init -valid 72:0 -cert /tmp/x509up_u`id -u`.orig -key /tmp/x509up_u`id -u`.orig
-  rm -f /tmp/x509up_u`id -u`.orig
-  grid-proxy-info
+  PROXY_TYPE=`grid-proxy-info -type | tr -d ' '`
+  if [ x${PROXY_TYPE} == 'xRFC3820compliantimpersonationproxy' ] ; then
+    grid-proxy-info
+  else
+    cp /tmp/x509up_u`id -u` /tmp/x509up_u`id -u`.orig
+    grid-proxy-init -valid 72:0 -cert /tmp/x509up_u`id -u`.orig -key /tmp/x509up_u`id -u`.orig
+    rm -f /tmp/x509up_u`id -u`.orig
+    grid-proxy-info
+  fi
 else
   echo "Error: Could not find a valid grid proxy to submit workflow."
   exit 1
@@ -439,10 +444,15 @@ fi
 grid-proxy-info -exists
 RESULT=$?
 if [ ${RESULT} -eq 0 ] ; then
-  cp /tmp/x509up_u`id -u` /tmp/x509up_u`id -u`.orig
-  grid-proxy-init -valid 72:0 -cert /tmp/x509up_u`id -u`.orig -key /tmp/x509up_u`id -u`.orig
-  rm -f /tmp/x509up_u`id -u`.orig
-  grid-proxy-info
+  PROXY_TYPE=`grid-proxy-info -type | tr -d ' '`
+  if [ x${PROXY_TYPE} == 'xRFC3820compliantimpersonationproxy' ] ; then
+    grid-proxy-info
+  else
+    cp /tmp/x509up_u`id -u` /tmp/x509up_u`id -u`.orig
+    grid-proxy-init -valid 72:0 -cert /tmp/x509up_u`id -u`.orig -key /tmp/x509up_u`id -u`.orig
+    rm -f /tmp/x509up_u`id -u`.orig
+    grid-proxy-info
+  fi
 else
   echo "Error: Could not find a valid grid proxy to submit workflow."
   exit 1

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -75,7 +75,8 @@ You first set up a new virtual environment. A virtual environment is defined by 
     
     virtualenv ~/src/pycbc
 
-You can create as many different virtual environments as you like, as long as they all have different paths.
+You can create as many different virtual environments as you like, as long as
+they all have different paths. 
 
 .. note::
 
@@ -86,8 +87,12 @@ To enter your virtual environment run the command (replacing the string ``~/src/
 .. code-block:: bash
     
     source ~/src/pycbc/bin/activate
-    
-You will now be in your virtual environment, and so you can install packages, etc, without conflicting with either the system build, or other builds that you may have sitting around. You may install other programs and libraries, such as lalsuite (:ref:`lalsuite_install`), into this virtual environment. The ``activate`` script also sets the environment variable ``${VIRTUAL_ENV}`` to the full path to your virtual environment.
+
+After running the ``activate`` script, you will now be in your virtual environment, and so you can install packages without conflicting with either the system build, or other builds that you may have sitting around. You may install other programs and libraries, such as lalsuite (:ref:`lalsuite_install`), into this virtual environment. The ``activate`` script also sets the environment variable ``${VIRTUAL_ENV}`` to the full path to your virtual environment.
+
+.. note::
+
+    Python implements a `per user site packages directory <https://www.python.org/dev/peps/pep-0370/>`_ to install packages in the user's home directory. By default this is ``~/.local`` but the location is controlled by the ``PYTHONUSERBASE`` environment variable. If you make use of the ``~/.local`` directory, you should add the line ``export PYTHONUSERBASE=${VIRTUAL_ENV}/.local`` to the end of your virtual environment's ``activate`` script to prevent conflicts. Similarly, pip caches data in the directory ``~/.caches/pip``. To prevent conflicts with this directory, you can add the line ``export XDG_CACHE_HOME=${VIRTUAL_ENV}/.cache`` to the virtual environment ``activate`` script so that pip uses a cache that is specific to the virtual environment.
 
 To leave this virtual environment type
 

--- a/docs/workflow/pycbc_make_coinc_search_workflow.rst
+++ b/docs/workflow/pycbc_make_coinc_search_workflow.rst
@@ -683,24 +683,31 @@ There are a number of requirements on the machine on which the workflow will be 
 Configuring the workflow
 ------------------------
 
-In order for ``pycbc_inspiral`` to be sent to worker nodes it must be available
-via a remote protocol, either http or gsiftp. The LDG head nodes run a gridftp
-server that should be able to serve this, or code can obtain the code from the
-web server on ``code.pycbc.phy.syr.edu``. Edit your ``executables.ini`` to 
-specify this path or give the path when you run
-``pycbc_make_coinc_search_workflow``, for example, with the option::
+In order for ``pycbc_inspiral`` to be sent to worker nodes it must be
+available via a remote protocol, either http, gsiftp, or CVMFS. Releases of
+pycbc are installed in CVMFS and the LDG head nodes run a gridftp server that
+can serve your own development copy.  Specify this path when you run
+``pycbc_make_coinc_search_workflow``. To run from a released bundle in CVMFS 
+give the following argument to the ``--config-overrides`` option (changing the
+path to point to the release that you want to use)::
 
-    --config-overrides 'executables:inspiral:gsiftp://server.name/path/to/pycbc_inspiral'
+    'executables:inspiral:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/x86_64_rhel_6/bundle/v1.5.7/pycbc_inspiral'
 
-Add the following to the list of ``--config-overrides`` when running ``pycbc_make_coinc_search_workflow``::
+If you are running your own build of ``pycbc_inspiral``, you will need to give
+a path to a gsiftp URL and tell Pegasus that the executable is not installed
+on the OSG with the two ``--config-overrides`` options::
+
+    'executables:inspiral:gsiftp://server.hostname/path/to/pycbc_inspiral' \
+    'pegasus_profile-inspiral:pycbc|installed:False'
+
+Add the following to the list of ``--config-overrides`` when running ``pycbc_make_coinc_search_workflow`` to tell Pegasus to run the inspiral code on the OSG::
      
     'pegasus_profile-inspiral:pycbc|site:osg' \
-    'pegasus_profile-inspiral:hints|execution.site:osg' \
-    'pegasus_profile-inspiral:condor|request_memory:1920M' \
+    'pegasus_profile-inspiral:hints|execution.site:osg'
 
 You also need a ``--config-overrides`` to ``pycbc_make_coinc_search_workflow`` that sets the staging site for the main workflow to the local site. To do this, add the following argument, replacing ``${WORKFLOW_NAME}`` with the string that is given as the argument to the option ``--workflow-name ``::
 
-    'workflow-${WORKFLOW_NAME}-main:staging-site:osg=local' \
+    'workflow-${WORKFLOW_NAME}-main:staging-site:osg=local'
 
 Optionally, you can add a configuration that will check that your grid proxy
 is valid locally before submitting the job. This means that if your grid proxy
@@ -708,7 +715,7 @@ expires before the workflow is complete, the failure will be on the local site
 before the job is actually submitted, and not on the remote site once the job
 has been scheduled and matched::
 
-    'pegasus_profile-inspiral:dagman|pre:/usr/bin/grid-proxy-info' \
+    'pegasus_profile-inspiral:dagman|pre:/usr/bin/grid-proxy-info'
 
 Another useful enhancement for OSG running is to add profiles to your inspiral
 job that will tell Condor to put it on hold if it has been running for more


### PR DESCRIPTION
Change ``pycbc_submit_dax`` so that it does not create a proxy if the certificate is already a proxy. This fixes https://github.com/ligo-cbc/pycbc/issues/1248.

Change the OSG instructions now that ``pycbc_inspiral`` releases are available from CVMFS and the default Pegasus profile for the inspiral executable is ``installed = true``:

https://code.pycbc.phy.syr.edu/ligo-cbc/pycbc-config/commit/ca493a05911c7ece3864b1e7bfe8c43ae2c3d49b