### PR TITLE
Fix the way that executables are added to the DAX

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -209,7 +209,8 @@ class Executable(pegasus_workflow.Executable):
                 # Check that executables at file urls on the local site exist
                    if os.path.isfile(exe_url.path) is False:
                        raise TypeError("Failed to find %s executable " 
-                                       "at %s" % (name, exe_path))
+                                       "at %s on site %s" % (name, exe_path,
+                                       exe_site))
             else:
                 # Could be http, gsiftp, etc. so it needs fetching if run now
                 self.needs_fetching = True


### PR DESCRIPTION
This cleans up some messy code in the Executable() class that also prevents file urls being used on remote sites (see https://github.com/ligo-cbc/pycbc/issues/1264).

I have tested it with various combinations, including missing executables to trigger the error.