### PR TITLE
Update versioning

### DIFF
--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -29,64 +29,89 @@ def get_library_version_info():
     import lal, lalframe, lalmetaio, lalinspiral, lalsimulation
     import glue.git_version, pycbc.version
 
+    def add_info_new_version(info_dct, curr_module):    
+        info_dct['ID'] = curr_module.VCSInfo.vcsId
+        info_dct['Status'] = curr_module.VCSInfo.vcsStatus
+        info_dct['Version'] =  curr_module.VCSInfo.version
+        info_dct['Tag'] = curr_module.VCSInfo.vcsTag
+        info_dct['Author'] = curr_module.VCSInfo.vcsAuthor
+        info_dct['Branch'] = curr_module.VCSInfo.vcsBranch
+        info_dct['Committer'] = curr_module.VCSInfo.vcsCommitter
+        info_dct['Date'] = curr_module.VCSInfo.vcsDate
+
     lalinfo = {}
     lalinfo['Name'] = 'LAL'
-    lalinfo['ID'] = lal.VCSId
-    lalinfo['Status'] = lal.VCSStatus
-    lalinfo['Version'] = lal.VCSVersion
-    lalinfo['Tag'] = lal.VCSTag
-    lalinfo['Author'] = lal.VCSAuthor
-    lalinfo['Branch'] = lal.VCSBranch
-    lalinfo['Committer'] = lal.VCSCommitter
-    lalinfo['Date'] = lal.VCSDate
+    try:
+        lalinfo['ID'] = lal.VCSId
+        lalinfo['Status'] = lal.VCSStatus
+        lalinfo['Version'] = lal.VCSVersion
+        lalinfo['Tag'] = lal.VCSTag
+        lalinfo['Author'] = lal.VCSAuthor
+        lalinfo['Branch'] = lal.VCSBranch
+        lalinfo['Committer'] = lal.VCSCommitter
+        lalinfo['Date'] = lal.VCSDate
+    except AttributeError:
+        add_info_new_version(lalinfo, lal)
     library_list.append(lalinfo)
 
     lalframeinfo = {}
-    lalframeinfo['Name'] = 'LALFrame'
-    lalframeinfo['ID'] = lalframe.FrameVCSId
-    lalframeinfo['Status'] = lalframe.FrameVCSStatus
-    lalframeinfo['Version'] = lalframe.FrameVCSVersion
-    lalframeinfo['Tag'] = lalframe.FrameVCSTag
-    lalframeinfo['Author'] = lalframe.FrameVCSAuthor
-    lalframeinfo['Branch'] = lalframe.FrameVCSBranch
-    lalframeinfo['Committer'] = lalframe.FrameVCSCommitter
-    lalframeinfo['Date'] = lalframe.FrameVCSDate
+    try:
+        lalframeinfo['Name'] = 'LALFrame'
+        lalframeinfo['ID'] = lalframe.FrameVCSId
+        lalframeinfo['Status'] = lalframe.FrameVCSStatus
+        lalframeinfo['Version'] = lalframe.FrameVCSVersion
+        lalframeinfo['Tag'] = lalframe.FrameVCSTag
+        lalframeinfo['Author'] = lalframe.FrameVCSAuthor
+        lalframeinfo['Branch'] = lalframe.FrameVCSBranch
+        lalframeinfo['Committer'] = lalframe.FrameVCSCommitter
+        lalframeinfo['Date'] = lalframe.FrameVCSDate
+    except AttributeError:
+        add_info_new_version(lalframeinfo, lalframe)
     library_list.append(lalframeinfo)
 
     lalmetaioinfo = {}
     lalmetaioinfo['Name'] = 'LALMetaIO'
-    lalmetaioinfo['ID'] = lalmetaio.MetaIOVCSId
-    lalmetaioinfo['Status'] = lalmetaio.MetaIOVCSStatus
-    lalmetaioinfo['Version'] = lalmetaio.MetaIOVCSVersion
-    lalmetaioinfo['Tag'] = lalmetaio.MetaIOVCSTag
-    lalmetaioinfo['Author'] = lalmetaio.MetaIOVCSAuthor
-    lalmetaioinfo['Branch'] = lalmetaio.MetaIOVCSBranch
-    lalmetaioinfo['Committer'] = lalmetaio.MetaIOVCSCommitter
-    lalmetaioinfo['Date'] = lalmetaio.MetaIOVCSDate
+    try:
+        lalmetaioinfo['ID'] = lalmetaio.MetaIOVCSId
+        lalmetaioinfo['Status'] = lalmetaio.MetaIOVCSStatus
+        lalmetaioinfo['Version'] = lalmetaio.MetaIOVCSVersion
+        lalmetaioinfo['Tag'] = lalmetaio.MetaIOVCSTag
+        lalmetaioinfo['Author'] = lalmetaio.MetaIOVCSAuthor
+        lalmetaioinfo['Branch'] = lalmetaio.MetaIOVCSBranch
+        lalmetaioinfo['Committer'] = lalmetaio.MetaIOVCSCommitter
+        lalmetaioinfo['Date'] = lalmetaio.MetaIOVCSDate
+    except AttributeError:
+        add_info_new_version(lalmetaioinfo, lalmetaio)
     library_list.append(lalmetaioinfo)
 
     lalinspiralinfo = {}
     lalinspiralinfo['Name'] = 'LALInspiral'
-    lalinspiralinfo['ID'] = lalinspiral.InspiralVCSId
-    lalinspiralinfo['Status'] = lalinspiral.InspiralVCSStatus
-    lalinspiralinfo['Version'] = lalinspiral.InspiralVCSVersion
-    lalinspiralinfo['Tag'] = lalinspiral.InspiralVCSTag
-    lalinspiralinfo['Author'] = lalinspiral.InspiralVCSAuthor
-    lalinspiralinfo['Branch'] = lalinspiral.InspiralVCSBranch
-    lalinspiralinfo['Committer'] = lalinspiral.InspiralVCSCommitter
-    lalinspiralinfo['Date'] = lalinspiral.InspiralVCSDate
+    try:
+        lalinspiralinfo['ID'] = lalinspiral.InspiralVCSId
+        lalinspiralinfo['Status'] = lalinspiral.InspiralVCSStatus
+        lalinspiralinfo['Version'] = lalinspiral.InspiralVCSVersion
+        lalinspiralinfo['Tag'] = lalinspiral.InspiralVCSTag
+        lalinspiralinfo['Author'] = lalinspiral.InspiralVCSAuthor
+        lalinspiralinfo['Branch'] = lalinspiral.InspiralVCSBranch
+        lalinspiralinfo['Committer'] = lalinspiral.InspiralVCSCommitter
+        lalinspiralinfo['Date'] = lalinspiral.InspiralVCSDate
+    except AttributeError:
+        add_info_new_version(lalinspiralinfo, lalinspiral)
     library_list.append(lalinspiralinfo)
 
     lalsimulationinfo = {}
     lalsimulationinfo['Name'] = 'LALSimulation'
-    lalsimulationinfo['ID'] = lalsimulation.SimulationVCSId
-    lalsimulationinfo['Status'] = lalsimulation.SimulationVCSStatus
-    lalsimulationinfo['Version'] = lalsimulation.SimulationVCSVersion
-    lalsimulationinfo['Tag'] = lalsimulation.SimulationVCSTag
-    lalsimulationinfo['Author'] = lalsimulation.SimulationVCSAuthor
-    lalsimulationinfo['Branch'] = lalsimulation.SimulationVCSBranch
-    lalsimulationinfo['Committer'] = lalsimulation.SimulationVCSCommitter
-    lalsimulationinfo['Date'] = lalsimulation.SimulationVCSDate
+    try:
+        lalsimulationinfo['ID'] = lalsimulation.SimulationVCSId
+        lalsimulationinfo['Status'] = lalsimulation.SimulationVCSStatus
+        lalsimulationinfo['Version'] = lalsimulation.SimulationVCSVersion
+        lalsimulationinfo['Tag'] = lalsimulation.SimulationVCSTag
+        lalsimulationinfo['Author'] = lalsimulation.SimulationVCSAuthor
+        lalsimulationinfo['Branch'] = lalsimulation.SimulationVCSBranch
+        lalsimulationinfo['Committer'] = lalsimulation.SimulationVCSCommitter
+        lalsimulationinfo['Date'] = lalsimulation.SimulationVCSDate
+    except AttributeError:
+        add_info_new_version(lalsimulationinfo, lalsimulation)
     library_list.append(lalsimulationinfo)
 
     glueinfo = {}

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -31,16 +31,15 @@ def get_library_version_info():
     library_list = []
 
     def add_info_new_version(info_dct, curr_module, extra_str):
-        crm = curr_module
-        exs = extra_str
-        info_dct['ID'] = eval(crm + '.' + exs + 'VCSInfo.vcsId')
-        info_dct['Status'] = eval(crm + '.' + exs + 'VCSInfo.vcsStatus')
-        info_dct['Version'] = eval(crm + '.' + exs + 'VCSInfo.version')
-        info_dct['Tag'] = eval(crm + '.' + exs + 'VCSInfo.vcsTag')
-        info_dct['Author'] = eval(crm + '.' + exs + 'VCSInfo.vcsAuthor')
-        info_dct['Branch'] = eval(crm + '.' + exs + 'VCSInfo.vcsBranch')
-        info_dct['Committer'] = eval(crm + '.' + exs + 'VCSInfo.vcsCommitter')
-        info_dct['Date'] = eval(crm + '.' + exs + 'VCSInfo.vcsDate')
+        vcs_object = getattr(curr_module, extra_str +'VCSInfo')
+        info_dct['ID'] =  vcs_object.vcsId
+        info_dct['Status'] = vcs_object.vcsStatus
+        info_dct['Version'] = vcs_object.version
+        info_dct['Tag'] = vcs_object.vcsTag
+        info_dct['Author'] = vcs_object.vcsAuthor
+        info_dct['Branch'] = vcs_object.vcsBranch
+        info_dct['Committer'] = vcs_object.vcsCommitter
+        info_dct['Date'] = vcs_object.vcsDate
 
     lalinfo = {}
     lalinfo['Name'] = 'LAL'
@@ -54,7 +53,7 @@ def get_library_version_info():
         lalinfo['Committer'] = lal.VCSCommitter
         lalinfo['Date'] = lal.VCSDate
     except AttributeError:
-        add_info_new_version(lalinfo, 'lal', '')
+        add_info_new_version(lalinfo, lal, '')
     library_list.append(lalinfo)
 
     lalframeinfo = {}
@@ -69,7 +68,7 @@ def get_library_version_info():
         lalframeinfo['Committer'] = lalframe.FrameVCSCommitter
         lalframeinfo['Date'] = lalframe.FrameVCSDate
     except AttributeError:
-        add_info_new_version(lalframeinfo, 'lalframe', 'Frame')
+        add_info_new_version(lalframeinfo, lalframe, 'Frame')
     library_list.append(lalframeinfo)
 
     lalmetaioinfo = {}
@@ -84,7 +83,7 @@ def get_library_version_info():
         lalmetaioinfo['Committer'] = lalmetaio.MetaIOVCSCommitter
         lalmetaioinfo['Date'] = lalmetaio.MetaIOVCSDate
     except AttributeError:
-        add_info_new_version(lalmetaioinfo, 'lalmetaio', 'MetaIO')
+        add_info_new_version(lalmetaioinfo, lalmetaio, 'MetaIO')
     library_list.append(lalmetaioinfo)
 
     lalinspiralinfo = {}
@@ -99,7 +98,7 @@ def get_library_version_info():
         lalinspiralinfo['Committer'] = lalinspiral.InspiralVCSCommitter
         lalinspiralinfo['Date'] = lalinspiral.InspiralVCSDate
     except AttributeError:
-        add_info_new_version(lalinspiralinfo, 'lalinspiral', 'Inspiral')
+        add_info_new_version(lalinspiralinfo, lalinspiral, 'Inspiral')
     library_list.append(lalinspiralinfo)
 
     lalsimulationinfo = {}
@@ -114,7 +113,7 @@ def get_library_version_info():
         lalsimulationinfo['Committer'] = lalsimulation.SimulationVCSCommitter
         lalsimulationinfo['Date'] = lalsimulation.SimulationVCSDate
     except AttributeError:
-        add_info_new_version(lalsimulationinfo, 'lalsimulation', 'Simulation')
+        add_info_new_version(lalsimulationinfo, lalsimulation, 'Simulation')
     library_list.append(lalsimulationinfo)
 
     glueinfo = {}

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -21,23 +21,26 @@ import os
 import subprocess
 from pycbc.results import save_fig_with_metadata, html_escape
 
+import lal, lalframe, lalmetaio, lalinspiral, lalsimulation
+import glue.git_version, pycbc.version
+
 def get_library_version_info():
     """This will return a list of dictionaries containing versioning
     information about the various LIGO libraries that PyCBC will use in an
     analysis run."""
     library_list = []
-    import lal, lalframe, lalmetaio, lalinspiral, lalsimulation
-    import glue.git_version, pycbc.version
 
-    def add_info_new_version(info_dct, curr_module):    
-        info_dct['ID'] = curr_module.VCSInfo.vcsId
-        info_dct['Status'] = curr_module.VCSInfo.vcsStatus
-        info_dct['Version'] =  curr_module.VCSInfo.version
-        info_dct['Tag'] = curr_module.VCSInfo.vcsTag
-        info_dct['Author'] = curr_module.VCSInfo.vcsAuthor
-        info_dct['Branch'] = curr_module.VCSInfo.vcsBranch
-        info_dct['Committer'] = curr_module.VCSInfo.vcsCommitter
-        info_dct['Date'] = curr_module.VCSInfo.vcsDate
+    def add_info_new_version(info_dct, curr_module, extra_str):
+        crm = curr_module
+        exs = extra_str
+        info_dct['ID'] = eval(crm + '.' + exs + 'VCSInfo.vcsId')
+        info_dct['Status'] = eval(crm + '.' + exs + 'VCSInfo.vcsStatus')
+        info_dct['Version'] = eval(crm + '.' + exs + 'VCSInfo.version')
+        info_dct['Tag'] = eval(crm + '.' + exs + 'VCSInfo.vcsTag')
+        info_dct['Author'] = eval(crm + '.' + exs + 'VCSInfo.vcsAuthor')
+        info_dct['Branch'] = eval(crm + '.' + exs + 'VCSInfo.vcsBranch')
+        info_dct['Committer'] = eval(crm + '.' + exs + 'VCSInfo.vcsCommitter')
+        info_dct['Date'] = eval(crm + '.' + exs + 'VCSInfo.vcsDate')
 
     lalinfo = {}
     lalinfo['Name'] = 'LAL'
@@ -51,7 +54,7 @@ def get_library_version_info():
         lalinfo['Committer'] = lal.VCSCommitter
         lalinfo['Date'] = lal.VCSDate
     except AttributeError:
-        add_info_new_version(lalinfo, lal)
+        add_info_new_version(lalinfo, 'lal', '')
     library_list.append(lalinfo)
 
     lalframeinfo = {}
@@ -66,7 +69,7 @@ def get_library_version_info():
         lalframeinfo['Committer'] = lalframe.FrameVCSCommitter
         lalframeinfo['Date'] = lalframe.FrameVCSDate
     except AttributeError:
-        add_info_new_version(lalframeinfo, lalframe)
+        add_info_new_version(lalframeinfo, 'lalframe', 'Frame')
     library_list.append(lalframeinfo)
 
     lalmetaioinfo = {}
@@ -81,7 +84,7 @@ def get_library_version_info():
         lalmetaioinfo['Committer'] = lalmetaio.MetaIOVCSCommitter
         lalmetaioinfo['Date'] = lalmetaio.MetaIOVCSDate
     except AttributeError:
-        add_info_new_version(lalmetaioinfo, lalmetaio)
+        add_info_new_version(lalmetaioinfo, 'lalmetaio', 'MetaIO')
     library_list.append(lalmetaioinfo)
 
     lalinspiralinfo = {}
@@ -96,7 +99,7 @@ def get_library_version_info():
         lalinspiralinfo['Committer'] = lalinspiral.InspiralVCSCommitter
         lalinspiralinfo['Date'] = lalinspiral.InspiralVCSDate
     except AttributeError:
-        add_info_new_version(lalinspiralinfo, lalinspiral)
+        add_info_new_version(lalinspiralinfo, 'lalinspiral', 'Inspiral')
     library_list.append(lalinspiralinfo)
 
     lalsimulationinfo = {}
@@ -111,7 +114,7 @@ def get_library_version_info():
         lalsimulationinfo['Committer'] = lalsimulation.SimulationVCSCommitter
         lalsimulationinfo['Date'] = lalsimulation.SimulationVCSDate
     except AttributeError:
-        add_info_new_version(lalsimulationinfo, lalsimulation)
+        add_info_new_version(lalsimulationinfo, 'lalsimulation', 'Simulation')
     library_list.append(lalsimulationinfo)
 
     glueinfo = {}


### PR DESCRIPTION
This patch updates the versioning module in results to match changes in lal. For post-O2 releases I think we should remove support for the "old" version information.