### PR TITLE
Set dpi, start/end sample in plot movie

### DIFF
--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -31,6 +31,7 @@ import numpy
 import matplotlib
 matplotlib.use('agg')
 from matplotlib import pyplot
+from multiprocessing import Pool
 import pycbc.results
 from pycbc.inference import option_utils
 from pycbc.io.inference_hdf import InferenceFile
@@ -60,6 +61,9 @@ parser.add_argument("--parameters", type=str, nargs="+",
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--dpi', type=int, default=200,
                     help='Set the dpi for each frame; default is 200')
+parser.add_argument("--nprocesses", type=int, default=None,
+                    help="Number of processes to use. If not given then "
+                         "use maximum.")
 # add options for what plots to create
 option_utils.add_plot_posterior_option_group(parser)
 # add scatter and density configuration options
@@ -131,8 +135,10 @@ for p in parameters:
 # for sorting purposes, we will need to zero-pad the sample numer with the
 # appriopriate number of 0's
 max_sample_num = nframes * thinint
-for frame in range(nframes):
-    logging.info('Plotting frame %i' %(frame+1))
+
+def _make_frame(frame):
+    """Wrapper for making the plot in a pooled environment.
+    """
     plotargs = samples[:,frame]
     if zvals is not None:
         z = zvals[:,frame]
@@ -169,5 +175,18 @@ for frame in range(nframes):
 
     fig.savefig(output, bbox_inches='tight', dpi=opts.dpi)
     pyplot.close()
+
+# create the pool
+if opts.nprocesses is None or opts.nprocesses > 1:
+    global make_frame
+    make_frame = _make_frame
+    pool = Pool(opts.nprocesses)
+    mfunc = pool.map
+else:
+    make_frame = _make_frame
+    mfunc = map
+
+logging.info("Making frames")
+mfunc(make_frame, range(nframes))
 
 logging.info('Done')

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -131,7 +131,7 @@ fp, parameters, labels, _ = option_utils.results_from_cli(opts,
                             load_samples=False)
 
 if opts.end_sample is None:
-    opts.end_sample = fp.niterations + 1
+    opts.end_sample = fp.niterations
 
 if opts.log_steps and not opts.frame_number:
     raise ValueError("log-steps requires a non-zero frame-number to be "
@@ -143,10 +143,15 @@ end_index = opts.end_sample - 1
 
 # Define thin interval based on number of frames or frame step
 if opts.frame_number and opts.frame_step:
-    raise ValueError("Only one of frame-number or frame-step must be provided.")
+    raise ValueError("Only one of frame-number or frame-step must be "
+                     "provided.")
 elif opts.frame_number:
+    if opts.frame_number > fp.niterations:
+        raise ValueError("frame number is > the number of iterations "
+                         "({})".format(fp.niterations))
     if opts.log_steps:
-        iterations = integer_logspace(start_index, end_index, opts.frame_number)
+        iterations = integer_logspace(start_index, end_index,
+                                      opts.frame_number)
     else:
         iterations = numpy.unique(numpy.linspace(start_index, end_index,
                                     num=opts.frame_number).astype(int))
@@ -158,12 +163,13 @@ elif opts.frame_number:
 elif opts.frame_step:
     thinint = opts.frame_step
     thin_start = start_index
-    thin_end = end_index
+    thin_end = end_index + thinint
     itermask = None
-    nframes = (thin_end - thin_start)/thinint
-    iterations = numpy.arange(nframes) * thinint + thin_start
+    nframes = 1 + (thin_end - thin_start)/thinint
+    iterations = numpy.arange(nframes-1) * thinint + thin_start
 else:
-    raise ValueError("At least one of frame-number or frame-step must be provided.")
+    raise ValueError("At least one of frame-number or frame-step must be "
+                     "provided.")
 
 samples = fp.read_samples(parameters, thin_start=thin_start,
                           thin_end=thin_end, thin_interval=thinint,

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -45,7 +45,7 @@ parser.add_argument("--input-file", type=str, required=True,
 parser.add_argument("--start-sample", type=int, default=0,
                     help="Start sample for the first frame. Default is 0.")
 parser.add_argument("--end-sample", type=int, default=None,
-                    help="Start sample for the first frame. If None, will "
+                    help="End sample for the last frame. If None, will "
                          "default to the last sample.")
 parser.add_argument("--frame-number", type=int,
                     help="Number of frames for the movie.")
@@ -132,7 +132,7 @@ for p in parameters:
         maxs[p] = samples[p].max()
 
 # Make each figure
-# for sorting purposes, we will need to zero-pad the sample numer with the
+# for sorting purposes, we will need to zero-pad the sample number with the
 # appriopriate number of 0's
 max_sample_num = nframes * thinint
 

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -38,12 +38,58 @@ from pycbc.io.inference_hdf import InferenceFile
 from pycbc.results.scatter_histograms import create_multidim_plot, \
     get_scale_fac
 
+def integer_logspace(start, end, num):
+    """Generates a list of integers that are spaced approximately uniformly
+    in log10 space between `start` and `end`. This is done such that the
+    length of the output array is guaranteed to have length equal to num.
+
+    Parameters
+    ----------
+    start : int
+        Integer to start with; must be >= 0.
+    end : int
+        Integer to end with; must be > start.
+    num : int
+        The number of integers to generate.
+
+    Returns
+    -------
+    array
+        The output array of integers.
+    """
+    start += 1
+    end += 1
+    out = numpy.zeros(num, dtype=int)
+    x = numpy.round(numpy.logspace(numpy.log10(start), numpy.log10(end),
+                       num=num)).astype(int) - 1
+    dx = numpy.diff(x)
+    start_idx = 0
+    while (dx == 0).any():
+        # collect the unique values up to the point that their
+        # difference becomes > 1
+        x = numpy.unique(x)
+        dx = numpy.diff(x)
+        stop_idx = numpy.where(dx > 1)[0][0]
+        keep = x[:stop_idx]
+        stop_idx += start_idx
+        out[start_idx:stop_idx] = keep
+        start_idx = stop_idx
+        # regenerate, starting from the new starting point
+        num -= len(keep)
+        start = keep[-1] + 2
+        x = numpy.round(numpy.logspace(numpy.log10(start), numpy.log10(end),
+                           num=num)).astype(int) - 1
+        dx = numpy.diff(x)
+    out[start_idx:len(x)+start_idx] = x
+    return out
+
 parser = argparse.ArgumentParser()
 
 parser.add_argument("--input-file", type=str, required=True,
                     help="Results file path.")
-parser.add_argument("--start-sample", type=int, default=0,
-                    help="Start sample for the first frame. Default is 0.")
+parser.add_argument("--start-sample", type=int, default=1,
+                    help="Start sample for the first frame. Note: sample "
+                         "counting starts from 1. Default is 1.")
 parser.add_argument("--end-sample", type=int, default=None,
                     help="End sample for the last frame. If None, will "
                          "default to the last sample.")
@@ -52,6 +98,12 @@ parser.add_argument("--frame-number", type=int,
 parser.add_argument("--frame-step", type=int, 
                     help="Step in the sample between frames for the movie. "
                          "Only provide if not --frame-number given.")
+parser.add_argument("--log-steps", action="store_true", default=False,
+                    help="If frame-number is specified, make the number of "
+                         "samples between frames uniform in log10. This "
+                         "provides more detail of the early iterations, when "
+                         "the sampler is changing most rapidly. An error will "
+                         "be raised if frame-number is not provided.")
 parser.add_argument("--output-file", type=str, required=True,
                     help="Output plot path without extension.")
 parser.add_argument("--parameters", type=str, nargs="+",
@@ -79,28 +131,50 @@ fp, parameters, labels, _ = option_utils.results_from_cli(opts,
                             load_samples=False)
 
 if opts.end_sample is None:
-    opts.end_sample = fp.niterations
+    opts.end_sample = fp.niterations + 1
+
+if opts.log_steps and not opts.frame_number:
+    raise ValueError("log-steps requires a non-zero frame-number to be "
+                     "provided; see help for details.")
+
+# convert sample numbers to index
+start_index = opts.start_sample - 1
+end_index = opts.end_sample - 1
+
 # Define thin interval based on number of frames or frame step
 if opts.frame_number and opts.frame_step:
     raise ValueError("Only one of frame-number or frame-step must be provided.")
 elif opts.frame_number:
-    nframes = opts.frame_number
-    thinint = (opts.end_sample - opts.start_sample)/nframes
+    if opts.log_steps:
+        iterations = integer_logspace(start_index, end_index, opts.frame_number)
+    else:
+        iterations = numpy.unique(numpy.linspace(start_index, end_index,
+                                    num=opts.frame_number).astype(int))
+    nframes = len(iterations)
+    # create a mask to pull out the desired values
+    itermask = numpy.zeros(fp.niterations, dtype=bool)
+    itermask[iterations] = True
+    thinint = thin_start = thin_end = None
 elif opts.frame_step:
     thinint = opts.frame_step
-    nframes = (opts.end_sample - opts.start_sample)/thinint
+    thin_start = start_index
+    thin_end = end_index
+    itermask = None
+    nframes = (thin_end - thin_start)/thinint
+    iterations = numpy.arange(nframes) * thinint + thin_start
 else:
     raise ValueError("At least one of frame-number or frame-step must be provided.")
 
-samples = fp.read_samples(parameters, thin_start=opts.start_sample,
-                          thin_end=opts.end_sample,
-                          thin_interval=thinint, flatten=False)
+samples = fp.read_samples(parameters, thin_start=thin_start,
+                          thin_end=thin_end, thin_interval=thinint,
+                          iteration=itermask, flatten=False)
 
 # Get z-values
 if opts.z_arg is not None:
     logging.info("Getting likelihood stats")
-    likelihood_stats = fp.read_likelihood_stats(thin_start=opts.start_sample,
-        thin_end=opts.end_sample, thin_interval=thinint, flatten=False)
+    likelihood_stats = fp.read_likelihood_stats(thin_start=thin_start,
+        thin_end=thin_end, thin_interval=thinint, iteration=itermask,
+        flatten=False)
     zvals, zlbl = option_utils.get_zvalues(fp, opts.z_arg, likelihood_stats)
     show_colorbar = True
     # Set common min and max for colorbar in all plots
@@ -134,7 +208,7 @@ for p in parameters:
 # Make each figure
 # for sorting purposes, we will need to zero-pad the sample number with the
 # appriopriate number of 0's
-max_sample_num = nframes * thinint
+max_sample_num = iterations[-1] + 1
 
 def _make_frame(frame):
     """Wrapper for making the plot in a pooled environment.
@@ -144,7 +218,7 @@ def _make_frame(frame):
         z = zvals[:,frame]
     else:
         z = None
-    sample_num = str(frame * thinint + opts.start_sample)
+    sample_num = str(iterations[frame] + 1)
     sample_num = sample_num.zfill(len(str(max_sample_num)))
     output = opts.output_file + '-{}.png'.format(sample_num)
 
@@ -187,6 +261,6 @@ else:
     mfunc = map
 
 logging.info("Making frames")
-mfunc(make_frame, range(nframes))
+mfunc(make_frame, range(len(iterations)))
 
 logging.info('Done')

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -95,8 +95,8 @@ samples = fp.read_samples(parameters, thin_start=opts.start_sample,
 # Get z-values
 if opts.z_arg is not None:
     logging.info("Getting likelihood stats")
-    likelihood_stats = fp.read_likelihood_stats(thin_start=0,
-                                    thin_interval=thinint, flatten=False)
+    likelihood_stats = fp.read_likelihood_stats(thin_start=opts.start_sample,
+        thin_end=opts.end_sample, thin_interval=thinint, flatten=False)
     zvals, zlbl = option_utils.get_zvalues(fp, opts.z_arg, likelihood_stats)
     show_colorbar = True
     # Set common min and max for colorbar in all plots

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -41,6 +41,11 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument("--input-file", type=str, required=True,
                     help="Results file path.")
+parser.add_argument("--start-sample", type=int, default=0,
+                    help="Start sample for the first frame. Default is 0.")
+parser.add_argument("--end-sample", type=int, default=None,
+                    help="Start sample for the first frame. If None, will "
+                         "default to the last sample.")
 parser.add_argument("--frame-number", type=int,
                     help="Number of frames for the movie.")
 parser.add_argument("--frame-step", type=int, 
@@ -52,13 +57,9 @@ parser.add_argument("--parameters", type=str, nargs="+",
                     metavar="PARAM[:LABEL]",
                     help="Name of parameters to plot in same format "
                          "as for pycbc_inference_plot_posterior.")
-parser.add_argument("--thin-start", type=int, default=0,
-                    help="Sample number to start collecting samples to plot. "
-                         "If none provided, will start at 0.")
-parser.add_argument("--thin-end", type=int,
-                    help="Sample number to stop collecting samples to plot. "
-                         "If none provided, will stop at the last sample.")
 parser.add_argument('--verbose', action='store_true')
+parser.add_argument('--dpi', type=int, default=200,
+                    help='Set the dpi for each frame; default is 200')
 # add options for what plots to create
 option_utils.add_plot_posterior_option_group(parser)
 # add scatter and density configuration options
@@ -73,19 +74,22 @@ logging.info('Loading parameters')
 fp, parameters, labels, _ = option_utils.results_from_cli(opts,
                             load_samples=False)
 
+if opts.end_sample is None:
+    opts.end_sample = fp.niterations
 # Define thin interval based on number of frames or frame step
 if opts.frame_number and opts.frame_step:
     raise ValueError("Only one of frame-number or frame-step must be provided.")
 elif opts.frame_number:
     nframes = opts.frame_number
-    thinint = (fp.niterations / (nframes - 1)) - 1
+    thinint = (opts.end_sample - opts.start_sample)/nframes
 elif opts.frame_step:
     thinint = opts.frame_step
-    nframes = (fp.niterations / (thinint + 1)) + 1
+    nframes = (opts.end_sample - opts.start_sample)/thinint
 else:
     raise ValueError("At least one of frame-number or frame-step must be provided.")
 
-samples = fp.read_samples(parameters, thin_start=0, 
+samples = fp.read_samples(parameters, thin_start=opts.start_sample,
+                          thin_end=opts.end_sample,
                           thin_interval=thinint, flatten=False)
 
 # Get z-values
@@ -134,7 +138,7 @@ for frame in range(nframes):
         z = zvals[:,frame]
     else:
         z = None
-    sample_num = str(frame * thinint + 1)
+    sample_num = str(frame * thinint + opts.start_sample)
     sample_num = sample_num.zfill(len(str(max_sample_num)))
     output = opts.output_file + '-{}.png'.format(sample_num)
 
@@ -163,7 +167,7 @@ for frame in range(nframes):
         xycoords='figure fraction', horizontalalignment='right',
         verticalalignment='top', fontsize=fontsize)
 
-    fig.savefig(output, bbox_inches='tight', dpi=200)
+    fig.savefig(output, bbox_inches='tight', dpi=opts.dpi)
     pyplot.close()
 
 logging.info('Done')

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -140,7 +140,7 @@ def construct_kde(samples_array, use_kombine=False):
             raise ImportError("kombine is not installed.")
     # construct the kde
     if use_kombine:
-        kde = kombine.KDE(samples_array)
+        kde = kombine.clustered_kde.KDE(samples_array)
     else:
         kde = scipy.stats.gaussian_kde(samples_array.T)
     return kde


### PR DESCRIPTION
This gives adds ability to set the dpi and start/end samples on the command-line for `plot_movie`. Right now the code will always use the last iteration, which is a problem if trying to run plot movie on an result file that hasn't completed yet (since everything after the checkpoint is just 0). I also changed the argument names from "thin-start" and "thin-end" to "start-sample" and "end-sample" to make it more clear what their purpose is.