### PR TITLE
Fixes to sharedoptions section

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -520,6 +520,7 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
                                %(arg,'sharedoptions-%s' %(key)))
                     self.set(section, arg, val)
             self.remove_section('sharedoptions-%s' %(key))
+        self.remove_section('sharedoptions')
 
     def add_options_to_section(self ,section, items, overwrite_options=False):
         """

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -510,6 +510,8 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
             values = value.split(',')
             common_options = self.items('sharedoptions-%s' %(key))
             for section in values:
+                if not self.has_section(section):
+                    self.add_section(section)
                 for arg, val in common_options:
                     if arg in self.options(section):
                         raise ValueError('Option exists in both original ' + \
@@ -517,6 +519,7 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
                                'sharedoptions section: %s %s' \
                                %(arg,'sharedoptions-%s' %(key)))
                     self.set(section, arg, val)
+            self.remove_section('sharedoptions-%s' %(key))
 
     def add_options_to_section(self ,section, items, overwrite_options=False):
         """


### PR DESCRIPTION
There are two issues with the recently added sharedoptions section if using it in coinc_search workflows:

 * The sharedoptions section must be removed after parsing, to avoid sub-daxes trying to repeat the sharedoption parsing and failing because options are already there.
 * I want to support sharedoptions with sections that may not exist. In the case a section does not exist, just make it.

I would like this included in the next release, as I am using it with proposed O2 injection set (see today's call for more update).

Still being tested.