### PR TITLE
Format value drops minus sign

### DIFF
--- a/pycbc/results/str_utils.py
+++ b/pycbc/results/str_utils.py
@@ -195,6 +195,7 @@ def format_value(value, error, plus_error=None, use_scientific_notation=3,
         decs = error
     # now round the the appropriate number of sig figs
     valtxt = get_signum(value, decs)
+    valtxt = '{}{}'.format(minus_sign, valtxt)
 
     if include_error:
         if plus_error is None:
@@ -226,5 +227,5 @@ def format_value(value, error, plus_error=None, use_scientific_notation=3,
                 txt = r'%s^{+%s}_{-%s}%s' %(valtxt, plus_err_txt,
                     minus_err_txt, powfactor)
     else:
-        txt = r'%s%s%s' %(minus_sign, valtxt, powfactor)
+        txt = r'%s%s' %(valtxt, powfactor)
     return txt 


### PR DESCRIPTION
Currently, `format_value` in `str_utils` will drop the leading minus sign. This causes, e.g., the titles in `plot_posterior` to mis-report negative values as positive. For example, the reported median value of the secondary spin in [this plot](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/pycbc_inference/cbc/gw150914/kombine/no_burnin/density-last_pt.png) is 0.641, when it should be -0.641. I believe @Cyberface had run into this when creating posterior plots of effective spin in his runs.

This patch fixes this, adding a leading minus sign if the given value < 0 (it looks like I had originally addressed this at some point in the past, but it got messed up in subsequent edits). 
