### PR TITLE
Distribution for pycbc_inference that reads parameters from a file

### DIFF
--- a/pycbc/inference/boundaries.py
+++ b/pycbc/inference/boundaries.py
@@ -30,19 +30,19 @@ cyclic boundaries or reflected boundaries.
 import numpy
 
 class _Bound(float):
-    """Adds methods to float for bondary comparisons."""
+    """Adds methods to float for boundary comparisons."""
 
     name = None
 
     def larger(self, other):
-        """A function to determine whehter or not `other` is larger
+        """A function to determine whether or not `other` is larger
         than the bound. This raises a NotImplementedError; classes that
         inherit from this must define it.
         """
         raise NotImplementedError("larger function not set")
 
     def smaller(self, other):
-        """A function to determine whehter or not `other` is smaller
+        """A function to determine whether or not `other` is smaller
         than the bound. This raises a NotImplementedError; classes that
         inherit from this must define it.
         """

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1344,7 +1344,7 @@ class FromFile(_BoundedDist):
         """
         for p in self._params:
             if p not in kwargs.keys():
-                raise ValueError('Missing parameter %s to construct pdf.' %p)
+                raise ValueError('Missing parameter {} to construct pdf.'.format(p))
         if kwargs in self:
             return self._norm * self._kde.evaluate([kwargs[p]
                                                     for p in self._params])
@@ -1358,7 +1358,7 @@ class FromFile(_BoundedDist):
         """
         for p in self._params:
             if p not in kwargs.keys():
-                raise ValueError('Missing parameter %s to construct pdf.' %p)
+                raise ValueError('Missing parameter {} to construct pdf.'.format(p))
         if kwargs in self:
             return self._lognorm + self._kde.logpdf([kwargs[p]
                                                      for p in self._params])
@@ -1393,6 +1393,43 @@ class FromFile(_BoundedDist):
         for order, param in enumerate(dtype):
             arr[param[0]] = randoms[order]
         return arr
+
+    @classmethod
+    def from_config(cls, cp, section, variable_args):
+        """Returns a distribution based on a configuration file. The parameters
+        for the distribution are retrieved from the section titled
+        "[`section`-`variable_args`]" in the config file.
+
+        The file to construct the distribution from must be provided by setting
+        `file_name`. Boundary arguments can be provided in the same way as
+        described in `get_param_bounds_from_config`.
+
+        .. code::
+            [{section}-{tag}]
+            name = fromfile
+            file_name = ra_prior.hdf
+            min-ra = 0
+            max-ra = 6.28
+
+        Parameters
+        ----------
+        cp : pycbc.workflow.WorkflowConfigParser
+            A parsed configuration file that contains the distribution
+            options.
+        section : str
+            Name of the section in the configuration file.
+        variable_args : str
+            The names of the parameters for this distribution, separated by
+            `prior.VARARGS_DELIM`. These must appear in the "tag" part
+            of the section header.
+
+        Returns
+        -------
+        Uniform
+            A distribution instance from the pycbc.inference.prior module.
+        """
+        return super(FromFile, cls).from_config(cp, section, variable_args,
+                                                bounds_required=False)
 
 distribs = {
     Uniform.name : Uniform,

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1347,7 +1347,7 @@ class FromFile(_BoundedDist):
                 raise ValueError('Missing parameter {} to construct pdf.'.format(p))
         if kwargs in self:
             # for scipy < 0.15.0, gaussian_kde.pdf = gaussian_kde.evaluate
-            this_pdf = self._norm * self._kde.evaluate([kwargs[p] 
+            this_pdf = self._norm * self._kde.evaluate([kwargs[p]
                                                         for p in self._params])
             if len(this_pdf) == 1:
                 return float(this_pdf)

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -215,7 +215,13 @@ def get_kde_from_file(params_file, params=None):
         f = h5py.File(params_file, 'r')
     except:
         raise ValueError('File not found.')
-    if params is None:
+    if params is not None:
+        if str(params)[0] != '[':
+            params = [params]
+        for p in params:
+            if p not in f.keys():
+                raise ValueError('Parameter %s is not in %s' %(p, params_file))
+    else:
         params = f.keys()
     params_values = {p:f[p][:] for p in params}
     f.close()

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -220,7 +220,7 @@ def get_kde_from_file(params_file, params=None):
             params = [params]
         for p in params:
             if p not in f.keys():
-                raise ValueError('Parameter %s is not in %s' %(p, params_file))
+                raise ValueError('Parameter {} is not in {}'.format(p, params_file))
     else:
         params = f.keys()
     params_values = {p:f[p][:] for p in params}
@@ -1303,13 +1303,14 @@ class FromFile(_BoundedDist):
         lower_bounds = [self.bounds[p][0] for p in pnames]
         higher_bounds = [self.bounds[p][1] for p in pnames]
         # Avoid inf because of inconsistencies in integrate_box
-        for p in range(len(lower_bounds)):
-            if abs(lower_bounds[p]) == numpy.inf:
-                lower_bounds[p] = numpy.sign(lower_bounds[p]) * 2 ** 31
-            if abs(higher_bounds[p]) == numpy.inf:
-                higher_bounds[p] = numpy.sign(higher_bounds[p]) * 2 ** 31
+        for ii, bnd in enumerate(lower_bounds):
+            if abs(bnd) == numpy.inf:
+                lower_bounds[ii] = numpy.sign(bnd) * 2 ** 31
+        for ii, bnd in enumerate(higher_bounds):
+            if abs(bnd) == numpy.inf:
+                higher_bounds[ii] = numpy.sign(bnd) * 2 ** 31
         # Array of -inf for the lower limits in integrate_box
-        lower_limits = - 2**31 * numpy.ones(shape=len(lower_bounds))
+        lower_limits = - 2 ** 31 * numpy.ones(shape=len(lower_bounds))
         # CDF(-inf,b) - CDF(-inf, a)
         invnorm = self._kde.integrate_box(lower_limits, higher_bounds) - \
                     self._kde.integrate_box(lower_limits, lower_bounds)
@@ -1329,7 +1330,7 @@ class FromFile(_BoundedDist):
         return self._norm
 
     @property
-    def lognorm():
+    def lognorm(self):
         return self._lognorm
 
     @property
@@ -1345,7 +1346,7 @@ class FromFile(_BoundedDist):
             if p not in kwargs.keys():
                 raise ValueError('Missing parameter %s to construct pdf.' %p)
         if kwargs in self:
-            return self._norm * self._kde.evaluate([kwargs[p] 
+            return self._norm * self._kde.evaluate([kwargs[p]
                                                     for p in self._params])
         else:
             return 0.
@@ -1359,7 +1360,7 @@ class FromFile(_BoundedDist):
             if p not in kwargs.keys():
                 raise ValueError('Missing parameter %s to construct pdf.' %p)
         if kwargs in self:
-            return self._lognorm + self._kde.logpdf([kwargs[p] 
+            return self._lognorm + self._kde.logpdf([kwargs[p]
                                                      for p in self._params])
         else:
             return -numpy.inf

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1402,7 +1402,7 @@ class FromFile(_BoundedDist):
         except:
             raise ValueError('File not found.')
         if params is not None:
-            if type(params) != list:
+            if not isinstance(params, list):
                 params = [params]
             for p in params:
                 if p not in f.keys():

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -193,42 +193,6 @@ def _bounded_from_config(cls, cp, section, variable_args,
     return cls(**dist_args)
 
 
-def get_kde_from_file(params_file, params=None):
-    """Reads the values of one or more parameters from an hdf file and
-    computes the kernel density estimate (kde).
-
-    Parameters
-    ----------
-    params_file : str
-        The hdf file that contains the values of the parameters.
-    params : {None, list}
-        If provided, will just use the values for the given parameter.
-        Otherwise, uses the values for each parameter in the file.
-    Returns
-    -------
-    values
-        Array with the values of the parameters.
-    kde
-        The kde from the parameters.
-    """
-    try:
-        f = h5py.File(params_file, 'r')
-    except:
-        raise ValueError('File not found.')
-    if params is not None:
-        if type(params) != list:
-            params = [params]
-        for p in params:
-            if p not in f.keys():
-                raise ValueError('Parameter {} is not in {}'.format(p, params_file))
-    else:
-        params = [str(k) for k in f.keys()]
-    params_values = {p:f[p][:] for p in params}
-    f.close()
-    values = numpy.vstack((params_values[p] for p in params))
-    return params, scipy.stats.gaussian_kde(values)
-
-
 class _BoundedDist(object):
     """
     A generic class for storing common properties of distributions in which
@@ -1413,6 +1377,42 @@ class FromFile(_BoundedDist):
         for order, param in enumerate(dtype):
             arr[param[0]] = randoms[order]
         return arr
+
+    @classmethod
+    def get_kde_from_file(params_file, params=None):
+        """Reads the values of one or more parameters from an hdf file and
+        computes the kernel density estimate (kde).
+
+        Parameters
+        ----------
+        params_file : str
+            The hdf file that contains the values of the parameters.
+        params : {None, list}
+            If provided, will just use the values for the given parameter.
+            Otherwise, uses the values for each parameter in the file.
+        Returns
+        -------
+        values
+            Array with the values of the parameters.
+        kde
+            The kde from the parameters.
+        """
+        try:
+            f = h5py.File(params_file, 'r')
+        except:
+            raise ValueError('File not found.')
+        if params is not None:
+            if type(params) != list:
+                params = [params]
+            for p in params:
+                if p not in f.keys():
+                    raise ValueError('Parameter {} is not in {}'.format(p, params_file))
+        else:
+            params = [str(k) for k in f.keys()]
+        params_values = {p:f[p][:] for p in params}
+        f.close()
+        values = numpy.vstack((params_values[p] for p in params))
+        return params, scipy.stats.gaussian_kde(values)
 
     @classmethod
     def from_config(cls, cp, section, variable_args):

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1378,8 +1378,8 @@ class FromFile(_BoundedDist):
             arr[param[0]] = randoms[order]
         return arr
 
-    @classmethod
-    def get_kde_from_file(cls, params_file, params=None):
+    @staticmethod
+    def get_kde_from_file(params_file, params=None):
         """Reads the values of one or more parameters from an hdf file and
         computes the kernel density estimate (kde).
 

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1262,7 +1262,7 @@ class FromFile(_BoundedDist):
             ps = None
         else:
             ps = params.keys()
-        pnames, self._kde = get_kde_from_file(file_name, params=ps)
+        pnames, self._kde = self.get_kde_from_file(file_name, params=ps)
         # If no parameters where given, populate with pnames
         for param in pnames:
             if param not in params:
@@ -1379,7 +1379,7 @@ class FromFile(_BoundedDist):
         return arr
 
     @classmethod
-    def get_kde_from_file(params_file, params=None):
+    def get_kde_from_file(cls, params_file, params=None):
         """Reads the values of one or more parameters from an hdf file and
         computes the kernel density estimate (kde).
 


### PR DESCRIPTION
The goal of this pull request is to have a distribution fro pycbc_inference that can take a file (given in the config file) and read the parameters from it. This could be, e.g., the posterior from one PE run that wants to be used as prior in another run.
Then distributions.py will compute the kde from the values in that file, construct the pdf, and draw a set of random variables to feed them to the walkers.