### PR TITLE
Setuptools now has additional dependencies

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -143,7 +143,6 @@ Make sure your versions of ``pip`` and ``setuptools`` are up to date by running 
 .. code-block:: bash
 
     pip install --upgrade pip
-    pip install six packaging appdirs
     pip install --upgrade setuptools
 
 Install unittest2, python-cjson, and numpy with the command:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -142,7 +142,9 @@ Make sure your versions of ``pip`` and ``setuptools`` are up to date by running 
 
 .. code-block:: bash
 
-    pip install --upgrade pip setuptools
+    pip install --upgrade pip
+    pip install six packaging appdirs
+    pip install --upgrade setuptools
 
 Install unittest2, python-cjson, and numpy with the command:
 


### PR DESCRIPTION
It appears that setuptools has additional dependencies that pip is not fetching for some reason. You need to manually install six, packaging, and appdirs before upgrading setuptools.

This changes the install instructions to reflect that.