### PR TITLE
Move gating functions and options from pycbc_inference to its own module

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -25,7 +25,6 @@ import numpy
 import pycbc
 import pycbc.opt
 import pycbc.weave
-import random
 from pycbc import fft
 from pycbc import gates
 from pycbc import inference
@@ -157,6 +156,7 @@ pycbc.weave.verify_weave_options(opts, parser)
 if os.path.exists(opts.output_file) and not opts.force:
     raise OSError("output-file already exists; use --force if you wish to "
                   "overwrite it.")
+
 # create the file for adding to
 fp = InferenceFile(opts.output_file, "w")
 fp.close()
@@ -228,16 +228,19 @@ with ctx:
     # apply any gates to overwhitened data, if desired
     if opts.gate_overwhitened and opts.gate is not None:
         logging.info("Applying gates to overwhitened data")
+
         # overwhiten the data
         for ifo in gates:
             stilde_dict[ifo] /= psd_dict[ifo]
         stilde_dict = gates.apply_gates_to_fd(stilde_dict, gates)
+
         # unwhiten the data for the likelihood generator
         for ifo in gates:
             stilde_dict[ifo] *= psd_dict[ifo]
 
     # save PSD
     if opts.save_psd:
+
         # apply dynamic range factor for saving PSDs since
         # plotting code expects it
         logging.info("Saving PSDs")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -26,7 +26,6 @@ import pycbc
 import pycbc.opt
 import pycbc.weave
 import random
-import pycbc
 from pycbc import fft
 from pycbc import inference
 from pycbc import psd
@@ -64,100 +63,6 @@ def convert_liststring_to_list(lstring):
         lvalue = [str(lstring[1:-1].split(',')[n].strip().strip("'"))
                       for n in range(len(lstring[1:-1].split(',')))]
     return lvalue
-
-
-def _gates_from_cli(opts, gate_opt):
-    """Parses the given `gate_opt` into something understandable by
-    `strain.gate_data`.
-    """
-    gates = {}
-    if getattr(opts, gate_opt) is None:
-        return gates
-    for gate in getattr(opts, gate_opt):
-        try:
-            ifo, central_time, half_dur, taper_dur = gate.split(':')
-            central_time = float(central_time)
-            half_dur = float(half_dur)
-            taper_dur = float(taper_dur)
-        except ValueError:
-            raise ValueError("--gate {} not formatted correctly; ".format(
-                gate) + "see help")
-        try:
-            gates[ifo].append((central_time, half_dur, taper_dur))
-        except KeyError:
-            gates[ifo] = [(central_time, half_dur, taper_dur)]
-    return gates
-
-
-def gates_from_cli(opts):
-    """Parses the --gate option into something understandable by
-    `strain.gate_data`.
-    """
-    return _gates_from_cli(opts, 'gate')
-
-
-def psd_gates_from_cli(opts):
-    """Parses the --psd-gate option into something understandable by
-    `strain.gate_data`.
-    """
-    return _gates_from_cli(opts, 'psd_gate')
-
-
-def apply_gates_to_td(strain_dict, gates):
-    """Applies the given dictionary of gates to the given dictionary of
-    strain.
-
-    Parameters
-    ----------
-    strain_dict : dict
-        Dictionary of time-domain strain, keyed by the ifos.
-    gates : dict
-        Dictionary of gates. Keys should be the ifo to apply the data to,
-        values are a tuple giving the central time of the gate, the half
-        duration, and the taper duration.
-
-    Returns
-    -------
-    dict
-        Dictionary of time-domain strain with the gates applied.
-    """
-    # copy data to new dictionary
-    outdict = dict(strain_dict.items())
-    for ifo in gates:
-        logging.info("Gating {} strain".format(ifo))
-        outdict[ifo] = strain.gate_data(outdict[ifo], gates[ifo])
-    return outdict
-
-
-def apply_gates_to_fd(stilde_dict, gates):
-    """Applies the given dictionary of gates to the given dictionary of
-    strain in the frequency domain.
-
-    Gates are applied by IFFT-ing the strain data to the time domain, applying
-    the gate, then FFT-ing back to the frequency domain.
-
-    Parameters
-    ----------
-    stilde_dict : dict
-        Dictionary of frequency-domain strain, keyed by the ifos.
-    gates : dict
-        Dictionary of gates. Keys should be the ifo to apply the data to,
-        values are a tuple giving the central time of the gate, the half
-        duration, and the taper duration.
-
-    Returns
-    -------
-    dict
-        Dictionary of frequency-domain strain with the gates applied.
-    """
-    # copy data to new dictionary
-    outdict = dict(stilde_dict.items())
-    # create a time-domin strain dictionary to apply the gates to
-    strain_dict = dict([[ifo, outdict[ifo].to_timeseries()] for ifo in gates])
-    # apply gates and fft back to the frequency domain
-    for ifo,d in apply_gates_to_td(strain_dict, gates).items():
-        outdict[ifo] = d.to_frequencyseries()
-    return outdict
 
 
 # command line usage

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -27,6 +27,7 @@ import pycbc.opt
 import pycbc.weave
 import random
 from pycbc import fft
+from pycbc import gates
 from pycbc import inference
 from pycbc import psd
 from pycbc import scheme
@@ -84,20 +85,6 @@ parser.add_argument("--psd-start-time", type=float, default=None,
 parser.add_argument("--psd-end-time", type=float, default=None,
                     help="End time to use for PSD estimation if different "
                          "from analysis.")
-parser.add_argument("--gate", nargs="+", type=str,
-                    metavar="IFO:CENTRALTIME:HALFDUR:TAPERDUR",
-                    help="Apply one or more gates to the data before "
-                         "filtering.")
-parser.add_argument("--gate-overwhitened", action="store_true", default=False,
-                    help="Overwhiten data first, then apply the gates "
-                         "specified in --gate. Overwhitening allows for "
-                         "sharper tapers to be used, since lines are not "
-                         "blurred.")
-parser.add_argument("--psd-gate", nargs="+", type=str,
-                    metavar="IFO:CENTRALTIME:HALFDUR:TAPERDUR",
-                    help="Apply one or more gates to the data used for "
-                         "computing the PSD. Gates are applied prior to "
-                         "FFT-ing the data for PSD estimation.")
 
 # add inference options
 parser.add_argument("--likelihood-evaluator", required=True,
@@ -153,6 +140,7 @@ psd.insert_psd_option_group_multi_ifo(parser)
 scheme.insert_processing_option_group(parser)
 strain.insert_strain_option_group_multi_ifo(parser)
 pycbc.weave.insert_weave_option_group(parser)
+gates.add_gates_option_group(parser)
 
 # parse command line
 opts = parser.parse_args()
@@ -188,8 +176,8 @@ ctx = scheme.from_cli(opts)
 fft.from_cli(opts)
 
 # get gates to apply
-gates = gates_from_cli(opts)
-psd_gates = psd_gates_from_cli(opts)
+gates = gates.gates_from_cli(opts)
+psd_gates = gates.psd_gates_from_cli(opts)
 
 # get strain time series
 strain_dict = strain.from_cli_multi_ifos(opts, opts.instruments,
@@ -197,7 +185,7 @@ strain_dict = strain.from_cli_multi_ifos(opts, opts.instruments,
 # apply gates if not waiting to overwhiten
 if not opts.gate_overwhitened:
     logging.info("Applying gates to strain data")
-    strain_dict = apply_gates_to_td(strain_dict, gates)
+    strain_dict = gates.apply_gates_to_td(strain_dict, gates)
 
 # get strain time series to use for PSD estimation
 # if user has not given the PSD time options then use same data as analysis
@@ -210,7 +198,7 @@ if opts.psd_start_time and opts.psd_end_time:
                                                 precision="double")
     # apply any gates
     logging.info("Applying gates to PSD data")
-    psd_strain_dict = apply_gates_to_td(psd_strain_dict, psd_gates)
+    psd_strain_dict = gates.apply_gates_to_td(psd_strain_dict, psd_gates)
 
 elif opts.psd_start_time or opts.psd_end_time:
     raise ValueError("Must give --psd-start-time and --psd-end-time")
@@ -243,7 +231,7 @@ with ctx:
         # overwhiten the data
         for ifo in gates:
             stilde_dict[ifo] /= psd_dict[ifo]
-        stilde_dict = apply_gates_to_fd(stilde_dict, gates)
+        stilde_dict = gates.apply_gates_to_fd(stilde_dict, gates)
         # unwhiten the data for the likelihood generator
         for ifo in gates:
             stilde_dict[ifo] *= psd_dict[ifo]

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -26,7 +26,7 @@ import pycbc
 import pycbc.opt
 import pycbc.weave
 from pycbc import fft
-from pycbc import gates
+from pycbc import gate
 from pycbc import inference
 from pycbc import psd
 from pycbc import scheme
@@ -139,7 +139,7 @@ psd.insert_psd_option_group_multi_ifo(parser)
 scheme.insert_processing_option_group(parser)
 strain.insert_strain_option_group_multi_ifo(parser)
 pycbc.weave.insert_weave_option_group(parser)
-gates.add_gates_option_group(parser)
+gate.add_gate_option_group(parser)
 
 # parse command line
 opts = parser.parse_args()
@@ -176,8 +176,8 @@ ctx = scheme.from_cli(opts)
 fft.from_cli(opts)
 
 # get gates to apply
-gates = gates.gates_from_cli(opts)
-psd_gates = gates.psd_gates_from_cli(opts)
+gates = gate.gates_from_cli(opts)
+psd_gates = gate.psd_gates_from_cli(opts)
 
 # get strain time series
 strain_dict = strain.from_cli_multi_ifos(opts, opts.instruments,
@@ -185,7 +185,7 @@ strain_dict = strain.from_cli_multi_ifos(opts, opts.instruments,
 # apply gates if not waiting to overwhiten
 if not opts.gate_overwhitened:
     logging.info("Applying gates to strain data")
-    strain_dict = gates.apply_gates_to_td(strain_dict, gates)
+    strain_dict = gate.apply_gates_to_td(strain_dict, gates)
 
 # get strain time series to use for PSD estimation
 # if user has not given the PSD time options then use same data as analysis
@@ -198,7 +198,7 @@ if opts.psd_start_time and opts.psd_end_time:
                                                 precision="double")
     # apply any gates
     logging.info("Applying gates to PSD data")
-    psd_strain_dict = gates.apply_gates_to_td(psd_strain_dict, psd_gates)
+    psd_strain_dict = gate.apply_gates_to_td(psd_strain_dict, psd_gates)
 
 elif opts.psd_start_time or opts.psd_end_time:
     raise ValueError("Must give --psd-start-time and --psd-end-time")
@@ -232,7 +232,7 @@ with ctx:
         # overwhiten the data
         for ifo in gates:
             stilde_dict[ifo] /= psd_dict[ifo]
-        stilde_dict = gates.apply_gates_to_fd(stilde_dict, gates)
+        stilde_dict = gate.apply_gates_to_fd(stilde_dict, gates)
 
         # unwhiten the data for the likelihood generator
         for ifo in gates:

--- a/bin/pycbc_make_html_page
+++ b/bin/pycbc_make_html_page
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (C) 2015 Christopher M. Biwer
 #

--- a/pycbc/gate.py
+++ b/pycbc/gate.py
@@ -113,7 +113,7 @@ def apply_gates_to_fd(stilde_dict, gates):
     return outdict
 
 
-def add_gates_option_group(parser):
+def add_gate_option_group(parser):
     """Adds the options needed to apply gates to data.
 
     Parameters
@@ -121,21 +121,21 @@ def add_gates_option_group(parser):
     parser : object
         ArgumentParser instance.
     """
-    gates_group = parser.add_argument_group("Options for gating data.")
+    gate_group = parser.add_argument_group("Options for gating data.")
 
-    gates_group.add_argument("--gate", nargs="+", type=str,
-                             metavar="IFO:CENTRALTIME:HALFDUR:TAPERDUR",
-                             help="Apply one or more gates to the data before "
-                                  "filtering.")
-    gates_group.add_argument("--gate-overwhitened", action="store_true",
-                             help="Overwhiten data first, then apply the "
-                                  "gates specified in --gate. Overwhitening "
-                                  "allows for sharper tapers to be used, "
-                                  "since lines are not blurred.")
-    gates_group.add_argument("--psd-gate", nargs="+", type=str,
-                             metavar="IFO:CENTRALTIME:HALFDUR:TAPERDUR",
-                             help="Apply one or more gates to the data used "
-                                  "for computing the PSD. Gates are applied "
-                                  "prior to FFT-ing the data for PSD "
-                                  "estimation.")
-    return gates_group
+    gate_group.add_argument("--gate", nargs="+", type=str,
+                            metavar="IFO:CENTRALTIME:HALFDUR:TAPERDUR",
+                            help="Apply one or more gates to the data before "
+                                 "filtering.")
+    gate_group.add_argument("--gate-overwhitened", action="store_true",
+                            help="Overwhiten data first, then apply the "
+                                 "gates specified in --gate. Overwhitening "
+                                 "allows for sharper tapers to be used, "
+                                 "since lines are not blurred.")
+    gate_group.add_argument("--psd-gate", nargs="+", type=str,
+                            metavar="IFO:CENTRALTIME:HALFDUR:TAPERDUR",
+                            help="Apply one or more gates to the data used "
+                                 "for computing the PSD. Gates are applied "
+                                 "prior to FFT-ing the data for PSD "
+                                 "estimation.")
+    return gate_group

--- a/pycbc/gates.py
+++ b/pycbc/gates.py
@@ -1,0 +1,114 @@
+# Copyright (C) 2016 Collin Capano
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+""" Functions for applying gates to data.
+"""
+
+import logging
+from pycbc import strain
+
+def _gates_from_cli(opts, gate_opt):
+    """Parses the given `gate_opt` into something understandable by
+    `strain.gate_data`.
+    """
+    gates = {}
+    if getattr(opts, gate_opt) is None:
+        return gates
+    for gate in getattr(opts, gate_opt):
+        try:
+            ifo, central_time, half_dur, taper_dur = gate.split(':')
+            central_time = float(central_time)
+            half_dur = float(half_dur)
+            taper_dur = float(taper_dur)
+        except ValueError:
+            raise ValueError("--gate {} not formatted correctly; ".format(
+                gate) + "see help")
+        try:
+            gates[ifo].append((central_time, half_dur, taper_dur))
+        except KeyError:
+            gates[ifo] = [(central_time, half_dur, taper_dur)]
+    return gates
+
+
+def gates_from_cli(opts):
+    """Parses the --gate option into something understandable by
+    `strain.gate_data`.
+    """
+    return _gates_from_cli(opts, 'gate')
+
+
+def psd_gates_from_cli(opts):
+    """Parses the --psd-gate option into something understandable by
+    `strain.gate_data`.
+    """
+    return _gates_from_cli(opts, 'psd_gate')
+
+
+def apply_gates_to_td(strain_dict, gates):
+    """Applies the given dictionary of gates to the given dictionary of
+    strain.
+
+    Parameters
+    ----------
+    strain_dict : dict
+        Dictionary of time-domain strain, keyed by the ifos.
+    gates : dict
+        Dictionary of gates. Keys should be the ifo to apply the data to,
+        values are a tuple giving the central time of the gate, the half
+        duration, and the taper duration.
+
+    Returns
+    -------
+    dict
+        Dictionary of time-domain strain with the gates applied.
+    """
+    # copy data to new dictionary
+    outdict = dict(strain_dict.items())
+    for ifo in gates:
+        logging.info("Gating {} strain".format(ifo))
+        outdict[ifo] = strain.gate_data(outdict[ifo], gates[ifo])
+    return outdict
+
+
+def apply_gates_to_fd(stilde_dict, gates):
+    """Applies the given dictionary of gates to the given dictionary of
+    strain in the frequency domain.
+
+    Gates are applied by IFFT-ing the strain data to the time domain, applying
+    the gate, then FFT-ing back to the frequency domain.
+
+    Parameters
+    ----------
+    stilde_dict : dict
+        Dictionary of frequency-domain strain, keyed by the ifos.
+    gates : dict
+        Dictionary of gates. Keys should be the ifo to apply the data to,
+        values are a tuple giving the central time of the gate, the half
+        duration, and the taper duration.
+
+    Returns
+    -------
+    dict
+        Dictionary of frequency-domain strain with the gates applied.
+    """
+    # copy data to new dictionary
+    outdict = dict(stilde_dict.items())
+    # create a time-domin strain dictionary to apply the gates to
+    strain_dict = dict([[ifo, outdict[ifo].to_timeseries()] for ifo in gates])
+    # apply gates and fft back to the frequency domain
+    for ifo,d in apply_gates_to_td(strain_dict, gates).items():
+        outdict[ifo] = d.to_frequencyseries()
+    return outdict
+

--- a/pycbc/gates.py
+++ b/pycbc/gates.py
@@ -112,3 +112,30 @@ def apply_gates_to_fd(stilde_dict, gates):
         outdict[ifo] = d.to_frequencyseries()
     return outdict
 
+
+def add_gates_option_group(parser):
+    """Adds the options needed to apply gates to data.
+
+    Parameters
+    ----------
+    parser : object
+        ArgumentParser instance.
+    """
+    gates_group = parser.add_argument_group("Options for gating data.")
+
+    gates_group.add_argument("--gate", nargs="+", type=str,
+                             metavar="IFO:CENTRALTIME:HALFDUR:TAPERDUR",
+                             help="Apply one or more gates to the data before "
+                                  "filtering.")
+    gates_group.add_argument("--gate-overwhitened", action="store_true",
+                             help="Overwhiten data first, then apply the "
+                                  "gates specified in --gate. Overwhitening "
+                                  "allows for sharper tapers to be used, "
+                                  "since lines are not blurred.")
+    gates_group.add_argument("--psd-gate", nargs="+", type=str,
+                             metavar="IFO:CENTRALTIME:HALFDUR:TAPERDUR",
+                             help="Apply one or more gates to the data used "
+                                  "for computing the PSD. Gates are applied "
+                                  "prior to FFT-ing the data for PSD "
+                                  "estimation.")
+    return gates_group


### PR DESCRIPTION
This PR moves all the gating functions at the top of ``pycbc_inference`` to its own module. This isn't specific to what's going on in ``pycbc_inference`` so lets just move it to its own module.

This PR also creates a option group for the gating options that were added to ``pycbc_inference`` for these functions.

This PR also removes 2 unused imports in ``pycbc_inference`` and fixes the shebang line in ``pycbc_make_html_page``.