### PR TITLE
Remove the profile hints.executionPool

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -687,7 +687,6 @@ class Node(pegasus_workflow.Node):
         
         if hasattr(executable, 'execution_site'):
             self.add_profile('hints', 'execution.site', executable.execution_site)
-            self.add_profile('hints', 'executionPool', executable.execution_site)
             
         self._options += self.executable.common_options
         for inp in self.executable.common_input_files:


### PR DESCRIPTION
This stops pegasus from generating the warning message:
```
2016.11.20 13:09:22.656 EST: [WARNING]  profile hints.executionPool is deprecated. Replacing with hints.execution.site 
```