### PR TITLE
Some bug fixes to the new posterior plots

### DIFF
--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -34,7 +34,8 @@ from matplotlib import pyplot
 import pycbc.results
 from pycbc.inference import option_utils
 from pycbc.io.inference_hdf import InferenceFile
-from pycbc.results.scatter_histograms import create_multidim_plot
+from pycbc.results.scatter_histograms import create_multidim_plot, \
+    get_scale_fac
 
 parser = argparse.ArgumentParser()
 
@@ -94,9 +95,19 @@ if opts.z_arg is not None:
                                     thin_interval=thinint, flatten=False)
     zvals, zlbl = option_utils.get_zvalues(fp, opts.z_arg, likelihood_stats)
     show_colorbar = True
+    # Set common min and max for colorbar in all plots
+    if opts.vmin is None:
+        vmin = zvals.min()
+    else:
+        vmin = opts.vmin
+    if opts.vmax is None:
+        vmax = zvals.max()
+    else:
+        vmax = opts.vmax
 else:
     zvals = None
     zlbl = None
+    vmin = vmax = None
     show_colorbar = False
 
 fp.close()
@@ -111,22 +122,21 @@ for p in parameters:
 for p in parameters:
     if p not in maxs:
         maxs[p] = samples[p].max()
-# Set common min and max for colorbar in all plots
-if opts.vmin is None:
-    vmin = zvals.min()
-else:
-    vmin = opts.vmin
-if opts.vmax is None:
-    vmax = zvals.max()
-else:
-    vmax = opts.vmax
 
 # Make each figure
+# for sorting purposes, we will need to zero-pad the sample numer with the
+# appriopriate number of 0's
+max_sample_num = nframes * thinint
 for frame in range(nframes):
     logging.info('Plotting frame %i' %(frame+1))
     plotargs = samples[:,frame]
-    z = zvals[:,frame]
-    output = opts.output_file + '%d.png' %(frame+1)
+    if zvals is not None:
+        z = zvals[:,frame]
+    else:
+        z = None
+    sample_num = str(frame * thinint + 1)
+    sample_num = sample_num.zfill(len(str(max_sample_num)))
+    output = opts.output_file + '-{}.png'.format(sample_num)
 
     fig, axis_dict = create_multidim_plot(parameters, plotargs, labels=labels,
                         mins=mins, maxs=maxs,
@@ -142,7 +152,16 @@ for frame in range(nframes):
                             use_kombine=opts.use_kombine_kde)
 
     # Write sample number
-    pyplot.annotate('Sample %d' %(frame*thinint+1), xy=(0.8,0.95), xycoords='figure fraction')
+    if show_colorbar:
+        xtxt = 0.85
+    else:
+        xtxt = 0.9
+    ytxt = 0.95
+    scale_fac = get_scale_fac(fig)
+    fontsize = 8*scale_fac
+    pyplot.annotate('Sample {}'.format(sample_num), xy=(xtxt, ytxt),
+        xycoords='figure fraction', horizontalalignment='right',
+        verticalalignment='top', fontsize=fontsize)
 
     fig.savefig(output, bbox_inches='tight', dpi=200)
     pyplot.close()

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -129,7 +129,6 @@ for frame in range(nframes):
     fig, axis_dict = create_multidim_plot(parameters, plotargs, labels=labels,
                         mins=mins, maxs=maxs,
                         plot_marginal=opts.plot_marginal,
-                            small_marginal_plots=opts.small_marginal_plots,
                         plot_scatter=opts.plot_scatter,
                             zvals=z, show_colorbar=not opts.no_colorbar,
                             cbar_label=zlbl, vmin=vmin, vmax=vmax,

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -58,16 +58,8 @@ parser.add_argument("--thin-end", type=int,
                     help="Sample number to stop collecting samples to plot. "
                          "If none provided, will stop at the last sample.")
 parser.add_argument('--verbose', action='store_true')
-parser.add_argument('--plot-marginal', action='store_true', default=False,
-                    help="Plot 1D marginalized distributions on the diagonal "
-                         "axes.")
-parser.add_argument("--plot-scatter", action='store_true', default=False,
-                    help="Plot each sample point as a scatter plot.")
-parser.add_argument("--plot-density", action="store_true", default=False,
-                    help="Plot the posterior density as a color map.")
-parser.add_argument("--plot-contours", action="store_true", default=False,
-                    help="Draw contours showing the 50th and 90th percentile "
-                         "confidence regions.")
+# add options for what plots to create
+option_utils.add_plot_posterior_option_group(parser)
 # add scatter and density configuration options
 option_utils.add_scatter_option_group(parser) 
 option_utils.add_density_option_group(parser)
@@ -109,8 +101,14 @@ fp.close()
 
 logging.info('Choosing common characteristics for all figures')
 # Set common min and max for axis in all plots
-mins = {p:samples[p].min() for p in parameters}
-maxs = {p:samples[p].max() for p in parameters}
+mins, maxs = option_utils.plot_ranges_from_cli(opts)
+# add any missing parameters
+for p in parameters:
+    if p not in mins:
+        mins[p] = samples[p].min()
+for p in parameters:
+    if p not in maxs:
+        maxs[p] = samples[p].max()
 # Set common min and max for colorbar in all plots
 if opts.vmin is None:
     vmin = zvals.min()
@@ -131,6 +129,7 @@ for frame in range(nframes):
     fig, axis_dict = create_multidim_plot(parameters, plotargs, labels=labels,
                         mins=mins, maxs=maxs,
                         plot_marginal=opts.plot_marginal,
+                            small_marginal_plots=opts.small_marginal_plots,
                         plot_scatter=opts.plot_scatter,
                             zvals=z, show_colorbar=not opts.no_colorbar,
                             cbar_label=zlbl, vmin=vmin, vmax=vmax,

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -93,9 +93,11 @@ if opts.z_arg is not None:
     likelihood_stats = fp.read_likelihood_stats(thin_start=0,
                                     thin_interval=thinint, flatten=False)
     zvals, zlbl = option_utils.get_zvalues(fp, opts.z_arg, likelihood_stats)
+    show_colorbar = True
 else:
     zvals = None
     zlbl = None
+    show_colorbar = False
 
 fp.close()
 
@@ -130,7 +132,7 @@ for frame in range(nframes):
                         mins=mins, maxs=maxs,
                         plot_marginal=opts.plot_marginal,
                         plot_scatter=opts.plot_scatter,
-                            zvals=z, show_colorbar=not opts.no_colorbar,
+                            zvals=z, show_colorbar=show_colorbar,
                             cbar_label=zlbl, vmin=vmin, vmax=vmax,
                             scatter_cmap=opts.scatter_cmap,
                         plot_density=opts.plot_density,

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -65,9 +65,11 @@ if opts.z_arg is not None:
             thin_end=opts.thin_end, thin_interval=opts.thin_interval,
             iteration=opts.iteration)
     zvals, zlbl = option_utils.get_zvalues(fp, opts.z_arg, likelihood_stats)
+    show_colorbar = True
 else:
     zvals = None
     zlbl = None
+    show_colorbar = False
 fp.close()
 
 mins, maxs = option_utils.plot_ranges_from_cli(opts)
@@ -84,7 +86,7 @@ fig, axis_dict = create_multidim_plot(
                 parameters, samples, labels=labels,
                 plot_marginal=opts.plot_marginal,
                 plot_scatter=opts.plot_scatter,
-                    zvals=zvals, show_colorbar=not opts.no_colorbar,
+                    zvals=zvals, show_colorbar=show_colorbar,
                     cbar_label=zlbl, vmin=opts.vmin, vmax=opts.vmax,
                     scatter_cmap=opts.scatter_cmap,
                 plot_density=opts.plot_density,

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -58,6 +58,9 @@ option_utils.add_scatter_option_group(parser)
 option_utils.add_density_option_group(parser)
 # add standard option utils
 option_utils.add_inference_results_option_group(parser)
+# add mins, maxs options
+parser.add_argument('--mins', nargs='+', metavar='PARAM:VAL', default=[])
+parser.add_argument('--maxs', nargs='+', metavar='PARAM:VAL', default=[])
 
 opts = parser.parse_args()
 
@@ -78,6 +81,21 @@ else:
     zlbl = None
 fp.close()
 
+def strfloat(x):
+    return x.split(':')[0], float(x.split(':')[1])
+
+mins = dict(map(strfloat, opts.mins))
+# add any missing parameters
+for p in parameters:
+    if p not in mins:
+        mins[p] = samples[p].min()
+
+maxs = dict(map(strfloat, opts.maxs))
+# add any missing parameters
+for p in parameters:
+    if p not in maxs:
+        maxs[p] = samples[p].max()
+
 logging.info("Plotting")
 fig, axis_dict = create_multidim_plot(
                 parameters, samples, labels=labels,
@@ -90,7 +108,8 @@ fig, axis_dict = create_multidim_plot(
                 plot_contours=opts.plot_contours,
                     density_cmap=opts.density_cmap,
                     contour_color=opts.contour_color,
-                    use_kombine=opts.use_kombine_kde)
+                    use_kombine=opts.use_kombine_kde,
+                mins=mins, maxs=maxs)
 
 # save
 fig.savefig(opts.output_file, bbox_inches='tight', dpi=200)

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -83,7 +83,6 @@ logging.info("Plotting")
 fig, axis_dict = create_multidim_plot(
                 parameters, samples, labels=labels,
                 plot_marginal=opts.plot_marginal,
-                    small_marginal_plots=opts.small_marginal_plots,
                 plot_scatter=opts.plot_scatter,
                     zvals=zvals, show_colorbar=not opts.no_colorbar,
                     cbar_label=zlbl, vmin=opts.vmin, vmax=opts.vmax,

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -42,25 +42,14 @@ parser.add_argument("--output-file", type=str, required=True,
                     help="Output plot path.")
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="Be verbose")
-parser.add_argument('--plot-marginal', action='store_true', default=False,
-                    help="Plot 1D marginalized distributions on the diagonal "
-                         "axes.")
-parser.add_argument("--plot-scatter", action='store_true', default=False,
-                    help="Plot each sample point as a scatter plot.")
-parser.add_argument("--plot-density", action="store_true", default=False,
-                    help="Plot the posterior density as a color map.")
-parser.add_argument("--plot-contours", action="store_true", default=False,
-                    help="Draw contours showing the 50th and 90th percentile "
-                         "confidence regions.")
+# add options for what plots to create
+option_utils.add_plot_posterior_option_group(parser)
 # Scatter configuration
 option_utils.add_scatter_option_group(parser)
 # Density configuration
 option_utils.add_density_option_group(parser)
 # add standard option utils
 option_utils.add_inference_results_option_group(parser)
-# add mins, maxs options
-parser.add_argument('--mins', nargs='+', metavar='PARAM:VAL', default=[])
-parser.add_argument('--maxs', nargs='+', metavar='PARAM:VAL', default=[])
 
 opts = parser.parse_args()
 
@@ -81,17 +70,11 @@ else:
     zlbl = None
 fp.close()
 
-def strfloat(x):
-    return x.split(':')[0], float(x.split(':')[1])
-
-mins = dict(map(strfloat, opts.mins))
+mins, maxs = option_utils.plot_ranges_from_cli(opts)
 # add any missing parameters
 for p in parameters:
     if p not in mins:
         mins[p] = samples[p].min()
-
-maxs = dict(map(strfloat, opts.maxs))
-# add any missing parameters
 for p in parameters:
     if p not in maxs:
         maxs[p] = samples[p].max()
@@ -100,6 +83,7 @@ logging.info("Plotting")
 fig, axis_dict = create_multidim_plot(
                 parameters, samples, labels=labels,
                 plot_marginal=opts.plot_marginal,
+                    small_marginal_plots=opts.small_marginal_plots,
                 plot_scatter=opts.plot_scatter,
                     zvals=zvals, show_colorbar=not opts.no_colorbar,
                     cbar_label=zlbl, vmin=opts.vmin, vmax=opts.vmax,

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -244,17 +244,6 @@ def add_plot_posterior_option_group(parser):
     pgroup.add_argument('--plot-marginal', action='store_true', default=False,
                         help="Plot 1D marginalized distributions on the "
                              "diagonal axes.")
-    pgroup.add_argument('--small-marginal-plots', action="store_true",
-                        default=False,
-                        help="Make the marginal plots 1/3 the size of the "
-                             "density/scatter plots. In this case, the last "
-                             "marginal plot (the one furthest to the right) "
-                             "will be rotated such that distribution runs "
-                             "along the y-axis instead of the x. This is "
-                             "useful if creating plots for publications or "
-                             "slides, where space is at a premium. Otherwise, "
-                             "marginal plots are the same size as the "
-                             "density/scatter plots.")
     pgroup.add_argument("--plot-scatter", action='store_true', default=False,
                         help="Plot each sample point as a scatter plot.")
     pgroup.add_argument("--plot-density", action="store_true", default=False,

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -23,16 +23,16 @@ from pycbc.io import InferenceFile
 import pycbc.inference.sampler
 from pycbc.inference import likelihood
 
+
 def add_sampler_option_group(parser):
-    """
-    Adds the options needed to set up an inference sampler.
+    """Adds the options needed to set up an inference sampler.
 
     Parameters
     ----------
     parser : object
         ArgumentParser instance.
     """
-    sampler_group = parser.add_argument_group("arguments for setting up "
+    sampler_group = parser.add_argument_group("Arguments for setting up "
         "a sampler")
 
     # required options
@@ -63,6 +63,7 @@ def add_sampler_option_group(parser):
 
     return sampler_group
 
+
 def sampler_from_cli(opts, likelihood_evaluator):
     """Parses the given command-line options to set up a sampler.
 
@@ -84,9 +85,9 @@ def sampler_from_cli(opts, likelihood_evaluator):
         raise ValueError("both skip-burn-in and min-burn-in specified")
     return sclass.from_cli(opts, likelihood_evaluator)
 
+
 def add_inference_results_option_group(parser):
-    """
-    Adds the options used to call pycbc.inference.results_from_cli function
+    """Adds the options used to call pycbc.inference.results_from_cli function
     to an argument parser. These are options releated to loading the results
     from a run of pycbc_inference, for purposes of plotting and/or creating
     tables.
@@ -97,7 +98,7 @@ def add_inference_results_option_group(parser):
         ArgumentParser instance.
     """
 
-    results_reading_group = parser.add_argument_group("arguments for loading "
+    results_reading_group = parser.add_argument_group("Arguments for loading "
         "inference results")
 
     # required options
@@ -134,6 +135,7 @@ def add_inference_results_option_group(parser):
              "the thin-start/interval/end options.")
 
     return results_reading_group
+
 
 def results_from_cli(opts, load_samples=True, walkers=None):
     """
@@ -185,9 +187,29 @@ def results_from_cli(opts, load_samples=True, walkers=None):
         samples = None
     return fp, parameters, labels, samples
 
+
 def get_zvalues(fp, arg, likelihood_stats):
     """Reads the data for the z-value of the plots from the inference file.
 
+    Parameters
+    ----------
+    fp : InferenceFile
+        An open inference file; needed to get the value of the log noise
+        likelihood.
+    arg : str
+        The argument to plot; must be one of `loglr`, `snr`, `logplr`,
+        `logposterior`, or `prior`. If not one of these, a ValueError is
+        raised.
+    likelihood_stats : FieldArray
+        The likelihood stats; the sort of thing returned by
+        `fp.read_likelihood_stats`.
+
+    Returns
+    -------
+    zvals : numpy.array
+        An array of the desired likelihood values to plot.
+    zlbl : str
+        The label to use for the values on a plot.
     """
     if arg == 'loglr':
         zvals = likelihood_stats.loglr
@@ -204,11 +226,96 @@ def get_zvalues(fp, arg, likelihood_stats):
     elif arg == 'prior':
         zvals = likelihood_stats.prior
         zlbl = r'$\log p(\vec{\vartheta})$'
+    else:
+        raise ValueError("Unrecognized arg {}".format(arg))
     return zvals, zlbl
 
-def add_scatter_option_group(parser):
+
+def add_plot_posterior_option_group(parser):
+    """Adds the options needed to configure plots of posterior results.
+
+    Parameters
+    ----------
+    parser : object
+        ArgumentParser instance.
     """
-    Adds the options needed to configure scatter plots.
+    pgroup = parser.add_argument_group("Options for what plots to create and "
+                                         "their formats.")
+    pgroup.add_argument('--plot-marginal', action='store_true', default=False,
+                        help="Plot 1D marginalized distributions on the "
+                             "diagonal axes.")
+    pgroup.add_argument('--small-marginal-plots', action="store_true",
+                        default=False,
+                        help="Make the marginal plots 1/3 the size of the "
+                             "density/scatter plots. In this case, the last "
+                             "marginal plot (the one furthest to the right) "
+                             "will be rotated such that distribution runs "
+                             "along the y-axis instead of the x. This is "
+                             "useful if creating plots for publications or "
+                             "slides, where space is at a premium. Otherwise, "
+                             "marginal plots are the same size as the "
+                             "density/scatter plots.")
+    pgroup.add_argument("--plot-scatter", action='store_true', default=False,
+                        help="Plot each sample point as a scatter plot.")
+    pgroup.add_argument("--plot-density", action="store_true", default=False,
+                        help="Plot the posterior density as a color map.")
+    pgroup.add_argument("--plot-contours", action="store_true", default=False,
+                        help="Draw contours showing the 50th and 90th "
+                             "percentile confidence regions.")
+    # add mins, maxs options
+    pgroup.add_argument('--mins', nargs='+', metavar='PARAM:VAL', default=[],
+                        help="Specify minimum parameter values to plot. This "
+                             "should be done by specifying the parameter name "
+                             "followed by the value. Parameter names must be "
+                             "the same as the PARAM argument in --parameters "
+                             "(or, if no parameters are provided, the same as "
+                             "the parameter name specified in the variable "
+                             "args in the input file. If none provided, "
+                             "the smallest parameter value in the posterior "
+                             "will be used.")
+    pgroup.add_argument('--maxs', nargs='+', metavar='PARAM:VAL', default=[],
+                        help="Same as mins, but for the maximum values to "
+                             "plot.")
+    return pgroup
+
+
+def plot_ranges_from_cli(opts):
+    """Parses the mins and maxs arguments from the `plot_posterior` option
+    group.
+
+    Parameters
+    ----------
+    opts : ArgumentParser
+        The parsed arguments from the command line.
+
+    Returns
+    -------
+    mins : dict
+        Dictionary of parameter name -> specified mins. Only parameters that
+        were specified in the --mins option will be included; if no parameters 
+        were provided, will return an empty dictionary.
+    maxs : dict
+        Dictionary of parameter name -> specified maxs. Only parameters that
+        were specified in the --mins option will be included; if no parameters 
+        were provided, will return an empty dictionary.
+    """
+    mins = {}
+    for x in opts.mins:
+        x = x.split(':')
+        if len(x) != 2:
+            raise ValueError("option --mins not specified correctly; see help")
+        mins[x[0]] = float(x[1])
+    maxs = {}
+    for x in opts.maxs:
+        x = x.split(':')
+        if len(x) != 2:
+            raise ValueError("option --maxs not specified correctly; see help")
+        maxs[x[0]] = float(x[1])
+    return mins, maxs
+
+
+def add_scatter_option_group(parser):
+    """Adds the options needed to configure scatter plots.
 
     Parameters
     ----------
@@ -227,7 +334,8 @@ def add_scatter_option_group(parser):
                          'logplr: loglr + log of the prior; '
                          'logposterior: log likelihood function + log prior; '
                          'prior: the log of the prior.')
-    scatter_group.add_argument('--no-colorbar', action='store_true', default=False,
+    scatter_group.add_argument('--no-colorbar', action='store_true',
+                    default=False,
                     help='Do not show the color bar for the scatter plot. ')
     scatter_group.add_argument("--vmin", type=float,
                     help="Minimum value for the colorbar.")
@@ -239,9 +347,9 @@ def add_scatter_option_group(parser):
 
     return scatter_group
 
+
 def add_density_option_group(parser):
-    """
-    Adds the options needed to configure contours and density colour map.
+    """Adds the options needed to configure contours and density colour map.
 
     Parameters
     ----------

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -327,9 +327,9 @@ def add_scatter_option_group(parser):
                     help="Minimum value for the colorbar.")
     scatter_group.add_argument("--vmax", type=float,
                     help="Maximum value for the colorbar.")
-    scatter_group.add_argument("--scatter-cmap", type=str, default='viridis',
+    scatter_group.add_argument("--scatter-cmap", type=str, default='plasma',
                     help="Specify the colormap to use for points. Default is "
-                         "viridis.")
+                         "plasma.")
 
     return scatter_group
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -281,7 +281,7 @@ def plot_ranges_from_cli(opts):
     -------
     mins : dict
         Dictionary of parameter name -> specified mins. Only parameters that
-        were specified in the --mins option will be included; if no parameters 
+        were specified in the --mins option will be included; if no parameters
         were provided, will return an empty dictionary.
     maxs : dict
         Dictionary of parameter name -> specified maxs. Only parameters that

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -285,7 +285,7 @@ def plot_ranges_from_cli(opts):
         were provided, will return an empty dictionary.
     maxs : dict
         Dictionary of parameter name -> specified maxs. Only parameters that
-        were specified in the --mins option will be included; if no parameters 
+        were specified in the --mins option will be included; if no parameters
         were provided, will return an empty dictionary.
     """
     mins = {}

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -323,9 +323,6 @@ def add_scatter_option_group(parser):
                          'logplr: loglr + log of the prior; '
                          'logposterior: log likelihood function + log prior; '
                          'prior: the log of the prior.')
-    scatter_group.add_argument('--no-colorbar', action='store_true',
-                    default=False,
-                    help='Do not show the color bar for the scatter plot. ')
     scatter_group.add_argument("--vmin", type=float,
                     help="Minimum value for the colorbar.")
     scatter_group.add_argument("--vmax", type=float,

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -367,7 +367,7 @@ def create_marginalized_hist(ax, param, samples, percentiles=None, label=None,
 def create_multidim_plot(parameters, samples, labels=None,
                 mins=None, maxs=None,
                 plot_marginal=True,
-                    small_marginals=False,
+                    small_marginal_plots=False,
                 plot_scatter=True,
                     zvals=None, show_colorbar=True, cbar_label=None,
                     vmin=None, vmax=None, scatter_cmap='plasma_r',
@@ -464,9 +464,9 @@ def create_multidim_plot(parameters, samples, labels=None,
         if plot_marginal:
             rotated = small_marginal_plots and pi == len(parameters)-1
             create_marginalized_hist(ax, param, samples, label=labels[param],
-                    color='navy', filled=False, linecolor='b', title=True,
-                    rotated=rotated, plot_min=mins[param], plot_max=maxs[param]
-                    scale_fac=get_scale_fac(fig))
+                color='navy', filled=False, linecolor='b', title=True,
+                rotated=rotated, plot_min=mins[param], plot_max=maxs[param],
+                scale_fac=get_scale_fac(fig))
         # ... or turn off
         else:
             ax.axis('off')

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -376,7 +376,7 @@ def create_multidim_plot(parameters, samples, labels=None,
                 plot_marginal=True,
                 plot_scatter=True,
                     zvals=None, show_colorbar=True, cbar_label=None,
-                    vmin=None, vmax=None, scatter_cmap='plasma_r',
+                    vmin=None, vmax=None, scatter_cmap='plasma',
                 plot_density=False, plot_contours=True,
                     density_cmap='viridis', contour_color=None,
                     use_kombine=False):
@@ -467,12 +467,9 @@ def create_multidim_plot(parameters, samples, labels=None,
             raise ValueError("must provide z values to create a colorbar")
         else:
             # just make all scatter points same color
-            if plot_contours:
-                zvals = 'gray'
-                if contour_color is None:
-                    contour_color = 'navy'
-            else:
-                zvals = 'k'
+            zvals = 'gray'
+            if plot_contours and contour_color is None:
+                contour_color = 'navy'
 
     # convert samples to a dictionary to avoid re-computing derived parameters
     # every time they are needed

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -471,6 +471,7 @@ def create_multidim_plot(parameters, samples, labels=None,
         mins = {p:val for p,val in mins.items()}
     if maxs is None:
         maxs = {p:samples[p].max() for p in parameters}
+    else:
         # copy the dict
         maxs = {p:val for p,val in maxs.items()}
 
@@ -481,8 +482,8 @@ def create_multidim_plot(parameters, samples, labels=None,
             # we'll add the offset removed to the label
             labels[param] = '{} - {:d}'.format(labels[param], offset)
             samples[param] = values
-            mins[param] -= float(offset)
-            maxs[param] -= float(offset)
+            mins[param] = mins[param] - float(offset)
+            maxs[param] = maxs[param] - float(offset)
 
     # create the axis grid
     fig, axis_dict = create_axes_grid(parameters, labels=labels,

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -100,13 +100,12 @@ def create_axes_grid(parameters, labels=None, height_ratios=None,
                 axis_dict[parameters[px], parameters[py]] = (ax, nrow, ncolumn)
                 # x labels only on bottom
                 if nrow + 1 == ndim:
-                    ax.set_xlabel('{}'.format(labels[px]),
-                                              fontsize=20)
+                    ax.set_xlabel('{}'.format(labels[px]), fontsize=18)
                 else:
                     pyplot.setp(ax.get_xticklabels(), visible=False)
                 # y labels only on left
                 if ncolumn == 0:
-                    ax.set_ylabel('{}'.format(labels[py]), fontsize=20)
+                    ax.set_ylabel('{}'.format(labels[py]), fontsize=18)
                 else:
                     pyplot.setp(ax.get_yticklabels(), visible=False)
             else:
@@ -258,11 +257,7 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
         # label contours
         lbls = ['{p}%'.format(p=int(p)) for p in (100. - percentiles)]
         fmt = dict(zip(ct.levels, lbls))
-        fs = 14
-        if fig is not None:
-            # scale appropriately
-            scale_fac = get_scale_fac(fig)
-            fs *= scale_fac
+        fs = 12
         ax.clabel(ct, ct.levels, inline=True, fmt=fmt, fontsize=fs)
 
     return fig, ax
@@ -335,7 +330,7 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
         if rotated:
             ax.yaxis.set_label_position("right")
             ax.set_ylabel('{} = {}'.format(label, fmt), rotation=-90,
-                labelpad=26, fontsize=20)
+                labelpad=26, fontsize=18)
             # Remove x-ticks
             ax.set_xticks([])
             # turn off x-labels
@@ -348,8 +343,7 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
                 ymax = plot_max
             ax.set_ylim(ymin, ymax)
         else:
-            ax.set_title('{} = {}'.format(label, fmt), fontsize=20,
-                         y=1.04)
+            ax.set_title('{} = {}'.format(label, fmt), fontsize=18, y=1.04)
             # Remove y-ticks
             ax.set_yticks([])
             # turn off y-label

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -457,7 +457,7 @@ def create_multidim_plot(parameters, samples, labels=None,
             raise ValueError("must provide z values to create a colorbar")
         else:
             # just make all scatter points same color
-            zvals = 'k'
+            zvals = 'gray'
 
     # convert samples to a dictionary to avoid re-computing derived parameters
     # every time they are needed

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -68,7 +68,7 @@ def create_axes_grid(parameters, labels=None, height_ratios=None,
     """
     if labels is None:
         labels = {p: p for p in parameters}
-    elif any([p not in labels for p in parameters]):
+    elif any(p not in labels for p in parameters):
         raise ValueError("labels must be provided for all parameters")
     # Create figure with adequate size for number of parameters.
     ndim = len(parameters)
@@ -566,7 +566,7 @@ def remove_common_offset(arr):
         # order of magintude and > O(1000)
         minpwr = numpy.log10(abs(arr).min())
         maxpwr = numpy.log10(abs(arr).max())
-        if numpy.floor(minpwr) == numpy.floor(maxpwr) and minpwr > 3: 
+        if numpy.floor(minpwr) == numpy.floor(maxpwr) and minpwr > 3:
             offset = numpy.floor(10**minpwr)
             if isneg:
                 offset *= -1

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -395,7 +395,7 @@ def create_multidim_plot(parameters, samples, labels=None,
     plot_marginal : {True, bool}
         Plot the marginalized distribution on the diagonals. If False, the
         diagonal axes will be turned off.
-    small_marginals : {False, bool}
+    small_marginal_plots : {False, bool}
         If True, make the marginal plots 1/3 the size of the density/scatter
         plots. In this case, the last marginal plot (the one furthest to the
         right) will be rotated such that distribution runs along the y-axis
@@ -446,7 +446,7 @@ def create_multidim_plot(parameters, samples, labels=None,
 
     # set up the figure with a grid of axes
     fig, axis_dict = create_axes_grid(parameters, labels=labels,
-        small_diagonals=small_marginals)
+        small_diagonals=small_marginal_plots)
 
     # turn labels into a dict for easier access
     labels = dict(zip(parameters, labels))
@@ -462,7 +462,7 @@ def create_multidim_plot(parameters, samples, labels=None,
         ax, _, _ = axis_dict[param, param]
         # plot marginal...
         if plot_marginal:
-            rotated = small_marginals and pi == len(parameters)-1
+            rotated = small_marginal_plots and pi == len(parameters)-1
             create_marginalized_hist(ax, param, samples, label=labels[param],
                     color='navy', filled=False, linecolor='b', title=True,
                     rotated=rotated, plot_min=mins[param], plot_max=maxs[param]

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -419,7 +419,8 @@ def create_multidim_plot(parameters, samples, labels=None,
         The color map to use for the density plot.
     contour_color : {None, string}
         The color to use for the contour lines. Defaults to white for
-        density plots and black for other plots.
+        density plots, yellow for scatter plots without zvals, and black
+        otherwise.
     use_kombine : {False, bool}
         Use kombine's KDE to calculate density. Otherwise, will use
         `scipy.stats.gaussian_kde.` Default is False.
@@ -453,11 +454,15 @@ def create_multidim_plot(parameters, samples, labels=None,
             sort_indices = zvals.argsort()
             zvals = zvals[sort_indices]
             samples = samples[sort_indices]
+            if contour_color is None:
+                contour_color = 'k'
         elif show_colorbar:
             raise ValueError("must provide z values to create a colorbar")
         else:
             # just make all scatter points same color
-            zvals = 'gray'
+            zvals = 'navy'
+            if contour_color is None:
+                contour_color = 'yellow'
 
     # convert samples to a dictionary to avoid re-computing derived parameters
     # every time they are needed


### PR DESCRIPTION
We found a couple bugs while using the new `plot_posterior` and `plot_movie` added in PR #1050: the marginal plots do not always have the same limits as the scatter/density plots, there is a large white space between the last plot and the colorbar when no marginal plots are created. This patch fixes these two issues and introduces a few new things:
 * When just creating a 2D plot, the marginal plots are made to be 1/3 the density/scatter plot and the right one is rotated. I've found this is useful when creating plots for presentations and/or papers. (See 2D density plot example, below.)
 * The colorbar is automatically turned on/off depending on whether a `z-arg` is specified, rather than making the user do it.
 * Minimum and maximum values to plot for each parameter can be specified on the command line. This is useful for comparing posteriors from different runs.
 * If all values for a parameter have a common offset > 1000, that offset is removed automatically and added to the parameter label. This is so you don't have to specify `tc-11...` on the command line whenever you want to plot coalescence time. See the `tc` axes in the example plots, below.
 * Output files made by `plot_movie` now have the sample number in their name rather than frame number, and the sample number is appropriately zero-padded to make for easy sorting in bash when feeding to `ffmpeg`.
 * `--plot-contour/scatter/density` have been moved over to their own option group in `option_utils.py`, which `plot_posterior` and `plot_scatter` inherit from.
 * Some adjustments to font sizes.

Examples of different configurations:
 * [Scatter plot, no z-arg, no marginal plots](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/inspiral-12ms_taylorf2_hmeco/posterior_plots_test/scatter_no_marginal.png)
 * [Scatter plot, points colored by SNR, no marginal plots](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/inspiral-12ms_taylorf2_hmeco/posterior_plots_test/scatter_nomarginal_snr.png)
 * [Scatter plot, points colored by SNR, marginal plots](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/inspiral-12ms_taylorf2_hmeco/posterior_plots_test/scatter_marginal-snr.png)
 * [Scatter plot with contours, points colored by SNR, marginal plots](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/inspiral-12ms_taylorf2_hmeco/posterior_plots_test/scatter_marginal_contours-snr.png)
 * [Scatter plot with contours, no z-arg, marginal plots](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/inspiral-12ms_taylorf2_hmeco/posterior_plots_test/scatter_marginal_contours.png)
 * [Density plot with contours, marginal plots](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/inspiral-12ms_taylorf2_hmeco/posterior_plots_test/density_standard.png)
 * [2D density plot with contours, marginal plots](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/inspiral-12ms_taylorf2_hmeco/posterior_plots_test/density_mp_ms.png)
 * [1D marginal plot](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/inspiral-12ms_taylorf2_hmeco/posterior_plots_test/density_mchirp.png)

As this depends on PR #1050, I'm putting this on hold until that is merged.