### PR TITLE
initialize findtrigs with empty list

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_findtrigs
+++ b/bin/hdfcoinc/pycbc_coinc_findtrigs
@@ -179,8 +179,8 @@ det0, det1 = detector.Detector(trigs0.ifo), detector.Detector(trigs1.ifo)
 time_window = det0.light_travel_time_to_detector(det1) + args.coinc_threshold
 logging.info('The coincidence window is %3.1f ms' % (time_window * 1000))
 
-data = {'stat':[], 'decimation_factor':[], 'time1':[], 'time2':[],
-        'trigger_id1':[], 'trigger_id2':[], 'timeslide_id':[], 'template_id':[]}
+data = {'stat':[[]], 'decimation_factor':[[]], 'time1':[[]], 'time2':[[]],
+        'trigger_id1':[[]], 'trigger_id2':[[]], 'timeslide_id':[[]], 'template_id':[[]]}
 
 for tnum in range(tmin, tmax):
     tid0 = trigs0.set_template(tnum)


### PR DESCRIPTION
This allows the coincidence to proceed in the event there are absolutely not single detector triggers....