### PR TITLE
Metadata

### DIFF
--- a/pycbc/workflow/pegasus_files/pegasus-properties.conf
+++ b/pycbc/workflow/pegasus_files/pegasus-properties.conf
@@ -38,3 +38,8 @@ pegasus.dir.submit.mapper=Flat
 pegasus.dir.staging.mapper=Flat
 
 pegasus.metrics.app=ligo-pycbc
+
+# turn off the creation of the registration jobs even 
+# though the files maybe marked to be registered in the 
+# replica catalog
+pegasus.register=False

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -426,7 +426,7 @@ class File(DataStorage, dax.File):
             transfer_file = True
         else:
             transfer_file = False
-        node._dax_node.uses(self, link=dax.Link.OUTPUT, register=False, 
+        node._dax_node.uses(self, link=dax.Link.OUTPUT, register=True, 
                                                         transfer=transfer_file)                                                       
     def output_map_str(self):
         if self.storage_path:


### PR DESCRIPTION
@vahi asked me to turn on metadata registration at the job level in the DAX, but then turn it off for the whole workflow in the properties. This changes nothing for our usual workflow running, but allows us to turn registration on on a per-workflow basis to test Pegasus' metadata handling (without editing the DAX).