### PR TITLE
Change pycbc_inspiral workflow node output file default to HDF.

### DIFF
--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -736,9 +736,7 @@ class PyCBCInspiralExecutable(Executable):
         except:
             outtype = None
 
-        if outtype is None or 'xml' in outtype:
-            self.ext = '.xml.gz'
-        elif 'hdf' in outtype:
+        if outtype is None or 'hdf' in outtype:
             self.ext = '.hdf'
         else:
             raise ValueError('Invalid output type for PyCBC Inspiral: %s' % outtype)

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -730,16 +730,7 @@ class PyCBCInspiralExecutable(Executable):
         self.cp = cp
         self.set_memory(2000)
         self.injection_file = injection_file
-
-        try:
-            outtype = cp.get('workflow-matchedfilter', 'output-type')
-        except:
-            outtype = None
-
-        if outtype is None or 'hdf' in outtype:
-            self.ext = '.hdf'
-        else:
-            raise ValueError('Invalid output type for PyCBC Inspiral: %s' % outtype)
+        self.ext = '.hdf'
 
         self.num_threads = 1
         if self.get_opt('processing-scheme') is not None:


### PR DESCRIPTION
As title says.

The ``EventManager`` object used by ``pycbc_inspiral`` doesn't write XML files anymore so we should change the default.