### PR TITLE
Reinstating pycbc_splitbank as executable class

### DIFF
--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1662,7 +1662,7 @@ class PycbcTimeslidesExecutable(Executable):
         return node
 
 class PycbcSplitBankExecutable(Executable):
-    """ The class responsible for creating jobs for pycbc_splitbank. """
+    """ The class responsible for creating jobs for pycbc_hdf5_splitbank. """
 
     current_retention_level = Executable.ALL_TRIGGERS
     def __init__(self, cp, exe_name, num_banks,
@@ -1704,3 +1704,48 @@ class PycbcSplitBankExecutable(Executable):
             out_files.append(out_file)
         node.add_output_list_opt('--output-filenames', out_files)
         return node
+
+class PycbcSplitBankXmlExecutable(Executable):
+    """ The class responsible for creating jobs for pycbc_splitbank. """
+
+    current_retention_level = Executable.ALL_TRIGGERS
+    def __init__(self, cp, exe_name, num_banks,
+                 ifo=None, out_dir=None, universe=None):
+        super(PycbcSplitBankXmlExecutable, self).__init__(cp, exe_name, universe,
+                ifo, out_dir, tags=[])
+        self.num_banks = int(num_banks)
+
+    def create_node(self, bank, tags=None):
+        """
+        Set up a CondorDagmanNode class to run lalapps_splitbank code
+
+        Parameters
+        ----------
+        bank : pycbc.workflow.core.File
+            The File containing the template bank to be split
+
+        Returns
+        --------
+        node : pycbc.workflow.core.Node
+            The node to run the job
+        """
+        if tags is None:
+            tags = []
+        node = Node(self)
+        node.add_input_opt('--bank-file', bank)
+
+        # Get the output (taken from inspiral.py)
+        out_files = FileList([])
+        for i in range( 0, self.num_banks):
+            curr_tag = 'bank%d' %(i)
+            # FIXME: What should the tags actually be? The job.tags values are
+            #        currently ignored.
+            curr_tags = bank.tags + [curr_tag] + tags
+            job_tag = bank.description + "_" + self.name.upper()
+            out_file = File(bank.ifo_list, job_tag, bank.segment,
+                               extension=".xml.gz", directory=self.out_dir,
+                               tags=curr_tags, store_file=self.retain_files)
+            out_files.append(out_file)
+        node.add_output_list_opt('--output-filenames', out_files)
+        return node
+

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1662,7 +1662,7 @@ class PycbcTimeslidesExecutable(Executable):
         return node
 
 class PycbcSplitBankExecutable(Executable):
-    """ The class responsible for creating jobs for splitbank. """
+    """ The class responsible for creating jobs for pycbc_hdf5_splitbank. """
 
     extension = 'hdf'
     current_retention_level = Executable.ALL_TRIGGERS
@@ -1707,6 +1707,7 @@ class PycbcSplitBankExecutable(Executable):
         return node
 
 class PycbcSplitBankXmlExecutable(PycbcSplitBankExecutable):
+    """ Subclass resonsible for creating jobs for pycbc_splitbank. """
 
     extension='xml.gz'
 

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1662,8 +1662,9 @@ class PycbcTimeslidesExecutable(Executable):
         return node
 
 class PycbcSplitBankExecutable(Executable):
-    """ The class responsible for creating jobs for pycbc_hdf5_splitbank. """
+    """ The class responsible for creating jobs for splitbank. """
 
+    extension = 'hdf'
     current_retention_level = Executable.ALL_TRIGGERS
     def __init__(self, cp, exe_name, num_banks,
                  ifo=None, out_dir=None, universe=None):
@@ -1673,7 +1674,7 @@ class PycbcSplitBankExecutable(Executable):
 
     def create_node(self, bank, tags=None):
         """
-        Set up a CondorDagmanNode class to run lalapps_splitbank code
+        Set up a CondorDagmanNode class to run splitbank code
 
         Parameters
         ----------
@@ -1699,53 +1700,13 @@ class PycbcSplitBankExecutable(Executable):
             curr_tags = bank.tags + [curr_tag] + tags
             job_tag = bank.description + "_" + self.name.upper()
             out_file = File(bank.ifo_list, job_tag, bank.segment,
-                               extension=".hdf", directory=self.out_dir,
-                               tags=curr_tags, store_file=self.retain_files)
+                            extension=self.extension, directory=self.out_dir,
+                            tags=curr_tags, store_file=self.retain_files)
             out_files.append(out_file)
         node.add_output_list_opt('--output-filenames', out_files)
         return node
 
-class PycbcSplitBankXmlExecutable(Executable):
-    """ The class responsible for creating jobs for pycbc_splitbank. """
+class PycbcSplitBankXmlExecutable(PycbcSplitBankExecutable):
 
-    current_retention_level = Executable.ALL_TRIGGERS
-    def __init__(self, cp, exe_name, num_banks,
-                 ifo=None, out_dir=None, universe=None):
-        super(PycbcSplitBankXmlExecutable, self).__init__(cp, exe_name, universe,
-                ifo, out_dir, tags=[])
-        self.num_banks = int(num_banks)
-
-    def create_node(self, bank, tags=None):
-        """
-        Set up a CondorDagmanNode class to run lalapps_splitbank code
-
-        Parameters
-        ----------
-        bank : pycbc.workflow.core.File
-            The File containing the template bank to be split
-
-        Returns
-        --------
-        node : pycbc.workflow.core.Node
-            The node to run the job
-        """
-        if tags is None:
-            tags = []
-        node = Node(self)
-        node.add_input_opt('--bank-file', bank)
-
-        # Get the output (taken from inspiral.py)
-        out_files = FileList([])
-        for i in range( 0, self.num_banks):
-            curr_tag = 'bank%d' %(i)
-            # FIXME: What should the tags actually be? The job.tags values are
-            #        currently ignored.
-            curr_tags = bank.tags + [curr_tag] + tags
-            job_tag = bank.description + "_" + self.name.upper()
-            out_file = File(bank.ifo_list, job_tag, bank.segment,
-                               extension=".xml.gz", directory=self.out_dir,
-                               tags=curr_tags, store_file=self.retain_files)
-            out_files.append(out_file)
-        node.add_output_list_opt('--output-filenames', out_files)
-        return node
+    extension='xml.gz'
 

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -1664,7 +1664,7 @@ class PycbcTimeslidesExecutable(Executable):
 class PycbcSplitBankExecutable(Executable):
     """ The class responsible for creating jobs for pycbc_hdf5_splitbank. """
 
-    extension = 'hdf'
+    extension = '.hdf'
     current_retention_level = Executable.ALL_TRIGGERS
     def __init__(self, cp, exe_name, num_banks,
                  ifo=None, out_dir=None, universe=None):
@@ -1709,5 +1709,5 @@ class PycbcSplitBankExecutable(Executable):
 class PycbcSplitBankXmlExecutable(PycbcSplitBankExecutable):
     """ Subclass resonsible for creating jobs for pycbc_splitbank. """
 
-    extension='xml.gz'
+    extension='.xml.gz'
 

--- a/pycbc/workflow/splittable.py
+++ b/pycbc/workflow/splittable.py
@@ -34,7 +34,8 @@ from __future__ import division
 import os
 import logging
 from pycbc.workflow.core import FileList, make_analysis_dir
-from pycbc.workflow.jobsetup import PycbcSplitBankExecutable, PycbcSplitInspinjExecutable
+from pycbc.workflow.jobsetup import (PycbcSplitBankExecutable,
+        PycbcSplitBankXmlExecutable, PycbcSplitInspinjExecutable)
 
 def select_splitfilejob_instance(curr_exe):
     """
@@ -59,6 +60,8 @@ def select_splitfilejob_instance(curr_exe):
     """
     if curr_exe == 'pycbc_hdf5_splitbank':
         exe_class = PycbcSplitBankExecutable
+    elif curr_exe == 'pycbc_splitbank':
+        exe_class = PycbcSplitBankXmlExecutable
     elif curr_exe == 'pycbc_split_inspinj':
         exe_class = PycbcSplitInspinjExecutable
     else:


### PR DESCRIPTION
Proposed patch to re-allow the use of pycbc_splitbank in workflows. This is still used in PyGRB as of the beginning of O2.