### PR TITLE
Changes to make pycbc_make_coinc_search_workflow flexible to reading in a template bank in both hdf and xml format

### DIFF
--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -152,25 +152,10 @@ precalc_psd_files = wf.setup_psd_workflow(workflow, analyzable_segs,
                                             datafind_files, "psdfiles")
 
 # Template bank stuff
-bank_files = wf.setup_tmpltbank_workflow(workflow, analyzable_segs,
-                                         datafind_files, output_dir="bank",
-                                         psd_files=precalc_psd_files)
-
-# Determine the extension of the bank file taken as input
-cp = workflow.cp
-tmpltbankMethod = cp.get_opt_tags("workflow-tmpltbank", "tmpltbank-method", '')
-if tmpltbankMethod == "PREGENERATED_BANK":
-    pre_gen_bank = cp.get_opt_tags('workflow-tmpltbank',
-                                           'tmpltbank-pregenerated-bank', '')
-    bank_filename, ext = (pre_gen_bank.split('/')[-1].split('.'))
-
-# If the bank is a hdf or h5 file do not change the format. If not,
-# convert it to hdf
-if ext == 'hdf' or ext == 'h5' :
-    hdfbank = bank_files
-else :
-    hdfbank = wf.convert_bank_to_hdf(workflow, bank_files, "bank")
-logging.info("Input bank is a %s file", ext)
+hdfbank = wf.setup_tmpltbank_workflow(workflow, analyzable_segs,
+                                      datafind_files, output_dir="bank",
+                                      psd_files=precalc_psd_files,
+                                      return_format='hdf')
 
 splitbank_files_fd = wf.setup_splittable_workflow(workflow, hdfbank,
                                                   out_dir="bank",

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -155,7 +155,23 @@ precalc_psd_files = wf.setup_psd_workflow(workflow, analyzable_segs,
 bank_files = wf.setup_tmpltbank_workflow(workflow, analyzable_segs,
                                          datafind_files, output_dir="bank",
                                          psd_files=precalc_psd_files)
-hdfbank = wf.convert_bank_to_hdf(workflow, bank_files, "bank")
+
+# Determine the extension of the bank file taken as input
+cp = workflow.cp
+tmpltbankMethod = cp.get_opt_tags("workflow-tmpltbank", "tmpltbank-method", '')
+if tmpltbankMethod == "PREGENERATED_BANK":
+    pre_gen_bank = cp.get_opt_tags('workflow-tmpltbank',
+                                           'tmpltbank-pregenerated-bank', '')
+    bank_filename, ext = (pre_gen_bank.split('/')[-1].split('.'))
+
+# If the bank is a hdf or h5 file do not change the format. If not,
+# convert it to hdf
+if ext == 'hdf' or ext == 'h5' :
+    hdfbank = bank_files
+else :
+    hdfbank = wf.convert_bank_to_hdf(workflow, bank_files, "bank")
+logging.info("Input bank is a %s file", ext)
+
 splitbank_files_fd = wf.setup_splittable_workflow(workflow, hdfbank,
                                                   out_dir="bank",
                                                   tags=['full_data'])

--- a/pycbc/workflow/tmpltbank.py
+++ b/pycbc/workflow/tmpltbank.py
@@ -142,14 +142,14 @@ def setup_tmpltbank_workflow(workflow, science_segs, datafind_outs,
     logging.info("Input bank is a %s file", ext)
     if return_format is None :
         tmplt_banks_return = tmplt_banks
-    elif return_format in ('hdf', 'h5') :
-        if ext in ('hdf', 'h5') :
+    elif return_format in ('hdf', 'h5', 'hdf5'):
+        if ext in ('hdf', 'h5', 'hdf5'):
             tmplt_banks_return = tmplt_banks
-        elif ext in ('xml.gz' , 'xml') :
+        elif ext in ('xml.gz' , 'xml'):
             tmplt_banks_return = pycbc.workflow.convert_bank_to_hdf(workflow,
                                                         tmplt_banks, "bank")
     else :
-        if ext == return_format :
+        if ext == return_format:
             tmplt_banks_return = tmplt_banks
         else:
             raise NotImplementedError("{0} to {1} conversion is not "

--- a/pycbc/workflow/tmpltbank.py
+++ b/pycbc/workflow/tmpltbank.py
@@ -142,18 +142,18 @@ def setup_tmpltbank_workflow(workflow, science_segs, datafind_outs,
     logging.info("Input bank is a %s file", ext)
     if return_format is None :
         tmplt_banks_return = tmplt_banks
-    elif return_format == 'hdf' or return_format == 'h5' :
-        if ext == 'hdf' or ext == 'h5' :
+    elif return_format in ('hdf', 'h5') :
+        if ext in ('hdf', 'h5') :
             tmplt_banks_return = tmplt_banks
-        elif ext == 'xml.gz' or ext == 'xml':
+        elif ext in ('xml.gz' , 'xml') :
             tmplt_banks_return = pycbc.workflow.convert_bank_to_hdf(workflow,
                                                         tmplt_banks, "bank")
     else :
         if ext == return_format :
             tmplt_banks_return = tmplt_banks
         else:
-            raise NotImplementedError("%s to %s conversion is not "
-                                      "supported." % (ext, return_format))
+            raise NotImplementedError("{0} to {1} conversion is not "
+                                      "supported.".format(ext, return_format))
     logging.info("Leaving template bank generation module.")
     return tmplt_banks_return
 


### PR DESCRIPTION
This PR is about making `pycbc_make_coinc_search_workflow` flexible to be able to read in the template bank in both hdf/h5 and xml format. If the bank read in is in hdf format, it is used as it is in the workflow. If not in hdf/h5 format (like xml), it is converted to hdf format and then used in the full data and injections jobs.    