### PR TITLE
H5 support

### DIFF
--- a/bin/pycbc_banksim
+++ b/bin/pycbc_banksim
@@ -391,7 +391,7 @@ logging.info("Determining maximum overlaps and outputting results")
 
 # Find the maximum overlap in the bank and output to a file
 with open(options.out_file, "w") as fout:
-    for i, (stilde, s_norm, matches, sim_template, hfc) in enumerate(signals):
+    for i, (stilde, s_norm, matches, sim_template) in enumerate(signals):
         match_str = "%5.5f " % max(matches)
         match_str += " " + options.bank_file
         match_str += " " + str(matches.index(max(matches)))

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -247,7 +247,7 @@ class TemplateBank(object):
             **kwds):
         ext = os.path.basename(filename)
         self.compressed_waveforms = None
-        if ext.endswith('.xml') or ext.endswith('.xml.gz') or ext.endswith('.xmlgz'):
+        if ext.endswith(('.xml', '.xml.gz', '.xmlgz')):
             self.filehandler = None
             self.indoc = ligolw_utils.load_filename(
                 filename, False, contenthandler=LIGOLWContentHandler)

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -264,7 +264,7 @@ class TemplateBank(object):
             names = tuple([n if n!= 'alpha6' else 'f_lower' for n in names])
             self.table.dtype.names = names
 
-        elif ext.endswith('hdf'):
+        elif ext.endswith(('hdf', '.h5')):
             self.indoc = None
             f = h5py.File(filename, 'r')
             self.filehandler = f


### PR DESCRIPTION
While @ahnitz is right that I should use the standard .hdf extension in the various template-bank related workflows in PyCBC (and I'll do that), `.h5` is still a valid extension for HDF files, and TemplateBank should be able to handle it (especially if it support the `.xmlgz` extension that I've *never* seen used).

Patch also includes a bug-fix in pycbc_banksim. This was introduced in the final round of commits when introducing bank_verificator and is causing banksim to fail (as `hfc` doesn't exist at all any more).