### PR TITLE
make sure bank2hdf also looks for f_lower column by default

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_bank2hdf
+++ b/bin/hdfcoinc/pycbc_coinc_bank2hdf
@@ -32,7 +32,8 @@ default_parameters = [
     "mass1", "mass2",
     "spin1x", "spin1y", "spin1z",
     "spin2x", "spin2y", "spin2z",
-    "inclination:alpha3"
+    "inclination:alpha3",
+    "f_lower:alpha6",
     ]
 
 def parse_parameters(parameters):


### PR DESCRIPTION
This changes the default, so that xml files with a populated f_lower column actually pass that to the output hdf file in pycbc_coinc_bank2hdf. This has become an issue because this hdf bank is now used internally for the inspiral jobs and we want to make use of this column. 