### PR TITLE
Fixes to two issues reported by Anuradha

### DIFF
--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -150,10 +150,10 @@ for ii in range(imin, imax):
     # get the compressed sample points
     if args.compression_algorithm == 'mchirp':
         sample_points = compress.mchirp_compression(tmplt.mass1, tmplt.mass2,
-            fmin, (kmax-1)*df, min_seglen=args.t_pad, df_multiple=df).astype(
+            fmin, kmax*df, min_seglen=args.t_pad, df_multiple=df).astype(
             real_same_precision_as(htilde))
     elif args.compression_algorithm == 'spa':
-        sample_points = compress.spa_compression(htilde, fmin, (kmax-1)*df,
+        sample_points = compress.spa_compression(htilde, fmin, kmax*df,
             min_seglen=args.t_pad).astype(real_same_precision_as(htilde))
     else:
         raise ValueError("unrecognized compression algorithm %s" %(

--- a/pycbc/fft/fft_callback.py
+++ b/pycbc/fft/fft_callback.py
@@ -21,7 +21,7 @@ full_corr = """
 zero_corr = """
     __device__ cufftComplex in_call(void* input, size_t offset, 
                                 void* caller_info, void* shared) {      
-        if (offset > callback_params.in_kmax)                       
+        if (offset >= callback_params.in_kmax)                       
             return (cufftComplex){0, 0};
         else{                                   
             cufftComplex r;

--- a/pycbc/psd/analytical.py
+++ b/pycbc/psd/analytical.py
@@ -119,10 +119,6 @@ def from_string(psd_name, length, delta_f, low_freq_cutoff):
     kmin = int(low_freq_cutoff / delta_f)
     psd.data[:kmin] = 0
 
-    # Sometimes the last value can be 0, this can cause problems down the line
-    if psd.data[length-1] == 0:
-        psd.data[length-1] = psd.data[length-2]
-
     return psd
 
 def flat_unity(length, delta_f, low_freq_cutoff):

--- a/pycbc/psd/analytical.py
+++ b/pycbc/psd/analytical.py
@@ -119,6 +119,10 @@ def from_string(psd_name, length, delta_f, low_freq_cutoff):
     kmin = int(low_freq_cutoff / delta_f)
     psd.data[:kmin] = 0
 
+    # Sometimes the last value can be 0, this can cause problems down the line
+    if psd.data[length-1] == 0:
+        psd.data[length-1] = psd.data[length-2]
+
     return psd
 
 def flat_unity(length, delta_f, low_freq_cutoff):

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -928,8 +928,10 @@ class StrainSegments(object):
 
             if filter_inj_only and hasattr(strain, 'injections'):
                 analyze_this = False
+                inj_window = strain.sample_rate * 8
                 for inj_id in inj_idx:
-                    if inj_id < cum_end and inj_id > cum_start:
+                    if inj_id < (cum_end + inj_window) and \
+                            inj_id > (cum_start - inj_window):
                         analyze_this = True
 
                 if not analyze_this:

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -66,7 +66,8 @@ def sigma_cached(self, psd):
                 self.sigma_scale = (DYN_RANGE_FAC * amp_norm) ** 2.0
 
 
-            self._sigmasq[key] = psd.sigmasq_vec[self.approximant][self.end_idx] * self.sigma_scale
+            self._sigmasq[key] = self.sigma_scale * \
+                psd.sigmasq_vec[self.approximant][self.end_idx-1]
 
         else:
             if not hasattr(self, 'sigma_view'):


### PR DESCRIPTION
Anuradha (no git-hub handle) recently reported two issues when using an analytic PSD with SPA templates in PyCBC.

One is a bug in the filter-inj-only option, which I think is easily resolved. I hardcode the window, but I think this is "safe", and should not ever need changing ... So I don't want to complicate the code by making this a parameter.

Second is an issue between the SPA template norm and analytical PSDs having a 0 value at Nyquist. I resolved this by making the analytical PSDs match the second-to-last value at Nyquist, but I'm not sure this is the right solution ... We should *not* be using the Nyquist in *any* matched-filter calculations. However, I worry that we probably are in *many* places, so this approach seems safer. @ahnitz, what do you think?