### PR TITLE
Fix the docs ... again.

### DIFF
--- a/docs/Makefile.std
+++ b/docs/Makefile.std
@@ -45,7 +45,7 @@ clean:
 
 html:
 	python removeGPUmods.py
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -W -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/psd.rst
+++ b/docs/psd.rst
@@ -23,8 +23,6 @@ and demonstrate how to generate one.
 .. plot:: ../examples/psd/analytic.py
    :include-source:
 
-.. command-output:: python ../examples/psd/analytic.py
-
 ====================================
 Estimating the PSD of a time series
 ====================================

--- a/pycbc/results/followup.py
+++ b/pycbc/results/followup.py
@@ -25,7 +25,14 @@
 time series.
 """ 
 import h5py, numpy, matplotlib
-matplotlib.use('Agg')
+# Only if a backend is not already set ... This should really *not* be done
+# here, but in the executables you should set matplotlib.use()
+# This matches the check that matplotlib does internally, but this *may* be
+# version dependenant. If this is a problem then remove this and control from
+# the executables directly.
+import sys
+if not 'matplotlib.backends' in sys.modules:
+    matplotlib.use('agg')
 import pylab, mpld3, mpld3.plugins
 from glue.segments import segment
 

--- a/pycbc/results/legacy_grb.py
+++ b/pycbc/results/legacy_grb.py
@@ -25,7 +25,15 @@ from __future__ import division
 import re
 import os
 from argparse import ArgumentParser
-import matplotlib; matplotlib.use("Agg")
+import matplotlib
+# Only if a backend is not already set ... This should really *not* be done
+# here, but in the executables you should set matplotlib.use()
+# This matches the check that matplotlib does internally, but this *may* be
+# version dependenant. If this is a problem then remove this and control from
+# the executables directly.
+import sys
+if not 'matplotlib.backends' in sys.modules:
+    matplotlib.use('agg')
 import matplotlib.pyplot as plt
 from glue import markup, segments
 from lal.gpstime import gps_to_utc, LIGOTimeGPS

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -30,7 +30,14 @@ import numpy
 import scipy.stats
 import itertools
 import matplotlib
-matplotlib.use('agg')
+# Only if a backend is not already set ... This should really *not* be done
+# here, but in the executables you should set matplotlib.use()
+# This matches the check that matplotlib does internally, but this *may* be
+# version dependenant. If this is a problem then remove this and control from
+# the executables directly.
+import sys
+if not 'matplotlib.backends' in sys.modules:
+    matplotlib.use('agg')
 from matplotlib import pyplot
 import matplotlib.gridspec as gridspec
 from pycbc.results import str_utils


### PR DESCRIPTION
This fixes #1379. That was caused by an error in psd.rst. I've also put a check around the matplotlib.use calls in the results module (matching the check that matplotlib does internally). I don't think these module code should be setting the backend at all. That should be the task of the executable. I didn't want to make that change mid-science run though. After O2 ends, I would like to just delete the matplotlib.use statements, and then codes can be fixed as they fail.

I've also enabled raise error on warning in the docs build, because the docs are *already* giving a warning from #1367. The effort that's going into improving documentation at the moment is awesome, but no-one seems to actually build and check that this documentation works. For e.g.:

http://galahad.aei.mpg.de/~spxiwh/pycbc_docs/distributions

So this change will cause the docs building to fail (*not* the gh-pages build, only the standard `python setup.py build_docs`). @stevereyes01 should be able to fix the problem quickly though.

