### PR TITLE
Distributions examples for Documentation Purposes

### DIFF
--- a/docs/distributions.rst
+++ b/docs/distributions.rst
@@ -1,0 +1,24 @@
+###################################################
+Using PyCBC Distributions from PyCBC Inference
+###################################################
+
+The aim of this page is to demonstrate some simple uses of the distributions available from the distributions.py module available at <https://github.com/ligo-cbc/pycbc/blob/master/pycbc/inference/distributions.py>.
+
+=========================================
+Making Mass Distributions in M1 and M2
+=========================================
+
+Here we will demonstrate how to make different mass populations of binaries. This example shows uniform and gaussian mass distributions.
+.. literalinclude:: ../examples/inference/mass_examples.py
+.. command-output:: python ../examples/inference/mass_examples.py
+
+========================================================
+Sky Location Distribution as Spin Distribution Example 
+========================================================
+Here we can make a distribution of spins of unit length with equal distribution in x, y, and z to sample the surface of a unit sphere.
+.. literalinclude:: ../examples/inference/spin_examples.py
+.. command-output:: python ../examples/inference/spin_examples.py
+
+Using much of the same code we can also show how this sampling accurately covers the surface of a unit sphere.
+.. literalinclude:: ../examples/inferences/spin_spatial_distr_example.py
+.. command-output:: python ../examples/inference/spin_spatial_example.py

--- a/examples/distributions/mass_examples.py
+++ b/examples/distributions/mass_examples.py
@@ -20,8 +20,8 @@ mass2_distribution = distributions.Gaussian(mass2=(0.5, 1.5), mass2_mean=1.2,
 mass2_samples = mass2_distribution.rvs(size=1000000)
 
 # We can make pairs of distributions together, instead of apart.
-two_mass_distributions = distributions.Uniform(mass1=(1.6, 3.0),
-                                               mass2=(1.6, 3.0))
+two_mass_distributions = distributions.Uniform(mass3=(1.6, 3.0),
+                                               mass4=(1.6, 3.0))
 two_mass_samples = two_mass_distributions.rvs(size=1000000)
 
 # Choose 20 mass bins for the histogram subplots.
@@ -33,8 +33,8 @@ ax0, ax1, ax2, ax3, = axes.flat
 
 ax0.hist(mass1_samples['mass1'], bins = n_bins)
 ax1.hist(mass2_samples['mass2'], bins = n_bins)
-ax2.hist(two_mass_samples['mass1'], bins = n_bins)
-ax3.hist(two_mass_samples['mass2'], bins = n_bins)
+ax2.hist(two_mass_samples['mass3'], bins = n_bins)
+ax3.hist(two_mass_samples['mass4'], bins = n_bins)
 
 ax0.set_title('Mass 1 samples')
 ax1.set_title('Mass 2 samples')

--- a/examples/distributions/mass_examples.py
+++ b/examples/distributions/mass_examples.py
@@ -1,6 +1,5 @@
 import matplotlib.pyplot as plt
 from pycbc.inference import distributions
-import numpy as np
 
 # Create a mass distribution object that is uniform between 0.5 and 1.5
 # solar masses.

--- a/examples/distributions/mass_examples.py
+++ b/examples/distributions/mass_examples.py
@@ -23,8 +23,8 @@ two_mass_distributions = distributions.Uniform(mass3=(1.6, 3.0),
                                                mass4=(1.6, 3.0))
 two_mass_samples = two_mass_distributions.rvs(size=1000000)
 
-# Choose 20 bins for the histogram subplots.
-n_bins = 20
+# Choose 50 bins for the histogram subplots.
+n_bins = 50
 
 # Plot histograms of samples in subplots
 fig, axes = plt.subplots(nrows=2, ncols=2)

--- a/examples/distributions/mass_examples.py
+++ b/examples/distributions/mass_examples.py
@@ -7,26 +7,26 @@ mass1_distribution = distributions.Uniform(mass1=(0.5, 1.5))
 # Take 100000 random variable samples from this uniform mass distribution.
 mass1_samples = mass1_distribution.rvs(size=1000000)
 
-# Create another mass distribution object that is Gaussian between 0.5 and
-# 1.5 solar masses with a mean of 1.2 solar masses and a standard deviation
-# of 0.15 solar masses. Gaussian takes the variance as an output so square
-# the standard deviation.
+# Draw another distribution that is Gaussian between 0.5 and 1.5 solar masses
+# with a mean of 1.2 solar masses and a standard deviation of 0.15 solar
+# masses. Gaussian takes the variance as an input so square the standard
+# deviation.
 variance = 0.15*0.15
-mass2_distribution = distributions.Gaussian(mass2=(0.5, 1.5), mass2_mean=1.2,
-                                            mass2_var=variance)
+mass2_gaussian = distributions.Gaussian(mass2=(0.5, 1.5), mass2_mean=1.2,
+                                        mass2_var=variance)
 
 # Take 100000 random variable samples from this gaussian mass distribution.
-mass2_samples = mass2_distribution.rvs(size=1000000)
+mass2_samples = mass2_gaussian.rvs(size=1000000)
 
 # We can make pairs of distributions together, instead of apart.
 two_mass_distributions = distributions.Uniform(mass3=(1.6, 3.0),
                                                mass4=(1.6, 3.0))
 two_mass_samples = two_mass_distributions.rvs(size=1000000)
 
-# Choose 20 mass bins for the histogram subplots.
+# Choose 20 bins for the histogram subplots.
 n_bins = 20
 
-# Make some subplots
+# Plot histograms of samples in subplots
 fig, axes = plt.subplots(nrows=2, ncols=2)
 ax0, ax1, ax2, ax3, = axes.flat
 

--- a/examples/distributions/mass_examples.py
+++ b/examples/distributions/mass_examples.py
@@ -1,0 +1,45 @@
+import matplotlib.pyplot as plt
+from pycbc.inference import distributions
+import numpy as np
+
+# Create a mass distribution object that is uniform between 0.5 and 1.5
+# solar masses.
+mass1_distribution = distributions.Uniform(mass1=(0.5, 1.5))
+# Take 100000 random variable samples from this uniform mass distribution.
+mass1_samples = mass1_distribution.rvs(size=1000000)
+
+# Create another mass distribution object that is Gaussian between 0.5 and
+# 1.5 solar masses with a mean of 1.2 solar masses and a standard deviation
+# of 0.15 solar masses. Gaussian takes the variance as an output so square
+# the standard deviation.
+variance = 0.15*0.15
+mass2_distribution = distributions.Gaussian(mass2=(0.5, 1.5), mass2_mean=1.2,
+                                            mass2_var=variance)
+
+# Take 100000 random variable samples from this gaussian mass distribution.
+mass2_samples = mass2_distribution.rvs(size=1000000)
+
+# We can make pairs of distributions together, instead of apart.
+two_mass_distributions = distributions.Uniform(mass1=(1.6, 3.0),
+                                               mass2=(1.6, 3.0))
+two_mass_samples = two_mass_distributions.rvs(size=1000000)
+
+# Choose 20 mass bins for the histogram subplots.
+n_bins = 20
+
+# Make some subplots
+fig, axes = plt.subplots(nrows=2, ncols=2)
+ax0, ax1, ax2, ax3, = axes.flat
+
+ax0.hist(mass1_samples['mass1'], bins = n_bins)
+ax1.hist(mass2_samples['mass2'], bins = n_bins)
+ax2.hist(two_mass_samples['mass1'], bins = n_bins)
+ax3.hist(two_mass_samples['mass2'], bins = n_bins)
+
+ax0.set_title('Mass 1 samples')
+ax1.set_title('Mass 2 samples')
+ax2.set_title('Mass 3 samples')
+ax3.set_title('Mass 4 samples')
+
+plt.tight_layout()
+plt.show()

--- a/examples/distributions/spin_examples.py
+++ b/examples/distributions/spin_examples.py
@@ -3,46 +3,39 @@ from pycbc.inference import distributions
 import pycbc.coordinates as co
 import numpy as np
 
-# We can choose any bounds between 0 and pi
-# for this distribution but in units of pi
-# so we use between 0 and 1
+# We can choose any bounds between 0 and pi for this distribution but in
+# units of pi so we use between 0 and 1
 theta_low = 0.
 theta_high = 1.
 
-# Units of pi for the bounds of the azimuthal angle
-# which goes from 0 to 2 pi
+# Units of pi for the bounds of the azimuthal angle which goes from 0 to 2 pi
 phi_low = 0.
 phi_high = 2.
 
-# Create a distribution object from distributions.py
-# Here we are using the Uniform Solid Angle function
-# which takes theta = polar_bounds(theta_lower_bound
-# to a theta_upper_bound), and then phi = azimuthal_
-# bound(phi_lower_bound to a phi_upper_bound).
+# Create a distribution object from distributions.py. Here we are using the
+# Uniform Solid Angle function which takes
+# theta = polar_bounds(theta_lower_bound to a theta_upper_bound), and then
+# phi = azimuthal_ bound(phi_lower_bound to a phi_upper_bound).
 uniform_solid_angle_distribution = distributions.UniformSolidAngle(
                                           polar_bounds=(theta_low,theta_high),
                                           azimuthal_bounds=(phi_low,phi_high))
 
-# Now we can take a random variable sample from that
-# distribution. In this case we want 50000 samples.
+# Now we can take a random variable sample from that distribution. In this
+# case we want 50000 samples.
 solid_angle_samples = uniform_solid_angle_distribution.rvs(size=50000)
 
-# Make a spin 1 magnitude since solid angle is only
-# 2 dimensions and we need a 3rd dimension for a 3D
-# plot that we make later on
+# Make spins with unit length for coordinate transformation below.
 spin_mag = np.ndarray(shape=(50000), dtype=float)
 
 for i in range(0,50000):
     spin_mag[i] = 1.
 
-# Use the pycbc.coordinates as co
-# spherical_to_cartesian function to convert from
-# spherical polar coordinates to cartesian coordinates
+# Use the pycbc.coordinates as co spherical_to_cartesian function to convert
+# from spherical polar coordinates to cartesian coordinates
 spinx, spiny, spinz = co.spherical_to_cartesian(spin_mag,
                                                 solid_angle_samples['phi'],
                                                 solid_angle_samples['theta'])
 
-# Let's plot what we've made so far with histograms.
 # Choose 20 mass bins for the histograms.
 n_bins = 20
 

--- a/examples/distributions/spin_examples.py
+++ b/examples/distributions/spin_examples.py
@@ -1,0 +1,63 @@
+import matplotlib.pyplot as plt
+from pycbc.inference import distributions
+import pycbc.coordinates as co
+import numpy as np
+
+# We can choose any bounds between 0 and pi
+# for this distribution but in units of pi
+# so we use between 0 and 1
+theta_low = 0.
+theta_high = 1.
+
+# Units of pi for the bounds of the azimuthal angle
+# which goes from 0 to 2 pi
+phi_low = 0.
+phi_high = 2.
+
+# Create a distribution object from distributions.py
+# Here we are using the Uniform Solid Angle function
+# which takes theta = polar_bounds(theta_lower_bound
+# to a theta_upper_bound), and then phi = azimuthal_
+# bound(phi_lower_bound to a phi_upper_bound).
+uniform_solid_angle_distribution = distributions.UniformSolidAngle(
+                                          polar_bounds=(theta_low,theta_high),
+                                          azimuthal_bounds=(phi_low,phi_high))
+
+# Now we can take a random variable sample from that
+# distribution. In this case we want 50000 samples.
+solid_angle_samples = uniform_solid_angle_distribution.rvs(size=50000)
+
+# Make a spin 1 magnitude since solid angle is only
+# 2 dimensions and we need a 3rd dimension for a 3D
+# plot that we make later on
+spin_mag = np.ndarray(shape=(50000), dtype=float)
+
+for i in range(0,50000):
+    spin_mag[i] = 1.
+
+# Use the pycbc.coordinates as co
+# spherical_to_cartesian function to convert from
+# spherical polar coordinates to cartesian coordinates
+spinx, spiny, spinz = co.spherical_to_cartesian(spin_mag,
+                                                solid_angle_samples['phi'],
+                                                solid_angle_samples['theta'])
+
+# Let's plot what we've made so far with histograms.
+# Choose 20 mass bins for the histograms.
+n_bins = 20
+
+plt.figure(figsize=(10,10))
+plt.subplot(2, 2, 1)
+plt.hist(spinx, bins = n_bins)
+plt.title('Spin x samples')
+
+plt.subplot(2, 2, 2)
+plt.hist(spiny, bins = n_bins)
+plt.title('Spin y samples')
+
+plt.subplot(2, 2, 3)
+plt.hist(spinz, bins = n_bins)
+plt.title('Spin z samples')
+
+plt.tight_layout()
+plt.show()

--- a/examples/distributions/spin_examples.py
+++ b/examples/distributions/spin_examples.py
@@ -22,12 +22,12 @@ uniform_solid_angle_distribution = distributions.UniformSolidAngle(
 
 # Now we can take a random variable sample from that distribution. In this
 # case we want 50000 samples.
-solid_angle_samples = uniform_solid_angle_distribution.rvs(size=50000)
+solid_angle_samples = uniform_solid_angle_distribution.rvs(size=500000)
 
 # Make spins with unit length for coordinate transformation below.
-spin_mag = np.ndarray(shape=(50000), dtype=float)
+spin_mag = np.ndarray(shape=(500000), dtype=float)
 
-for i in range(0,50000):
+for i in range(0,500000):
     spin_mag[i] = 1.
 
 # Use the pycbc.coordinates as co spherical_to_cartesian function to convert
@@ -36,8 +36,8 @@ spinx, spiny, spinz = co.spherical_to_cartesian(spin_mag,
                                                 solid_angle_samples['phi'],
                                                 solid_angle_samples['theta'])
 
-# Choose 20 bins for the histograms.
-n_bins = 20
+# Choose 50 bins for the histograms.
+n_bins = 50
 
 plt.figure(figsize=(10,10))
 plt.subplot(2, 2, 1)

--- a/examples/distributions/spin_examples.py
+++ b/examples/distributions/spin_examples.py
@@ -36,7 +36,7 @@ spinx, spiny, spinz = co.spherical_to_cartesian(spin_mag,
                                                 solid_angle_samples['phi'],
                                                 solid_angle_samples['theta'])
 
-# Choose 20 mass bins for the histograms.
+# Choose 20 bins for the histograms.
 n_bins = 20
 
 plt.figure(figsize=(10,10))

--- a/examples/distributions/spin_spatial_distr_example.py
+++ b/examples/distributions/spin_spatial_distr_example.py
@@ -1,0 +1,57 @@
+import matplotlib.pyplot as plt
+from pycbc.inference import distributions
+import pycbc.coordinates as co
+from mpl_toolkits.mplot3d import Axes3D
+import numpy as np
+
+# We can choose any bounds between 0 and pi
+# for this distribution but in units of pi
+# so we use between 0 and 1
+theta_low = 0.
+theta_high = 1.
+
+# Units of pi for the bounds of the azimuthal angle
+# which goes from 0 to 2 pi
+phi_low = 0.
+phi_high = 2.
+
+# Create a distribution object from distributions.py
+# Here we are using the Uniform Solid Angle function
+# which takes theta = polar_bounds(theta_lower_bound
+# to a theta_upper_bound), and then phi = azimuthal_
+# bound(phi_lower_bound to a phi_upper_bound).
+uniform_solid_angle_distribution = distributions.UniformSolidAngle(
+                                          polar_bounds=(theta_low,theta_high),
+                                          azimuthal_bounds=(phi_low,phi_high))
+
+# Now we can take a random variable sample from that
+# distribution. In this case we want 50000 samples.
+solid_angle_samples = uniform_solid_angle_distribution.rvs(size=10000)
+
+# Make a spin 1 magnitude since solid angle is only
+# 2 dimensions and we need a 3rd dimension for a 3D
+# plot that we make later on
+spin_mag = np.ndarray(shape=(10000), dtype=float)
+
+for i in range(0,10000):
+    spin_mag[i] = 1.
+
+# Use the pycbc.coordinates as co
+# spherical_to_cartesian function to convert from
+# spherical polar coordinates to cartesian coordinates
+spinx, spiny, spinz = co.spherical_to_cartesian(spin_mag,
+                                                solid_angle_samples['phi'],
+                                                solid_angle_samples['theta'])
+
+# Let's plot the spherical distribution of spins
+# to make sure that we distributed properly across
+# the surface of a sphere.
+
+fig = plt.figure(figsize=(10,10))
+ax = fig.add_subplot(111, projection='3d')
+ax.scatter(spinx, spiny, spinz, s=1)
+
+ax.set_xlabel('Spin X Axis')
+ax.set_ylabel('Spin Y Axis')
+ax.set_zlabel('Spin Z Axis')
+plt.show()

--- a/examples/distributions/spin_spatial_distr_example.py
+++ b/examples/distributions/spin_spatial_distr_example.py
@@ -4,48 +4,42 @@ import pycbc.coordinates as co
 from mpl_toolkits.mplot3d import Axes3D
 import numpy as np
 
-# We can choose any bounds between 0 and pi
-# for this distribution but in units of pi
-# so we use between 0 and 1
+# We can choose any bounds between 0 and pi for this distribution but in units
+# of pi so we use between 0 and 1.
 theta_low = 0.
 theta_high = 1.
 
-# Units of pi for the bounds of the azimuthal angle
-# which goes from 0 to 2 pi
+# Units of pi for the bounds of the azimuthal angle which goes from 0 to 2 pi.
 phi_low = 0.
 phi_high = 2.
 
 # Create a distribution object from distributions.py
-# Here we are using the Uniform Solid Angle function
-# which takes theta = polar_bounds(theta_lower_bound
-# to a theta_upper_bound), and then phi = azimuthal_
-# bound(phi_lower_bound to a phi_upper_bound).
+# Here we are using the Uniform Solid Angle function which takes
+# theta = polar_bounds(theta_lower_bound to a theta_upper_bound), and then
+# phi = azimuthal_bound(phi_lower_bound to a phi_upper_bound).
 uniform_solid_angle_distribution = distributions.UniformSolidAngle(
                                           polar_bounds=(theta_low,theta_high),
                                           azimuthal_bounds=(phi_low,phi_high))
 
-# Now we can take a random variable sample from that
-# distribution. In this case we want 50000 samples.
+# Now we can take a random variable sample from that distribution.
+# In this case we want 50000 samples.
 solid_angle_samples = uniform_solid_angle_distribution.rvs(size=10000)
 
-# Make a spin 1 magnitude since solid angle is only
-# 2 dimensions and we need a 3rd dimension for a 3D
-# plot that we make later on
+# Make a spin 1 magnitude since solid angle is only 2 dimensions and we need a
+# 3rd dimension for a 3D plot that we make later on.
 spin_mag = np.ndarray(shape=(10000), dtype=float)
 
 for i in range(0,10000):
     spin_mag[i] = 1.
 
-# Use the pycbc.coordinates as co
-# spherical_to_cartesian function to convert from
-# spherical polar coordinates to cartesian coordinates
+# Use pycbc.coordinates as co. Use  spherical_to_cartesian function to
+# convert from spherical polar coordinates to cartesian coordinates.
 spinx, spiny, spinz = co.spherical_to_cartesian(spin_mag,
                                                 solid_angle_samples['phi'],
                                                 solid_angle_samples['theta'])
 
-# Let's plot the spherical distribution of spins
-# to make sure that we distributed properly across
-# the surface of a sphere.
+# Plot the spherical distribution of spins to make sure that we
+# distributed across  the surface of a sphere.
 
 fig = plt.figure(figsize=(10,10))
 ax = fig.add_subplot(111, projection='3d')


### PR DESCRIPTION
An updated PR that includes using pycbc distributions.py to make distributions for mass and spins.

Note that this code will have to change as distributions.py moves from inference to wherever it goes next.