### PR TITLE
Add Geweke convergence diagnostic statistic

### DIFF
--- a/bin/inference/pycbc_inference_plot_geweke
+++ b/bin/inference/pycbc_inference_plot_geweke
@@ -20,11 +20,12 @@
 
 import argparse
 import logging
-#import matplotlib as mpl; mpl.use("Agg")
+import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
 from pycbc import results
 from pycbc.inference import geweke
 from pycbc.inference import option_utils
+import sys
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
@@ -83,6 +84,9 @@ fp, params, labels, _ = option_utils.results_from_cli(
 # get walkers to plot
 nwalkers = fp.nwalkers if opts.walkers is None else opts.walkers
 
+# create Figure
+fig = plt.figure()
+
 # loop over each parameter
 for param, label in zip(params, labels):
     logging.info("Plotting parameter %s", param)
@@ -110,15 +114,25 @@ for param, label in zip(params, labels):
         for start, end, stat in zip(starts, ends, stats):
             plt.plot([start, end], [stat, stat], "k")
 
-    # format plot
-    plt.ylabel(label)
-    plt.xlabel("Iteration")
+# format plot
+plt.ylabel(", ".join(labels))
+plt.xlabel("Iteration")
 
-    # plot horizontal lines at -1 and 1
-    plt.hlines([-1, 1], 0, len(vals), linestyles="dashed")
+# plot horizontal lines at -1 and 1
+plt.hlines([-1, 1], 0, len(vals), "r", linestyles="dashed")
 
-    # show plot for parameter
-    plt.show()
+# save figure with meta-data
+caption_kwargs = {
+    "parameters" : ", ".join(labels),
+}
+caption = """The Geweke convergence diagnostic statistic for {parameters}
+read from the input file.""".format(**caption_kwargs)
+title = "Geweke Convergence for {parameters}".format(**caption_kwargs)
+results.save_fig_with_metadata(fig, opts.output_file,
+                               cmd=" ".join(sys.argv),
+                               title=title,
+                               caption=caption)
+plt.close()
 
 # exit
 fp.close()

--- a/bin/inference/pycbc_inference_plot_geweke
+++ b/bin/inference/pycbc_inference_plot_geweke
@@ -82,7 +82,8 @@ fp, params, labels, _ = option_utils.results_from_cli(
                                          opts, load_samples=True, walkers=None)
 
 # get walkers to plot
-nwalkers = fp.nwalkers if opts.walkers is None else opts.walkers
+walkers = range(fp.nwalkers) if opts.walkers is None else opts.walkers
+nwalkers = len(walkers)
 
 # create Figure
 fig = plt.figure()
@@ -92,7 +93,8 @@ for param, label in zip(params, labels):
     logging.info("Plotting parameter %s", param)
 
     # loop over walkers
-    for j in nwalkers:
+    for j in walkers:
+        logging.info("Plotting walker %d of %d", j, nwalkers)
 
         # plot each walker
         y = fp.read_samples(param, walkers=j,

--- a/bin/inference/pycbc_inference_plot_geweke
+++ b/bin/inference/pycbc_inference_plot_geweke
@@ -34,9 +34,12 @@ parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
 parser.add_argument("--verbose", action="store_true", default=False,
     help="Print logging info.")
 
-# output 1-D histogram options
+# output options
 parser.add_argument("--output-file", type=str, required=True,
                     help="Path to output plot.")
+parser.add_argument("--walkers", type=int, nargs="+", default=None,
+                    help="Specific walkers to plot. Default is plot "
+                         "all walkers.")
 
 # add results group
 option_utils.add_inference_results_option_group(parser)
@@ -60,12 +63,15 @@ if opts.iteration is not None:
 fp, params, labels, _ = option_utils.results_from_cli(
                                          opts, load_samples=True, walkers=None)
 
+# get walkers to plot
+nwalkers = fp.nwalkers if opts.walkers is None else opts.walkers
+
 # loop over each parameter
 for param, label in zip(params, labels):
     logging.info("Plotting parameter %s", param)
 
     # loop over walkers
-    for j in range(fp.nwalkers):
+    for j in nwalkers:
 
         # plot each walker
         y = fp.read_samples(param, walkers=j,
@@ -77,10 +83,10 @@ for param, label in zip(params, labels):
         vals = y[param]
 
         # settings for Geweke
-        seg_length = 500
-        seg_stride = 250
-        end_idx = 30000 #len(vals) / 2
-        ref_start = -1000 #len(vals) / 2 + 1
+        seg_length = 2000
+        seg_stride = 1000
+        end_idx = len(vals) / 2
+        ref_start = len(vals) / 2 + 1
         ref_end = None
         seg_start = 0
 
@@ -94,8 +100,13 @@ for param, label in zip(params, labels):
         for start, end, stat in zip(starts, ends, stats):
             plt.plot([start, end], [stat, stat], "k")
 
-    # show plot for parameter
+    # format plot
     plt.ylabel(label)
+
+    # plot horizontal lines at -1 and 1
+    plt.hlines([-1, 1], 0, len(vals), linestyles="dashed")
+
+    # show plot for parameter
     plt.show()
 
 # exit

--- a/bin/inference/pycbc_inference_plot_geweke
+++ b/bin/inference/pycbc_inference_plot_geweke
@@ -1,0 +1,102 @@
+#! /usr/bin/env python
+
+# Copyright (C) 2017 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+""" Plots the Geweke convergence diagnositic statistic.
+"""
+
+import argparse
+import logging
+#import matplotlib as mpl; mpl.use("Agg")
+import matplotlib.pyplot as plt
+from pycbc import results
+from pycbc.inference import geweke
+from pycbc.inference import option_utils
+
+# command line usage
+parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
+                                 description=__doc__)
+
+# verbose option
+parser.add_argument("--verbose", action="store_true", default=False,
+    help="Print logging info.")
+
+# output 1-D histogram options
+parser.add_argument("--output-file", type=str, required=True,
+                    help="Path to output plot.")
+
+# add results group
+option_utils.add_inference_results_option_group(parser)
+
+# parse the command line
+opts = parser.parse_args()
+
+# setup log
+if opts.verbose:
+    log_level = logging.DEBUG
+else:
+    log_level = logging.WARN
+logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
+
+# enfore that this is not a single iteration
+# since that does not make sense for the Geweke convergence test
+if opts.iteration is not None:
+    raise ValueError("Cannot use --iteration")
+
+# load the results
+fp, params, labels, _ = option_utils.results_from_cli(
+                                         opts, load_samples=True, walkers=None)
+
+# loop over each parameter
+for param, label in zip(params, labels):
+
+    # loop over walkers
+    for j in range(fp.nwalkers):
+
+        # plot each walker
+        y = fp.read_samples(param, walkers=j,
+                            thin_start=opts.thin_start,
+                            thin_interval=opts.thin_interval,
+                            thin_end=opts.thin_end)
+
+        # get samples for this parameter
+        vals = y[param]
+
+        # settings for Geweke
+        seg_length = 500
+        seg_stride = 250
+        end_idx = 30000 #len(vals) / 2
+        ref_start = -1000 #len(vals) / 2 + 1
+        ref_end = None
+        seg_start = 0
+
+        # calculate the Geweke convergence statistic
+        starts, ends, stats = geweke.geweke(vals, seg_length, seg_stride,
+                                            end_idx, ref_start,
+                                            ref_end=ref_end,
+                                            seg_start=seg_start)
+
+        # plot walker
+        for start, end, stat in zip(starts, ends, stats):
+            plt.plot([start, end], [stat, stat], "k")
+
+    # show plot for parameter
+    plt.ylabel(label)
+    plt.show()
+
+# exit
+fp.close()
+logging.info("Done")

--- a/bin/inference/pycbc_inference_plot_geweke
+++ b/bin/inference/pycbc_inference_plot_geweke
@@ -41,6 +41,23 @@ parser.add_argument("--walkers", type=int, nargs="+", default=None,
                     help="Specific walkers to plot. Default is plot "
                          "all walkers.")
 
+# Geweke calculation options
+parser.add_argument("--segment-length", type=int, required=True,
+                    help="Number of iterations to use in calculation.")
+parser.add_argument("--segment-stride", type=int, required=True,
+                    help="How many iterations to advance for next calculation "
+                         "along chain.")
+parser.add_argument("--segment-start", type=int, required=True,
+                    help="Start iteration for calculating statistic.")
+parser.add_argument("--segment-end", type=int, required=True,
+                    help="End iteration for calculating statistic.")
+parser.add_argument("--reference-start", type=int, required=True,
+                    help="Start of reference segment for "
+                         "calculating statistic.")
+parser.add_argument("--reference-end", type=int, required=True,
+                    help="End of reference segment for "
+                         "calculating statistic.")
+
 # add results group
 option_utils.add_inference_results_option_group(parser)
 
@@ -82,19 +99,12 @@ for param, label in zip(params, labels):
         # get samples for this parameter
         vals = y[param]
 
-        # settings for Geweke
-        seg_length = 2000
-        seg_stride = 1000
-        end_idx = len(vals) / 2
-        ref_start = len(vals) / 2 + 1
-        ref_end = None
-        seg_start = 0
-
         # calculate the Geweke convergence statistic
-        starts, ends, stats = geweke.geweke(vals, seg_length, seg_stride,
-                                            end_idx, ref_start,
-                                            ref_end=ref_end,
-                                            seg_start=seg_start)
+        starts, ends, stats = geweke.geweke(
+                                vals, opts.segment_length, opts.segment_stride,
+                                opts.segment_end, opts.reference_start,
+                                ref_end=opts.reference_end,
+                                seg_start=opts.segment_start)
 
         # plot walker
         for start, end, stat in zip(starts, ends, stats):
@@ -102,6 +112,7 @@ for param, label in zip(params, labels):
 
     # format plot
     plt.ylabel(label)
+    plt.xlabel("Iteration")
 
     # plot horizontal lines at -1 and 1
     plt.hlines([-1, 1], 0, len(vals), linestyles="dashed")

--- a/bin/inference/pycbc_inference_plot_geweke
+++ b/bin/inference/pycbc_inference_plot_geweke
@@ -22,6 +22,7 @@ import argparse
 import logging
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
+import pycbc
 from pycbc import results
 from pycbc.inference import geweke
 from pycbc.inference import option_utils
@@ -66,11 +67,7 @@ option_utils.add_inference_results_option_group(parser)
 opts = parser.parse_args()
 
 # setup log
-if opts.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
+pycbc.init_logging(opts.verbose)
 
 # enfore that this is not a single iteration
 # since that does not make sense for the Geweke convergence test

--- a/bin/inference/pycbc_inference_plot_geweke
+++ b/bin/inference/pycbc_inference_plot_geweke
@@ -62,6 +62,7 @@ fp, params, labels, _ = option_utils.results_from_cli(
 
 # loop over each parameter
 for param, label in zip(params, labels):
+    logging.info("Plotting parameter %s", param)
 
     # loop over walkers
     for j in range(fp.nwalkers):

--- a/bin/inference/pycbc_inference_plot_geweke
+++ b/bin/inference/pycbc_inference_plot_geweke
@@ -76,7 +76,8 @@ if opts.iteration is not None:
 
 # load the results
 fp, params, labels, _ = option_utils.results_from_cli(
-                                         opts, load_samples=True, walkers=None)
+                                         opts, load_samples=False,
+                                         walkers=None)
 
 # get walkers to plot
 walkers = range(fp.nwalkers) if opts.walkers is None else opts.walkers

--- a/pycbc/inference/geweke.py
+++ b/pycbc/inference/geweke.py
@@ -1,3 +1,18 @@
+# Copyright (C) 2017 Christopher M. Biwer
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """ Functions for computing the Geweke convergence statistic.
 """
 

--- a/pycbc/inference/geweke.py
+++ b/pycbc/inference/geweke.py
@@ -10,6 +10,8 @@ def geweke(x, seg_length, seg_stride, end_idx, ref_idx):
         A one-dimensional array of data.
     seg_length : int
         Number of samples to use for each Geweke calculation.
+    seg_stride : int
+        Number of samples to advance before next Geweke calculation.
     end_idx : int
         Index of last start.
     ref_idx : int

--- a/pycbc/inference/geweke.py
+++ b/pycbc/inference/geweke.py
@@ -3,43 +3,45 @@
 
 import numpy
 
-def geweke(x, num_samples, last_start, last, intervals, stride):
+def geweke(x, seg_length, seg_stride, end_idx, ref_idx):
     """ Calculates Geweke.
 
     x : numpy.array
         A one-dimensional array of data.
-    num_samples : int
+    seg_length : int
         Number of samples to use for each Geweke calculation.
-    last_start : int
+    end_idx : int
         Index of last start.
-    last : int
+    ref_idx : int
         Index of beginning of end segment.
-    intervals : int
-        Number of intervals to split data into.
-    stride : int
+    seg_stride : int
         How far of a step to take for each point.
     """
+
+    # lists to hold statistic and end index
     stats = []
-
-    end = len(x) - 1
-
-    step = int(last / (intervals - 1))
-
-    starts = numpy.arange(0, last_start, stride)
     ends = []
 
+    # get the beginning of all segments
+    starts = numpy.arange(0, end_idx, seg_stride)
+
+    # get second segment of data at the end to compare
+    x_end = x[ref_idx:]
+
+    # loop over all segments
     for start in starts:
 
-        x_start_end = int(start + num_samples)
-        x_end_start = int(end - last)
+        # find the end of the first segment
+        x_start_end = int(start + seg_length)
 
+        # get first segment
         x_start = x[start:x_start_end]
-        x_end = x[x_end_start:]
 
-        print start, x_start_end, x_end_start
-
+        # compute statistic
         stats.append((x_start.mean() - x_end.mean())
                      / numpy.sqrt(x_start.var() + x_end.var()))
+
+        # store end of first segment
         ends.append(x_start_end)
 
     return numpy.array(starts), numpy.array(ends), numpy.array(stats)

--- a/pycbc/inference/geweke.py
+++ b/pycbc/inference/geweke.py
@@ -1,0 +1,45 @@
+""" Functions for computing the Geweke convergence statistic.
+"""
+
+import numpy
+
+def geweke(x, num_samples, last_start, last, intervals, stride):
+    """ Calculates Geweke.
+
+    x : numpy.array
+        A one-dimensional array of data.
+    num_samples : int
+        Number of samples to use for each Geweke calculation.
+    last_start : int
+        Index of last start.
+    last : int
+        Index of beginning of end segment.
+    intervals : int
+        Number of intervals to split data into.
+    stride : int
+        How far of a step to take for each point.
+    """
+    stats = []
+
+    end = len(x) - 1
+
+    step = int(last / (intervals - 1))
+
+    starts = numpy.arange(0, last_start, stride)
+    ends = []
+
+    for start in starts:
+
+        x_start_end = int(start + num_samples)
+        x_end_start = int(end - last)
+
+        x_start = x[start:x_start_end]
+        x_end = x[x_end_start:]
+
+        print start, x_start_end, x_end_start
+
+        stats.append((x_start.mean() - x_end.mean())
+                     / numpy.sqrt(x_start.var() + x_end.var()))
+        ends.append(x_start_end)
+
+    return numpy.array(starts), numpy.array(ends), numpy.array(stats)

--- a/pycbc/inference/geweke.py
+++ b/pycbc/inference/geweke.py
@@ -3,7 +3,8 @@
 
 import numpy
 
-def geweke(x, seg_length, seg_stride, end_idx, ref_idx):
+def geweke(x, seg_length, seg_stride, end_idx, ref_start,
+           ref_end=None, seg_start=0):
     """ Calculates Geweke.
 
     x : numpy.array
@@ -14,10 +15,14 @@ def geweke(x, seg_length, seg_stride, end_idx, ref_idx):
         Number of samples to advance before next Geweke calculation.
     end_idx : int
         Index of last start.
-    ref_idx : int
-        Index of beginning of end segment.
-    seg_stride : int
-        How far of a step to take for each point.
+    ref_start : int
+        Index of beginning of end reference segment.
+    ref_end : int
+        Index of end of end reference segment. Default is None which
+        will go to the end of the data array.
+    seg_start : int
+        What index to start computing the statistic. Default is 0 which
+        will go to the beginning of the data array.
     """
 
     # lists to hold statistic and end index
@@ -25,10 +30,10 @@ def geweke(x, seg_length, seg_stride, end_idx, ref_idx):
     ends = []
 
     # get the beginning of all segments
-    starts = numpy.arange(0, end_idx, seg_stride)
+    starts = numpy.arange(seg_start, end_idx, seg_stride)
 
     # get second segment of data at the end to compare
-    x_end = x[ref_idx:]
+    x_end = x[ref_start:ref_end]
 
     # loop over all segments
     for start in starts:

--- a/pycbc/inference/geweke.py
+++ b/pycbc/inference/geweke.py
@@ -5,7 +5,9 @@ import numpy
 
 def geweke(x, seg_length, seg_stride, end_idx, ref_start,
            ref_end=None, seg_start=0):
-    """ Calculates Geweke.
+    """ Calculates Geweke conervergence statistic for a chain of data.
+    This function will advance along the chain and calculate the
+    statistic for each step.
 
     x : numpy.array
         A one-dimensional array of data.

--- a/pycbc/inference/geweke.py
+++ b/pycbc/inference/geweke.py
@@ -9,6 +9,8 @@ def geweke(x, seg_length, seg_stride, end_idx, ref_start,
     This function will advance along the chain and calculate the
     statistic for each step.
 
+    Parameters
+    ----------
     x : numpy.array
         A one-dimensional array of data.
     seg_length : int
@@ -25,6 +27,15 @@ def geweke(x, seg_length, seg_stride, end_idx, ref_start,
     seg_start : int
         What index to start computing the statistic. Default is 0 which
         will go to the beginning of the data array.
+
+    Returns
+    -------
+    starts : numpy.array
+        The start index of the first segment in the chain.
+    ends : numpy.array
+        The end index of the first segment in the chain.
+    stats : numpy.array
+        The Geweke convergence diagnostic statistic for the segment.
     """
 
     # lists to hold statistic and end index

--- a/setup.py
+++ b/setup.py
@@ -440,6 +440,7 @@ setup (
                'bin/inference/pycbc_inference_plot_acf',
                'bin/inference/pycbc_inference_plot_acl',
                'bin/inference/pycbc_inference_plot_corner',
+               'bin/inference/pycbc_inference_plot_geweke',
                'bin/inference/pycbc_inference_plot_movie',
                'bin/inference/pycbc_inference_plot_posterior',
                'bin/inference/pycbc_inference_plot_prior',


### PR DESCRIPTION
There are a couple convergence/divergence tests for posteriors that I would like to add. The simplest convergence test to implement is the Geweke convergence diagnostic. Basically it checks how similar the mean for a segment at the beginning of a chain is to a segment at the end of the chain. If the chain has converged then the mean shouldn't vary much and should fall within [-1,1] if its converged.

This is marked worked in progress because I'm still making some example plots but wanted to share that this is being worked on. Other tests we should add (and I plan to look at after this) are the Gelman-Rubin convergence and Kullback-Leibler divergence statistics.