### PR TITLE
Fixes for pycbc_generate_hwinj

### DIFF
--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -200,8 +200,6 @@ _psd.insert_psd_option_group_multi_ifo(parser)
 opts = parser.parse_args()
 
 # verify options are sane if using strain options
-print bool(opts.psd_estimation)
-print "CHECKING"
 if opts.psd_estimation:
     _strain.verify_strain_options_multi_ifo(opts, parser, opts.instruments)
 if not opts.psd_estimation and (opts.frame_files or opts.frame_type

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -362,7 +362,6 @@ for ifo in opts.instruments:
                                                   sim.geocent_end_time)
     end_time = sim.geocent_end_time + time_delay
 
-
     # get antenna pattern
     f_plus, f_cross = det.antenna_pattern(sim.longitude, sim.latitude,
                                           sim.polarization,

--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -200,6 +200,8 @@ _psd.insert_psd_option_group_multi_ifo(parser)
 opts = parser.parse_args()
 
 # verify options are sane if using strain options
+print bool(opts.psd_estimation)
+print "CHECKING"
 if opts.psd_estimation:
     _strain.verify_strain_options_multi_ifo(opts, parser, opts.instruments)
 if not opts.psd_estimation and (opts.frame_files or opts.frame_type
@@ -355,6 +357,12 @@ for ifo in opts.instruments:
     # get Detector instance for IFO
     det = Detector(ifo)
 
+    # get time delay to detector from center of the Earth
+    time_delay = det.time_delay_from_earth_center(sim.longitude, sim.latitude,
+                                                  sim.geocent_end_time)
+    end_time = sim.geocent_end_time + time_delay
+
+
     # get antenna pattern
     f_plus, f_cross = det.antenna_pattern(sim.longitude, sim.latitude,
                                           sim.polarization,
@@ -410,7 +418,7 @@ for ifo in opts.instruments:
 network_snr = numpy.sqrt(network_snr)
 scale = network_snr / opts.network_snr
 sim.distance = scale*sim.distance
-for ifo in opt.instruments:
+for ifo in opts.instruments:
     attrname='eff_dist_'+ifo[0].lower()
     effdist=getattr(sim,attrname)
     setattr(sim,attrname,effdist*scale)

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -23,6 +23,18 @@ from collections import defaultdict
 class DictWithDefaultReturn(defaultdict):
     default_set = False
     ifo_set = False
+    def __bool__(self):
+        if self.items():
+            # True if any values are explictly set.
+            return True
+        elif self.default_factory() is not None:
+            # Or true if the default value was set
+            return True
+        else:
+            # Else false
+            return False
+    # Python 2 and 3 have different conventions for boolean method
+    __nonzero__ = __bool__
 
 class MultiDetOptionAction(argparse.Action):
     # Initialise the same as the standard 'append' action
@@ -272,7 +284,6 @@ def ensure_one_opt_multi_ifo(opt, parser, ifo, opt_list):
                               % (the_one, name))
 
     if the_one is None:
-        print opt, ifo
         parser.error("you must supply one of the following %s" \
                       % (', '.join(opt_list)))
 

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -24,11 +24,13 @@ class DictWithDefaultReturn(defaultdict):
     default_set = False
     ifo_set = False
     def __bool__(self):
-        if self.items():
+        if self.items() and not all(entry is None for entry in self.values()):
             # True if any values are explictly set.
             return True
-        elif self.default_factory() is not None:
+        elif self['RANDOM_STRING_314324'] is not None:
             # Or true if the default value was set
+            # NOTE: This stores the string RANDOM_STRING_314324 in the dict
+            # so subsequent calls will be caught in the first test here.
             return True
         else:
             # Else false


### PR DESCRIPTION
This fixes the issues noted in #1338. I have overridden the boolean built-in testing for the multi-inspiral option types to match better behaviour in the single-inspiral options (ie. False if option not given on command line, True is *anything* given on command line, regardless of format). I also fix two places in generate_hwinj where it is broken.

I have tested that the correct boolean is returned in each of the 3 possibilities for multi-inspiral options (option not given; option given as value for all ifos [this is the one that was broken]; option given separately for all ifos) .

Please squash when merging.