### PR TITLE
Remove setting measure level to 0 in pycbc_inference.

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -275,9 +275,6 @@ pycbc.init_logging(opts.verbose)
 numpy.random.seed(opts.seed)
 logging.info("Using seed %i" %(opts.seed))
 
-# change measure level for FFT to 0
-fft.fftw.set_measure_level(0)
-
 # get scheme
 ctx = scheme.from_cli(opts)
 fft.from_cli(opts)


### PR DESCRIPTION
These lines are redundant since the default in ``pycbc/pycbc/fft/fftw.py`` is measure level 0, and actually these lines override whatever is on the command line option since we have added the fft option group. Should be removed.