### PR TITLE
Generalize sngl_minifollowups

### DIFF
--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -17,6 +17,7 @@
 """ Followup foreground events
 """
 import os, sys, argparse, logging, h5py
+import numpy
 from glue.ligolw import lsctables, table
 from glue.ligolw import utils as ligolw_utils
 from pycbc.results import layout
@@ -66,6 +67,9 @@ parser.add_argument('--non-coinc-time-only', default=False,
                     help="If given remove (veto) single-detector triggers "
                          "that occur during a time when at least one other "
                          "instrument is taking science data.")
+parser.add_argument('--minimum-duration', default=None, type=int,
+                    help="If given only consider single-detector triggers "
+                         "with template duration larger than this.")
 parser.add_argument('--output-map')
 parser.add_argument('--output-file')
 parser.add_argument('--tags', nargs='+', default=[])
@@ -95,7 +99,7 @@ insp_data_seglists = select_segments_by_definer\
         (args.inspiral_segments, segment_name=args.inspiral_data_read_name,
          ifo=args.instrument)
 
-num_events = int(workflow.cp.get_opt_tags('workflow-minifollowups',
+num_events = int(workflow.cp.get_opt_tags('workflow-sngl_minifollowups',
                  'num-sngl-events', ''))
 
 trigs = hdf.SingleDetTriggers(args.single_detector_file, args.bank_file,
@@ -117,6 +121,15 @@ if args.non_coinc_time_only:
             trigs.end_time, [args.inspiral_segments],
             ifo=ifo, segment_name=args.inspiral_data_analyzed_name)
         trigs.mask = trigs.mask[curr_veto_mask]
+if args.minimum_duration is not None:
+    durations = trigs.template_duration
+    lgc_mask = durations > args.minimum_duration
+    if trigs.mask.dtype == 'bool':
+        orig_indices = trigs.mask.nonzero()[0][lgc_mask]
+        trigs.mask = numpy.in1d(numpy.arange(len(trigs.mask)), orig_indices,
+                                assume_unique=True)
+    else:
+        trigs.mask = trigs.mask[lgc_mask]
 
 if len(trigs.snr) == 0:
     # There are no triggers, make no-op job and exit

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -67,7 +67,7 @@ parser.add_argument('--non-coinc-time-only', default=False,
                     help="If given remove (veto) single-detector triggers "
                          "that occur during a time when at least one other "
                          "instrument is taking science data.")
-parser.add_argument('--minimum-duration', default=None, type=int,
+parser.add_argument('--minimum-duration', default=None, type=float,
                     help="If given only consider single-detector triggers "
                          "with template duration larger than this.")
 parser.add_argument('--output-map')

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -354,22 +354,25 @@ for bin_file in bin_files:
                                   'daxes', currdir, tags=bin_file.tags)
 
 # Also run minifollowups on loudest sngl detector events
+excl_subsecs = set([])
+
+for insp_file in full_insps:
+    for tag in insp_file.tags:
+        excl_subsecs.add(tag)
+
 for insp_file in full_insps:
     curr_ifo = insp_file.ifo
-    currdir = rdir['single_triggers/%s_loudest_all_time' %(curr_ifo,)]
-    wf.setup_single_det_minifollowups(workflow, insp_file, hdfbank[0],
-                                  insp_files_seg_file, data_analysed_name,
-                                  trig_generated_name, 'daxes', currdir,
-                                  veto_file=censored_veto,
-                                  veto_segment_name='closed_box',
-                                  tags=insp_file.tags)
-    currdir = rdir['single_triggers/%s_loudest_noncoinc_time' %(curr_ifo,)]
-    wf.setup_single_det_minifollowups(workflow, insp_file, hdfbank[0],
-                                  insp_files_seg_file, data_analysed_name,
-                                  trig_generated_name, 'daxes', currdir,
-                                  veto_file=censored_veto,
-                                  veto_segment_name='closed_box',
-                                  tags=insp_file.tags+['noncoinconly'])
+    for subsec in workflow.cp.get_subsections('workflow-sngl_minifollowups'):
+        if subsec in excl_subsecs:
+            continue
+        sec_name = 'workflow-sngl_minifollowups-{}'.format(subsec)
+        dir_str = workflow.cp.get(sec_name, section_header)
+        currdir = rdir['single_triggers/{}_{}'.format(curr_ifo, dir_str)]
+        wf.setup_single_det_minifollowups(workflow, insp_file, hdfbank[0],
+                                      insp_files_seg_file, data_analysed_name,
+                                      trig_generated_name, 'daxes', currdir,
+                                      veto_file=censored_veto,
+                                      veto_segment_name='closed_box',
 
 ################## Setup segment / veto related plots #########################
 # do plotting of segments / veto times

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -366,13 +366,14 @@ for insp_file in full_insps:
         if subsec in excl_subsecs:
             continue
         sec_name = 'workflow-sngl_minifollowups-{}'.format(subsec)
-        dir_str = workflow.cp.get(sec_name, section_header)
+        dir_str = workflow.cp.get(sec_name, 'section-header')
         currdir = rdir['single_triggers/{}_{}'.format(curr_ifo, dir_str)]
         wf.setup_single_det_minifollowups(workflow, insp_file, hdfbank[0],
                                       insp_files_seg_file, data_analysed_name,
                                       trig_generated_name, 'daxes', currdir,
                                       veto_file=censored_veto,
                                       veto_segment_name='closed_box',
+                                      tags=insp_file.tags + [subsec])
 
 ################## Setup segment / veto related plots #########################
 # do plotting of segments / veto times

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -368,15 +368,15 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
             # the user is trying to use an subsection name with '-' in it
             if (len(sp) > 1) and not self.has_section('%s-%s' % (section_name,
                                                                  sp[0])):
-                 raise ValueError( "Workflow uses the '-' as a delimiter so "
-                     "this is interpreted as section-subsection-tag. "
-                     "While checking section %s, no section with "
-                     "name %s-%s was found. " 
-                     "If you did not intend to use tags in an "
-                     "'advanced user' manner, or do not understand what "
-                     "this means, don't use dashes in section "
-                     "names. So [injection-nsbhinj] is good. "
-                     "[injection-nsbh-inj] is not." % (sec, sp[0], sp[1]))
+                raise ValueError( "Workflow uses the '-' as a delimiter so "
+                    "this is interpreted as section-subsection-tag. "
+                    "While checking section %s, no section with "
+                    "name %s-%s was found. " 
+                    "If you did not intend to use tags in an "
+                    "'advanced user' manner, or do not understand what "
+                    "this means, don't use dashes in section "
+                    "names. So [injection-nsbhinj] is good. "
+                    "[injection-nsbh-inj] is not." % (sec, sp[0], sp[1]))
         
         if len(subsections) > 0:
             return [sec.split('-')[0] for sec in subsections]

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -357,16 +357,19 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
     def get_subsections(self, section_name):
         """ Return a list of subsections for the given section name
         """
-        subsections = [sec for sec in  self.sections() if sec.startswith(section_name + '-')]   
+        # Keep only subsection names
+        subsections = [sec[len(section_name)+1:] for sec in self.sections()\
+                       if sec.startswith(section_name + '-')]   
 
         for sec in subsections:
             sp = sec.split('-')
             # This is unusual, but a format [section-subsection-tag] is okay. Just
             # check that [section-subsection] section exists. If not it is possible
             # the user is trying to use an subsection name with '-' in it
-            if (len(sp) > 1) and not self.has_section('%s-%s' % (sp[0], sp[1])):
-                 raise ValueError( "Workflow uses the '-' as a delimiter so this is"
-                     "interpreted as section-subsection-tag. "
+            if (len(sp) > 1) and not self.has_section('%s-%s' % (section_name,
+                                                                 sp[0])):
+                 raise ValueError( "Workflow uses the '-' as a delimiter so "
+                     "this is interpreted as section-subsection-tag. "
                      "While checking section %s, no section with "
                      "name %s-%s was found. " 
                      "If you did not intend to use tags in an "
@@ -376,7 +379,7 @@ class WorkflowConfigParser(glue.pipeline.DeepCopyableConfigParser):
                      "[injection-nsbh-inj] is not." % (sec, sp[0], sp[1]))
         
         if len(subsections) > 0:
-            return [sec.split('-')[1] for sec in subsections]
+            return [sec.split('-')[0] for sec in subsections]
         elif self.has_section(section_name):
             return ['']
         else:

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -145,8 +145,8 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     """
     logging.info('Entering minifollowups module')
 
-    if not workflow.cp.has_section('workflow-minifollowups'):
-        msg = 'There is no [workflow-minifollowups] section in '
+    if not workflow.cp.has_section('workflow-sngl_minifollowups'):
+        msg = 'There is no [workflow-sngl_minifollowups] section in '
         msg += 'configuration file'
         logging.info(msg)
         logging.info('Leaving minifollowups')


### PR DESCRIPTION
Make the sngl minifollowups a little more general in the coinc_search_workflow, allowing for a larger number of such settings, with parameters given in the ini file.

Additional filtering options can be added to pycbc_sngl_minifollowup if one wanted to filter by mass, or by spins.

Unfortunately, this does require config file changes and is not backwards compatible. I will open a pull request with changes needed in the ini files, but that probably shouldn't be merged until this appears in a release.

Note: The changes to get_subsections are to allow this to work when a section_name that is itself a subsection like ['workflow-minifollowups'] is given.