### PR TITLE
Fix bugs in condition strain

### DIFF
--- a/bin/pycbc_condition_strain
+++ b/bin/pycbc_condition_strain
@@ -46,20 +46,20 @@ parser.add_argument('--output-gates-file',
 parser.add_argument('--single-precision', action='store_true',
                     help='Multiply the conditioned strain by %f and save it '
                          'in single precision' % pycbc.DYN_RANGE_FAC)
+parser.add_argument('--low-frequency-cutoff', type=float,
+                    help='Provide a low-frequency-cutoff for fake strain. '
+                         'This is only needed if fake-strain or '
+                         'fake-strain-from-file is used.')
 pycbc.strain.insert_strain_option_group(parser)
 args = parser.parse_args()
 
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
-strain = pycbc.strain.from_cli(args, pycbc.DYN_RANGE_FAC)
-
 if args.single_precision:
-    out_strain = strain
+    precision = 'single'
 else:
-    out_strain = pycbc.types.TimeSeries(strain, delta_t=strain.delta_t,
-                                        epoch=strain.start_time,
-                                        dtype=pycbc.types.float64)
-    out_strain /= pycbc.DYN_RANGE_FAC
+    precision = 'double'
+out_strain = pycbc.strain.from_cli(args, pycbc.DYN_RANGE_FAC, precision=precision)
 
 logging.info('Writing output strain')
 output_channel_name = args.output_channel_name or args.channel_name


### PR DESCRIPTION
Currently, `pycbc_condition_strain` will fail if you try to generate fake strain from a psd file, as this option needs a `low-frequency-cutoff` option to be in the set of options. I suppose you could argue this is actually a bug in the strain module since `strain.insert_strain_option_group` doesn't add that option even though `strain.from_cli` looks for it when the fake strain options are used. However, since `pycbc_inspiral` and, I think, some other programs would get conflict errors if `low-frequency-cutoff` was added to the strain option group, the easiest thing to do is to just add this option separately to `pycbc_condition_strain`.

This patch also makes it so that if double precision is desired, that is just passed to `strain.from_cli`, instead of casting to single then casting back to double.