### PR TITLE
Minifollowups changes

### DIFF
--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -125,8 +125,8 @@ for num_event in range(num_events):
     bank_id = f['foreground/template_id'][:][sorting][num_event]
     
     layouts += (mini.make_coinc_info(workflow, single_triggers, tmpltbank_file,
-                              coinc_file, num_event, 
-                              args.output_dir, tags=args.tags + [str(num_event)]),)        
+                              coinc_file, args.output_dir, n_loudest=num_event, 
+                              tags=args.tags + [str(num_event)]),)        
     files += mini.make_trigger_timeseries(workflow, single_triggers,
                               ifo_times, args.output_dir, special_tids=ifo_tids,
                               tags=args.tags + [str(num_event)])

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -57,6 +57,9 @@ parser.add_argument('--inspiral-data-analyzed-name',
                          "analyzed by each analysis job.")
 parser.add_argument('--inj-window', type=int, default=0.5,
                     help="Time window in which to look for injection triggers")
+parser.add_argument('--ifar-threshold', type=float, default=None,
+                    help="If given also followup injections with ifar smaller "
+                         "than this threshold.")
 parser.add_argument('--output-map')
 parser.add_argument('--output-file')
 parser.add_argument('--tags', nargs='+', default=[])
@@ -93,6 +96,11 @@ for ifo in args.single_detector_triggers:
 
 f = h5py.File(args.injection_file, 'r')
 missed = f['missed/after_vetoes'][:]
+if args.ifar_threshold is not None:
+    ifars = f['found_after_vetoes']['ifar'][:]
+    lgc_arr = ifars < args.ifar_threshold
+    missed = numpy.append(missed,
+                          f['found_after_vetoes']['injection_index'][lgc_arr])
 
 num_events = int(workflow.cp.get_opt_tags('workflow-injection_minifollowups', 'num-events', ''))
 

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -131,6 +131,7 @@ if len(missed) < num_events:
     num_events = len(missed)
 
 # loop over number of loudest events to be followed up
+found_inj_idxes = f['found_after_vetoes/injection_index'][:]
 for num_event in range(num_events):
     files = wf.FileList([])
     
@@ -152,6 +153,13 @@ for num_event in range(num_events):
           
     layouts += [(mini.make_inj_info(workflow, injection_file, injection_index, num_event,
                                args.output_dir, tags=args.tags + [str(num_event)])[0],)]   
+    if injection_index in found_inj_idxes:
+        trig_id = numpy.where(found_inj_idxes == injection_index)[0][0]
+        layouts += [(mini.make_coinc_info
+                     (workflow, single_triggers, tmpltbank_file,
+                      injection_file, args.output_dir, trig_id=trig_id,
+                      file_substring='found_after_vetoes',
+                      tags=args.tags + [str(num_event)])[0],)]
     files += mini.make_trigger_timeseries(workflow, single_triggers,
                               ifo_times, args.output_dir,
                               tags=args.tags + [str(num_event)])

--- a/bin/minifollowups/pycbc_page_coincinfo
+++ b/bin/minifollowups/pycbc_page_coincinfo
@@ -32,16 +32,33 @@ parser.add_argument('--output-file')
 parser.add_argument('--statmap-file', required=True,
     help="HDF format clustered coincident statmap file containing the result "
          "triggers. Required")
-parser.add_argument('--n-loudest', type=int,
+parser.add_argument('--statmap-file-subspace-name', default='foreground',
+    help="If given look in this 'sub-directory' of the HDF file for triggers, "
+         "takes a default value of 'foreground'.")
+trig_input = parser.add_mutually_exclusive_group(required=True)
+trig_input.add_argument('--n-loudest', type=int,
     help="Examine the n'th loudest trigger, use with statmap file")
+trig_input.add_argument('--trigger-id', type=int,
+    help="Examine the trigger with specified ID, use with statmap file. An "
+         "alternative to --n-loudest. Cannot be used together")
 
 args = parser.parse_args()
 pycbc.init_logging(args.verbose)
 
 # Get the nth loudest trigger from the output of pycbc_coinc_statmap
 f = h5py.File(args.statmap_file, 'r')
-n = f['foreground/stat'][:].argsort()[::-1][args.n_loudest]
-d = f['foreground']
+d = f[args.statmap_file_subspace_name]
+if args.n_loudest is not None:
+    n = d['stat'][:].argsort()[::-1][args.n_loudest]
+    title = 'Parameters of coincident event ranked %s' % (args.n_loudest + 1)
+    caption = 'Parameters of event ranked %s by the search. The figures below show the mini-followup data for this event.' % (args.n_loudest + 1)
+elif args.trigger_id is not None:
+    n = args.trigger_id
+    title = 'Details of coincident trigger'
+    caption = 'Parameters of coincident event. The figures below show the mini-followup data for this event.'
+else:
+    # It shouldn't be possible to get here!
+    raise ValueError()
 
 # make a table for the coincident information #################################
 headers = ["Coincident ranking statistic",
@@ -110,6 +127,6 @@ html += str(pycbc.results.static_table(table, pycbc.results.sngl_table_headers))
 ###############################################################################
 
 pycbc.results.save_fig_with_metadata(html, args.output_file, {},
-                        cmd = ' '.join(sys.argv),
-                        title = 'Parameters of coincident event ranked %s' % (args.n_loudest + 1),
-                        caption = 'Parameters of event ranked %s by the search. The figures below show the mini-followup data for this event.' % (args.n_loudest + 1))
+                        cmd=' '.join(sys.argv),
+                        title=title,
+                        caption=caption)

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -70,6 +70,9 @@ parser.add_argument('--non-coinc-time-only', default=False,
 parser.add_argument('--minimum-duration', default=None, type=float,
                     help="If given only consider single-detector triggers "
                          "with template duration larger than this.")
+parser.add_argument('--maximum-duration', default=None, type=float,
+                    help="If given only consider single-detector triggers "
+                         "with template duration smaller than this.")
 parser.add_argument('--output-map')
 parser.add_argument('--output-file')
 parser.add_argument('--tags', nargs='+', default=[])
@@ -121,15 +124,25 @@ if args.non_coinc_time_only:
             trigs.end_time, [args.inspiral_segments],
             ifo=ifo, segment_name=args.inspiral_data_analyzed_name)
         trigs.mask = trigs.mask[curr_veto_mask]
+
+def restrict_triggers_to_logic_mask(triggers, logic_mask):
+    if triggers.mask.dtype == 'bool':
+        orig_indices = triggers.mask.nonzero()[0][logic_mask]
+        triggers.mask = numpy.in1d(numpy.arange(len(triggers.mask)),
+                                                orig_indices,
+                                                assume_unique=True)
+    else:
+        triggers.mask = triggers.mask[logic_mask]
+
 if args.minimum_duration is not None:
     durations = trigs.template_duration
     lgc_mask = durations > args.minimum_duration
-    if trigs.mask.dtype == 'bool':
-        orig_indices = trigs.mask.nonzero()[0][lgc_mask]
-        trigs.mask = numpy.in1d(numpy.arange(len(trigs.mask)), orig_indices,
-                                assume_unique=True)
-    else:
-        trigs.mask = trigs.mask[lgc_mask]
+    restrict_triggers_to_logic_mask(trigs, lgc_mask)
+if args.maximum_duration is not None:
+    durations = trigs.template_duration
+    lgc_mask = durations < args.maximum_duration
+    restrict_triggers_to_logic_mask(trigs, lgc_mask)
+    
 
 if len(trigs.snr) == 0:
     # There are no triggers, make no-op job and exit

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -504,7 +504,13 @@ for inj_file, tag in zip(inj_files, inj_tags):
     if len(f) > 0: layout.two_column_layout(rdir['injections/%s' % tag], inj_layout)
 
     # run minifollowups on nearest missed injections
-    currdir = rdir['injections/followup_of_missed_%s' % tag]
+    curr_dir_nam = 'injections/followup_of_{}'.format(tag)
+    if workflow.cp.has_option_tags('workflow-injection_minifollowups',
+                                   'subsection-suffix', tags=[tag]):
+        suf_str = workflow.cp.get_opt_tags('workflow-injection_minifollowups',
+                                           'subsection-suffix', tags=[tag])
+        curr_dir_nam += '_' + suf_str
+    currdir = rdir[curr_dir_nam]
     wf.setup_injection_minifollowups(workflow, found_inj, small_inj_file,
                                      insps,  hdfbank[0], insp_files_seg_file,
                                      data_analysed_name, trig_generated_name,

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -469,7 +469,9 @@ def make_inj_info(workflow, injection_file, injection_index, num, out_dir,
     files += node.output_files
     return files
 
-def make_coinc_info(workflow, singles, bank, coinc, num, out_dir, tags=None):
+def make_coinc_info(workflow, singles, bank, coinc, out_dir,
+                    n_loudest=None, trig_id=None, file_substring=None,
+                    tags=None):
     tags = [] if tags is None else tags
     makedir(out_dir)
     name = 'page_coincinfo'
@@ -479,7 +481,12 @@ def make_coinc_info(workflow, singles, bank, coinc, num, out_dir, tags=None):
     node.add_input_list_opt('--single-trigger-files', singles)
     node.add_input_opt('--statmap-file', coinc)
     node.add_input_opt('--bank-file', bank)
-    node.add_opt('--n-loudest', str(num))
+    if n_loudest is not None:
+        node.add_opt('--n-loudest', str(n_loudest))
+    if trig_id is not None:
+        node.add_opt('--trigger-id', str(trig_id))
+    if file_substring is not None:
+        node.add_opt('--statmap-file-subspace-name', file_substring)
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow += node
     files += node.output_files


### PR DESCRIPTION
This patch makes a few more changes to minifollowups:

 * Missed injection followups can now take a `--ifar-threshold` option. If given missed injections will include *all* injections with ifar less than this (including injections with no trigger). If not given the previous behaviour (of only considering injections with no trigger) will be used.
 * For injections with an associated trigger, the injection minifollowups will also run a coinc_infopage job to display the parameters of the coincident trigger, including IFAR. (This is the same format as for foreground minifollowups, but some minor code changes is needed to use the same code for both cases).
 * A maximum duration option is added to sngl_minifollowups.

An example of this is here:

https://galahad.aei.mpg.de/~spxiwh/LVC/aLIGO/O2/analyses/O2_chunk3/prelim_analyses/C00_ODC_MASTER/run7a

I will suggest some configuration file changes to use this well, but this change does not *require* any config file changes.