### PR TITLE
PyCBC bank codes will use HDF5 format

### DIFF
--- a/bin/pycbc_aligned_bank_cat
+++ b/bin/pycbc_aligned_bank_cat
@@ -38,6 +38,7 @@ import pycbc.psd
 import pycbc.strain
 import pycbc.version
 import pycbc.tmpltbank
+from pycbc.waveform import get_waveform_filter_length_in_time
 
 __author__  = "Ian Harry <ian.harry@astro.cf.ac.uk>"
 __version__ = pycbc.version.git_verbose_msg
@@ -170,9 +171,27 @@ if options.metadata_file:
                                      contenthandler=LIGOLWContentHandler)
 else:
     outdoc = None
-tmpltbank.output_sngl_inspiral_table(options.output_file, temp_bank,
-    metricParams, ethincaParams, programName=__program__,
-    optDict=options.__dict__,
-    outdoc=outdoc, comment="", version=pycbc.version.git_hash,
-    cvs_repository='pycbc/'+pycbc.version.git_branch,
-    cvs_entry_time=pycbc.version.date)
+if options.output_file.endswith(('.xml','.xml.gz','.xmlgz')):
+    tmpltbank.output_sngl_inspiral_table(options.output_file, temp_bank,
+        metricParams, ethincaParams, programName=__program__,
+        optDict=options.__dict__,
+        outdoc=outdoc, comment="", version=pycbc.version.git_hash,
+        cvs_repository='pycbc/'+pycbc.version.git_branch,
+        cvs_entry_time=pycbc.version.date)
+elif options.output_file.endswith(('.h5','.hdf','.hdf5')):
+    out_fp = h5py.File(options.output_file, 'w')
+    out_fp['mass1'] = temp_bank[:,0]
+    out_fp['mass2'] = temp_bank[:,1]
+    out_fp['spin1z'] = temp_bank[:,2]
+    out_fp['spin2z'] = temp_bank[:,3]
+    out_fp['f_lower'] = [options.f_low] * len(temp_bank[:,0])
+    tmplt_durations = []
+    for i in xrange(len(temp_bank[:,0])):
+        gwflit = get_waveform_filter_length_in_time
+        wfrm_length = gwflit('SPAtmplt', mass1=temp_bank[i,0],
+                             mass2=temp_bank[i,1], f_lower=options.f_low,
+                             phase_order=7)
+        tmplt_durations.append(wfrm_length)
+    out_fp['template_duration'] = tmplt_durations
+    out_fp['approximant'] = ['TaylorF2'] * len(temp_bank[:,0])
+    out_fp.close()

--- a/bin/pycbc_aligned_bank_cat
+++ b/bin/pycbc_aligned_bank_cat
@@ -195,3 +195,6 @@ elif options.output_file.endswith(('.h5','.hdf','.hdf5')):
     out_fp['template_duration'] = tmplt_durations
     out_fp['approximant'] = ['TaylorF2'] * len(temp_bank[:,0])
     out_fp.close()
+else:
+    err_msg = "Unrecognized extension for file {}.".format(options.output_file)
+    raise ValueError(err_msg)

--- a/bin/pycbc_bank_verification
+++ b/bin/pycbc_bank_verification
@@ -36,6 +36,7 @@ import os, sys
 import copy
 import logging
 import numpy
+import h5py
 from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
 from pycbc import tmpltbank, psd, strain, pnutils
 import matplotlib
@@ -184,26 +185,37 @@ partitioned_bank_object = tmpltbank.PartitionedTmpltbank(massRangeParams,
                                metricParams, refFreq, (opts.bin_spacing)**0.5,
                                bin_range_check=1)
 
-# dummy class needed for loading LIGOLW files
-class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
-    pass
-
-lsctables.use_in(LIGOLWContentHandler)
-
-# Reading in the template bank
-logging.info("Reading template bank.")
-
-indoc = ligolw_utils.load_filename(opts.input_bank,
-                                   contenthandler=LIGOLWContentHandler)
-template_list = table.get_table(indoc, lsctables.SnglInspiralTable.tableName)
-
 # Map the frequency values to idx if --vary-fupper is used
 if opts.vary_fupper:
     partitioned_bank_object.get_freq_map_and_normalizations(fs,
                                                       opts.bank_fupper_formula)
 
-partitioned_bank_object.add_tmpltbank_from_xml_table(template_list,
-                                                  vary_fupper=opts.vary_fupper)
+# Reading in the template bank
+logging.info("Reading template bank.")
+
+
+if opts.input_bank.endswith(('.xml','.xml.gz','.xmlgz')):
+    # dummy class needed for loading LIGOLW files
+    class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
+        pass
+
+    lsctables.use_in(LIGOLWContentHandler)
+
+    indoc = ligolw_utils.load_filename(opts.input_bank,
+                                       contenthandler=LIGOLWContentHandler)
+    template_list = table.get_table(indoc,
+                                    lsctables.SnglInspiralTable.tableName)
+
+    partitioned_bank_object.add_tmpltbank_from_xml_table\
+        (template_list, vary_fupper=opts.vary_fupper)
+
+elif opts.input_bank.endswith(('.h5','.hdf','.hdf5')):
+    h5_fp = h5py.File(opts.input_bank, 'r')
+    partitioned_bank_object.add_tmpltbank_from_hdf_file\
+        (h5_fp, vary_fupper=opts.vary_fupper)
+else:
+    err_msg = "Don't know how to read extension {}.".format(opts.input_bank)
+    raise NotImplementedError(err_msg)
 
 logging.info("Bank read in and sorted")
 # Okay, now lets test a bunch of matches

--- a/bin/pycbc_geom_aligned_bank
+++ b/bin/pycbc_geom_aligned_bank
@@ -95,7 +95,7 @@ class AlignedBankCatExecutable(wf.Executable):
         node.add_input_opt('--metadata-file', metadata_file)
 
         if output_file_path is None:
-            node.new_output_file_opt(analysis_time, '.xml', '--output-file',
+            node.new_output_file_opt(analysis_time, '.h5', '--output-file',
                                      tags=self.tags)
         else:
             # Convert path to file

--- a/bin/pycbc_tmpltbank_to_chi_params
+++ b/bin/pycbc_tmpltbank_to_chi_params
@@ -35,6 +35,7 @@ import os, sys
 import copy
 import logging
 import numpy
+import h5py
 from glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
 from pycbc import tmpltbank, psd, strain, pnutils
 import matplotlib
@@ -146,29 +147,42 @@ evalsCV,evecsCV = numpy.linalg.eig(cov)
 metricParams.evecsCV = {}
 metricParams.evecsCV[refFreq] = evecsCV
 
-# dummy class needed for loading LIGOLW files
-class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
-    pass
-
-lsctables.use_in(LIGOLWContentHandler)
-
-# Reading in the template bank
 logging.info("Reading template bank.")
+if opts.input_bank.endswith(('.xml','.xml.gz','.xmlgz')):
+    # dummy class needed for loading LIGOLW files
+    class LIGOLWContentHandler(ligolw.LIGOLWContentHandler):
+        pass
 
-indoc = ligolw_utils.load_filename(opts.input_bank,
-                                   contenthandler=LIGOLWContentHandler)
-template_list = table.get_table(indoc, lsctables.SnglInspiralTable.tableName)
+    lsctables.use_in(LIGOLWContentHandler)
+
+    indoc = ligolw_utils.load_filename(opts.input_bank,
+                                       contenthandler=LIGOLWContentHandler)
+    template_list = table.get_table(indoc,
+                                    lsctables.SnglInspiralTable.tableName)
+    mass1 = [template.mass1 for template in template_list]
+    mass2 = [template.mass2 for template in template_list]
+    spin1z = [template.spin1z for template in template_list]
+    spin2z = [template.spin2z for template in template_list]
+elif opts.input_bank.endswith(('.h5','.hdf','.hdf5')):
+    h5_fp = h5py.File(opts.input_bank, 'r')
+    mass1 = h5_fp['mass1'][:]
+    mass2 = h5_fp['mass2'][:]
+    spin1z = h5_fp['spin1z'][:]
+    spin2z = h5_fp['spin2z'][:]
+else:
+    err_msg = "Don't know how to read extension {}.".format(opts.input_bank)
+    raise NotImplementedError(err_msg)
 
 fP = open(opts.output_file, "w")
-for template in template_list:
-    tot_mass = template.mass1 + template.mass2
-    eta = template.mass1 * template.mass2 / (tot_mass * tot_mass)
-    beta, sigma, gamma, chis = pnutils.get_beta_sigma_from_aligned_spins(\
-                                         eta, template.spin1z, template.spin2z)
+for idx in xrange(len(mass1)):
+    tot_mass = mass1[idx] + mass2[idx]
+    eta = mass1[idx] * mass2[idx] / (tot_mass * tot_mass)
+    beta, sigma, gamma, chis = pnutils.get_beta_sigma_from_aligned_spins\
+        (eta, spin1z[idx], spin2z[idx])
     chi_coords = tmpltbank.get_cov_params(tot_mass, eta, beta, sigma, gamma,
-                                                   chis, metricParams, refFreq)
-    vals = " ".join([str(template.mass1), str(template.mass2),
-                                   str(template.spin1z), str(template.spin2z)])
+                                          chis, metricParams, refFreq)
+    vals = " ".join([str(mass1[idx]), str(mass2[idx]), str(spin1z[idx]),
+                     str(spin2z[idx])])
     vals += " "
     vals += " ".join([str(i) for i in chi_coords])
     fP.write("%s\n" %(vals))

--- a/bin/workflows/pycbc_create_sbank_workflow
+++ b/bin/workflows/pycbc_create_sbank_workflow
@@ -79,7 +79,7 @@ class SbankExecutable(wf.Executable):
 
         # Here we add the output file, but we are letting pycbc.workflow
         # handle how to name the file
-        node.new_output_file_opt(analysis_time, '.xml.gz',
+        node.new_output_file_opt(analysis_time, '.h5',
                               '--output-filename', tags=self.tags + extra_tags)
         return node
 
@@ -126,6 +126,38 @@ class LigolwAddExecutable(wf.LigolwAddExecutable):
                         (jobSegment, input_files, output=out_file,
                          use_tmp_subdirs=use_tmp_subdirs, tags=tags)
 
+class CombineHDFBanksExecutable(wf.Executable):
+    """ Class for running a combination of hdf banks
+    """
+    current_retention_level = wf.Executable.ALL_TRIGGERS
+
+    def create_node(self, analysis_time, input_file_list, output=None,
+                    tags=None):
+        node = wf.Executable.create_node(self)
+
+        # Here we add the input files
+        node.add_input_list_opt('--input-filenames', input_file_list)
+
+        curr_tags = self.tags
+        if tags is not None:
+            curr_tags += tags
+
+        # Output file
+        if output is not None:
+            # Convert path to file
+            out_file = wf.File.from_path(output)
+            if self.retain_files:
+                if not os.path.isabs(output):
+                    out_file.storage_path = os.path.join(self.out_dir,
+                                                         output)
+                else:
+                    out_file.storage_path = output
+            node.add_output_opt('--output-file', out_file)
+        else:
+            node.new_output_file_opt(analysis_time, '.h5',
+                                     '--output-file', tags=curr_tags)
+
+        return node
 
 
 ##############################################################################
@@ -203,18 +235,18 @@ if workflow.cp.has_option_tags('workflow', 'seed-bank', args.tags):
     if len(seed_files) == 1:
         seed_file = seed_files[0]
     else:
-        # Combine with llwadd
+        # Combine with h5add
         out_dir = os.path.join(args.output_dir, 'input_combine')
-        llwadd_exe = LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
-                                         out_dir=out_dir,
-                                         tags=['INPUT'] + args.tags)
-        llwadd_exe.update_current_retention_level(wf.Executable.ALL_TRIGGERS)
-        llwadd_node = llwadd_exe.create_node(workflow.analysis_time,
-                                             seed_files,
-                                             use_tmp_subdirs=False)
-        workflow += llwadd_node
-        assert(len(llwadd_node.output_files) == 1)
-        seed_file = llwadd_node.output_files[0]
+        h5add_exe = CombineHDFBanksExecutable(workflow.cp, 'h5add',
+                                              ifos=['H1L1V1'],
+                                              out_dir=out_dir,
+                                              tags=['INPUT'] + args.tags)
+        h5add_exe.update_current_retention_level(wf.Executable.ALL_TRIGGERS)
+        h5add_node = h5add_exe.create_node(workflow.analysis_time,
+                                           seed_files)
+        workflow += h5add_node
+        assert(len(h5add_node.output_files) == 1)
+        seed_file = h5add_node.output_files[0]
 
     # bins_inp_file will go to the mchirp_bins generator. seed file will go to
     # the first set of sbank jobs if not None.
@@ -266,13 +298,15 @@ bins_exe = SbankChooseMchirpBinsExecutable(workflow.cp, 'sbank_mchirp_bins',
                                     ifos=workflow.ifos, tags=args.tags)
 main_sbank_exe = SbankExecutable(workflow.cp, 'sbank', ifos=workflow.ifos,
                                      tags=['parallel'] + args.tags)
-llwadd_first_exe = LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
-                                     tags=['FIRST'] + args.tags)
+h5add_first_exe = CombineHDFBanksExecutable(workflow.cp, 'h5add',
+                                            ifos=['H1L1V1'],
+                                            tags=['FIRST'] + args.tags)
 readder_sbank_exe = SbankExecutable(workflow.cp, 'sbank',
                                     ifos=workflow.ifos,
                                     tags=['readder'] + args.tags)
-llwadd_final_exe = LigolwAddExecutable(workflow.cp, 'llwadd', ifos=['H1L1V1'],
-                                     tags=['FINAL'] + args.tags)
+h5add_final_exe = CombineHDFBanksExecutable(workflow.cp, 'h5add',
+                                            ifos=['H1L1V1'],
+                                            tags=['FINAL'] + args.tags)
 
 for cycle_idx in range(num_cycles):
     #########
@@ -325,15 +359,14 @@ for cycle_idx in range(num_cycles):
     # COMBINER #
     ############
 
-    llwadd_first_exe.update_current_tags([cycle_tag, 'FIRST'] + args.tags)
-    llwadd_first_exe.update_output_directory(out_dir=out_dir)
-    llwadd_first_exe.update_current_retention_level(wf.Executable.ALL_TRIGGERS)
-    llwadd_node = llwadd_first_exe.create_node(workflow.analysis_time,
-                                         main_sbank_files,
-                                         use_tmp_subdirs=False)
-    workflow += llwadd_node
-    assert(len(llwadd_node.output_files) == 1)
-    llwadd_out = llwadd_node.output_files[0]
+    h5add_first_exe.update_current_tags([cycle_tag, 'FIRST'] + args.tags)
+    h5add_first_exe.update_output_directory(out_dir=out_dir)
+    h5add_first_exe.update_current_retention_level(wf.Executable.ALL_TRIGGERS)
+    h5add_node = h5add_first_exe.create_node(workflow.analysis_time,
+                                              main_sbank_files)
+    workflow += h5add_node
+    assert(len(h5add_node.output_files) == 1)
+    h5add_out = h5add_node.output_files[0]
 
     ###########
     # READDER #
@@ -344,7 +377,7 @@ for cycle_idx in range(num_cycles):
     readder_sbank_exe.update_current_retention_level\
             (wf.Executable.ALL_TRIGGERS)
     readder_sbank_node = readder_sbank_exe.create_node(workflow.analysis_time,
-                                                       trial_bank=llwadd_out)
+                                                       trial_bank=h5add_out)
     workflow += readder_sbank_node
     assert(len(readder_sbank_node.output_files) == 1)
     readder_out = readder_sbank_node.output_files[0]
@@ -362,22 +395,21 @@ for cycle_idx in range(num_cycles):
         crl = wf.Executable.MERGED_TRIGGERS
         output_path = None
 
-    llwadd_final_exe.update_current_tags([cycle_tag, 'FINAL'] + args.tags)
-    llwadd_final_exe.update_output_directory(out_dir)
-    llwadd_final_exe.update_current_retention_level(crl)
+    h5add_final_exe.update_current_tags([cycle_tag, 'FINAL'] + args.tags)
+    h5add_final_exe.update_output_directory(out_dir)
+    h5add_final_exe.update_current_retention_level(crl)
 
     if seed_file is None:
         inputs = [readder_out]
     else:
         inputs = [seed_file, readder_out]
 
-    llwadd_node = llwadd_final_exe.create_node(workflow.analysis_time,
-                                         inputs, output=output_path,
-                                         use_tmp_subdirs=False)
-    workflow += llwadd_node
-    assert(len(llwadd_node.output_files) == 1)
+    h5add_node = h5add_final_exe.create_node(workflow.analysis_time,
+                                             inputs, output=output_path)
+    workflow += h5add_node
+    assert(len(h5add_node.output_files) == 1)
     # This becomes the input file for the next loop if going again
-    seed_file = llwadd_node.output_files[0]
+    seed_file = h5add_node.output_files[0]
     bins_inp_file = seed_file
 
 workflow.save(filename=args.dax_filename, output_map=args.map_filename)

--- a/bin/workflows/pycbc_create_uberbank_workflow
+++ b/bin/workflows/pycbc_create_uberbank_workflow
@@ -174,7 +174,7 @@ geom_exe = GeomBankExecutable(workflow.cp, 'geom_aligned_bank',
 # for a later sub-workflow.
 geom_out_dir = os.path.abspath('initial_geom_bank')
 geom_out_file = wf.File(geom_exe.ifo_list, geom_exe.name,
-                        workflow.analysis_time, extension='.xml',
+                        workflow.analysis_time, extension='.h5',
                         store_file=True, directory=geom_out_dir,
                         tags=[], use_tmp_subdirs=False)
 geom_node = geom_exe.create_node(workflow.analysis_time, geom_out_file,
@@ -222,7 +222,7 @@ sbank_exe = SbankDaxGenerator(workflow.cp, 'sbank_workflow',
                               ifos=workflow.ifos, out_dir='daxes')
 
 sbank_out_file_bbh = wf.File(sbank_exe.ifo_list, sbank_exe.name,
-                             workflow.analysis_time, extension='.xml',
+                             workflow.analysis_time, extension='.h5',
                              store_file=True, directory=sbank_exe.out_dir,
                              tags=['sbank_bbh'], use_tmp_subdirs=False)
 
@@ -260,7 +260,7 @@ sbank_bbh_dax_job = dax_job
 ###############################################
 
 sbank_out_file_final = wf.File(sbank_exe.ifo_list, sbank_exe.name,
-                         workflow.analysis_time, extension='.xml',
+                         workflow.analysis_time, extension='.h5',
                          store_file=True, directory='.',
                          tags=['sbank_final'], use_tmp_subdirs=False)
 

--- a/docs/resources/sbank_example1.ini
+++ b/docs/resources/sbank_example1.ini
@@ -58,8 +58,8 @@ v1=
 
 ; All executables are listed here
 sbank = ${which:lalapps_cbc_sbank}
-sbank_mchirp_bins = ${which:lalapps_cbc_sbank_choose_mchirp_boundaries}
-llwadd = ${which:ligolw_add}
+sbank_mchirp_bins = ${which:lalapps_cbc_sbank_hdf5_choose_mchirp_boundaries}
+h5add = ${which:lalapps_cbc_sbank_hdf5_bankcombiner}
 
 ; Then options for all executables are added. These are added directly to the
 ; jobs as described here:

--- a/docs/resources/sbank_example2.ini
+++ b/docs/resources/sbank_example2.ini
@@ -58,8 +58,8 @@ v1=
 
 ; All executables are listed here
 sbank = ${which:lalapps_cbc_sbank}
-sbank_mchirp_bins = ${which:lalapps_cbc_sbank_choose_mchirp_boundaries}
-llwadd = ${which:ligolw_add}
+sbank_mchirp_bins = ${which:lalapps_cbc_sbank_hdf5_choose_mchirp_boundaries}
+h5add = ${which:lalapps_cbc_sbank_hdf5_bankcombiner}
 
 ; Then options for all executables are added. These are added directly to the
 ; jobs as described here:

--- a/docs/resources/uberbank_example1.ini
+++ b/docs/resources/uberbank_example1.ini
@@ -93,8 +93,8 @@ l1 =
 ; All executables are listed here, will be equivalent to `which exe`
 sbank = ${which:lalapps_cbc_sbank}
 sbank_workflow = ${which:pycbc_create_sbank_workflow}
-sbank_mchirp_bins = ${which:lalapps_cbc_sbank_choose_mchirp_boundaries}
-llwadd = ${which:ligolw_add}
+sbank_mchirp_bins = ${which:lalapps_cbc_sbank_hdf5_choose_mchirp_boundaries}
+h5add = ${which:lalapps_cbc_sbank_hdf5_bankcombiner}
 geom_aligned_bank = ${which:pycbc_geom_aligned_bank}
 
 ; Then options for all executables are added. These are added directly to the

--- a/pycbc/tmpltbank/partitioned_bank.py
+++ b/pycbc/tmpltbank/partitioned_bank.py
@@ -583,6 +583,28 @@ class PartitionedTmpltbank(object):
             self.add_point_by_masses(sngl.mass1, sngl.mass2, sngl.spin1z,
                                      sngl.spin2z, vary_fupper=vary_fupper)
 
+    def add_tmpltbank_from_hdf_file(self, hdf_fp, vary_fupper=False):
+        """
+        This function will take a pointer to an open HDF File object containing
+        a list of templates and add them into the partitioned template bank
+        object.
+
+        Parameters
+        -----------
+        hdf_fp : h5py.File object
+            The template bank in HDF5 format.
+        vary_fupper : False
+            If given also include the additional information needed to compute
+            distances with a varying upper frequency cutoff.
+        """
+        mass1s = hdf_fp['mass1'][:]
+        mass2s = hdf_fp['mass2'][:]
+        spin1zs = hdf_fp['spin1z'][:]
+        spin2zs = hdf_fp['spin2z'][:]
+        for idx in xrange(len(mass1s)):
+            self.add_point_by_masses(mass1s[idx], mass2s[idx], spin1zs[idx],
+                                     spin2zs[idx], vary_fupper=vary_fupper)
+
     def output_all_points(self):
         """
         Return all point in the bank as lists of m1, m2, spin1z, spin2z.

--- a/setup.py
+++ b/setup.py
@@ -392,8 +392,6 @@ setup (
                'bin/pycbc_optimal_snr',
                'bin/pycbc_fit_sngl_trigs',
                'bin/pycbc_randomize_inj_dist_by_optsnr',
-               'bin/hdfcoinc/pycbc_make_coinc_search_workflow',
-               'bin/hdfcoinc/pycbc_make_psd_estimation_workflow',
                'bin/hdfcoinc/pycbc_calculate_psd',
                'bin/hdfcoinc/pycbc_average_psd',
                'bin/hdfcoinc/pycbc_coinc_mergetrigs',

--- a/setup.py
+++ b/setup.py
@@ -392,6 +392,8 @@ setup (
                'bin/pycbc_optimal_snr',
                'bin/pycbc_fit_sngl_trigs',
                'bin/pycbc_randomize_inj_dist_by_optsnr',
+               'bin/hdfcoinc/pycbc_make_coinc_search_workflow',
+               'bin/hdfcoinc/pycbc_make_psd_estimation_workflow',
                'bin/hdfcoinc/pycbc_calculate_psd',
                'bin/hdfcoinc/pycbc_average_psd',
                'bin/hdfcoinc/pycbc_coinc_mergetrigs',


### PR DESCRIPTION
This patch converts all uberbank-related codes to write HDF banks. This means that the uberbank construction will not write an XML bank, and will not use the XML format at any point duration bank generation.

@cdcapano agreed to make changes to the Bank class he wrote to allow creating a bank class from arbitrary sets of columns (m1,m2,s1z,s2z,[extra precessing/higher-order mode columns]) and then being able to write such a dataset as XML or HDF. In anticipation of this aligned_bank_cat uses a temporary short set of lines to write it's own HDF file, and the old code for XML writing. The *other* PyCBC bank generation utilities (not used for uberbank) currently cannot write to HDF. Once @cdcapano makes this change I will update all the PyCBC bank generation tools to use this.

It is possible to convert from a HDF -> XML bank using existing codes and tools. But if people want to continue to use XML banks for O2, the existing PyCBC releases will be sufficient. PyCBC codes for bank generation are reasonably well separated from other PyCBC modules, especially waveform generation, so this should not be a problem. However, with changes from @soumide1102 to be able to use HDF banks throughout the workflow, I hope we can remove XML banks *completely* in O2B.