### PR TITLE
Fix minor bugs in FieldArray and WaveformArray

### DIFF
--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1618,7 +1618,7 @@ class WaveformArray(_FieldArrayWithDefaults):
     @property
     def m_p(self):
         """Returns the larger of self.mass1 and self.mass2 (p = primary)."""
-        out = numpy.zeros(self.size, dtype=self.mass1.dtype)
+        out = numpy.zeros(self.shape, dtype=self.mass1.dtype)
         out[:] = self.mass1
         mask = self.mass1 < self.mass2
         out[mask] = self.mass2[mask]
@@ -1627,7 +1627,7 @@ class WaveformArray(_FieldArrayWithDefaults):
     @property
     def m_s(self):
         """Returns the smaller of self.mass1 and self.mass2 (s = secondary)."""
-        out = numpy.zeros(self.size, dtype=self.mass2.dtype)
+        out = numpy.zeros(self.shape, dtype=self.mass2.dtype)
         out[:] = self.mass2
         mask = self.mass1 < self.mass2
         out[mask] = self.mass1[mask]
@@ -1665,7 +1665,7 @@ class WaveformArray(_FieldArrayWithDefaults):
     @property
     def spin_px(self):
         """Returns the x-component of the primary mass."""
-        out = numpy.zeros(self.size, dtype=self.spin1x.dtype)
+        out = numpy.zeros(self.shape, dtype=self.spin1x.dtype)
         out[:] = self.spin1x
         mask = self.mass1 < self.mass2
         out[mask] = self.spin2x[mask]
@@ -1674,7 +1674,7 @@ class WaveformArray(_FieldArrayWithDefaults):
     @property
     def spin_py(self):
         """Returns the y-component of the primary mass."""
-        out = numpy.zeros(self.size, dtype=self.spin1y.dtype)
+        out = numpy.zeros(self.shape, dtype=self.spin1y.dtype)
         out[:] = self.spin1y
         mask = self.mass1 < self.mass2
         out[mask] = self.spin2y[mask]
@@ -1683,7 +1683,7 @@ class WaveformArray(_FieldArrayWithDefaults):
     @property
     def spin_pz(self):
         """Returns the z-component of the secondary mass."""
-        out = numpy.zeros(self.size, dtype=self.spin1z.dtype)
+        out = numpy.zeros(self.shape, dtype=self.spin1z.dtype)
         out[:] = self.spin1z
         mask = self.mass1 < self.mass2
         out[mask] = self.spin2z[mask]
@@ -1692,7 +1692,7 @@ class WaveformArray(_FieldArrayWithDefaults):
     @property
     def spin_sx(self):
         """Returns the x-component of the secondary mass."""
-        out = numpy.zeros(self.size, dtype=self.spin2x.dtype)
+        out = numpy.zeros(self.shape, dtype=self.spin2x.dtype)
         out[:] = self.spin2x
         mask = self.mass1 < self.mass2
         out[mask] = self.spin1x[mask]
@@ -1701,7 +1701,7 @@ class WaveformArray(_FieldArrayWithDefaults):
     @property
     def spin_sy(self):
         """Returns the y-component of the secondary mass."""
-        out = numpy.zeros(self.size, dtype=self.spin2y.dtype)
+        out = numpy.zeros(self.shape, dtype=self.spin2y.dtype)
         out[:] = self.spin2y
         mask = self.mass1 < self.mass2
         out[mask] = self.spin1y[mask]
@@ -1710,7 +1710,7 @@ class WaveformArray(_FieldArrayWithDefaults):
     @property
     def spin_sz(self):
         """Returns the z-component of the secondary mass."""
-        out = numpy.zeros(self.size, dtype=self.spin2z.dtype)
+        out = numpy.zeros(self.shape, dtype=self.spin2z.dtype)
         out[:] = self.spin2z
         mask = self.mass1 < self.mass2
         out[mask] = self.spin1z[mask]

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -894,6 +894,9 @@ class FieldArray(numpy.recarray):
         are properties that are assumed to operate on one or more of self's
         fields, thus returning an array of values.
         """
+        if isinstance(names, str) or isinstance(names, unicode):
+            names = [names]
+            methods = [methods]
         out = self.add_properties(names, methods)
         if out._virtualfields is None:
             out._virtualfields = []


### PR DESCRIPTION
This patch fixes a couple of bugs I've noticed when using `FieldArray` and `WaveformArray`. If adding a single new virtualfield to a field array, you should be able to do:
```
farr = FieldArray.from_kwargs(foo=numpy.arange(10))
def bar(self):
    return self.foo + 2
f2 = farr.add_virtualfields('bar', bar)
```
However, currently this ends up adding 3 virtual fields called `'b', 'a', 'r'`. This patch fixes this by converting the input arguments to lists if they are not already.

The second bug is specific to `WaveformArray`: if you have a waveform array that is not 1D, the current version will raise an error if you try to use derived fields such as `m_p` or `m_s`. For example, the following will raise an error:
```
>>> from pycbc.io import WaveformArray
>>> import numpy
>>> m1 = numpy.arange(10).reshape((5,2))
>>> m2 = numpy.arange(10,20).reshape((5,2))
>>> warr = WaveformArray.from_kwargs(mass1=m1, mass2=m2)
>>> warr.m_p
```
This is because the shape of the array is not being preserved by derived fields, only the size. This fixes this by ensuring that the derived fields have the correct shape. With this patch, the above example correctly yields:
```
>>> warr.m_p
array([[10, 11],
       [12, 13],
       [14, 15],
       [16, 17],
       [18, 19]])
```