### PR TITLE
if using --fixed-weave-cache, set LAL_DATA_PATH to the cache directory

### DIFF
--- a/pycbc/weave.py
+++ b/pycbc/weave.py
@@ -136,6 +136,8 @@ def verify_weave_options(opt, parser):
         sys.path = [cache_dir] + sys.path
         try: os.makedirs(cache_dir)
         except OSError: pass
+        if not os.environ.get("LAL_DATA_PATH", None):
+            os.environ['LAL_DATA_PATH'] = cache_dir
 
     # Check whether to use a private directory for scipy.weave
     if opt.per_process_weave_cache:


### PR DESCRIPTION
- only if it has not been set externally

- this is meant to allow using ROM files contained in a PyInstaller bundle

- untested yet, as the test analysis currently doesn't work for other reasons