### PR TITLE
change name to pycbc_inference in example script

### DIFF
--- a/examples/inference/run_ringdown_example.sh
+++ b/examples/inference/run_ringdown_example.sh
@@ -67,7 +67,7 @@ lalapps_inspinj \
 
 echo "Running MCMC"
 echo "============================"
-pycbc_mcmc --verbose \
+pycbc_inference --verbose \
     --instruments ${IFOS} \
     --gps-start-time ${GPS_START_TIME} \
     --gps-end-time ${GPS_END_TIME} \


### PR DESCRIPTION
pycbc inference example script had the old name 'pycbc_mcmc', i've changed this to 'pycbc_inference'.

However, I think the example case is still broken but for a different reason. Xisco and I will figure it out.