### PR TITLE
Add distribution for uniform volume sampling

### DIFF
--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1640,7 +1640,7 @@ class UniformRadius(_BoundedDist):
         if kwargs in self:
             log_pdf = self._lognorm + \
                       (self.dim - 1) * \
-                      sum([numpy.log(kwargs[p]) for p in self._params])
+                      numpy.log([kwargs[p] for p in self._params]).sum()
             return log_pdf
         else:
             return -numpy.inf

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1480,7 +1480,7 @@ class UniformRadius(_BoundedDist):
     lognorm : float
         The log of the normalization.
     """
-    name = 'uniform_cube_root'
+    name = 'uniform_radius'
     def __init__(self, **params):
         super(UniformRadius, self).__init__(**params)
 

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1557,7 +1557,7 @@ class UniformRadius(_BoundedDist):
                 raise ValueError(
                             'Missing parameter {} to construct pdf.'.format(p))
         if kwargs in self:
-            this_pdf = numpy.log(numpy.prod([3 * (kwargs[p] / self._bounds[p][1])**(1.0 / 2)
+            this_pdf = numpy.log(numpy.prod([3 * (kwargs[p] / self._bounds[p][1])**(2)
                             for p in self._params]))
             return this_pdf
         else:

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1534,8 +1534,11 @@ class UniformRadius(_BoundedDist):
     def __init__(self, **params):
         super(UniformRadius, self).__init__(**params)
         for p in self._params:
-            if self._bounds[p] is not 0:
+            if self._bounds[p][0] != 0:
                 raise ValueError("Lower bound must be 0 for %s" % p)
+            if not self.bounds[p][1] > 0:
+                raise ValueError("Upper bound must be greater than 0 "
+                                 "for %s" % p)
 
     @property
     def norm(self):
@@ -1570,9 +1573,7 @@ class UniformRadius(_BoundedDist):
             dtype = [(p, float) for p in self.params]
         arr = numpy.zeros(size, dtype=dtype)
         for (p,_) in dtype:
-            arr[p] = numpy.random.uniform(
-                            self._bounds[p][1] - self._bounds[p][0],
-                            self._bounds[p][1], size=size) + self._bounds[p][0]
+            arr[p] = numpy.random.uniform(0.0, 1.0, size=size)
             arr[p] = self._bounds[p][1] * numpy.power(arr[p], 1.0 / self.dim)
         return arr
 
@@ -1594,7 +1595,7 @@ class UniformRadius(_BoundedDist):
                 raise ValueError(
                             'Missing parameter {} to construct pdf.'.format(p))
         if kwargs in self:
-            this_pdf = numpy.prod([self.dim * (kwargs[p] / self._bounds[p][1])**(self.dim - 1)
+            this_pdf = numpy.prod([ self.dim  / self._bounds[p][1] * (kwargs[p] / self._bounds[p][1])**(self.dim - 1)
                                    for p in self._params])
             return float(this_pdf)
         else:

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1457,7 +1457,7 @@ class FromFile(_BoundedDist):
         return super(FromFile, cls).from_config(cp, section, variable_args,
                                                 bounds_required=False)
 
-class UniformCubeRoot(_BoundedDist):
+class UniformRadius(_BoundedDist):
     """
     \**params :
         The keyword arguments should provide the names of parameters and their
@@ -1482,7 +1482,7 @@ class UniformCubeRoot(_BoundedDist):
     """
     name = 'uniform_cube_root'
     def __init__(self, **params):
-        super(UniformCubeRoot, self).__init__(**params)
+        super(UniformRadius, self).__init__(**params)
 
     @property
     def norm(self):
@@ -1586,7 +1586,7 @@ class UniformCubeRoot(_BoundedDist):
         Uniform
             A distribution instance from the pycbc.inference.prior module.
         """
-        return super(UniformCubeRoot, cls).from_config(cp, section,
+        return super(UniformRadius, cls).from_config(cp, section,
                                                        variable_args,
                                                        bounds_required=True)
 
@@ -1597,7 +1597,7 @@ distribs = {
     SinAngle.name : SinAngle,
     UniformSolidAngle.name : UniformSolidAngle,
     UniformSky.name : UniformSky,
-    UniformCubeRoot.name : UniformCubeRoot,
+    UniformRadius.name : UniformRadius,
     Gaussian.name : Gaussian,
     FromFile.name : FromFile,
 }

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1502,11 +1502,17 @@ class UniformRadius(_BoundedDist):
 
         1 = \frac{1}{n + 1} c (R)^{n + 1}
 
-    Can see that :math:`c= \frac{n + 1}{R^{n + 1}}`. So the CDF is:
+    Can see that :math:`c= \frac{n + 1}{R^{n + 1}}`. So can see that the CDF is:
 
     .. math::
 
-        F(r) = \frac{1}{2} \frac{2}{R^{n + 1}} r^n = \frac{1}{R} (\frac{r}{R})^n
+        F(r) = \frac{1}{n + 1} \frac{n + 1}{R^{n + 1}} r^{n + 1} = (\frac{r}{R})^{n + 1}
+
+    And the PDF is the derivative of the CDF:
+
+    .. math::
+
+        f(r) = \frac{(n + 1)}{R} \left(\frac{r}{R} \right)^n
 
     Now we use the probabilty integral transform method to get sampling on
     uniform numbers from a continuous random variable. To do this we find
@@ -1520,12 +1526,12 @@ class UniformRadius(_BoundedDist):
 
     .. math::
 
-        u = (\frac{r}{R})^n
+        u = (\frac{r}{R})^{n + 1}
 
     And solving for :math:`r` gives:
 
     .. math::
-        r = R u^{1/n}
+        r = R u^{\frac{1}{n + 1}}
 
     Therefore the radius can be sampled by taking the n-th root of uniform
     numbers and multiplying by the radius.

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1458,55 +1458,85 @@ class FromFile(_BoundedDist):
                                                 bounds_required=False)
 
 class UniformRadius(_BoundedDist):
-    """
+    r"""
     For a uniform distribution in volume using spherical coordinates, this
     is the distriubtion to use for the radius. The parameters are
     independent of each other. Instances of this class can be called like
     a function. By default, logpdf will be called, but this can be changed
     by setting the class's __call__ method to its pdf method.
 
-    We know that the infitesimal volume on a sphere is dV = r^2 * sin(phi) * dphi * dtheta * dr
+    The cumulative distribution function (CDF) will be the ratio of volumes:
 
-    We want our sampling to be proportional to volume so we assume a probability density function (PDF)
-        f(r) = c * r^n
-    For generality we use n for the dimension of the infitestimal volume element, eg. 2 in the case above.
+    .. math::
 
-    So now we calculate a cumulative distribution function (CDF)
-        F(r) = int f(r) dr
-             = int c * r^n dr
-             = \frac{1}{2} * c * r^n + k
+        F(r) = \frac{V(r)}{V(R)}
 
-    Now with the definition of the CDF at radius 0 is equal to 0 and at radius R
-    is equal to 1 we find that
-        0 = \frac{1}{n} * c * (0)^n + k
-        k = 0
-    and
-        1 = \frac{1}{n} * c * (R)^n
-        c = \frac{n}{R^n}
+    Where :math:`R` is the radius of the sphere. So we can write our
+    probability density function (PDF) as:
 
-    so
-        F(r) = \frac{1}{2} * \frac{2}{R^n} r^n = (\frac{r}{R})^n
+    .. math::
 
-    now we use probabilty integral transform method to get sampling on uniform numbers
-    from a continuous random variable
-        F(r) = u = (\frac{r}{R})^n
+        f(r) = c r^n
 
-    so
-        F^{-1}(u)
-    gives
+    For generality we use :math:`n` for the dimension of the volume element,
+    eg. :math:`n=2` for a 3-dimensional sphere. And use
+    :math:`c` as a general constant.
+
+    So now we calculate the CDF in general for this type of PDF:
+
+    .. math::
+
+        F(r) = \int f(r) dr = \int c r^n dr = \frac{1}{n + 1} c r^{n + 1} + k
+
+    Now with the definition of the CDF at radius 0 is equal to 0 and at
+    radius :math:`R` is equal to 1 we find that the constant from
+    integration is:
+
+    .. math::
+
+        0 = \frac{1}{n + 1} c (0)^{n + 1} + k
+
+    Can see that :math:`k=0`. And :math:`c` is:
+
+    .. math::
+
+        1 = \frac{1}{n + 1} c (R)^{n + 1}
+
+    Can see that :math:`c= \frac{n + 1}{R^{n + 1}}`. So the CDF is:
+
+    .. math::
+
+        F(r) = \frac{1}{2} \frac{2}{R^{n + 1}} r^n = \frac{1}{R} (\frac{r}{R})^n
+
+    Now we use the probabilty integral transform method to get sampling on
+    uniform numbers from a continuous random variable. To do this we find
+    the inverse of the CDF evaluated for uniform numbers:
+
+    .. math::
+
+        F(r) = u = \left(\frac{r}{R}\right)^{n + 1}
+
+    And find :math:`F^{-1}(u)` gives:
+
+    .. math::
+
         u = (\frac{r}{R})^n
-        r^n = R^n * u
-        r = R * u^{1/n}
 
-    Therefore the radius can be sampled by taking the cube root of uniform numbers and
-    multiplying by the radius.
+    And solving for :math:`r` gives:
 
-    .note:: Alternative method is drawing uniform points in a box and regarding
-    everything not in the sphere. This is quicker but loose half the samples you draw.
-    You know how many samples you throw away by calculating the probability inside sphere
-    given inside cube for 3 dimensions is
-        p(in sphere|in cube) = \frac{\frac{4}{3} * \pi * R^3}{8 * R^3} = 0.52
-    note that we use 8 * R^3 for the volume because the length of one side is 2 * R.
+    .. math::
+        r = R u^{1/n}
+
+    Therefore the radius can be sampled by taking the n-th root of uniform
+    numbers and multiplying by the radius.
+
+    Alternative method is drawing uniform points in a box and
+    regarding everything not in the sphere. This is quicker but loose half the
+    samples you draw. You know how many samples you throw away by calculating
+    the probability inside sphere given inside cube for 3 dimensions is
+    :math:`p(\mathrm{in sphere}|\mathrm{in cube}) = \frac{\frac{4}{3} \pi R^3}{8 R^3} = 0.52`.
+    Note that we use :math:`8 R^3` for the volume because the length of one
+    side is :math:`2 R`.
 
     \**params :
         The keyword arguments should provide the names of parameters and their
@@ -1517,6 +1547,8 @@ class UniformRadius(_BoundedDist):
     ----------------
     name : 'uniform_radius'
         The name of this distribution.
+    dim : int
+        The dimension of volume space. For a 3-dimensional sphere this is 3.
 
     Attributes
     ----------

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1469,7 +1469,7 @@ class UniformRadius(_BoundedDist):
 
     We want our sampling to be proportional to volume so we assume a probability density function (PDF)
         f(r) = c * r^n
-    For generality we use n for the dimension of the volume. Generally this is 3.
+    For generality we use n for the dimension of the infitestimal volume element, eg. 2 in the case above.
 
     So now we calculate a cumulative distribution function (CDF)
         F(r) = int f(r) dr
@@ -1482,7 +1482,7 @@ class UniformRadius(_BoundedDist):
         k = 0
     and
         1 = \frac{1}{n} * c * (R)^n
-        c = \frac{2}{R^n}
+        c = \frac{n}{R^n}
 
     so
         F(r) = \frac{1}{2} * \frac{2}{R^n} r^n = (\frac{r}{R})^n
@@ -1530,8 +1530,12 @@ class UniformRadius(_BoundedDist):
         The log of the normalization.
     """
     name = 'uniform_radius'
+    dim = 3
     def __init__(self, **params):
         super(UniformRadius, self).__init__(**params)
+        for p in self._params:
+            if self._bounds[p] is not 0:
+                raise ValueError("Lower bound must be 0 for %s" % p)
 
     @property
     def norm(self):
@@ -1569,7 +1573,7 @@ class UniformRadius(_BoundedDist):
             arr[p] = numpy.random.uniform(
                             self._bounds[p][1] - self._bounds[p][0],
                             self._bounds[p][1], size=size) + self._bounds[p][0]
-            arr[p] = numpy.power(arr[p], 1.0 / 3)
+            arr[p] = self._bounds[p][1] * numpy.power(arr[p], 1.0 / self.dim)
         return arr
 
     def pdf(self, **kwargs):
@@ -1590,7 +1594,7 @@ class UniformRadius(_BoundedDist):
                 raise ValueError(
                             'Missing parameter {} to construct pdf.'.format(p))
         if kwargs in self:
-            this_pdf = numpy.prod([3 * (kwargs[p] / self._bounds[p][1])**(2)
+            this_pdf = numpy.prod([self.dim * (kwargs[p] / self._bounds[p][1])**(self.dim - 1)
                                    for p in self._params])
             return float(this_pdf)
         else:

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1546,7 +1546,7 @@ class UniformRadius(_BoundedDist):
 
     @property
     def lognorm(self):
-        raise NotImplementedError("Not implemented %s." % name)
+        raise NotImplementedError("Not implemented for %s." % name)
 
     def rvs(self, size=1, param=None):
         """Gives a set of random values drawn from this distribution.
@@ -1595,11 +1595,12 @@ class UniformRadius(_BoundedDist):
                 raise ValueError(
                             'Missing parameter {} to construct pdf.'.format(p))
         if kwargs in self:
-            this_pdf = numpy.prod([ self.dim  / self._bounds[p][1] * (kwargs[p] / self._bounds[p][1])**(self.dim - 1)
-                                   for p in self._params])
-            return float(this_pdf)
+            pdf = numpy.prod([self.dim  / self._bounds[p][1] *
+                              (kwargs[p] / self._bounds[p][1])**(self.dim - 1)
+                              for p in self._params])
+            return float(pdf)
         else:
-            return 0.
+            return 0.0
 
     def _logpdf(self, **kwargs):
         """The underlying pdf function called by `self.pdf`. This must be set

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1612,9 +1612,9 @@ class UniformRadius(_BoundedDist):
         return arr
 
     def _pdf(self, **kwargs):
-        """The underlying pdf function called by `self.pdf`. This must be set
-        by any class that inherits from this class. Otherwise, a
-        `NotImplementedError` is raised.
+        """Returns the pdf at the given values. The keyword arguments must
+        contain all of parameters in self's params. Unrecognized arguments are
+        ignored.
         """
         for p in self._params:
             if p not in kwargs.keys():
@@ -1629,9 +1629,9 @@ class UniformRadius(_BoundedDist):
             return 0.0
 
     def _logpdf(self, **kwargs):
-        """The underlying pdf function called by `self.pdf`. This must be set
-        by any class that inherits from this class. Otherwise, a
-        `NotImplementedError` is raised.
+        """Returns the log of the pdf at the given values. The keyword
+        arguments must contain all of parameters in self's params. Unrecognized
+        arguments are ignored.
         """
         for p in self._params:
             if p not in kwargs.keys():

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1536,14 +1536,6 @@ class UniformRadius(_BoundedDist):
     Therefore the radius can be sampled by taking the n-th root of uniform
     numbers and multiplying by the radius.
 
-    Alternative method is drawing uniform points in a box and
-    regarding everything not in the sphere. This is quicker but loose half the
-    samples you draw. You know how many samples you throw away by calculating
-    the probability inside sphere given inside cube for 3 dimensions is
-    :math:`p(\mathrm{in sphere}|\mathrm{in cube}) = \frac{\frac{4}{3} \pi R^3}{8 R^3} = 0.52`.
-    Note that we use :math:`8 R^3` for the volume because the length of one
-    side is :math:`2 R`.
-
     \**params :
         The keyword arguments should provide the names of parameters and their
         corresponding bounds, as either tuples or a `boundaries.Bounds`

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1611,14 +1611,6 @@ class UniformRadius(_BoundedDist):
             arr[p] = self._bounds[p][1] * numpy.power(arr[p], 1.0 / self.dim)
         return arr
 
-    def pdf(self, **kwargs):
-        """Returns the pdf at the given values. The keyword arguments must
-        contain all of parameters in self's params. Unrecognized arguments are
-        ignored. Any boundary conditions are applied to the values before the
-        pdf is evaluated.
-        """
-        return self._pdf(**self.apply_boundary_conditions(**kwargs))
-
     def _pdf(self, **kwargs):
         """The underlying pdf function called by `self.pdf`. This must be set
         by any class that inherits from this class. Otherwise, a

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1459,6 +1459,55 @@ class FromFile(_BoundedDist):
 
 class UniformRadius(_BoundedDist):
     """
+    For a uniform distribution in volume using spherical coordinates, this
+    is the distriubtion to use for the radius. The parameters are
+    independent of each other. Instances of this class can be called like
+    a function. By default, logpdf will be called, but this can be changed
+    by setting the class's __call__ method to its pdf method.
+
+    We know that the infitesimal volume on a sphere is dV = r^2 * sin(phi) * dphi * dtheta * dr
+
+    We want our sampling to be proportional to volume so we assume a probability density function (PDF)
+        f(r) = c * r^n
+    For generality we use n for the dimension of the volume. Generally this is 3.
+
+    So now we calculate a cumulative distribution function (CDF)
+        F(r) = int f(r) dr
+             = int c * r^n dr
+             = \frac{1}{2} * c * r^n + k
+
+    Now with the definition of the CDF at radius 0 is equal to 0 and at radius R
+    is equal to 1 we find that
+        0 = \frac{1}{n} * c * (0)^n + k
+        k = 0
+    and
+        1 = \frac{1}{n} * c * (R)^n
+        c = \frac{2}{R^n}
+
+    so
+        F(r) = \frac{1}{2} * \frac{2}{R^n} r^n = (\frac{r}{R})^n
+
+    now we use probabilty integral transform method to get sampling on uniform numbers
+    from a continuous random variable
+        F(r) = u = (\frac{r}{R})^n
+
+    so
+        F^{-1}(u)
+    gives
+        u = (\frac{r}{R})^n
+        r^n = R^n * u
+        r = R * u^{1/n}
+
+    Therefore the radius can be sampled by taking the cube root of uniform numbers and
+    multiplying by the radius.
+
+    .note:: Alternative method is drawing uniform points in a box and regarding
+    everything not in the sphere. This is quicker but loose half the samples you draw.
+    You know how many samples you throw away by calculating the probability inside sphere
+    given inside cube for 3 dimensions is
+        p(in sphere|in cube) = \frac{\frac{4}{3} * \pi * R^3}{8 * R^3} = 0.52
+    note that we use 8 * R^3 for the volume because the length of one side is 2 * R.
+
     \**params :
         The keyword arguments should provide the names of parameters and their
         corresponding bounds, as either tuples or a `boundaries.Bounds`
@@ -1466,7 +1515,7 @@ class UniformRadius(_BoundedDist):
 
     Class Attributes
     ----------------
-    name : 'uniform'
+    name : 'uniform_radius'
         The name of this distribution.
 
     Attributes
@@ -1486,11 +1535,11 @@ class UniformRadius(_BoundedDist):
 
     @property
     def norm(self):
-        raise NotImplementedError("Not implemented.")
+        raise NotImplementedError("Not implemented for %s." % name)
 
     @property
     def lognorm(self):
-        raise NotImplementedError("Not implemented.")
+        raise NotImplementedError("Not implemented %s." % name)
 
     def rvs(self, size=1, param=None):
         """Gives a set of random values drawn from this distribution.
@@ -1517,9 +1566,9 @@ class UniformRadius(_BoundedDist):
             dtype = [(p, float) for p in self.params]
         arr = numpy.zeros(size, dtype=dtype)
         for (p,_) in dtype:
-            arr[p] = numpy.random.uniform(self._bounds[p][0],
-                                        self._bounds[p][1],
-                                        size=size)
+            arr[p] = numpy.random.uniform(
+                            self._bounds[p][1] - self._bounds[p][0],
+                            self._bounds[p][1], size=size) + self._bounds[p][0]
             arr[p] = numpy.power(arr[p], 1.0 / 3)
         return arr
 

--- a/pycbc/inference/distributions.py
+++ b/pycbc/inference/distributions.py
@@ -1542,7 +1542,7 @@ class UniformRadius(_BoundedDist):
                             'Missing parameter {} to construct pdf.'.format(p))
         if kwargs in self:
             this_pdf = numpy.prod([3 * (kwargs[p] / self._bounds[p][1])**(2)
-                            for p in self._params])
+                                   for p in self._params])
             return float(this_pdf)
         else:
             return 0.

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -106,16 +106,14 @@ def generator_spin_spherical_to_spin_cartesian(generator):
     to cartesian component spins.
     """
     x, y, z = coordinates.spherical_to_cartesian(
-                                   generator.current_params["spin1_a"] *
-                                   generator.current_params["mass1"]**2,
+                                   generator.current_params["spin1_a"],
                                    generator.current_params["spin1_azimuthal"],
                                    generator.current_params["spin1_polar"])
     generator.current_params["spin1x"] = x
     generator.current_params["spin1y"] = y
     generator.current_params["spin1z"] = z
     x, y, z = coordinates.spherical_to_cartesian(
-                                   generator.current_params["spin2_a"] *
-                                   generator.current_params["mass2"]**2,
+                                   generator.current_params["spin2_a"],
                                    generator.current_params["spin2_azimuthal"],
                                    generator.current_params["spin2_polar"])
     generator.current_params["spin2x"] = x


### PR DESCRIPTION
This PR adds a new distribution ``UniformRadius`` that can be used for sampling in uniform volume. I'm sure this would have other uses but the immediate idea I have is to use this for sampling spin magnitude and angles in ``pycbc_inference``. I've labeled this as work in progress because the docstrings need to be added and ``_pdf`` and ``_logpdf`` could be re-written. But this at least lets people know I've done this for now.

Since radius goes as cubed in volume you cannot just sample uniformly in radius. You will get a bunch of points near the center of the sphere.

Here's an example on uniform volume sampling I put together to test ``UniformRadius``:
```
#! /usr/bin/env python

import matplotlib.pyplot as plt
from mpl_toolkits.mplot3d import Axes3D
import numpy
from pycbc import coordinates as coords
from pycbc.inference import distributions

# get distributions
r_dist = distributions.distribs["uniform_radius"](spin1_a=(0, 1))
phi_dist = distributions.distribs["uniform"](spin1_azimuthal=(0, 2 * numpy.pi))
theta_dist = distributions.distribs["sin_angle"](spin1_polar=None)

# draw a bunch of random samples
n = 100000
r = r_dist.rvs(n)["spin1_a"]
phi = phi_dist.rvs(n)["spin1_azimuthal"]
theta = theta_dist.rvs(n)["spin1_polar"]

# get radius PDF
x = numpy.arange(0, 1.01, 0.01)
r_pdf = [r_dist.pdf(spin1_a=i) for i in x]

# plot radius PDF
if 1:
    nbins = 50
    plt.plot(x, r_pdf, "r")
    plt.hist(r, nbins, normed=True, histtype="step")
    plt.ylabel("PDF")
    plt.xlabel("radius")
    plt.show()

# plot 3-D scatter of drawn points
if 1:
    x, y, z = coords.spherical_to_cartesian(r, phi, theta)
    fig = plt.figure()
    ax = Axes3D(fig)
    ax.scatter(x, y, z, s=1)
    plt.zlabel("z")
    plt.ylabel("y")
    plt.xlabel("x")
    plt.show()

# plot slice of the sphere
if 1:
    x, y, z = coords.spherical_to_cartesian(r, phi, theta)
    idx = numpy.where((x > - 0.01) & (x <  0.01))
    x, y, z = coords.spherical_to_cartesian(r[idx], phi[idx], theta[idx])
    plt.scatter(y, z, s=1)
    plt.ylabel("z")
    plt.xlabel("y")
    plt.show()
```

Change the number of points if you look at the 3-D point, there's too many with the settings I've put in.

Configuration files could use the following settings:
```
[prior-spin1_a]
name = uniform_radius
min-spin1_a = 0.0
max-spin1_a = 1.0

[prior-spin1_azimuthal]
name = uniform
min-spin1_azimuthal = 0.
max-spin1_azimuthal = 6.283185307179586

[prior-spin1_polar]
name = sin_angle
```