### PR TITLE
Update lalsuite version and fix a bug in waveform.py

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -26,7 +26,7 @@
 waveforms.
 """
 
-import lalsimulation, numpy, copy
+import lal, lalsimulation, numpy, copy
 from pycbc.types import TimeSeries, FrequencySeries, zeros, Array
 from pycbc.types import real_same_precision_as, complex_same_precision_as
 import pycbc.scheme as _scheme

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -56,8 +56,8 @@ else
     cd ${SRC}
     git clone -q https://github.com/lscsoft/lalsuite.git
     cd lalsuite
-    # see PR #1067 for the choice of commit
-    git checkout ab5d37d296a7024fb7cdebd585c7b1c99e4b8d6c
+    # This sets the test release to https://versions.ligo.org/cgit/lalsuite/commit/?id=a2a5a476d33f169b8749e2840c306a48df63c936
+    git checkout a2a5a476d33f169b8749e2840c306a48df63c936
 
     ./00boot
     ./configure -q --prefix=${INST} --enable-swig-python \

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -15,6 +15,12 @@ export LD_LIBRARY_PATH=${INST}/lib:${INST}/lib64
 export PKG_CONFIG_PATH=${INST}/lib/pkgconfig
 export PATH=/usr/lib/ccache:${PATH}:${INST}/bin
 
+# Update setuptools
+pip install --upgrade pip setuptools
+
+# Install needed version of numpy
+pip install 'numpy==1.9.3' --upgrade 
+
 if [ -f ${INST}/dep_install.done ]
 then
     echo "Found cache of installed dependencies, using it"
@@ -77,14 +83,11 @@ fi
 
 source ${INST}/etc/lal-user-env.sh
 
-# Install needed version of numpy
-pip install 'numpy==1.9.3' --upgrade 
-
 # Scipy would be required to build scikit-learn but that does not work with travis currently
 #pip install 'scipy==0.16.0' --upgrade
 
 # Install Pegasus
-pip install http://download.pegasus.isi.edu/pegasus/4.5.2/pegasus-python-source-4.5.2.tar.gz
+pip install http://download.pegasus.isi.edu/pegasus/4.7.2/pegasus-python-source-4.7.2.tar.gz
 
 # Needed by mock 
 pip install 'setuptools==18.2' --upgrade


### PR DESCRIPTION
Set the lalsuite version to the commit https://versions.ligo.org/cgit/lalsuite/commit/?id=a2a5a476d33f169b8749e2840c306a48df63c936

This includes the new waveform interface and the patch to change the SEOBNRv4 ROM data to the version 2 hdf files.