### PR TITLE
Make sure that the environment is empty on OSG

### DIFF
--- a/docs/workflow/pycbc_make_coinc_search_workflow.rst
+++ b/docs/workflow/pycbc_make_coinc_search_workflow.rst
@@ -705,6 +705,10 @@ Add the following to the list of ``--config-overrides`` when running ``pycbc_mak
     'pegasus_profile-inspiral:pycbc|site:osg' \
     'pegasus_profile-inspiral:hints|execution.site:osg'
 
+To prevent the bundles executable picking up a bad environment on OSG machines, you should also use the ``--config-overrides`` option::
+
+    'pegasus_profile-inspiral:condor|getenv:False'
+
 You also need a ``--config-overrides`` to ``pycbc_make_coinc_search_workflow`` that sets the staging site for the main workflow to the local site. To do this, add the following argument, replacing ``${WORKFLOW_NAME}`` with the string that is given as the argument to the option ``--workflow-name ``::
 
     'workflow-${WORKFLOW_NAME}-main:staging-site:osg=local'


### PR DESCRIPTION
If the workflow uses a bundles installed in CVMFS, then the pipeline sets
```
getenv = True
```
in the condor profile for the job. If the user is using the RHEL7 virtual environment to create the workflow, then this causes jobs to fail on RHEL6 sites with
```
python: error while loading shared libraries: libpython2.7.so.1.0: cannot open shared object file: No such file or directory
2016-11-20 19:58:16: Last command exited with 127
```

This documentation patch tells the user to make sure that the environment is empty when running on OSG to prevent this. A better long-term patch is to fix the workflow code that is setting ``getenv = True``, but this will work for now.