### PR TITLE
Ensure minimum data length is always an option

### DIFF
--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -863,7 +863,6 @@ class PyCBCInspiralExecutable(Executable):
         valid_regions = []
         for nsegs in seg_ranges:
             analysis_length = (segment_length - start_pad - end_pad) * nsegs
-            data_length = analysis_length + pad_data * 2
             if not self.zero_padding:
                 data_length = analysis_length + pad_data * 2 \
                               + start_pad + end_pad
@@ -877,6 +876,19 @@ class PyCBCInspiralExecutable(Executable):
             if data_length < min_analysis_length: continue
             data_lengths += [data_length]
             valid_regions += [segments.segment(start, end)]
+        # If min_analysis_length is given, ensure that it is added as an option
+        # for job analysis length.
+        if min_analysis_length:
+            data_length = min_analysis_length
+            if not self.zero_padding:
+                start = pad_data + start_pad
+                end = data_length - pad_data - end_pad
+            else:
+                start = pad_data
+                end = data_length - pad_data
+            if end > start:
+                data_lengths += [data_length]
+                valid_regions += [segments.segment(start, end)]
 
         return data_lengths, valid_regions
 


### PR DESCRIPTION
Alright @ahnitz @titodalcanton @duncan-brown, here's my attempt to fix #1311.

First the problem: Currently the JobSegmenter in pycbc.workflow chooses a set of potential lengths of data for jobs to read in based on length of the lock stretch. For shorter lock stretches less data is read in per job than for longer lock stretches. Bounds can be placed on this in terms of *either* number of inspiral analysis segments *or* total data read in ... We currently use *both* bounds, which is also allowed.

Now, when choosing the data stretches JobSegmenter uses the possible number of analysis segments (which becomes somewhat more tricksy when zero-padding is enabled). Our stated minimum analysable lock length for O2 is 528s. This is *not* a multiple of analysis segments. So JobSegmenter rejects ~350s as a valid length as it is less than 528, accepts ~700s (and larger values) as these are larger, but does *not* allow any possibility of analysing lock stretches > 512 and < ~700s. For job segments > ~700s the current setup minimizes the number of FFTs being performed, so should probably not change*. However, we should add explicitly the minimum data stretch that is possible to analyse as an option.

This patch simply adds that. Now the failing segment is analysed as two 

*Note that the Segmenter is now a bit of a mash of @ahnitz's and my code, as the requirements and structure of pycbc_inspiral has changed over the last 3 years a few times. It might be worth rewriting this at some point. Some silly things are present in the current version, for example a lock stretch of 529s (1s longer than the minimum) would be analysed in 2 blocks of 528s (because we choose a set of options for data length read in), rather than 1 block of 529s. The FFT count actually doesn't (shouldn't) change between the two cases, but there is some unnecessary data read-in, injection generation etc. overhead here.

Line 866 was always redundant, so I remove it now. I'll start a copy of Denty's run off on atlas with this change included now.