### PR TITLE
Support Michael

### DIFF
--- a/bin/pycbc_make_html_page
+++ b/bin/pycbc_make_html_page
@@ -22,6 +22,7 @@ import pycbc.results
 import random
 import shutil
 import zipfile
+import codecs
 from glue import segments
 from jinja2 import Environment, FileSystemLoader
 from pycbc.results.render import get_embedded_config, render_workflow_html_template, setup_template_render
@@ -231,7 +232,8 @@ for cwd in dirs:
         shutil.copymode(opts.plots_dir+cwd.path, opts.output_path+'/'+cwd.path)
 
     # save html page
-    with open(opts.output_path+cwd.path+'/index.html', "wb") as fp:
+    with codecs.open(opts.output_path+cwd.path+'/index.html', "w",
+                     encoding='utf-8') as fp:
         fp.write(output)
 
 # copy all files to html directory

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -17,6 +17,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import os.path, types
+import codecs
 
 from ConfigParser import ConfigParser
 from jinja2 import Environment, FileSystemLoader
@@ -180,7 +181,7 @@ def render_text(path, cp):
     content = None
 
     # read file as a string
-    with open(path, 'rb') as fp:
+    with codecs.open(path, 'r', encoding='utf-8', errors='replace') as fp:
         content = fp.read()
 
     # replace all the escaped characters


### PR DESCRIPTION
If Michael Pürrer makes a commit on lalsuite that we run with pycbc_make_html_page will break.

This patch supports Michael by using utf-8 encoding when reading and writing files in the html generation.

This has been tested and I have verified that Michael's patches now build a web-page. Thanks to stackoverflow:

http://stackoverflow.com/questions/10908761/printing-non-ascii-characters-in-python-jinja

for the solution, I 1-upped the suggestion in use here.

Note that the errors.replace line will mean that even if you add in non-UTF8 characters into the html files, it should get converted into something that will at least show on the web-page (maybe you get a '?' symbol, not really sure).