### PR TITLE
Add ability to set kombine's update interval and only save points since last checkpoint

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -490,7 +490,7 @@ with ctx:
 
             logging.info("Writing results to file")
             sampler.write_results(fp, start_iteration=start,
-                                  end_iterations=end,
+                                  end_iteration=end,
                                   max_iterations=opts.niterations+n_burnin)
 
             if not opts.checkpoint_fast or end == opts.niterations:

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -507,5 +507,9 @@ with ctx:
                 except NotImplementedError:
                     pass
 
+            # clear the in-memory chain to save memory
+            logging.info("Clearing chain")
+            sampler.clear_chain()
+
 # exit
 logging.info("Done")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -442,7 +442,8 @@ with ctx:
     if opts.checkpoint_interval:
 
         # determine intervals to run sampler until we save the new samples 
-        intervals = [i for i in range(0, opts.niterations, opts.checkpoint_interval)]
+        intervals = [i for i in range(0, opts.niterations,
+                                      opts.checkpoint_interval)]
 
         # determine if there is a small bit at the end
         remainder = opts.niterations % opts.checkpoint_interval
@@ -481,14 +482,16 @@ with ctx:
         # run sampler and set initial values to None so that sampler
         # picks up from where it left off next call
         logging.info("Running sampler for %i to %i out of %i iterations"%(
-            start-n_burnin,end-n_burnin,opts.niterations))
+            start-n_burnin, end-n_burnin, opts.niterations))
         sampler.run(end-start)
 
         # write new samples
         with InferenceFile(opts.output_file, "a") as fp:
 
             logging.info("Writing results to file")
-            sampler.write_results(fp, max_iterations=opts.niterations+n_burnin)
+            sampler.write_results(fp, start_iteration=start,
+                                  end_iterations=end,
+                                  max_iterations=opts.niterations+n_burnin)
 
             if not opts.checkpoint_fast or end == opts.niterations:
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -62,7 +62,12 @@ def add_sampler_option_group(parser):
              "min-burn-in is also provided.")
     sampler_group.add_argument("--update-interval", type=int, default=None,
         help="If using kombine, specify the number of steps to take between "
-             " proposal updates.")
+             "proposal updates. Note: for purposes of updating, kombine "
+             "counts iterations since the last checkpoint. This interval "
+             "should therefore be less than the checkpoint interval, else "
+             "no updates will occur. To ensure that updates happen at equal "
+             "intervals, make checkpoint-interval a multiple of "
+             "update-interval.")
 
     return sampler_group
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -60,6 +60,9 @@ def add_sampler_option_group(parser):
         default=False,
         help="Do not burn in with sampler. An error will be raised if "
              "min-burn-in is also provided.")
+    sampler_group.add_argument("--update-interval", type=int, default=None,
+        help="If using kombine, specify the number of steps to take between "
+             " proposal updates.")
 
     return sampler_group
 

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -437,7 +437,7 @@ class BaseMCMCSampler(_BaseSampler):
                     # dataset doesn't exist yet
                     fp.create_dataset(dataset_name, (fb,),
                                       maxshape=(max_iterations,),
-                                      dtype=stats.dtype)
+                                      dtype=stats[param].dtype)
                     fp[dataset_name][fa:fb] = stats[param][wi, ma:mb]
         return stats
 

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -336,6 +336,12 @@ class BaseMCMCSampler(_BaseSampler):
         ma = fa - self._lastclear # memory start index
         mb = fb - self._lastclear # memory end index
 
+        if max_iterations is not None and max_iterations < niterations:
+            raise IndexError("The provided max size is less than the "
+                             "number of iterations")
+        elif max_iterations is None:
+            max_iterations = niterations
+
         # map sample values to the values that were actually passed to the
         # waveform generator and prior evaluator
         samples = numpy.array(
@@ -343,14 +349,6 @@ class BaseMCMCSampler(_BaseSampler):
             samples.transpose(2,0,1))).transpose(1,2,0)
 
         group = fp.samples_group + '/{name}/walker{wi}'
-
-        # if this is the first time writing, we'll need some scratch space to
-        # copy results for writing to the output file
-        if max_iterations is not None and max_iterations < niterations:
-            raise IndexError("The provided max size is less than the "
-                             "number of iterations")
-        elif max_iterations is None:
-            max_iterations = niterations
 
         # loop over number of dimensions
         widx = numpy.arange(nwalkers)
@@ -426,9 +424,6 @@ class BaseMCMCSampler(_BaseSampler):
             max_iterations = niterations
 
         for param in fields:
-            # we'll wait to create the scratch space until the first time
-            # we need it
-            out = None
             # loop over number of walkers
             for wi in range(nwalkers):
                 dataset_name = group.format(param=param, wi=wi)

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -349,11 +349,10 @@ class BaseMCMCSampler(_BaseSampler):
 
         # if this is the first time writing, we'll need some scratch space to
         # copy results for writing to the output file
-        if max_iterations is not None:
-            if max_iterations < niterations:
-                raise IndexError("The provided max size is less than the "
-                                 "number of iterations")
-        else:
+        if max_iterations is not None and max_iterations < niterations:
+            raise IndexError("The provided max size is less than the "
+                             "number of iterations")
+        elif max_iterations is None:
             max_iterations = niterations
 
         # loop over number of dimensions
@@ -431,7 +430,7 @@ class BaseMCMCSampler(_BaseSampler):
         if max_iterations is not None and max_iterations < niterations:
             raise IndexError("The provided max size is less than the "
                              "number of iterations")
-        else:
+        elif max_iterations is None:
             max_iterations = niterations
 
         for param in fields:
@@ -478,6 +477,12 @@ class BaseMCMCSampler(_BaseSampler):
         if end_iteration is None:
             end_iteration = acf.size
         bb = end_iteration
+
+        if max_iterations is not None and max_iterations < niterations:
+            raise IndexError("The provided max size is less than the "
+                             "number of iterations")
+        elif max_iterations is None:
+            max_iterations = niterations
 
         try:
             if bb > fp[dataset_name].size:

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -206,6 +206,7 @@ class BaseMCMCSampler(_BaseSampler):
         self._sampler = sampler
         self._pos = None
         self._p0 = None
+        self._currentblob = None
         self._nwalkers = None
         if min_burn_in is None:
             min_burn_in = 0
@@ -332,13 +333,8 @@ class BaseMCMCSampler(_BaseSampler):
         if end_iteration is None:
             end_iteration = niterations
         fb = end_iteration # file end index
-        if self._lastclear != 0:
-            # we add one to lastclear to skip the point from the previous clear
-            ma = fa - self._lastclear + 1
-            mb = fb - self._lastclear + 1
-        else:
-            ma = fa
-            mb = fb
+        ma = fa - self._lastclear # memory start index
+        mb = fb - self._lastclear # memory end index
 
         # map sample values to the values that were actually passed to the
         # waveform generator and prior evaluator
@@ -418,13 +414,8 @@ class BaseMCMCSampler(_BaseSampler):
         if end_iteration is None:
             end_iteration = niterations
         fb = end_iteration # file end index
-        if self._lastclear != 0:
-            # we add one to lastclear to skip the point from the previous clear
-            ma = fa - self._lastclear + 1
-            mb = fb - self._lastclear + 1
-        else:
-            ma = fa
-            mb = fb
+        ma = fa - self._lastclear # memory start index
+        mb = fb - self._lastclear # memory end index
 
         group = fp.stats_group + '/{param}/walker{wi}'
 

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -364,7 +364,8 @@ class BaseMCMCSampler(_BaseSampler):
                 except KeyError:
                     # dataset doesn't exist yet
                     fp.create_dataset(dataset_name, (fb,),
-                                      maxshape=(max_iterations,))
+                                      maxshape=(max_iterations,),
+                                      dtype=samples.dtype)
                     fp[dataset_name][fa:fb] = samples[wi, ma:mb, pi]
 
 
@@ -435,7 +436,8 @@ class BaseMCMCSampler(_BaseSampler):
                 except KeyError:
                     # dataset doesn't exist yet
                     fp.create_dataset(dataset_name, (fb,),
-                                      maxshape=(max_iterations,))
+                                      maxshape=(max_iterations,),
+                                      dtype=stats.dtype)
                     fp[dataset_name][fa:fb] = stats[param][wi, ma:mb]
         return stats
 
@@ -479,7 +481,8 @@ class BaseMCMCSampler(_BaseSampler):
         except KeyError:
             # dataset doesn't exist yet
             fp.create_dataset(dataset_name, (bb,),
-                              maxshape=(max_iterations,))
+                              maxshape=(max_iterations,),
+                              dtype=acf.dtype)
             fp[dataset_name][aa:bb] = acf[aa:bb]
 
 

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -472,9 +472,9 @@ class BaseMCMCSampler(_BaseSampler):
             max_iterations = acf.size
 
         try:
-            if bb > fp[dataset_name].size:
+            if end_iteration > fp[dataset_name].size:
                 # resize the dataset
-                fp[dataset_name].resize(bb, axis=0)
+                fp[dataset_name].resize(end_iteration, axis=0)
             fp[dataset_name][start_iteration:end_iteration] = \
                 acf[start_iteration:end_iteration]
         except KeyError:

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -51,6 +51,7 @@ class _BaseSampler(object):
 
     def __init__(self, likelihood_evaluator):
         self.likelihood_evaluator = likelihood_evaluator
+        self._lastclear = 0
 
     @classmethod
     def from_cli(cls, opts, likelihood_evaluator):
@@ -89,7 +90,7 @@ class _BaseSampler(object):
     @property
     def niterations(self):
         """Get the current number of iterations."""
-        return self.chain.shape[-2]
+        return self.chain.shape[-2] + self._lastclear
 
     @property
     def acceptance_fraction(self):

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -462,10 +462,8 @@ class BaseMCMCSampler(_BaseSampler):
         dataset_name = "acceptance_fraction"
         acf = self.acceptance_fraction
 
-        aa = start_iteration
         if end_iteration is None:
             end_iteration = acf.size
-        bb = end_iteration
 
         if max_iterations is not None and max_iterations < acf.size:
             raise IndexError("The provided max size is less than the "
@@ -477,13 +475,15 @@ class BaseMCMCSampler(_BaseSampler):
             if bb > fp[dataset_name].size:
                 # resize the dataset
                 fp[dataset_name].resize(bb, axis=0)
-            fp[dataset_name][aa:bb] = acf[aa:bb]
+            fp[dataset_name][start_iteration:end_iteration] = \
+                acf[start_iteration:end_iteration]
         except KeyError:
             # dataset doesn't exist yet
-            fp.create_dataset(dataset_name, (bb,),
+            fp.create_dataset(dataset_name, (end_iteration,),
                               maxshape=(max_iterations,),
                               dtype=acf.dtype)
-            fp[dataset_name][aa:bb] = acf[aa:bb]
+            fp[dataset_name][start_iteration:end_iteration] = \
+                acf[start_iteration:end_iteration]
 
 
     def write_results(self, fp, start_iteration=0, end_iteration=None,

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -478,11 +478,11 @@ class BaseMCMCSampler(_BaseSampler):
             end_iteration = acf.size
         bb = end_iteration
 
-        if max_iterations is not None and max_iterations < niterations:
+        if max_iterations is not None and max_iterations < acf.size:
             raise IndexError("The provided max size is less than the "
                              "number of iterations")
         elif max_iterations is None:
-            max_iterations = niterations
+            max_iterations = acf.size
 
         try:
             if bb > fp[dataset_name].size:

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -331,9 +331,13 @@ class BaseMCMCSampler(_BaseSampler):
         if end_iteration is None:
             end_iteration = niterations
         fb = end_iteration # file end index
-        ma = fa - self._lastclear
-        mb = fb - self._lastclear
-
+        if self._lastclear != 0:
+            # we add one to lastclear to skip the point from the previous clear
+            ma = fa - self._lastclear + 1
+            mb = fb - self._lastclear + 1
+        else:
+            ma = fa
+            mb = fb
 
         # map sample values to the values that were actually passed to the
         # waveform generator and prior evaluator
@@ -367,7 +371,7 @@ class BaseMCMCSampler(_BaseSampler):
                     # dataset doesn't exist yet, use scratch space for writing
                     if out is None:
                         out = numpy.zeros(max_iterations, dtype=samples.dtype)
-                    out[aa:bb] = samples[wi, ma:mb, pi]
+                    out[fa:fb] = samples[wi, ma:mb, pi]
                     fp[dataset_name] = out
 
 
@@ -415,8 +419,13 @@ class BaseMCMCSampler(_BaseSampler):
         if end_iteration is None:
             end_iteration = niterations
         fb = end_iteration # file end index
-        ma = fa - self._lastclear
-        mb = fb - self._lastclear
+        if self._lastclear != 0:
+            # we add one to lastclear to skip the point from the previous clear
+            ma = fa - self._lastclear + 1
+            mb = fb - self._lastclear + 1
+        else:
+            ma = fa
+            mb = fb
 
         group = fp.stats_group + '/{param}/walker{wi}'
 
@@ -466,7 +475,8 @@ class BaseMCMCSampler(_BaseSampler):
 
         aa = start_iteration
         if end_iteration is None:
-            bb = acf.size
+            end_iteration = acf.size
+        bb = end_iteration
 
         try:
             fp[dataset_name][aa:bb] = acf[aa:bb]

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -583,7 +583,8 @@ class EmceePTSampler(BaseMCMCSampler):
                     except KeyError:
                         # dataset doesn't exist yet
                         fp.create_dataset(dataset_name, (fb,),
-                                          maxshape=(max_iterations,))
+                                          maxshape=(max_iterations,),
+                                          dtype=samples.dtype)
                         fp[dataset_name][fa:fb] = samples[tk, wi, ma:mb, pi]
 
 
@@ -646,7 +647,8 @@ class EmceePTSampler(BaseMCMCSampler):
                     except KeyError:
                         # dataset doesn't exist yet
                         fp.create_dataset(dataset_name, (fb,),
-                                          maxshape=(max_iterations,))
+                                          maxshape=(max_iterations,),
+                                          dtype=arr.dtype)
                         fp[dataset_name][fa:fb] = arr[tk, wi, ma:mb, pi]
 
 

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -130,7 +130,7 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
         """Clears the chain and blobs from memory.
         """
         # store the iteration that the clear is occuring on
-        self._lastclear = self.iterations
+        self._lastclear = self.niterations
         # now clear the chain
         self._sampler.reset()
         self._sampler.clear_blobs()

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -347,6 +347,14 @@ class EmceePTSampler(BaseMCMCSampler):
         # emcee returns the chain as ntemps x nwalker x niterations x ndim
         return self._sampler.chain
 
+    def clear_chain(self):
+        """Clears the chain and blobs from memory.
+        """
+        # store the iteration that the clear is occuring on
+        self._lastclear = self.niterations
+        # now clear the chain
+        self._sampler.reset()
+
     @property
     def likelihood_stats(self):
         """Returns the log likelihood ratio and log prior as a FieldArray.
@@ -588,7 +596,8 @@ class EmceePTSampler(BaseMCMCSampler):
                         fp[dataset_name][fa:fb] = samples[tk, wi, ma:mb, pi]
 
 
-    def write_likelihood_stats(self, fp, max_iterations=None):
+    def write_likelihood_stats(self, fp, start_iteration=0, end_iteration=None,
+                               max_iterations=None):
         """Writes the given likelihood array to the given file. Results are
         written to: `fp[fp.stats_group/{field}/temp{k}/walker{i}]`, where
         `{field}` is the name of stat (`loglr`, `prior`), `{k}` is a
@@ -599,6 +608,10 @@ class EmceePTSampler(BaseMCMCSampler):
         -----------
         fp : InferenceFile
             A file handler to an open inference file.
+        start_iteration : {0, int}
+            Write results starting from the given iteration.
+        end_iteration : {None, int}
+            Write results up to the given iteration.
         max_iterations : {None, int}
             See `write_chain` for details.
         """
@@ -649,7 +662,7 @@ class EmceePTSampler(BaseMCMCSampler):
                         fp.create_dataset(dataset_name, (fb,),
                                           maxshape=(max_iterations,),
                                           dtype=arr.dtype)
-                        fp[dataset_name][fa:fb] = arr[tk, wi, ma:mb, pi]
+                        fp[dataset_name][fa:fb] = arr[tk, wi, ma:mb]
 
 
     def write_results(self, fp, start_iteration=0, end_iteration=None,

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -224,7 +224,8 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
             wmask[walkers] = True
         return fp[group][wmask]
 
-    def write_results(self, fp, max_iterations=None):
+    def write_results(self, fp, start_iteration=0, end_iteration=None,
+                      max_iterations=None):
         """Writes metadata, samples, likelihood stats, and acceptance fraction
         to the given file. See the write function for each of those for
         details.
@@ -233,6 +234,10 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
         -----------
         fp : InferenceFile
             A file handler to an open inference file.
+        start_iteration : {0, int}
+            Write results starting from the given iteration.
+        end_iteration : {None, int}
+            Write results up to the given iteration.
         max_iterations : {None, int}
             If results have not previously been written to the
             file, new datasets will be created. By default, the size of these
@@ -242,8 +247,12 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
             large enough to accomodate future data.
         """
         self.write_metadata(fp)
-        self.write_chain(fp, max_iterations=max_iterations)
-        self.write_likelihood_stats(fp, max_iterations=max_iterations)
+        self.write_chain(fp, start_iteration=start_iteration,
+                         end_iteration=end_iteration,
+                         max_iterations=max_iterations)
+        self.write_likelihood_stats(fp, start_iteration=start_iteration,
+                                    end_iteration=end_iteration,
+                                    max_iterations=max_iterations)
         self.write_acceptance_fraction(fp)
 
 
@@ -640,8 +649,10 @@ class EmceePTSampler(BaseMCMCSampler):
                                           maxshape=(max_iterations,))
                         fp[dataset_name][fa:fb] = arr[tk, wi, ma:mb, pi]
 
-    def write_results(self, fp, max_iterations=None):
-        """Writes metadata, samples, lnpost, lnprior,  and acceptance fraction
+
+    def write_results(self, fp, start_iteration=0, end_iteration=None,
+                      max_iterations=None):
+        """Writes metadata, samples, likelihood stats, and acceptance fraction
         to the given file. See the write function for each of those for
         details.
 
@@ -649,6 +660,10 @@ class EmceePTSampler(BaseMCMCSampler):
         -----------
         fp : InferenceFile
             A file handler to an open inference file.
+        start_iteration : {0, int}
+            Write results starting from the given iteration.
+        end_iteration : {None, int}
+            Write results up to the given iteration.
         max_iterations : {None, int}
             If results have not previously been written to the
             file, new datasets will be created. By default, the size of these
@@ -658,9 +673,14 @@ class EmceePTSampler(BaseMCMCSampler):
             large enough to accomodate future data.
         """
         self.write_metadata(fp)
-        self.write_chain(fp, max_iterations=max_iterations)
-        self.write_likelihood_stats(fp, max_iterations=max_iterations)
+        self.write_chain(fp, start_iteration=start_iteration,
+                         end_iteration=end_iteration,
+                         max_iterations=max_iterations)
+        self.write_likelihood_stats(fp, start_iteration=start_iteration,
+                                    end_iteration=end_iteration,
+                                    max_iterations=max_iterations)
         self.write_acceptance_fraction(fp)
+
 
     @staticmethod
     def _read_fields(fp, fields_group, fields, array_class,

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -126,6 +126,15 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
         # emcee returns the chain as nwalker x niterations x ndim
         return self._sampler.chain
 
+    def clear_chain(self):
+        """Clears the chain and blobs from memory.
+        """
+        # store the iteration that the clear is occuring on
+        self._lastclear = self.iterations
+        # now clear the chain
+        self._sampler.reset()
+        self._sampler.clear_blobs()
+
     def run(self, niterations, **kwargs):
         """Advance the ensemble for a number of samples.
 

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -504,7 +504,8 @@ class EmceePTSampler(BaseMCMCSampler):
             arrays.append(fp[group.format(tk=tk)][wmask])
         return numpy.vstack(arrays)
 
-    def write_chain(self, fp, max_iterations=None):
+    def write_chain(self, fp, start_iteration=0, end_iteration=None,
+                    max_iterations=None):
         """Writes the samples from the current chain to the given file. Results
         are written to: `fp[fp.samples_group/{vararg}/temp{k}/walker{i}]`,
         where `{vararg}` is the name of a variable arg, `{k}` is a temperature
@@ -514,6 +515,10 @@ class EmceePTSampler(BaseMCMCSampler):
         -----------
         fp : InferenceFile
             A file handler to an open inference file.
+        start_iteration : {0, int}
+            Write results starting from the given iteration.
+        end_iteration : {None, int}
+            Write results up to the given iteration.
         max_iterations : {None, int}
             If samples have not previously been written to the file, a new
             dataset will be created. By default, the size of this dataset will
@@ -526,6 +531,22 @@ class EmceePTSampler(BaseMCMCSampler):
         samples = self.chain
         ntemps, nwalkers, niterations, _ = samples.shape
 
+        # due to clearing memory, there can be a difference between indices in
+        # memory and on disk
+        niterations += self._lastclear
+        fa = start_iteration # file start index
+        if end_iteration is None:
+            end_iteration = niterations
+        fb = end_iteration # file end index
+        ma = fa - self._lastclear # memory start index
+        mb = fb - self._lastclear # memory end index
+
+        if max_iterations is not None and max_iterations < niterations:
+            raise IndexError("The provided max size is less than the "
+                             "number of iterations")
+        elif max_iterations is None:
+            max_iterations = niterations
+
         # map sample values to the values that were actually passed to the
         # waveform generator and prior evaluator
         samples = numpy.array(
@@ -533,14 +554,6 @@ class EmceePTSampler(BaseMCMCSampler):
             samples.transpose(3,0,1,2))).transpose(1,2,3,0)
 
         group = fp.samples_group + '/{name}/temp{tk}/walker{wi}'
-
-        # create an empty array if desired, in case this is the first time
-        # writing
-        if max_iterations is not None:
-            if max_iterations < niterations:
-                raise IndexError("The provided max size is less than the "
-                                 "number of iterations")
-            out = numpy.zeros(max_iterations, dtype=samples.dtype)
 
         # create indices for faster sub-looping
         widx = numpy.arange(nwalkers)
@@ -554,15 +567,16 @@ class EmceePTSampler(BaseMCMCSampler):
                 for wi in widx:
                     dataset_name = group.format(name=param, tk=tk, wi=wi)
                     try:
-                        fp[dataset_name][:niterations] = samples[tk, wi, :, pi]
+                        if fb > fp[dataset_name].size:
+                            # resize the dataset
+                            fp[dataset_name].resize(fb, axis=0)
+                        fp[dataset_name][fa:fb] = samples[tk, wi, ma:mb, pi]
                     except KeyError:
-                        # dataset doesn't exist yet, see if a larger array is
-                        # desired
-                        if max_iterations is not None:
-                            out[:niterations] = samples[tk, wi, :, pi]
-                            fp[dataset_name] = out
-                        else:
-                            fp[dataset_name] = samples[tk, wi, :, pi]
+                        # dataset doesn't exist yet
+                        fp.create_dataset(dataset_name, (fb,),
+                                          maxshape=(max_iterations,))
+                        fp[dataset_name][fa:fb] = samples[tk, wi, ma:mb, pi]
+
 
     def write_likelihood_stats(self, fp, max_iterations=None):
         """Writes the given likelihood array to the given file. Results are
@@ -581,11 +595,23 @@ class EmceePTSampler(BaseMCMCSampler):
         lls = self.likelihood_stats
         ntemps, nwalkers, niterations = lls.shape
 
-        group = fp.stats_group + '/{field}/temp{tk}/walker{wi}'
+        # due to clearing memory, there can be a difference between indices in
+        # memory and on disk
+        niterations += self._lastclear
+        fa = start_iteration # file start index
+        if end_iteration is None:
+            end_iteration = niterations
+        fb = end_iteration # file end index
+        ma = fa - self._lastclear # memory start index
+        mb = fb - self._lastclear # memory end index
 
         if max_iterations is not None and max_iterations < niterations:
             raise IndexError("The provided max size is less than the "
                              "number of iterations")
+        elif max_iterations is None:
+            max_iterations = niterations
+
+        group = fp.stats_group + '/{field}/temp{tk}/walker{wi}'
 
         # create indices for faster sub-looping
         widx = numpy.arange(nwalkers)
@@ -604,15 +630,15 @@ class EmceePTSampler(BaseMCMCSampler):
                 for wi in widx:
                     dataset_name = group.format(field=stat, tk=tk, wi=wi)
                     try:
-                        fp[dataset_name][:niterations] = arr[tk, wi, :]
+                        if fb > fp[dataset_name].size:
+                            # resize the dataset
+                            fp[dataset_name].resize(fb, axis=0)
+                        fp[dataset_name][fa:fb] = arr[tk, wi, ma:mb]
                     except KeyError:
-                        # dataset doesn't exist yet, see if a larger array is
-                        # desired
-                        if max_iterations is not None:
-                            out[:niterations] = arr[tk, wi, :]
-                            fp[dataset_name] = out
-                        else:
-                            fp[dataset_name] = arr[tk, wi, :]
+                        # dataset doesn't exist yet
+                        fp.create_dataset(dataset_name, (fb,),
+                                          maxshape=(max_iterations,))
+                        fp[dataset_name][fa:fb] = arr[tk, wi, ma:mb, pi]
 
     def write_results(self, fp, max_iterations=None):
         """Writes metadata, samples, lnpost, lnprior,  and acceptance fraction

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -643,10 +643,6 @@ class EmceePTSampler(BaseMCMCSampler):
         # loop over stats
         for stat in lls.fieldnames:
             arr = lls[stat]
-            # create an empty array if desired, in case this is the first time
-            # writing
-            if max_iterations is not None:
-                out = numpy.zeros(max_iterations, dtype=arr.dtype)
             # loop over temps
             for tk in tidx:
                 # loop over number of walkers

--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -170,7 +170,8 @@ class KombineSampler(BaseMCMCSampler):
         # clear the blobs
         if len(self._sampler._blobs) != 0:
             self._sampler._blobs = [self._sampler._blobs[-1]]
-        self._lastclear += shape[0]
+        # store the iteration that the clear happened on
+        self._lastclear = self._sampler.iterations
 
     def burn_in(self):
         """Use kombine's `burnin` routine to advance the sampler.

--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -158,6 +158,20 @@ class KombineSampler(BaseMCMCSampler):
         # kombine returns niterations x nwalkers x ndim
         return self._sampler.chain.transpose((1, 0, 2))
 
+    def clear_chain(self):
+        """Clears the chain and blobs from memory, keeping only the last point.
+        """
+        # kombine stores its chain as niterations x nwalkers x ndim
+        current_chain = self._sampler._chain
+        shape = current_chain.shape
+        self._sampler._chain = current_chain[-1,:,:].reshape(1,
+            shape[1], shape[2])
+        self._sampler.stored_iterations = 1
+        # clear the blobs
+        if len(self._sampler._blobs) != 0:
+            self._sampler._blobs = [self._sampler._blobs[-1]]
+        self._lastclear = shape[0]
+
     def burn_in(self):
         """Use kombine's `burnin` routine to advance the sampler.
 

--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -26,6 +26,7 @@ This modules provides classes and functions for using the kombine sampler
 packages for parameter estimation.
 """
 
+import numpy
 from pycbc.inference.sampler_base import BaseMCMCSampler
 
 #
@@ -141,8 +142,8 @@ class KombineSampler(BaseMCMCSampler):
         p, lnpost, lnprop = res[0], res[1], res[2]
         # update the positions
         self._pos = p
-        if self.likelihood_evalutor.return_meta:
-            self._currentblob = self._sapmler.blobs[-1]
+        if self.likelihood_evaluator.return_meta:
+            self._currentblob = self._sampler.blobs[-1]
         return p, lnpost, lnprop
 
     @property
@@ -163,15 +164,15 @@ class KombineSampler(BaseMCMCSampler):
         """Clears the chain and blobs from memory.
         """
         # store the iteration that the clear is occuring on
-        self._lastclear = self.iterations
+        self._lastclear = self.niterations
         # kombine stores its chain as niterations x nwalkers x ndim
         current_shape = self._sampler._chain.shape
-        new_shape = (0, current_shape[1], current_shape[1])
+        new_shape = (0, current_shape[1], current_shape[2])
         if isinstance(self._sampler._chain, numpy.ma.MaskedArray):
             self._sampler._chain = numpy.ma.resize(self._sampler._chain,
                                                    new_shape)
         else:
-            self._sampler._chain = self._sampler._chain.resize(new_shape)
+            self._sampler._chain.resize(new_shape)
         self._sampler.stored_iterations = 0
         # clear the blobs
         self._sampler._blobs = []

--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -123,8 +123,8 @@ class KombineSampler(BaseMCMCSampler):
             with shape (nwalkers, ndim).
         """
         blob0 = None
-        if self.burn_in_iterations == 0:
-            # no burn in, use the initial positions
+        if self.niterations == 0:
+            # first time running, use the initial positions
             p0 = self.p0
             if self.likelihood_evaluator.return_meta:
                 blob0 = [self.likelihood_evaluator(p0[wi, :])[1]

--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -170,7 +170,7 @@ class KombineSampler(BaseMCMCSampler):
         # clear the blobs
         if len(self._sampler._blobs) != 0:
             self._sampler._blobs = [self._sampler._blobs[-1]]
-        self._lastclear = shape[0]
+        self._lastclear += shape[0]
 
     def burn_in(self):
         """Use kombine's `burnin` routine to advance the sampler.


### PR DESCRIPTION
This patch does a few things:
 1. An update interval can be set on the command line to pass to kombine. This will cause kombine's internal kde to be updated after the given number of iterations. This is useful if we want to be able to skip using kombine's burn in function, or if its burn in function finishes before the sampler is actually burned in.
 2. Only points since the last checkpoint are written to the output file. Right now, all points in the chain are re-written to the file on every checkpoint (that was my fault). This can result in the file writing taking just as long or longer than the actual MCMC evolution, particularly as the number of iterations gets large.
 3. After checkpointing, the in-memory chain is cleared except for the last point. This is so that when doing a large number of iterations, the memory usage doesn't grow unbounded.

I still need to apply the last two to emcee, so marking this as a work in progress.