### PR TITLE
depend on release mpld3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,13 +62,12 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'pillow',
                       'h5py>=2.5',
                       'jinja2',
-                      'pycbc-mpld3>=0.3.dev0',
+                      'mpld3>=0.3',
                       'pyRXP>=2.1.0',
                       'pycbc-glue>=1.0.1',
                       'kombine',
                       'emcee>=2.2.0',
                       'corner>=2.0.1',
-                      #'scikit-learn>=0.17.0',  # travis does not like scikit-learn
                       ]
 
 #FIXME Remove me when we bump to h5py > 2.5


### PR DESCRIPTION
We no longer need our own fork as they have released a version of mpld3 that is new enough. (I'd also suggest we remove our fork). 