### PR TITLE
Show both command lines on sngl plots

### DIFF
--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -98,7 +98,7 @@ if args.plot_caption is None:
     args.plot_caption = ''
 
 if 'command_line' in f.attrs:
-    cmd = f.attrs['command_line'] + '\n\n' + ' '.join(sys.argv)
+    cmd = f.attrs['command_line'] + '\\n\\n' + ' '.join(sys.argv)
 else:
     cmd = ' '.join(sys.argv)
 

--- a/bin/minifollowups/pycbc_single_template_plot
+++ b/bin/minifollowups/pycbc_single_template_plot
@@ -97,7 +97,12 @@ if args.plot_title is None:
 if args.plot_caption is None:
     args.plot_caption = ''
 
+if 'command_line' in f.attrs:
+    cmd = f.attrs['command_line'] + '\n\n' + ' '.join(sys.argv)
+else:
+    cmd = ' '.join(sys.argv)
+
 pycbc.results.save_fig_with_metadata(fig, args.output_file, 
-                             cmd=' '.join(sys.argv), fig_kwds={'dpi': 150},
+                             cmd=cmd, fig_kwds={'dpi': 150},
                              title=args.plot_title,
                              caption=args.plot_caption)

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -17,7 +17,7 @@
 """ Calculate the SNR and CHISQ timeseries for either a chosen template, or 
 a specific Nth loudest coincident event.
 """
-import logging, argparse, numpy, pycbc, h5py
+import sys, logging, argparse, numpy, pycbc, h5py
 from pycbc import vetoes, psd, waveform, version, strain, scheme, fft, filter
 from pycbc.io import WaveformArray
 from pycbc import events
@@ -391,6 +391,7 @@ with ctx:
     f['chisq'].attrs['delta_t'] = snr.delta_t 
     f.attrs['approximant'] = approximant
     f.attrs['ifo'] = ifo
+    f.attrs['command_line'] = ' '.join(sys.argv)
     
 logging.info("Finished")
 


### PR DESCRIPTION
The `pycbc_single_template` plots can be a little difficult to reproduce because they only show the command line of the plotting utility, not the actual pycbc_single_template executable. This patch adds both command lines to the web page.

This has been tested.