### PR TITLE
Fix edge-condition in singles_timefreq

### DIFF
--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -164,7 +164,7 @@ for num_event in range(num_events):
     for single in single_triggers:
         time = times[single.ifo][num_event]
         files += mini.make_singles_timefreq(workflow, single, tmpltbank_file, 
-                                time - 10, time + 10, args.output_dir,
+                                time, args.output_dir,
                                 data_segments=insp_data_seglists[single.ifo],
                                 tags=args.tags + [str(num_event)])
     

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -19,6 +19,7 @@
 import os, sys, argparse, logging, h5py, pycbc.workflow as wf
 from pycbc.results import layout
 from pycbc.types import MultiDetOptionAction
+from pycbc.events import select_segments_by_definer
 import pycbc.workflow.minifollowups as mini
 import pycbc.workflow.pegasus_workflow as wdax
 import pycbc.version
@@ -71,10 +72,18 @@ insp_segs = to_file(args.inspiral_segments)
 
 single_triggers = []
 fsdt = {}
+insp_data_seglists = {}
 for ifo in args.single_detector_triggers:
     fname = args.single_detector_triggers[ifo]
     single_triggers.append(to_file(fname, ifo=ifo))
     fsdt[ifo] = h5py.File(args.single_detector_triggers[ifo], 'r')
+    insp_data_seglists[ifo] = select_segments_by_definer\
+        (args.inspiral_segments, segment_name=args.inspiral_data_read_name,
+         ifo=ifo)
+    # NOTE: make_singles_timefreq needs a coalesced set of segments. If this is
+    #       being used to determine command-line options for other codes,
+    #       please think if that code requires coalesced, or not, segments.
+    insp_data_seglists[ifo].coalesce()
     
 num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups', 'num-events', ''))
 f = h5py.File(args.statmap_file, 'r')
@@ -156,6 +165,7 @@ for num_event in range(num_events):
         time = times[single.ifo][num_event]
         files += mini.make_singles_timefreq(workflow, single, tmpltbank_file, 
                                 time - 10, time + 10, args.output_dir,
+                                data_segments=insp_data_seglists[single.ifo],
                                 tags=args.tags + [str(num_event)])
     
     layouts += list(layout.grouper(files, 2))

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -19,6 +19,7 @@
 import os, argparse, numpy, logging, h5py, copy
 import pycbc.workflow as wf
 from pycbc.types import MultiDetOptionAction
+from pycbc.events import select_segments_by_definer
 from pycbc.results import layout
 from pycbc.detector import Detector
 import pycbc.workflow.minifollowups as mini
@@ -78,9 +79,17 @@ injection_xml_file = to_file(args.injection_xml_file)
 insp_segs = to_file(args.inspiral_segments)
 
 single_triggers = []
+insp_data_seglists = {}
 for ifo in args.single_detector_triggers:
     fname = args.single_detector_triggers[ifo]
     single_triggers.append(to_file(fname, ifo=ifo))
+    insp_data_seglists[ifo] = select_segments_by_definer\
+        (args.inspiral_segments, segment_name=args.inspiral_data_read_name,
+         ifo=ifo)
+    # NOTE: make_singles_timefreq needs a coalesced set of segments. If this is
+    #       being used to determine command-line options for other codes,
+    #       please think if that code requires coalesced, or not, segments.
+    insp_data_seglists[ifo].coalesce()
 
 f = h5py.File(args.injection_file, 'r')
 missed = f['missed/after_vetoes'][:]
@@ -141,7 +150,8 @@ for num_event in range(num_events):
     
     for single in single_triggers:
         files += mini.make_singles_timefreq(workflow, single, tmpltbank_file, 
-                                time - 10, time + 10, args.output_dir,
+                                time, args.output_dir,
+                                data_segments=insp_data_seglists[single.ifo],
                                 tags=args.tags + [str(num_event)])
 
     files += mini.make_single_template_plots(workflow, insp_segs,

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -20,6 +20,7 @@ import os, sys, argparse, logging, h5py
 from glue.ligolw import lsctables, table
 from glue.ligolw import utils as ligolw_utils
 from pycbc.results import layout
+from pycbc.events import select_segments_by_definer
 import pycbc.workflow.minifollowups as mini
 import pycbc.workflow.pegasus_workflow as wdax
 import pycbc.version
@@ -90,6 +91,9 @@ if args.veto_file is not None:
 else:
     veto_file = None
 insp_segs = to_file(args.inspiral_segments)
+insp_data_seglists = select_segments_by_definer\
+        (args.inspiral_segments, segment_name=args.inspiral_data_read_name,
+         ifo=args.instrument)
 
 num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups',
                  'num-sngl-events', ''))
@@ -173,7 +177,8 @@ for num_event in range(num_events):
                             tags=args.tags+[str(num_event)])
 
     files += mini.make_singles_timefreq(workflow, sngl_file, tmpltbank_file, 
-                            time - 10, time + 10, args.output_dir,
+                            time, args.output_dir,
+                            data_segments=insp_data_seglists,
                             tags=args.tags + [str(num_event)])                 
 
     files += mini.make_plot_waveform_plot(workflow, curr_params,

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -753,10 +753,10 @@ class PyCBCInspiralExecutable(Executable):
         if tags is None:
             tags = []
         node = Node(self)
-        pad_data = int(self.get_opt('pad-data'))
-        if pad_data is None:
+        if not self.has_opt('pad-data'):
             raise ValueError("The option pad-data is a required option of "
                              "%s. Please check the ini file." % self.name)
+        pad_data = int(self.get_opt('pad-data'))
 
         if not dfParents:
             raise ValueError("%s must be supplied with data file(s)"
@@ -836,7 +836,7 @@ class PyCBCInspiralExecutable(Executable):
         segment_length = int(self.get_opt('segment-length'))
         pad_data = 0
         if self.has_opt('pad-data'):
-            pad_data += int(self.get_opt( 'pad-data'))
+            pad_data += int(self.get_opt('pad-data'))
 
         # NOTE: Currently the tapered data is ignored as it is short and
         #       will lie within the segment start/end pad. This means that

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -574,8 +574,9 @@ def make_singles_timefreq(workflow, single, bank_file, trig_time, out_dir,
     makedir(out_dir)
     name = 'plot_singles_timefreq'
 
-    node = PlotExecutable(workflow.cp, name, ifos=[single.ifo],
-                          out_dir=out_dir, tags=tags).create_node()
+    curr_exe = PlotExecutable(workflow.cp, name, ifos=[single.ifo],
+                          out_dir=out_dir, tags=tags)
+    node = curr_exe.create_node()
     node.add_input_opt('--trig-file', single)
     node.add_input_opt('--bank-file', bank_file)
 
@@ -597,22 +598,22 @@ def make_singles_timefreq(workflow, single, bank_file, trig_time, out_dir,
             err_msg += "This shouldn't be possible, please ask for help!"
             raise ValueError(err_msg)
         # Check for pad-data
-        if node.has_opt('pad-data')
-            pad_data = int(pad_data)
+        if curr_exe.has_opt('pad-data'):
+            pad_data = int(curr_exe.get_opt('pad-data'))
         else:
             pad_data = 0
-        if len(data_seg) < (2 * time_window + 2 * pad_data):
+        if abs(data_seg) < (2 * time_window + 2 * pad_data):
             tl = 2 * time_window + 2 * pad_data
             err_msg = "I was asked to use {} seconds of data ".format(tl)
             err_msg += "to run a plot_singles_timefreq job. However, I have "
-            err_msg += "only {} seconds available.".format(len(data_seg))
+            err_msg += "only {} seconds available.".format(abs(data_seg))
             raise ValueError(err_msg)
         if data_seg[0] > (start - pad_data):
             start = data_seg[0] + pad_data
-            end = start + 2 * time_window + 2 * pad_data
+            end = start + 2 * time_window
         if data_seg[1] < (end + pad_data):
             end = data_seg[1] - pad_data
-            start = end - 2 * time_window + 2 * pad_data
+            start = end - 2 * time_window
         # Sanity check, shouldn't get here!
         if data_seg[0] > (start - pad_data):
             err_msg = "I shouldn't be here! Go ask Ian what he broke."

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -530,8 +530,46 @@ def make_trigger_timeseries(workflow, singles, ifo_times, out_dir, special_tids=
     return files
 
     
-def make_singles_timefreq(workflow, single, bank_file, start, end, out_dir,
-                          veto_file=None, tags=None):
+def make_singles_timefreq(workflow, single, bank_file, trig_time, out_dir,
+                          veto_file=None, time_window=10, data_segments=None,
+                          tags=None):
+    """ Generate a singles_timefreq node and add it to workflow.
+
+    This function generates a single node of the singles_timefreq executable
+    and adds it to the current workflow. Parent/child relationships are set by
+    the input/output files automatically.
+
+    Parameters
+    -----------
+    workflow: pycbc.workflow.core.Workflow
+        The workflow class that stores the jobs that will be run.
+    single: pycbc.workflow.core.File instance
+        The File object storing the single-detector triggers to followup.
+    bank_file: pycbc.workflow.core.File instance
+        The File object storing the template bank.
+    trig_time: int
+        The time of the trigger being followed up.
+    out_dir: str
+        Location of directory to output to
+    veto_file: File (optional, default=None)
+        If given use this file to veto triggers to determine the loudest event.
+        FIXME: Veto files *should* be provided a definer argument and not just
+        assume that all segments should be read.
+    time_window: int (optional, default=None)
+        The amount of data (not including padding) that will be read in by the
+        singles_timefreq job. The default value of 10s should be fine for most
+        cases.
+    data_segments: glue.segments.segmentlist (optional, default=None)
+        The list of segments for which data exists and can be read in. If given
+        the start/end times given to singles_timefreq will be adjusted if
+        [trig_time - time_window, trig_time + time_window] does not completely
+        lie within a valid data segment. A ValueError will be raised if the
+        trig_time is not within a valid segment, or if it is not possible to
+        find 2*time_window (plus the padding) of continuous data around the
+        trigger. This **must** be coalesced.
+    tags: list (optional, default=None)
+        List of tags to add to the created nodes, which determine file naming.
+    """
     tags = [] if tags is None else tags
     makedir(out_dir)
     name = 'plot_singles_timefreq'
@@ -540,8 +578,49 @@ def make_singles_timefreq(workflow, single, bank_file, start, end, out_dir,
                           out_dir=out_dir, tags=tags).create_node()
     node.add_input_opt('--trig-file', single)
     node.add_input_opt('--bank-file', bank_file)
+
+    # Determine start/end times, using data segments if needed.
+    # Begin by choosing "optimal" times
+    start = trig_time - time_window
+    end = trig_time + time_window
+    # Then if data_segments is available, check against that, and move if
+    # needed
+    if data_segments is not None:
+        # Assumes coalesced, so trig_time can only be within one segment
+        for seg in data_segments:
+            if trig_time in seg:
+                data_seg = seg
+                break
+        else:
+            err_msg = "Trig time {} ".format(trig_time)
+            err_msg += "does not seem to lie within any data segments. "
+            err_msg += "This shouldn't be possible, please ask for help!"
+            raise ValueError(err_msg)
+        # Check for pad-data
+        if node.has_opt('pad-data')
+            pad_data = int(pad_data)
+        else:
+            pad_data = 0
+        if len(data_seg) < (2 * time_window + 2 * pad_data):
+            tl = 2 * time_window + 2 * pad_data
+            err_msg = "I was asked to use {} seconds of data ".format(tl)
+            err_msg += "to run a plot_singles_timefreq job. However, I have "
+            err_msg += "only {} seconds available.".format(len(data_seg))
+            raise ValueError(err_msg)
+        if data_seg[0] > (start - pad_data):
+            start = data_seg[0] + pad_data
+            end = start + 2 * time_window + 2 * pad_data
+        if data_seg[1] < (end + pad_data):
+            end = data_seg[1] - pad_data
+            start = end - 2 * time_window + 2 * pad_data
+        # Sanity check, shouldn't get here!
+        if data_seg[0] > (start - pad_data):
+            err_msg = "I shouldn't be here! Go ask Ian what he broke."
+            raise ValueError(err_msg)
+
     node.add_opt('--gps-start-time', int(start))
     node.add_opt('--gps-end-time', int(end))
+    node.add_opt('--center-time', int(trig_time))
     
     if veto_file:
         node.add_input_opt('--veto-file', veto_file)


### PR DESCRIPTION
This fixes the edge condition in singles_timefreq reported by @duncan-brown. To fix this the workflow setup can (optionally) use the list of science segments (- CAT 1) to determine what range of data should be read in. If it is not possible to use 10s on each side, the data segment is shifted.

This has been tested on @duncan-brown 's failing workflow here:

https://sugwg-jobs.phy.syr.edu/~spxiwh/aLIGO/O2/test_runs/singlestimefreqfix/run3

And specifically see the plot A22 from here:

https://sugwg-jobs.phy.syr.edu/~spxiwh/aLIGO/O2/test_runs/singlestimefreqfix/run3/5._injections/5.18_followup_of_missed_BBHSEOBNRV3_INJ/

which was the problem. The red lines on that plot are unrelated to the actual injection. The injection is missed because it is injected *right* at the start of the science segment. Some tapering is applied here as the data must be at 0 at t = 1166413228 to allow zero-padding off the edge. So only a small amount of the injection is actually recoverable with an SNR of ~ 2.5, as can be seen in plots above A22.