### PR TITLE
SNR - Rate histograms with Hierarchical Removal

### DIFF
--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -62,20 +62,6 @@ if h_inc_back_num > h_iterations:
     raise ValueError('User requested inclusive background after '
                      'hierarchical removals that does not exist!')
 
-#if args.h_iter_inc_background != None:
-#    h_inc_back_num = args.h_iter_inc_background
-#    if f.attrs['hierarchical_removal_iterations'] is not None:
-#        h_iterations = f.attrs['hierarchical_removal_iterations']
-#        if h_inc_back_num > h_iterations:
-#            raise ValueError('User requested inclusive background after '
-#                             'hierarchical removals that does not exist!')
-#else :
-#    if f.attrs['hierarchical_removal_iterations'] is not None:
-#        h_inc_back_num = f.attrs['hierarchical_removal_iterations']
-#        h_iterations = h_inc_back_num
-#    else :
-#        h_inc_back_num = 0
-
 if args.verbose:
     log_level = logging.INFO
     logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
@@ -91,7 +77,6 @@ else:
     if len(fstat) == 0:
         fstat = None
 
-#if f.attrs['hierarchical_removal_iterations'] is not None:
 if h_inc_back_num == 0:
     bstat = f['background/stat'][:]
     fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)
@@ -100,11 +85,6 @@ else :
     bstat = f['background_h%s/stat' % h_inc_back_num][:]
     fap = 1 - numpy.exp(- f.attrs['foreground_time_h%s' % h_inc_back_num] / f['background_h%s/ifar' % h_inc_back_num][:] / lal.YRJUL_SI)
     dec = f['background_h%s/decimation_factor' % h_inc_back_num][:]
-
-#else :
-#    bstat = f['background/stat'][:]
-#    fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)
-#    dec = f['background/decimation_factor'][:]
 
 s = bstat.argsort()
 dec, bstat, fap = dec[s], bstat[s], fap[s]
@@ -140,7 +120,6 @@ pylab.hist(bstat_exc, bins=bins, histtype='step',
 
 # plot full background
 if not args.closed_box:
-#    if f.attrs['hierarchical_removal_iterations'] is not None:
     if h_inc_back_num == 0:
         pylab.hist(bstat, bins=bins, histtype='step',
                    linewidth=2,
@@ -153,18 +132,11 @@ if not args.closed_box:
                    color='black', log=True,
                    label='Full Background',
                    weights=dec / f.attrs['background_time_h%s' % h_inc_back_num] * lal.YRJUL_SI)
- #   else :
- #       pylab.hist(bstat, bins=bins, histtype='step',
- #                  linewidth=2,
- #                  color='black', log=True,
- #                  label='Full Background',
- #                  weights=dec / f.attrs['background_time'] * lal.YRJUL_SI)
 
 if fstat is not None and not args.closed_box:
     le, re = bins[:-1], bins[1:]
     # We need to plot a histogram "errorbar" with the hierarchically
     # removed foreground triggers in purple.
-#    if f.attrs['hierarchical_removal_iterations'] is not None:
     if h_iterations > 0 :
         fstat_h_rm = numpy.array([], dtype=float)
 
@@ -251,13 +223,10 @@ if not args.closed_box:
 ax1 =  pylab.gca()
 ax2 = ax1.twinx()
 
-#if f.attrs['hierarchical_removal_iterations'] is not None:
 if h_inc_back_num == 0:
     fac = f.attrs['foreground_time'] / lal.YRJUL_SI
 else :
     fac = f.attrs['foreground_time_h%s' % h_inc_back_num] / lal.YRJUL_SI
-#else:
-#    fac = f.attrs['foreground_time'] / lal.YRJUL_SI
 
 ymin = ax1.get_ylim()[0] * fac
 ymax =  ax1.get_ylim()[1] * fac

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -51,8 +51,8 @@ if args.h_iter_inc_background != None:
     if f.attrs['hierarchical_removal_iterations'] is not None:
         h_iterations = f.attrs['hierarchical_removal_iterations']
         if h_inc_back_num > h_iterations:
-            raise ValueError('User requested inclusive background iteration '
-                             'that was not done. Exiting!')
+            raise ValueError('User requested inclusive background after '
+                             'hierarchical removals that does not exist!')
 else :
     if f.attrs['hierarchical_removal_iterations'] is not None:
         h_inc_back_num = f.attrs['hierarchical_removal_iterations']

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -35,7 +35,8 @@ parser.add_argument('--closed-box', action='store_true',
                          'foreground triggers')
 args = parser.parse_args()
 
-# Parse the command line value to an variable we can change.
+# Parse the command line value to a variable we can change if the user
+# wants to plot an inclusive background that doesn't exist.
 h_inc_back_num = args.h_iter_inc_background
 
 if args.verbose:
@@ -69,7 +70,7 @@ if f.attrs['hierarchical_removal_iterations'] is not None:
         fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)
         dec = f['background/decimation_factor'][:]   
     else :
-        bstat = f['background_h%s/stat%s' % h_inc_back_num][:]
+        bstat = f['background_h%s/stat' % h_inc_back_num][:]
         fap = 1 - numpy.exp(- f.attrs['foreground_time_h%s' % h_inc_back_num] / f['background_h%s/ifar' % h_inc_back_num][:] / lal.YRJUL_SI)
         dec = f['background_h%s/decimation_factor' % h_inc_back_num][:]
 
@@ -138,39 +139,34 @@ if fstat is not None and not args.closed_box:
     # removed foreground triggers in purple.
     if f.attrs['hierarchical_removal_iterations'] is not None:
         if h_iterations > 0 :
-            # If there were any hierarchically removed foreground triggers let's
-            # find them in our data set
-            fstat_unsorted = f['foreground/stat'][:]
+            fstat_h_rm = numpy.array([], dtype=float)
 
-            save_h_removed_indices = f['hierarchical_removed_fore_indices'][:]
+            # Since there is only one background bin we can just remove
+            # hierarchically removed triggers from highest ranking statistic
+            # to lower ranking statistic.
+            for i in range(0, h_inc_back_num):
+                rm_idx = fstat.argmax()
+                fstat_h_rm = numpy.append(fstat_h_rm, fstat[rm_idx])
+                fstat = numpy.delete(fstat, rm_idx)
 
-            fstat_h_rm = fstat_unsorted[save_h_removed_indices]
-            fstat_h_rm = numpy.sort(fstat_h_rm)
-
-            # Remove any hierarchically removed foreground triggers from the
-            # list of foreground triggers. Must remove them up the level
-            # indicated in plotting code, remove them in accordance with the
-            # inclusive background that the user wants to plot
-            h_remove_for_plot_indices = []
-            for i in range(len(fstat_h_rm)-1,
-                     len(fstat_h_rm) - h_inc_back_num - 1, -1):
-                h_remove_for_plot_indices.append(save_h_removed_indices[i-1])
-
-            fstat_h_rm = fstat_unsorted[h_remove_for_plot_indices]
-            fstat_h_rm = numpy.sort(fstat_h_rm)
-            fstat = numpy.delete(fstat_unsorted, h_remove_for_plot_indices)
+            # Sort these so the plotting doesn't screw up.
             fstat = numpy.sort(fstat)
+            fstat_h_rm = numpy.sort(fstat_h_rm)
 
             # Write "histogram" information.
             left_h_rm = numpy.searchsorted(fstat_h_rm, le)
             right_h_rm = numpy.searchsorted(fstat_h_rm, re)
+
+            # Just use the top level foreground time if you want background
+            # before h-removal.
             if h_inc_back_num == 0:
-                count_h_rm = (right_h_rm - left_h_rm) /
+                count_h_rm = (right_h_rm - left_h_rm) / \
                              f.attrs['foreground_time'] * lal.YRJUL_SI
 
+            # Or use the foreground time after h-removal
             else : 
-                count_h_rm = (right_h_rm - left_h_rm) /
-                             f.attrs['foreground_time_h%s' % h_inc_back_num] *
+                count_h_rm = (right_h_rm - left_h_rm) / \
+                             f.attrs['foreground_time_h%s' % h_inc_back_num] * \
                              lal.YRJUL_SI
 
             pylab.errorbar(bins[:-1] + args.bin_size / 2, count_h_rm, 

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -36,9 +36,9 @@ parser.add_argument('--h-iter-inc-background', type=int, default=None,
                          'background prior to any hierarchical removals. '
                          'Choosing 1 indicates the inclusive background '
                          'after the loudest foreground trigger was removed. '
-                         'Choosing N indicates plotting the inclusive '
-                         'background after N hierarchical removals. '
-                         '[default=None]')
+                         'Choose another integer for the inclusive '
+                         'background after that integer number of '
+                         'hierarchical removals. [default=None]')
 parser.add_argument('--closed-box', action='store_true',
                     help='Make a closed box version that excludes '
                          'foreground triggers')

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -69,7 +69,7 @@ if f.attrs['hierarchical_removal_iterations'] is not None:
         fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)
         dec = f['background/decimation_factor'][:]   
     else :
-        bstat = f['background_h%s/stat', h_inc_back_num][:]
+        bstat = f['background_h%s/stat%s' % h_inc_back_num][:]
         fap = 1 - numpy.exp(- f.attrs['foreground_time_h%s' % h_inc_back_num] / f['background_h%s/ifar' % h_inc_back_num][:] / lal.YRJUL_SI)
         dec = f['background_h%s/decimation_factor' % h_inc_back_num][:]
 
@@ -136,7 +136,6 @@ if fstat is not None and not args.closed_box:
     le, re = bins[:-1], bins[1:]
     # We need to plot a histogram "errorbar" with the hierarchically
     # removed foreground triggers in purple.
-
     if f.attrs['hierarchical_removal_iterations'] is not None:
         if h_iterations > 0 :
             # If there were any hierarchically removed foreground triggers let's

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -26,10 +26,17 @@ parser.add_argument('--output-file')
 parser.add_argument('--bin-size', type=float, default=0.1)
 parser.add_argument('--x-min', type=float, default=8.0)
 parser.add_argument('--trials-factor', type=int, default=1)
-parser.add_argument('--cumulative', action='store_true')
+parser.add_argument('--h-iter-inc-background', type=int, default=0,
+                    help='Indicate which inclusive background to plot '
+                         'with the foreground triggers if there were '
+                         'any hierarchical removals done.')
 parser.add_argument('--closed-box', action='store_true',
-      help="Make a closed box version that excludes foreground triggers")
+                    help='Make a closed box version that excludes '
+                         'foreground triggers')
 args = parser.parse_args()
+
+# Parse the command line value to an variable we can change.
+h_inc_back_num = args.h_iter_inc_background
 
 if args.verbose:
     log_level = logging.INFO
@@ -49,9 +56,28 @@ else:
     if len(fstat) == 0:
         fstat = None
 
-dec = f['background/decimation_factor'][:]
-bstat = f['background/stat'][:]
-fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)
+if f.attrs['hierarchical_removal_iterations'] is not None:
+    h_iterations = f.attrs['hierarchical_removal_iterations']
+    if h_inc_back_num > h_iterations:
+        logging.warn('User requested inclusive background iteration that was '
+                     'not done. Defaulting to last possible inclusive '
+                     'background.')
+        h_inc_back_num = h_iterations
+
+    h_iter_string = str(h_inc_back_num)
+    if h_inc_back_num == 0:
+        bstat = f['background/stat'][:]
+        fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)
+        dec = f['background/decimation_factor'][:]   
+    else :
+        bstat = f['background_h' + h_iter_string + '/stat'][:]
+        fap = 1 - numpy.exp(- f.attrs['foreground_time_h' + h_iter_string] / f['background_h' + h_iter_string + '/ifar'][:] / lal.YRJUL_SI)
+        dec = f['background_h' + h_iter_string + '/decimation_factor'][:]
+
+else :
+    bstat = f['background/stat'][:]
+    fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)
+    dec = f['background/decimation_factor'][:]
 
 s = bstat.argsort()
 dec, bstat, fap = dec[s], bstat[s], fap[s]
@@ -87,20 +113,80 @@ pylab.hist(bstat_exc, bins=bins, histtype='step',
 
 # plot full background
 if not args.closed_box:
-    pylab.hist(bstat, bins=bins, histtype='step',
-                  linewidth=2,
-                  color='black', log=True, 
-                  label='Full Background',
-                  weights=dec / f.attrs['background_time'] * lal.YRJUL_SI)
+    if f.attrs['hierarchical_removal_iterations'] is not None:
+        if h_inc_back_num == 0:
+            pylab.hist(bstat, bins=bins, histtype='step',
+                       linewidth=2,
+                       color='black', log=True, 
+                       label='Full Background',
+                       weights=dec / f.attrs['background_time'] * lal.YRJUL_SI)
+        else :
+            pylab.hist(bstat, bins=bins, histtype='step',
+                       linewidth=2,
+                       color='black', log=True,
+                       label='Full Background',
+                       weights=dec / f.attrs['background_time_h' + h_iter_string] * lal.YRJUL_SI)
+    else :
+        pylab.hist(bstat, bins=bins, histtype='step',
+                   linewidth=2,
+                   color='black', log=True,
+                   label='Full Background',
+                   weights=dec / f.attrs['background_time'] * lal.YRJUL_SI)
 
 if fstat is not None and not args.closed_box:
     le, re = bins[:-1], bins[1:]
+    # We need to plot a histogram "errorbar" with the hierarchically
+    # removed foreground triggers in purple.
+
+    if f.attrs['hierarchical_removal_iterations'] is not None:
+        if h_iterations > 0 :
+            # If there were any hierarchically removed foreground triggers let's
+            # find them in our data set
+            fstat_unsorted = f['foreground/stat'][:]
+
+            save_h_removed_indices = f['hierarchical_removed_fore_indices'][:]
+
+            fstat_h_rm = fstat_unsorted[save_h_removed_indices]
+            fstat_h_rm = numpy.sort(fstat_h_rm)
+
+            # Remove any hierarchically removed foreground triggers from the
+            # list of foreground triggers. Must remove them up the level
+            # indicated in plotting code, remove them in accordance with the
+            # inclusive background that the user wants to plot
+            h_remove_for_plot_indices = []
+            for i in range(len(fstat_h_rm)-1,
+                     len(fstat_h_rm) - h_inc_back_num - 1, -1):
+                h_remove_for_plot_indices.append(save_h_removed_indices[i-1])
+
+            fstat_h_rm = fstat_unsorted[h_remove_for_plot_indices]
+            fstat_h_rm = numpy.sort(fstat_h_rm)
+            fstat = numpy.delete(fstat_unsorted, h_remove_for_plot_indices)
+            fstat = numpy.sort(fstat)
+
+            # Write "histogram" information.
+            left_h_rm = numpy.searchsorted(fstat_h_rm, le)
+            right_h_rm = numpy.searchsorted(fstat_h_rm, re)
+            if h_inc_back_num == 0:
+                count_h_rm = (right_h_rm - left_h_rm) / \
+                             f.attrs['foreground_time'] * lal.YRJUL_SI
+
+            else : 
+                count_h_rm = (right_h_rm - left_h_rm) / \
+                             f.attrs['foreground_time_h' + \
+                             h_iter_string] * lal.YRJUL_SI
+
+            pylab.errorbar(bins[:-1] + args.bin_size / 2, count_h_rm, 
+                           xerr=args.bin_size/2,
+                           label='Hierarchically Removed Foreground', mec='none',
+                           fmt='s', ms=1, capthick=0, elinewidth=4,
+                           color='#b66dff')
+
     left = numpy.searchsorted(fstat, le)
     right = numpy.searchsorted(fstat, re)
     count = (right - left) / f.attrs['foreground_time'] * lal.YRJUL_SI
-    pylab.errorbar(bins[:-1] + args.bin_size / 2, count,
-                   xerr=args.bin_size/2, label='Foreground',
-                   mec='none', fmt='o', ms=1, capthick=0, elinewidth=4,  color='#ff6600')
+    pylab.errorbar(bins[:-1] + args.bin_size / 2, count, xerr=args.bin_size/2,
+                   label='Foreground', mec='none', fmt='o', ms=1, capthick=0,
+                   elinewidth=4,  color='#ff6600')
 
 pylab.xlabel('Weighted Network SNR, $\\rho_c$ (Bin Size = %.2f)' % args.bin_size)
 pylab.ylabel('Trigger Rate (yr$^{-1})$')
@@ -116,12 +202,16 @@ if not args.closed_box:
     for ii, sig in enumerate(sigmas[:-1]):
         next_sig = sigmas[ii + 1]
 
+        # Find the p-value of a sigma curve
         p1 = 1 - p_from_sigma(sig) / args.trials_factor
+
+        # Find the p-value of the next sigma curve
         p2 = 1 - p_from_sigma(next_sig) / args.trials_factor        
 
+        # Search the fap data for these p values
         x1 = numpy.searchsorted(fap[::-1], p1)
         x2 = numpy.searchsorted(fap[::-1], p2)
-        
+
         if x1 == x2:
             continue
         
@@ -139,7 +229,15 @@ if not args.closed_box:
 
 ax1 =  pylab.gca()
 ax2 = ax1.twinx()
-fac = f.attrs['foreground_time'] / lal.YRJUL_SI
+
+if f.attrs['hierarchical_removal_iterations'] is not None:
+    if h_inc_back_num == 0:
+        fac = f.attrs['foreground_time'] / lal.YRJUL_SI
+    else :
+        fac = f.attrs['foreground_time_h' + h_iter_string] / lal.YRJUL_SI
+else:
+    fac = f.attrs['foreground_time'] / lal.YRJUL_SI
+
 ymin = ax1.get_ylim()[0] * fac
 ymax =  ax1.get_ylim()[1] * fac
 
@@ -150,4 +248,4 @@ ax2.set_ylabel('Number per Experiment')
 pycbc.results.save_fig_with_metadata(fig, args.output_file,
      title="%s bin, Count vs Rank" % f.attrs['name'] if 'name' in f.attrs else "Count vs Rank", 
      caption="Histogram of the FAR vs the ranking statistic in the search.",
-     cmd=' '.join(sys.argv)) 
+     cmd=' '.join(sys.argv))

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -56,6 +56,7 @@ if args.h_iter_inc_background != None:
 else :
     if f.attrs['hierarchical_removal_iterations'] is not None:
         h_inc_back_num = f.attrs['hierarchical_removal_iterations']
+        h_iterations = h_inc_back_num
     else :
         h_inc_back_num = 0
 
@@ -75,7 +76,6 @@ else:
         fstat = None
 
 if f.attrs['hierarchical_removal_iterations'] is not None:
-    h_iterations = f.attrs['hierarchical_removal_iterations']
     if h_inc_back_num == 0:
         bstat = f['background/stat'][:]
         fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -37,8 +37,8 @@ parser.add_argument('--h-iter-inc-background', type=int, default=None,
                          'the inclusive background after the loudest '
                          'foreground trigger was removed. Choosing another '
                          'integer gives the inclusive background after that '
-                         'integer number of hierarchical removals. Choosing '
-                         'None defaults to the background from after all '
+                         'integer number of hierarchical removals. If not '
+                         'provided defaults to the background from after all '
                          'hierarchical removals performed. [default=None]')
 parser.add_argument('--closed-box', action='store_true',
                     help='Make a closed box version that excludes '

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -64,15 +64,15 @@ if f.attrs['hierarchical_removal_iterations'] is not None:
                      'background.')
         h_inc_back_num = h_iterations
 
-    h_iter_string = str(h_inc_back_num)
+#    h_iter_string = str(h_inc_back_num)
     if h_inc_back_num == 0:
         bstat = f['background/stat'][:]
         fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)
         dec = f['background/decimation_factor'][:]   
     else :
-        bstat = f['background_h' + h_iter_string + '/stat'][:]
-        fap = 1 - numpy.exp(- f.attrs['foreground_time_h' + h_iter_string] / f['background_h' + h_iter_string + '/ifar'][:] / lal.YRJUL_SI)
-        dec = f['background_h' + h_iter_string + '/decimation_factor'][:]
+        bstat = f['background_h%s/stat', h_inc_back_num][:]
+        fap = 1 - numpy.exp(- f.attrs['foreground_time_h%s' % h_inc_back_num] / f['background_h%s/ifar' % h_inc_back_num][:] / lal.YRJUL_SI)
+        dec = f['background_h%s/decimation_factor' % h_inc_back_num][:]
 
 else :
     bstat = f['background/stat'][:]
@@ -125,7 +125,7 @@ if not args.closed_box:
                        linewidth=2,
                        color='black', log=True,
                        label='Full Background',
-                       weights=dec / f.attrs['background_time_h' + h_iter_string] * lal.YRJUL_SI)
+                       weights=dec / f.attrs['background_time_h%s' % h_inc_back_num] * lal.YRJUL_SI)
     else :
         pylab.hist(bstat, bins=bins, histtype='step',
                    linewidth=2,
@@ -167,13 +167,13 @@ if fstat is not None and not args.closed_box:
             left_h_rm = numpy.searchsorted(fstat_h_rm, le)
             right_h_rm = numpy.searchsorted(fstat_h_rm, re)
             if h_inc_back_num == 0:
-                count_h_rm = (right_h_rm - left_h_rm) / \
+                count_h_rm = (right_h_rm - left_h_rm) /
                              f.attrs['foreground_time'] * lal.YRJUL_SI
 
             else : 
-                count_h_rm = (right_h_rm - left_h_rm) / \
-                             f.attrs['foreground_time_h' + \
-                             h_iter_string] * lal.YRJUL_SI
+                count_h_rm = (right_h_rm - left_h_rm) /
+                             f.attrs['foreground_time_h%s' % h_inc_back_num] *
+                             lal.YRJUL_SI
 
             pylab.errorbar(bins[:-1] + args.bin_size / 2, count_h_rm, 
                            xerr=args.bin_size/2,
@@ -234,7 +234,7 @@ if f.attrs['hierarchical_removal_iterations'] is not None:
     if h_inc_back_num == 0:
         fac = f.attrs['foreground_time'] / lal.YRJUL_SI
     else :
-        fac = f.attrs['foreground_time_h' + h_iter_string] / lal.YRJUL_SI
+        fac = f.attrs['foreground_time_h%s' % h_inc_back_num] / lal.YRJUL_SI
 else:
     fac = f.attrs['foreground_time'] / lal.YRJUL_SI
 

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -38,7 +38,7 @@ parser.add_argument('--h-iter-inc-background', type=int, default=None,
                          'foreground trigger was removed. Choosing another '
                          'integer gives the inclusive background after that '
                          'integer number of hierarchical removals. If not '
-                         'provided defaults to the background from after all '
+                         'provided, default to the background from after all '
                          'hierarchical removals performed. [default=None]')
 parser.add_argument('--closed-box', action='store_true',
                     help='Make a closed box version that excludes '

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -1,5 +1,7 @@
 #!/usr/bin/python
-""" Make table of the foreground coincident events
+""" Make SNR vs rate of triggers histogram for foreground coincident events.
+    Also has the ability to plot inclusive backgrounds from different stages
+    of hierarchical removal.
 """
 import argparse, h5py, numpy, logging, sys, lal
 import matplotlib
@@ -26,25 +28,40 @@ parser.add_argument('--output-file')
 parser.add_argument('--bin-size', type=float, default=0.1)
 parser.add_argument('--x-min', type=float, default=8.0)
 parser.add_argument('--trials-factor', type=int, default=1)
-parser.add_argument('--h-iter-inc-background', type=int, default=0,
+parser.add_argument('--h-iter-inc-background', type=int, default=None,
                     help='Indicate which inclusive background to plot '
                          'with the foreground triggers if there were '
-                         'any hierarchical removals done.')
+                         'any hierarchical removals done. Choosing 0 '
+                         'indicates plotting the inclusive background '
+                         'prior to any hierarchical removals. Choosing 1 '
+                         'indicates the inclusive background after the '
+                         'loudest foreground trigger was removed. '
+                         '[default=None]')
 parser.add_argument('--closed-box', action='store_true',
                     help='Make a closed box version that excludes '
                          'foreground triggers')
 args = parser.parse_args()
 
-# Parse the command line value to a variable we can change if the user
-# wants to plot an inclusive background that doesn't exist.
-h_inc_back_num = args.h_iter_inc_background
+logging.info('Read in the data')
+f = h5py.File(args.trigger_file, 'r')
+
+# Determine which inclusive background to plot.
+if args.h_iter_inc_background != None:
+    h_inc_back_num = args.h_iter_inc_background
+    if f.attrs['hierarchical_removal_iterations'] is not None:
+        h_iterations = f.attrs['hierarchical_removal_iterations']
+        if h_inc_back_num > h_iterations:
+            raise ValueError('User requested inclusive background iteration '
+                             'that was not done. Exiting!')
+else :
+    if f.attrs['hierarchical_removal_iterations'] is not None:
+        h_inc_back_num = f.attrs['hierarchical_removal_iterations']
+    else :
+        h_inc_back_num = 0
 
 if args.verbose:
     log_level = logging.INFO
     logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
-    
-logging.info('Read in the data')
-f = h5py.File(args.trigger_file, 'r')
 
 if args.closed_box:
     fstat = None
@@ -59,12 +76,6 @@ else:
 
 if f.attrs['hierarchical_removal_iterations'] is not None:
     h_iterations = f.attrs['hierarchical_removal_iterations']
-    if h_inc_back_num > h_iterations:
-        logging.warn('User requested inclusive background iteration that was '
-                     'not done. Defaulting to last possible inclusive '
-                     'background.')
-        h_inc_back_num = h_iterations
-
     if h_inc_back_num == 0:
         bstat = f['background/stat'][:]
         fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -64,7 +64,6 @@ if f.attrs['hierarchical_removal_iterations'] is not None:
                      'background.')
         h_inc_back_num = h_iterations
 
-#    h_iter_string = str(h_inc_back_num)
     if h_inc_back_num == 0:
         bstat = f['background/stat'][:]
         fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -32,10 +32,12 @@ parser.add_argument('--h-iter-inc-background', type=int, default=None,
                     help='Indicate which inclusive background to plot '
                          'with the foreground triggers if there were '
                          'any hierarchical removals done. Choosing 0 '
-                         'indicates plotting the inclusive background '
-                         'prior to any hierarchical removals. Choosing 1 '
-                         'indicates the inclusive background after the '
-                         'loudest foreground trigger was removed. '
+                         'or None indicates plotting the inclusive '
+                         'background prior to any hierarchical removals. '
+                         'Choosing 1 indicates the inclusive background '
+                         'after the loudest foreground trigger was removed. '
+                         'Choosing N indicates plotting the inclusive '
+                         'background after N hierarchical removals. '
                          '[default=None]')
 parser.add_argument('--closed-box', action='store_true',
                     help='Make a closed box version that excludes '
@@ -46,19 +48,33 @@ logging.info('Read in the data')
 f = h5py.File(args.trigger_file, 'r')
 
 # Determine which inclusive background to plot.
-if args.h_iter_inc_background != None:
-    h_inc_back_num = args.h_iter_inc_background
-    if f.attrs['hierarchical_removal_iterations'] is not None:
-        h_iterations = f.attrs['hierarchical_removal_iterations']
-        if h_inc_back_num > h_iterations:
-            raise ValueError('User requested inclusive background after '
-                             'hierarchical removals that does not exist!')
-else :
-    if f.attrs['hierarchical_removal_iterations'] is not None:
-        h_inc_back_num = f.attrs['hierarchical_removal_iterations']
-        h_iterations = h_inc_back_num
-    else :
-        h_inc_back_num = 0
+h_inc_back_num = args.h_iter_inc_background
+
+try:
+    h_iterations = f.attrs['hierarchical_removal_iterations']
+except KeyError:
+    h_iterations = 0
+
+if h_inc_back_num is None:
+    h_inc_back_num = h_iterations
+
+if h_inc_back_num > h_iterations:
+    raise ValueError('User requested inclusive background after '
+                     'hierarchical removals that does not exist!')
+
+#if args.h_iter_inc_background != None:
+#    h_inc_back_num = args.h_iter_inc_background
+#    if f.attrs['hierarchical_removal_iterations'] is not None:
+#        h_iterations = f.attrs['hierarchical_removal_iterations']
+#        if h_inc_back_num > h_iterations:
+#            raise ValueError('User requested inclusive background after '
+#                             'hierarchical removals that does not exist!')
+#else :
+#    if f.attrs['hierarchical_removal_iterations'] is not None:
+#        h_inc_back_num = f.attrs['hierarchical_removal_iterations']
+#        h_iterations = h_inc_back_num
+#    else :
+#        h_inc_back_num = 0
 
 if args.verbose:
     log_level = logging.INFO
@@ -75,20 +91,20 @@ else:
     if len(fstat) == 0:
         fstat = None
 
-if f.attrs['hierarchical_removal_iterations'] is not None:
-    if h_inc_back_num == 0:
-        bstat = f['background/stat'][:]
-        fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)
-        dec = f['background/decimation_factor'][:]   
-    else :
-        bstat = f['background_h%s/stat' % h_inc_back_num][:]
-        fap = 1 - numpy.exp(- f.attrs['foreground_time_h%s' % h_inc_back_num] / f['background_h%s/ifar' % h_inc_back_num][:] / lal.YRJUL_SI)
-        dec = f['background_h%s/decimation_factor' % h_inc_back_num][:]
-
-else :
+#if f.attrs['hierarchical_removal_iterations'] is not None:
+if h_inc_back_num == 0:
     bstat = f['background/stat'][:]
     fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)
-    dec = f['background/decimation_factor'][:]
+    dec = f['background/decimation_factor'][:]   
+else :
+    bstat = f['background_h%s/stat' % h_inc_back_num][:]
+    fap = 1 - numpy.exp(- f.attrs['foreground_time_h%s' % h_inc_back_num] / f['background_h%s/ifar' % h_inc_back_num][:] / lal.YRJUL_SI)
+    dec = f['background_h%s/decimation_factor' % h_inc_back_num][:]
+
+#else :
+#    bstat = f['background/stat'][:]
+#    fap = 1 - numpy.exp(- f.attrs['foreground_time'] / f['background/ifar'][:] / lal.YRJUL_SI)
+#    dec = f['background/decimation_factor'][:]
 
 s = bstat.argsort()
 dec, bstat, fap = dec[s], bstat[s], fap[s]
@@ -124,67 +140,67 @@ pylab.hist(bstat_exc, bins=bins, histtype='step',
 
 # plot full background
 if not args.closed_box:
-    if f.attrs['hierarchical_removal_iterations'] is not None:
-        if h_inc_back_num == 0:
-            pylab.hist(bstat, bins=bins, histtype='step',
-                       linewidth=2,
-                       color='black', log=True, 
-                       label='Full Background',
-                       weights=dec / f.attrs['background_time'] * lal.YRJUL_SI)
-        else :
-            pylab.hist(bstat, bins=bins, histtype='step',
-                       linewidth=2,
-                       color='black', log=True,
-                       label='Full Background',
-                       weights=dec / f.attrs['background_time_h%s' % h_inc_back_num] * lal.YRJUL_SI)
+#    if f.attrs['hierarchical_removal_iterations'] is not None:
+    if h_inc_back_num == 0:
+        pylab.hist(bstat, bins=bins, histtype='step',
+                   linewidth=2,
+                   color='black', log=True, 
+                   label='Full Background',
+                   weights=dec / f.attrs['background_time'] * lal.YRJUL_SI)
     else :
         pylab.hist(bstat, bins=bins, histtype='step',
                    linewidth=2,
                    color='black', log=True,
                    label='Full Background',
-                   weights=dec / f.attrs['background_time'] * lal.YRJUL_SI)
+                   weights=dec / f.attrs['background_time_h%s' % h_inc_back_num] * lal.YRJUL_SI)
+ #   else :
+ #       pylab.hist(bstat, bins=bins, histtype='step',
+ #                  linewidth=2,
+ #                  color='black', log=True,
+ #                  label='Full Background',
+ #                  weights=dec / f.attrs['background_time'] * lal.YRJUL_SI)
 
 if fstat is not None and not args.closed_box:
     le, re = bins[:-1], bins[1:]
     # We need to plot a histogram "errorbar" with the hierarchically
     # removed foreground triggers in purple.
-    if f.attrs['hierarchical_removal_iterations'] is not None:
-        if h_iterations > 0 :
-            fstat_h_rm = numpy.array([], dtype=float)
+#    if f.attrs['hierarchical_removal_iterations'] is not None:
+    if h_iterations > 0 :
+        fstat_h_rm = numpy.array([], dtype=float)
 
-            # Since there is only one background bin we can just remove
-            # hierarchically removed triggers from highest ranking statistic
-            # to lower ranking statistic.
-            for i in range(0, h_inc_back_num):
-                rm_idx = fstat.argmax()
-                fstat_h_rm = numpy.append(fstat_h_rm, fstat[rm_idx])
-                fstat = numpy.delete(fstat, rm_idx)
+        # Since there is only one background bin we can just remove
+        # hierarchically removed triggers from highest ranking statistic
+        # to lower ranking statistic.
+        for i in range(0, h_inc_back_num):
+            rm_idx = fstat.argmax()
+            fstat_h_rm = numpy.append(fstat_h_rm, fstat[rm_idx])
+            fstat = numpy.delete(fstat, rm_idx)
 
-            # Sort these so the plotting doesn't screw up.
-            fstat = numpy.sort(fstat)
-            fstat_h_rm = numpy.sort(fstat_h_rm)
+        # Sort these so the plotting doesn't screw up.
+        fstat = numpy.sort(fstat)
+        fstat_h_rm = numpy.sort(fstat_h_rm)
 
-            # Write "histogram" information.
-            left_h_rm = numpy.searchsorted(fstat_h_rm, le)
-            right_h_rm = numpy.searchsorted(fstat_h_rm, re)
+        # Write "histogram" information.
+        left_h_rm = numpy.searchsorted(fstat_h_rm, le)
+        right_h_rm = numpy.searchsorted(fstat_h_rm, re)
 
-            # Just use the top level foreground time if you want background
-            # before h-removal.
-            if h_inc_back_num == 0:
-                count_h_rm = (right_h_rm - left_h_rm) / \
-                             f.attrs['foreground_time'] * lal.YRJUL_SI
+        # Just use the top level foreground time if you want background
+        # before h-removal.
+        if h_inc_back_num == 0:
+            count_h_rm = (right_h_rm - left_h_rm) / \
+                         f.attrs['foreground_time'] * lal.YRJUL_SI
 
-            # Or use the foreground time after h-removal
-            else : 
-                count_h_rm = (right_h_rm - left_h_rm) / \
-                             f.attrs['foreground_time_h%s' % h_inc_back_num] * \
-                             lal.YRJUL_SI
+        # Or use the foreground time after h-removal
+        else : 
+            count_h_rm = (right_h_rm - left_h_rm) / \
+                         f.attrs['foreground_time_h%s' % h_inc_back_num] * \
+                         lal.YRJUL_SI
 
-            pylab.errorbar(bins[:-1] + args.bin_size / 2, count_h_rm, 
-                           xerr=args.bin_size/2,
-                           label='Hierarchically Removed Foreground', mec='none',
-                           fmt='s', ms=1, capthick=0, elinewidth=4,
-                           color='#b66dff')
+        pylab.errorbar(bins[:-1] + args.bin_size / 2, count_h_rm, 
+                       xerr=args.bin_size/2,
+                       label='Hierarchically Removed Foreground', mec='none',
+                       fmt='s', ms=1, capthick=0, elinewidth=4,
+                       color='#b66dff')
 
     left = numpy.searchsorted(fstat, le)
     right = numpy.searchsorted(fstat, re)
@@ -235,13 +251,13 @@ if not args.closed_box:
 ax1 =  pylab.gca()
 ax2 = ax1.twinx()
 
-if f.attrs['hierarchical_removal_iterations'] is not None:
-    if h_inc_back_num == 0:
-        fac = f.attrs['foreground_time'] / lal.YRJUL_SI
-    else :
-        fac = f.attrs['foreground_time_h%s' % h_inc_back_num] / lal.YRJUL_SI
-else:
+#if f.attrs['hierarchical_removal_iterations'] is not None:
+if h_inc_back_num == 0:
     fac = f.attrs['foreground_time'] / lal.YRJUL_SI
+else :
+    fac = f.attrs['foreground_time_h%s' % h_inc_back_num] / lal.YRJUL_SI
+#else:
+#    fac = f.attrs['foreground_time'] / lal.YRJUL_SI
 
 ymin = ax1.get_ylim()[0] * fac
 ymax =  ax1.get_ylim()[1] * fac

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -32,13 +32,14 @@ parser.add_argument('--h-iter-inc-background', type=int, default=None,
                     help='Indicate which inclusive background to plot '
                          'with the foreground triggers if there were '
                          'any hierarchical removals done. Choosing 0 '
-                         'or None indicates plotting the inclusive '
-                         'background prior to any hierarchical removals. '
-                         'Choosing 1 indicates the inclusive background '
-                         'after the loudest foreground trigger was removed. '
-                         'Choose another integer for the inclusive '
-                         'background after that integer number of '
-                         'hierarchical removals. [default=None]')
+                         'indicates plotting the inclusive background prior '
+                         'to any hierarchical removals. Choosing 1 indicates '
+                         'the inclusive background after the loudest '
+                         'foreground trigger was removed. Choosing another '
+                         'integer gives the inclusive background after that '
+                         'integer number of hierarchical removals. Choosing '
+                         'None defaults to the background from after all '
+                         'hierarchical removals performed. [default=None]')
 parser.add_argument('--closed-box', action='store_true',
                     help='Make a closed box version that excludes '
                          'foreground triggers')


### PR DESCRIPTION
The current code I've conjured up to make plots like those found on https://www.lsc-group.phys.uwm.edu/ligovirgo/cbcnote/PyCBC/hierarchical-removal-dev-O2

The gist of this is that we want to make plots that show the hierarchical removal process in motion. This code will plot the SNR - Rate histograms but with different inclusive backgrounds. The first plot is for the inclusive background made with no hierarchical removals. The second plot is for the inclusive background after removing the loudest foreground trigger that is louder than the background (GW150914). And the 3rd plot is for the inclusive background after removing the next loudest foreground trigger (GW151226):

https://sugwg-jobs.phy.syr.edu/~steven.reyes/ER10/hierarchical_removal_plots/bulk_bin_0th_background.png

https://sugwg-jobs.phy.syr.edu/~steven.reyes/ER10/hierarchical_removal_plots/bulk_bin_1st_background.png

https://sugwg-jobs.phy.syr.edu/~steven.reyes/ER10/hierarchical_removal_plots/bulk_bin_2nd_background.png

I'm not happy with the code block on lines 137 to 181 for plotting purple "error bars" on top of hierarchically removed triggers. It's very clunky and not transparent at all. [The color purple was chosen since this is more accessible to people that have color deficiencies]. I tried making this code backwards compatible with other hdf files from previous statmap codes as per Duncan's requests.
