### PR TITLE
write out weave cache settings only if INITIAL_LOG_LEVEL >= 10

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -128,11 +128,13 @@ _cache_dir_path = os.path.join(_tmp_dir, _cache_dir_name)
 _cache_dir_path = os.path.join(_cache_dir_path, pycbc_version)
 _cache_dir_path = os.path.join(_cache_dir_path, git_hash)
 if os.environ.get("NO_TMPDIR", None):
-    print >>sys.stderr, "__init__: Skipped creating %s as NO_TEMPDIR is set" % _cache_dir_path
+    if os.environ.get("INITIAL_LOG_LEVEL", 0) >= 10:
+        print >>sys.stderr, "__init__: Skipped creating %s as NO_TEMPDIR is set" % _cache_dir_path
 else:
     try: os.makedirs(_cache_dir_path)
     except OSError: pass
-    print >>sys.stderr, "__init__: Setting weave cache to %s" % _cache_dir_path
+    if os.environ.get("INITIAL_LOG_LEVEL", 0) >= 10:
+        print >>sys.stderr, "__init__: Setting weave cache to %s" % _cache_dir_path
 os.environ['PYTHONCOMPILED'] = _cache_dir_path
 
 # Check for MKL capability


### PR DESCRIPTION
IIRC these messages were annoying someone. It doesn't help to use the log functions since the logginng module has not been initialized at this point, so I filtered these with the value taken from INITIAL_LOG_LEVEL environment variable.