### PR TITLE
Require the new version of six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ python-dateutil==2.4.2
 pytz==2015.6
 requests==1.2.3
 setuptools==18.2
-six==1.9.0
+six==1.10.0
 snowballstemmer==1.2.0
 Sphinx==1.3.1
 sphinx-rtd-theme==0.1.9


### PR DESCRIPTION
The PyCBC E@H build script is failing as pkgconfig 1.1.0 requires six 1.10.0 (see below). This updates the requirements accordingly. 

```
[Fri Jan 27 14:07:34 EST 2017] install six, pkgconfig and matplotlib beforehand
Collecting six==1.9.0
  Downloading six-1.9.0-py2.py3-none-any.whl
Installing collected packages: six
  Found existing installation: six 1.10.0
    Uninstalling six-1.10.0:
      Successfully uninstalled six-1.10.0
Successfully installed six-1.9.0
Collecting pkgconfig==1.1.0
  Downloading pkgconfig-1.1.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-SrxO3B/pkgconfig/setup.py", line 16, in <module>
        test_suite='test',
      File "/home/dbrown/projects/pycbc/eah/pycbc-build/lib/python2.7/distutils/core.py", line 111, in setup
        _setup_distribution = dist = klass(attrs)
      File "/home/dbrown/projects/pycbc/eah/pycbc-build/environment/lib/python2.7/site-packages/setuptools/dist.py", line 320, in __init__
        _Distribution.__init__(self, attrs)
      File "/home/dbrown/projects/pycbc/eah/pycbc-build/lib/python2.7/distutils/dist.py", line 287, in __init__
        self.finalize_options()
      File "/home/dbrown/projects/pycbc/eah/pycbc-build/environment/lib/python2.7/site-packages/setuptools/dist.py", line 386, in finalize_options
        ep.require(installer=self.fetch_build_egg)
      File "/home/dbrown/projects/pycbc/eah/pycbc-build/environment/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2318, in require
        items = working_set.resolve(reqs, env, installer, extras=self.extras)
      File "/home/dbrown/projects/pycbc/eah/pycbc-build/environment/lib/python2.7/site-packages/pkg_resources/__init__.py", line 859, in resolve
        raise VersionConflict(dist, req).with_context(dependent_req)
    pkg_resources.VersionConflict: (six 1.9.0 (/home/dbrown/projects/pycbc/eah/pycbc-build/environment/lib/python2.7/site-packages), Requirement.parse('six>=1.10.0'))
```