### PR TITLE
make sure slice is integer in strain

### DIFF
--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -888,7 +888,7 @@ class StrainSegments(object):
             self.analyze_slices.append(ana_slice)
 
         # The last segment takes up any integer boundary slop
-        seg_end = data_end
+        seg_end = int(data_end)
         seg_start = int(seg_end - seg_len * strain.sample_rate)
         seg_slice = slice(seg_start, seg_end)
         self.segment_slices.append(seg_slice)


### PR DESCRIPTION
On newer numpy versions, using a float as an index fails. This fixes one place that was causing job failures. 