### PR TITLE
Close hdf files after usage

### DIFF
--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -132,6 +132,7 @@ class DictArray(object):
                 for g in groups:
                     if g in d:
                         self.data[g].append(d[g][:])
+                d.close()
                     
             for k in self.data:
                 if not len(self.data[k]) == 0:


### PR DESCRIPTION
Some clusters (e.g. LHO) cannot handle opening many files at once, so that for example one cannot look into all the PyCBC_Live trigger files from one day using DictArray.
This pull request is to close every file after being read.