### PR TITLE
Fix pickling error in pycbc inference

### DIFF
--- a/pycbc/inference/boundaries.py
+++ b/pycbc/inference/boundaries.py
@@ -309,10 +309,6 @@ class Bounds(object):
             raise ValueError("unrecognized btype_max {}".format(btype_max))
         # store cyclic conditions
         self._cyclic = cyclic
-        if cyclic:
-            self._constrain = self._apply_cyclic
-        else:
-            self._constrain = _pass
         # store reflection conditions; we'll vectorize them here so that they
         # can be used with arrays
         if self._min.name == 'reflected' and self._max.name == 'reflected':
@@ -397,7 +393,10 @@ class Bounds(object):
         float
             The value after the conditions are applied; see above for details.
         """
-        retval = self._reflect(self._constrain(value))
+        retval = value
+        if self._cyclic:
+            retval = apply_cyclic(value, self)
+        retval = self._reflect(retval)
         if isinstance(retval, numpy.ndarray) and retval.size == 1:
             try:
                 retval = retval[0]


### PR DESCRIPTION
My commit in PR #1149 broke pycbc inference if using a prior with cyclic boundaries on multiple cores. The problem is the way the way `apply_cyclic` is done cannot be pickled, which causes `pycbc_inference` to fail. I didn't hit this bug when testing because I was using a patched version of kombine that sets up the pool in a more efficient way (see PR #1308 for detail). @Cyberface, who has been trying to use pycbc inference on master, discovered it. Eventually this won't be a problem, but as PR #1308 is held up until the patch it relies on in kombine is merged, another fix is needed now.

This patch fixes the pickling problem, allowing pycbc inference to work again. I've tested this with the non-patched kombine.