### PR TITLE
Snr-rate Cumulative Histograms and Non-Cumulative Histograms (SNR- IFAR) Plots

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -320,6 +320,9 @@ while numpy.any(fnlouder == 0):
     f.attrs['foreground_time_h%s' % h_iterations] = coinc_time
 
     if fore_locs.sum() > 0:
+        # Write ranking statistic to file just for downstream plotting code
+        f['foreground_h%s/stat/'] = fore_stat
+
         ifar = background_time / (fnlouder + 1)
         fap = 1 - numpy.exp(- coinc_time / ifar)
 

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -321,7 +321,7 @@ while numpy.any(fnlouder == 0):
 
     if fore_locs.sum() > 0:
         # Write ranking statistic to file just for downstream plotting code
-        f['foreground_h%s/stat/' % h_iterations] = fore_stat
+        f['foreground_h%s/stat' % h_iterations] = fore_stat
 
         ifar = background_time / (fnlouder + 1)
         fap = 1 - numpy.exp(- coinc_time / ifar)

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -229,6 +229,13 @@ while numpy.any(fnlouder == 0):
     if (h_iterations == args.max_hier_removal): 
         break
 
+    # Write foreground trigger info before hierarchical removals for
+    # downstream codes.
+    if h_iterations == 0:
+        f['foreground_h%s/stat' % h_iterations] = fore_stat
+        f['foreground_h%s/ifar' % h_iterations] = sec_to_year(ifar)
+        f['foreground_h%s/fap' % h_iterations] = fap
+
     # Add the iteration number of hierarchical removals done.
     h_iterations += 1
 

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -321,7 +321,7 @@ while numpy.any(fnlouder == 0):
 
     if fore_locs.sum() > 0:
         # Write ranking statistic to file just for downstream plotting code
-        f['foreground_h%s/stat/'] = fore_stat
+        f['foreground_h%s/stat/' % h_iterations] = fore_stat
 
         ifar = background_time / (fnlouder + 1)
         fap = 1 - numpy.exp(- coinc_time / ifar)

--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -232,6 +232,8 @@ while numpy.any(fnlouder == 0):
     # Write foreground trigger info before hierarchical removals for
     # downstream codes.
     if h_iterations == 0:
+        f['background_h%s/stat' % h_iterations] = back_stat 
+        f['background_h%s/ifar' % h_iterations] = sec_to_year(background_time / (back_cnum + 1))
         f['foreground_h%s/stat' % h_iterations] = fore_stat
         f['foreground_h%s/ifar' % h_iterations] = sec_to_year(ifar)
         f['foreground_h%s/fap' % h_iterations] = fap

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -52,10 +52,19 @@ parser.add_argument('--trials-factor', type=int, default=1,
                          'divide from IFAR to account for look-elsewhere '
                          'effect. [default=1]')
 parser.add_argument('--no-sigma-shading', action='store_true')
-parser.add_argument('--h-iter-inc-background', type=int, default=0,
+parser.add_argument('--h-iter-inc-background', type=int, default=None,
                     help='Indicate which inclusive background to plot '
                          'with the foreground triggers if there were '
-                         'hierarchical removals done. [default=0]')
+                         'any hierarchical removals done. Choosing 0 '
+                         'or None indicates plotting the inclusive '
+                         'background prior to any hierarchical removals. '
+                         'Choosing 1 indicates the inclusive background '
+                         'after the loudest foreground trigger was removed. '
+                         'Choose other integers greater than this for other '
+                         'inclusive backgrounds after hierarchical removal. '
+                         '[default=None]')
+                         'with the foreground triggers if there were '
+                         'hierarchical removals done. [default=None]')
 parser.add_argument('--fg-marker', default='^',
                     help='Marker to use for the foreground triggers, '
                          '[default = ^]')

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -106,28 +106,16 @@ try:
         cstat_rate = numpy.arange(len(cstat_fore), 0, -1) / f.attrs['foreground_time'] * lal.YRJUL_SI
         fap_end = f['foreground/fap'][:].min() * args.trials_factor
     else:
-        if h_inc_back_num == 0:
-            cstat_fore = f['foreground/stat'][:]
-            print "The length of the foreground triggers is...", len(cstat_fore)
-            ssort = cstat_fore.argsort()
-            cstat_rate = 1.0 / f['foreground/ifar'][:] * args.trials_factor
-            cstat_rate = cstat_rate[ssort]
-            cstat_fore = cstat_fore[ssort]
-            cstat_fap = p_from_far(cstat_rate, foreground_livetime)
-        else :
-            cstat_fore = f['foreground_h%s/stat' % h_inc_back_num][:]
-            print "The length of the foreground triggers is...", len(cstat_fore)
-            ssort = cstat_fore.argsort()
-            cstat_rate = 1.0 / f['foreground_h%s/ifar' % h_inc_back_num][:] * args.trials_factor
-            cstat_rate = cstat_rate[ssort]
-            cstat_fore = cstat_fore[ssort]
-            cstat_fap = p_from_far(cstat_rate, foreground_livetime)
+         cstat_fore = f['foreground/stat'][:]
+         ssort = cstat_fore.argsort()
+         cstat_rate = 1.0 / f['foreground/ifar'][:] * args.trials_factor
+         cstat_rate = cstat_rate[ssort]
+         cstat_fore = cstat_fore[ssort]
+         cstat_fap = p_from_far(cstat_rate, foreground_livetime)
     
     logging.info('Found %s foreground triggers' % len(cstat_fore))
 except:
     cstat_fore = None
-
-print "The length of the foreground triggers is...", len(cstat_fore)
 
 if cstat_fore is not None and len(cstat_fore) == 0:
     cstat_fore = None

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -274,23 +274,35 @@ if not args.closed_box:
                 except ValueError:
                     logging.warn(" Can't find a place for the sigma labels ")
 
-#        if args.not_cumulative:
-#            # add arrows to any points > the loudest background
-#            far_min_possible = 1. / f.attrs['background_time']
-#            far_min_possible *= 3.15569e7 * args.trials_factor
-#            louder_pts = numpy.where(cstat_rate <= far_min_possible)
-#            for ii in louder_pts:
-#                r = cstat_fore[ii]
-#                arr_start = cstat_rate[ii]
-#                # make the arrow length 1/15 the height of the plot
-#                arr_end = arr_start * (plot_ymin / plot_ymax) ** (1./15)
-#                pylab.plot([r, r], [arr_start, arr_end], lw=2, color='black',
-#                    zorder=99)
-#                pylab.plot([r, r], [arr_start, arr_end], lw=2.6, color='white',
-#                    zorder=97)
-#                pylab.scatter([r], [arr_end], marker='v', c='black',
-#                    edgecolors='white', lw=0.5, s=40, zorder=98)
-            
+        if args.not_cumulative:
+            # add arrows to any points > the loudest background
+            louder_pts = numpy.where(cstat_fore > cstat_back.max())[0] 
+            for ii in louder_pts:
+                r = cstat_fore[ii]
+                arr_start = cstat_rate[ii]
+                # make the arrow length 1/15 the height of the plot
+                arr_end = arr_start * (plot_ymin / plot_ymax) ** (1./15)
+                pylab.plot([r, r], [arr_start, arr_end], lw=2, color='black',
+                           zorder=99)
+                pylab.plot([r, r], [arr_start, arr_end], lw=2.6, color='white',
+                           zorder=97)
+                pylab.scatter([r], [arr_end], marker='v', c='black',
+                              edgecolors='white', lw=0.5, s=40, zorder=98) 
+
+            if h_inc_back_num > 0:
+               #louder_pts = numpy.where(cstat_rate_h_rm > cstat_back.max())[0]
+               for ii in range(0, len(cstat_fore_h_rm)):
+                   r = cstat_fore_h_rm[ii]
+                   arr_start = cstat_rate_h_rm[ii]
+                   # make the arrow length 1/15 the height of the plot
+                   arr_end = arr_start * (plot_ymin / plot_ymax) ** (1./15)
+                   pylab.plot([r, r], [arr_start, arr_end], lw=2,
+                              color='black', zorder=99)
+                   pylab.plot([r, r], [arr_start, arr_end], lw=2.6,
+                              color='white', zorder=97)
+                   pylab.scatter([r], [arr_end], marker='v', c='black',
+                                 edgecolors='white', lw=0.5, s=40, zorder=98)
+
 if not args.cumulative:
     # add second y-axis for probabilities, sigmas
     sigmas = numpy.arange(6)+1

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -107,7 +107,7 @@ try:
         cstat_rate = numpy.arange(len(cstat_fore), 0, -1) / f.attrs['foreground_time'] * lal.YRJUL_SI
         fap_end = f['foreground/fap'][:].min() * args.trials_factor
     else:
-        if h_inc_back_num == -1:
+        if h_inc_back_num == 0:
             cstat_fore = f['foreground/stat'][:]
             ssort = cstat_fore.argsort()
             cstat_rate = 1.0 / f['foreground/ifar'][:] * args.trials_factor
@@ -219,8 +219,9 @@ if not args.closed_box:
                 cstat_rate = numpy.delete(cstat_rate, rm_idx)
 
             pylab.scatter(cstat_fore_h_rm, cstat_rate_h_rm, s=60, color='#b66dff',
-                          marker=args.fg_marker, label='Hierarchically Removed Foreground',
-                          zorder=100, linewidth=0.5, edgecolors='white')
+                          marker=args.fg_marker_h_rm,
+                          label='Hierarchically Removed Foreground', zorder=100,
+                          linewidth=0.5, edgecolors='white')
 
         pylab.scatter(cstat_fore, cstat_rate, s=60, color='#ff6600',
                       marker=args.fg_marker, label='Foreground', zorder=100,
@@ -291,16 +292,14 @@ if not args.cumulative:
         for ii,p in enumerate(sigps[:-1]):
             nextp = sigps[ii+1]
             pylab.axhspan(far_from_p(nextp, foreground_livetime, far_back.max()),
-                        far_from_p(p, foreground_livetime, far_back.max()),
-                        linewidth=0,
-                        color=pylab.cm.Blues(float(sigmas[ii+1]) / sigmas.size),
-                        alpha=0.3, zorder=-1) 
+                          far_from_p(p, foreground_livetime, far_back.max()),
+                          linewidth=0,
+                          color=pylab.cm.Blues(float(sigmas[ii+1]) / sigmas.size),
+                          alpha=0.3, zorder=-1) 
             # add sigma label
             pylab.annotate('%1.0f$\sigma$' % sigmas[ii],
                            (anntx, far_from_p(p, foreground_livetime,
                             far_back.max())), zorder=100)
-
-
     pylab.sca(ax1)
     
 if args.cumulative:
@@ -320,9 +319,9 @@ pylab.xlim(plot_xmin, plot_xmax)
 if args.cumulative:
     pylab.legend(loc="lower left")
     pylab.grid()
-    figure_caption =  "Cumulative histogram of foreground and background triggers."
+    figure_caption = "Cumulative histogram of foreground and background triggers."
 else:
-    figure_caption =  "Mapping between the ranking statistic and false alarm rate."
+    figure_caption = "Mapping between the ranking statistic and false alarm rate."
     pylab.grid()
     pylab.legend(loc="upper right")
     ax2.set_yscale('log')

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -106,16 +106,6 @@ if h_inc_back_num > h_iterations:
     raise ValueError('User requested inclusive background after '
                      'hierarchical removals that does not exist!')
 
-#if f.attrs['hierarchical_removal_iterations'] is not None:
-#    h_iterations = f.attrs['hierarchical_removal_iterations']
-#    if h_inc_back_num > h_iterations:
-#        h_inc_back_num = h_iterations
-#        logging.warn('User requested inclusive background iteration that does '
-#                     'not exist. Defaulting to last possible inclusive '
-#                     'background.')
-#else :
-#    h_inc_back_num = 0
-
 args.cumulative = not args.not_cumulative
 
 foreground_livetime = f.attrs['foreground_time'] / lal.YRJUL_SI

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -51,7 +51,7 @@ parser.add_argument('--trials-factor', type=int, default=1,
                     help='Trials factor to divide from p-value and '
                          'divide from IFAR to account for look-elsewhere '
                          'effect. [default=1]')
-parser.add_argument('--sigma-shading', action='store_false',
+parser.add_argument('--sigma-shading', action='store_true',
                     help='Use option --sigma-shading to include sigma '
                          'contours in the cumulative and non-cumulative '
                          'plots. If not given, defaults to no sigma '
@@ -239,7 +239,7 @@ if not args.closed_box:
                       marker=args.fg_marker, label='Foreground', zorder=100,
                       linewidth=0.5, edgecolors='white')
 
-        if args.cumulative and not args.sigma_shading:
+        if args.cumulative and args.sigma_shading:
             end = sigma_from_p(fap_end)
             sigmas = numpy.array([end, 4, 3, 2, 1])
             top = cstat_rate.max()
@@ -312,7 +312,7 @@ if not args.cumulative:
     # right axis
     anntx = plot_xmax - (plot_xmax - plot_xmin)/25.
     sigps = p_from_sigma(sigmas)
-    if not args.sigma_shading:
+    if args.sigma_shading:
         for ii,p in enumerate(sigps[:-1]):
             nextp = sigps[ii+1]
             pylab.axhspan(far_from_p(nextp, foreground_livetime, far_back.max()),

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -344,7 +344,7 @@ else:
     # Set the labels
     ax2.set_yticklabels(['$10^{%i}$' %(val) for val in pticks.astype(int)])
     # Add minor ticks
-    N_minor_per_decade = 10.
+    N_minor_per_decade = 10
     pminorticks = numpy.zeros(N_minor_per_decade * (pticks.size-1))
     for ii,p in enumerate(10**pticks[:-1]):
         idx = ii*N_minor_per_decade

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -275,7 +275,7 @@ else:
     # set the labels
     ax2.set_yticklabels(['$10^{%i}$' %(val) for val in pticks.astype(int)])
     # add minor ticks
-    N_minor_per_decade = 10
+    N_minor_per_decade = 10.
     pminorticks = numpy.zeros(N_minor_per_decade * (pticks.size-1))
     for ii,p in enumerate(10**pticks[:-1]):
         idx = ii*N_minor_per_decade

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -63,8 +63,6 @@ parser.add_argument('--h-iter-inc-background', type=int, default=None,
                          'Choose other integers greater than this for other '
                          'inclusive backgrounds after hierarchical removal. '
                          '[default=None]')
-                         'with the foreground triggers if there were '
-                         'hierarchical removals done. [default=None]')
 parser.add_argument('--fg-marker', default='^',
                     help='Marker to use for the foreground triggers, '
                          '[default = ^]')
@@ -96,15 +94,27 @@ f = h5py.File(args.trigger_file, 'r')
 # Parse which inclusive background to use for the plotting
 h_inc_back_num = args.h_iter_inc_background
 
-if f.attrs['hierarchical_removal_iterations'] is not None:
+try:
     h_iterations = f.attrs['hierarchical_removal_iterations']
-    if h_inc_back_num > h_iterations:
-        h_inc_back_num = h_iterations
-        logging.warn('User requested inclusive background iteration that does '
-                     'not exist. Defaulting to last possible inclusive '
-                     'background.')
-else :
-    h_inc_back_num = 0
+except KeyError:
+    h_iterations = 0
+
+if h_inc_back_num is None:
+    h_inc_back_num = h_iterations
+
+if h_inc_back_num > h_iterations:
+    raise ValueError('User requested inclusive background after '
+                     'hierarchical removals that does not exist!')
+
+#if f.attrs['hierarchical_removal_iterations'] is not None:
+#    h_iterations = f.attrs['hierarchical_removal_iterations']
+#    if h_inc_back_num > h_iterations:
+#        h_inc_back_num = h_iterations
+#        logging.warn('User requested inclusive background iteration that does '
+#                     'not exist. Defaulting to last possible inclusive '
+#                     'background.')
+#else :
+#    h_inc_back_num = 0
 
 args.cumulative = not args.not_cumulative
 
@@ -120,6 +130,16 @@ try:
          cstat_fore = f['foreground/stat'][:]
          ssort = cstat_fore.argsort()
          cstat_rate = 1.0 / f['foreground/ifar'][:] * args.trials_factor
+         # Correct the foreground ifars depending on the values calculated
+         # under a particular inclusive background distribution.
+         if h_inc_back_num > 0:
+             ifar_h_inc = f['foreground_h%s/ifar' % h_inc_back_num][:]
+             stat_h_inc = f['foreground_h%s/stat' % h_inc_back_num][:]
+             for i in range(0, len(ifar_h_inc)):
+                 orig_idx = numpy.where(cstat_fore == stat_h_inc[i])[0][0]
+                 if orig_idx is not None:
+                     cstat_rate[orig_idx] = 1.0 / ifar_h_inc[i] \
+                                            * args.trials_factor
          cstat_rate = cstat_rate[ssort]
          cstat_fore = cstat_fore[ssort]
          cstat_fap = p_from_far(cstat_rate, foreground_livetime)

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -275,7 +275,7 @@ else:
     # set the labels
     ax2.set_yticklabels(['$10^{%i}$' %(val) for val in pticks.astype(int)])
     # add minor ticks
-    N_minor_per_decade = 10.
+    N_minor_per_decade = 10
     pminorticks = numpy.zeros(N_minor_per_decade * (pticks.size-1))
     for ii,p in enumerate(10**pticks[:-1]):
         idx = ii*N_minor_per_decade

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -286,8 +286,9 @@ if not args.closed_box:
                 pylab.scatter([r], [arr_end], marker='v', c='black',
                               edgecolors='white', lw=0.5, s=40, zorder=98) 
 
+            louder_pts = numpy.where(cstat_fore_h_rm > cstat_back.max())[0]
             if h_inc_back_num > 0:
-               for ii in range(0, len(cstat_fore_h_rm)):
+               for ii in louder_pts:
                    r = cstat_fore_h_rm[ii]
                    arr_start = cstat_rate_h_rm[ii]
                    # make the arrow length 1/15 the height of the plot

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -51,7 +51,7 @@ parser.add_argument('--trials-factor', type=int, default=1,
                     help='Trials factor to divide from p-value and '
                          'divide from IFAR to account for look-elsewhere '
                          'effect. [default=1]')
-parser.add_argument('--no-sigma-shading', action='store_true')
+parser.add_argument('--no-sigma-shading', action='store_false')
 parser.add_argument('--h-iter-inc-background', type=int, default=None,
                     help='Indicate which inclusive background and FARs of '
                          'foreground triggers to plot if there were any '
@@ -103,7 +103,7 @@ except KeyError:
     h_iterations = 0
 
 if h_inc_back_num is None:
-    h_inc_back_num = None
+    h_inc_back_num = 0
 
 if h_inc_back_num > h_iterations:
     raise ValueError('User requested inclusive background after '
@@ -125,14 +125,12 @@ try:
          cstat_rate = 1.0 / f['foreground/ifar'][:] * args.trials_factor
          # Correct the foreground ifars depending on the values calculated
          # under a particular inclusive background distribution.
-         if h_inc_back_num >= 0:
-             ifar_h_inc = f['foreground_h%s/ifar' % h_inc_back_num][:]
-             stat_h_inc = f['foreground_h%s/stat' % h_inc_back_num][:]
-             for i in range(0, len(ifar_h_inc)):
-                 orig_idx = numpy.where(cstat_fore == stat_h_inc[i])[0][0]
-                 if orig_idx is not None:
-                     cstat_rate[orig_idx] = 1.0 / ifar_h_inc[i] \
-                                            * args.trials_factor
+         ifar_h_inc = f['foreground_h%s/ifar' % h_inc_back_num][:]
+         stat_h_inc = f['foreground_h%s/stat' % h_inc_back_num][:]
+         for i in range(0, len(ifar_h_inc)):
+             orig_idx = numpy.where(cstat_fore == stat_h_inc[i])[0][0]
+             if orig_idx is not None:
+                 cstat_rate[orig_idx] = 1.0 / ifar_h_inc[i] * args.trials_factor
          cstat_rate = cstat_rate[ssort]
          cstat_fore = cstat_fore[ssort]
          cstat_fap = p_from_far(cstat_rate, foreground_livetime)
@@ -144,13 +142,8 @@ except:
 if cstat_fore is not None and len(cstat_fore) == 0:
     cstat_fore = None
 
-if h_inc_back_num > 0:
-    back_ifar = f['background_h%s/ifar' % h_inc_back_num][:]
-    cstat_back = f['background_h%s/stat' % h_inc_back_num][:]
-
-else :
-    back_ifar = f['background/ifar'][:]
-    cstat_back = f['background/stat'][:]
+back_ifar = f['background_h%s/ifar' % h_inc_back_num][:]
+cstat_back = f['background_h%s/stat' % h_inc_back_num][:]
 
 back_sort = cstat_back.argsort()
 cstat_back = cstat_back[back_sort]
@@ -224,7 +217,7 @@ if not args.closed_box:
             # Since there is only one background bin we can just remove
             # hierarchically removed triggers from highest ranking statistic
             # to lower ranking statistic.
-            for i in range(0, h_inc_back_num):
+            for i in range(h_inc_back_num):
                 rm_idx = cstat_fore.argmax()
                 cstat_fore_h_rm = numpy.append(cstat_fore_h_rm,
                                                cstat_fore[rm_idx])
@@ -335,7 +328,7 @@ else:
         pylab.ylabel('False Alarm Rate (yr$^{-1}$)')
     elif args.trials_factor >= 1:
         pylab.ylabel('Combined False Alarm Rate (yr$^{-1}$)')
-    ax2.set_ylabel('False Alarm Probability')
+    ax2.set_ylabel('p-value')
 
 pylab.xlabel(r'Coincident Ranking Statistic')
 pylab.yscale('log')

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -92,7 +92,6 @@ if f.attrs['hierarchical_removal_iterations'] is not None:
         logging.warn('User requested inclusive background iteration that does '
                      'not exist. Defaulting to last possible inclusive '
                      'background.')
-
 else :
     h_inc_back_num = 0
 
@@ -109,6 +108,7 @@ try:
     else:
         if h_inc_back_num == 0:
             cstat_fore = f['foreground/stat'][:]
+            print "The length of the foreground triggers is...", len(cstat_fore)
             ssort = cstat_fore.argsort()
             cstat_rate = 1.0 / f['foreground/ifar'][:] * args.trials_factor
             cstat_rate = cstat_rate[ssort]
@@ -116,6 +116,7 @@ try:
             cstat_fap = p_from_far(cstat_rate, foreground_livetime)
         else :
             cstat_fore = f['foreground_h%s/stat' % h_inc_back_num][:]
+            print "The length of the foreground triggers is...", len(cstat_fore)
             ssort = cstat_fore.argsort()
             cstat_rate = 1.0 / f['foreground_h%s/ifar' % h_inc_back_num][:] * args.trials_factor
             cstat_rate = cstat_rate[ssort]
@@ -125,6 +126,8 @@ try:
     logging.info('Found %s foreground triggers' % len(cstat_fore))
 except:
     cstat_fore = None
+
+print "The length of the foreground triggers is...", len(cstat_fore)
 
 if cstat_fore is not None and len(cstat_fore) == 0:
     cstat_fore = None

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -365,7 +365,7 @@ else:
     ax2.set_yticks(fticks)
     # Set the labels
     ax2.set_yticklabels(['$10^{%i}$' %(val) for val in pticks.astype(int)])
-    # Add minor ticks
+    # add minor ticks
     N_minor_per_decade = 10
     pminorticks = numpy.zeros(N_minor_per_decade * (pticks.size-1))
     for ii,p in enumerate(10**pticks[:-1]):

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -1,5 +1,7 @@
 #!/usr/bin/python
-""" Make table of the foreground coincident events
+""" Make cumulative histogram of foreground coincident events via rate vs
+    ranking statistic, or make statistical significance vs ranking statistic
+    cumulative histograms. 
 """
 import argparse, h5py, numpy, logging, sys, lal
 import matplotlib

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -53,16 +53,19 @@ parser.add_argument('--trials-factor', type=int, default=1,
                          'effect. [default=1]')
 parser.add_argument('--no-sigma-shading', action='store_true')
 parser.add_argument('--h-iter-inc-background', type=int, default=None,
-                    help='Indicate which inclusive background to plot '
-                         'with the foreground triggers if there were '
-                         'any hierarchical removals done. Choosing 0 '
-                         'or None indicates plotting the inclusive '
-                         'background prior to any hierarchical removals. '
-                         'Choosing 1 indicates the inclusive background '
-                         'after the loudest foreground trigger was removed. '
-                         'Choose other integers greater than this for other '
-                         'inclusive backgrounds after hierarchical removal. '
-                         '[default=None]')
+                    help='Indicate which inclusive background and FARs of '
+                         'foreground triggers to plot if there were any '
+                         'hierarchical removals done. Choosing None plots '
+                         'the inclusive backgrounds prior to any '
+                         'hierarchical removals with the updated FARs for '
+                         'foreground triggers after hierarchical removal(s). '
+                         'Choosing 0 means plotting inclusive background '
+                         'from prior to any hierarchical removals with FARs '
+                         'for foreground triggers prior to hierarchical '
+                         'removal. Choosing 1 means plotting the inclusive '
+                         'background after doing 1 hierarchical removal, and '
+                         'includes updated FARs from after 1 hierarchical '
+                         'removal. [default=None]')
 parser.add_argument('--fg-marker', default='^',
                     help='Marker to use for the foreground triggers, '
                          '[default = ^]')

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -100,7 +100,7 @@ except KeyError:
     h_iterations = 0
 
 if h_inc_back_num is None:
-    h_inc_back_num = h_iterations
+    h_inc_back_num = None
 
 if h_inc_back_num > h_iterations:
     raise ValueError('User requested inclusive background after '
@@ -122,7 +122,7 @@ try:
          cstat_rate = 1.0 / f['foreground/ifar'][:] * args.trials_factor
          # Correct the foreground ifars depending on the values calculated
          # under a particular inclusive background distribution.
-         if h_inc_back_num > 0:
+         if h_inc_back_num >= 0:
              ifar_h_inc = f['foreground_h%s/ifar' % h_inc_back_num][:]
              stat_h_inc = f['foreground_h%s/stat' % h_inc_back_num][:]
              for i in range(0, len(ifar_h_inc)):

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -290,7 +290,6 @@ if not args.closed_box:
                               edgecolors='white', lw=0.5, s=40, zorder=98) 
 
             if h_inc_back_num > 0:
-               #louder_pts = numpy.where(cstat_rate_h_rm > cstat_back.max())[0]
                for ii in range(0, len(cstat_fore_h_rm)):
                    r = cstat_fore_h_rm[ii]
                    arr_start = cstat_rate_h_rm[ii]

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -51,11 +51,6 @@ parser.add_argument('--trials-factor', type=int, default=1,
                     help='Trials factor to divide from p-value and '
                          'divide from IFAR to account for look-elsewhere '
                          'effect. [default=1]')
-parser.add_argument('--sigma-shading', action='store_true',
-                    help='Use option --sigma-shading to include sigma '
-                         'contours in the cumulative and non-cumulative '
-                         'plots. If not given, defaults to no sigma '
-                         'contours.')
 parser.add_argument('--h-iter-inc-background', type=int, default=None,
                     help='Indicate which inclusive background and FARs of '
                          'foreground triggers to plot if there were any '
@@ -239,38 +234,6 @@ if not args.closed_box:
                       marker=args.fg_marker, label='Foreground', zorder=100,
                       linewidth=0.5, edgecolors='white')
 
-        if args.cumulative and args.sigma_shading:
-            end = sigma_from_p(fap_end)
-            sigmas = numpy.array([end, 4, 3, 2, 1])
-            top = cstat_rate.max()
-            for i in range(len(sigmas) - 1):
-                if sigmas[i+1] > end:
-                    continue
-
-                p1 = p_from_sigma(sigmas[i])
-                p2 = p_from_sigma(sigmas[i+1])
-                                
-                #offset the shading so it is valid for the foreground beyond the first point
-                if cstat_fore is not None and len(cstat_fore):
-                    offset = numpy.interp(cstat_back, cstat_fore, cstat_rate - cstat_rate[-1])
-                else:
-                    offset = 0
-                    
-                low = far_back / p2 * args.trials_factor + offset
-                high = far_back / p1 * args.trials_factor + offset
-                pylab.fill_between(cstat_back, low, high,
-                                   linewidth=0, color=pylab.cm.Blues(sigmas[i] / 5.0), zorder=-1)
-
-                try:
-                    left = cstat_back[high < top].min()
-
-                    if sigmas[i] == end:
-                        pylab.text(left, top*1.05, r"\textbf{%1.1f $\sigma$}"  % sigmas[i], fontsize=8)
-                    else:
-                        pylab.text(left, top*1.05, r"\textbf{%1.0f $\sigma$}"  % sigmas[i], fontsize=8) 
-                except ValueError:
-                    logging.warn(" Can't find a place for the sigma labels ")
-
         if args.not_cumulative:
             # add arrows to any points > the loudest background
             louder_pts = numpy.where(cstat_fore > cstat_back.max())[0] 
@@ -312,18 +275,17 @@ if not args.cumulative:
     # right axis
     anntx = plot_xmax - (plot_xmax - plot_xmin)/25.
     sigps = p_from_sigma(sigmas)
-    if args.sigma_shading:
-        for ii,p in enumerate(sigps[:-1]):
-            nextp = sigps[ii+1]
-            pylab.axhspan(far_from_p(nextp, foreground_livetime, far_back.max()),
-                          far_from_p(p, foreground_livetime, far_back.max()),
-                          linewidth=0,
-                          color=pylab.cm.Blues(float(sigmas[ii+1]) / sigmas.size),
-                          alpha=0.3, zorder=-1) 
+    for ii,p in enumerate(sigps[:-1]):
+        nextp = sigps[ii+1]
+        pylab.axhspan(far_from_p(nextp, foreground_livetime, far_back.max()),
+                      far_from_p(p, foreground_livetime, far_back.max()),
+                      linewidth=0,
+                      color=pylab.cm.Blues(float(sigmas[ii+1]) / sigmas.size),
+                      alpha=0.3, zorder=-1) 
             # add sigma label
-            pylab.annotate('%1.0f$\sigma$' % sigmas[ii],
-                           (anntx, far_from_p(p, foreground_livetime,
-                            far_back.max())), zorder=100)
+        pylab.annotate('%1.0f$\sigma$' % sigmas[ii],
+                       (anntx, far_from_p(p, foreground_livetime,
+                       far_back.max())), zorder=100)
     pylab.sca(ax1)
     
 if args.cumulative:

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -51,7 +51,11 @@ parser.add_argument('--trials-factor', type=int, default=1,
                     help='Trials factor to divide from p-value and '
                          'divide from IFAR to account for look-elsewhere '
                          'effect. [default=1]')
-parser.add_argument('--no-sigma-shading', action='store_false')
+parser.add_argument('--sigma-shading', action='store_false',
+                    help='Use option --sigma-shading to include sigma '
+                         'contours in the cumulative and non-cumulative '
+                         'plots. If not given, defaults to no sigma '
+                         'contours.')
 parser.add_argument('--h-iter-inc-background', type=int, default=None,
                     help='Indicate which inclusive background and FARs of '
                          'foreground triggers to plot if there were any '
@@ -235,7 +239,7 @@ if not args.closed_box:
                       marker=args.fg_marker, label='Foreground', zorder=100,
                       linewidth=0.5, edgecolors='white')
 
-        if args.cumulative and not args.no_sigma_shading:
+        if args.cumulative and not args.sigma_shading:
             end = sigma_from_p(fap_end)
             sigmas = numpy.array([end, 4, 3, 2, 1])
             top = cstat_rate.max()
@@ -307,7 +311,7 @@ if not args.cumulative:
     # right axis
     anntx = plot_xmax - (plot_xmax - plot_xmin)/25.
     sigps = p_from_sigma(sigmas)
-    if not args.no_sigma_shading:
+    if not args.sigma_shading:
         for ii,p in enumerate(sigps[:-1]):
             nextp = sigps[ii+1]
             pylab.axhspan(far_from_p(nextp, foreground_livetime, far_back.max()),

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -286,8 +286,8 @@ if not args.closed_box:
                 pylab.scatter([r], [arr_end], marker='v', c='black',
                               edgecolors='white', lw=0.5, s=40, zorder=98) 
 
-            louder_pts = numpy.where(cstat_fore_h_rm > cstat_back.max())[0]
             if h_inc_back_num > 0:
+               louder_pts = numpy.where(cstat_fore_h_rm > cstat_back.max())[0]
                for ii in louder_pts:
                    r = cstat_fore_h_rm[ii]
                    arr_start = cstat_rate_h_rm[ii]

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -27,6 +27,12 @@ def _far_from_p(p, livetime, max_far):
     if far > max_far:
         return max_far
     return far
+
+def pretty_num(num):
+    exp = numpy.floor(numpy.log10(num))
+    val = num / 10.0 ** exp
+    return '%2.1fe%.0f' % (val, exp)
+
 far_from_p = numpy.vectorize(_far_from_p)
 
 pylab.rc('text', usetex=True)
@@ -38,41 +44,83 @@ parser.add_argument('--version', action='version', version=pycbc.version.git_ver
 parser.add_argument('--trigger-file')
 parser.add_argument('--verbose', action='count')
 parser.add_argument('--output-file')
-parser.add_argument('--trials-factor', type=int, default=1)
 parser.add_argument('--not-cumulative', action='store_true')
+parser.add_argument('--trials-factor', type=int, default=1,
+                    help='Trials factor to divide from p-value and '
+                         'divide from IFAR to account for look-elsewhere '
+                         'effect. [default=1]')
 parser.add_argument('--no-sigma-shading', action='store_true')
-parser.add_argument('--fg-marker', default='^', help='Marker to use for the foreground triggers')
+parser.add_argument('--h-iter-inc-background', type=int, default=0,
+                    help='Indicate which inclusive background to plot '
+                         'with the foreground triggers if there were '
+                         'hierarchical removals done. [default=0]')
+parser.add_argument('--fg-marker', default='^',
+                    help='Marker to use for the foreground triggers, '
+                         '[default = ^]')
+parser.add_argument('--fg-marker-h-rm', default='v',
+                    help='Marker to use for the hierarchically removed '
+                         'foreground triggers. [default = v]')
 parser.add_argument('--closed-box', action='store_true',
-      help="Make a closed box version that excludes foreground triggers")
-parser.add_argument('--xmin', type=float, help='Set the minimum value of the x-axis')
-parser.add_argument('--xmax', type=float, help='Set the maximum value of the x-axis')
-parser.add_argument('--ymin', type=float, help='Set the minimum value of the y-axis (in units of 1/years)')
-parser.add_argument('--ymax', type=float, help='Set the maximum value of the y-axis (in units of 1/years)')
+                    help="Make a closed box version that excludes foreground "
+                         "triggers")
+parser.add_argument('--xmin', type=float,
+                    help='Set the minimum value of the x-axis')
+parser.add_argument('--xmax', type=float,
+                    help='Set the maximum value of the x-axis')
+parser.add_argument('--ymin', type=float,
+                    help='Set the minimum value of the y-axis ' 
+                         '(in units of 1/years)')
+parser.add_argument('--ymax', type=float,
+                    help='Set the maximum value of the y-axis '
+                         '(in units of 1/years)')
 args = parser.parse_args()
-
-args.cumulative = not args.not_cumulative
 
 if args.verbose:
     log_level = logging.INFO
     logging.basicConfig(format='%(asctime)s : %(message)s', level=log_level)
-    
+
 logging.info('Read in the data')
 f = h5py.File(args.trigger_file, 'r')
 
+# Parse which inclusive background to use for the plotting
+h_inc_back_num = args.h_iter_inc_background
+
+if f.attrs['hierarchical_removal_iterations'] is not None:
+    h_iterations = f.attrs['hierarchical_removal_iterations']
+    if h_inc_back_num > h_iterations:
+        h_inc_back_num = h_iterations
+        logging.warn('User requested inclusive background iteration that does '
+                     'not exist. Defaulting to last possible inclusive '
+                     'background.')
+
+else :
+    h_inc_back_num = 0
+
+args.cumulative = not args.not_cumulative
+
 foreground_livetime = f.attrs['foreground_time'] / lal.YRJUL_SI
 try:
-    cstat_fore = f['foreground/stat'][:]
     
     if args.cumulative:
+        cstat_fore = f['foreground/stat'][:]
         cstat_fore.sort()
-        cstat_rate = numpy.arange(len(cstat_fore), 0, -1) / f.attrs['foreground_time'] * 3.15569e7
+        cstat_rate = numpy.arange(len(cstat_fore), 0, -1) / f.attrs['foreground_time'] * lal.YRJUL_SI
         fap_end = f['foreground/fap'][:].min() * args.trials_factor
     else:
-        ssort = cstat_fore.argsort()
-        cstat_rate = 1.0 / f['foreground/ifar'][:] * args.trials_factor
-        cstat_rate = cstat_rate[ssort]
-        cstat_fore = cstat_fore[ssort]
-        cstat_fap = p_from_far(cstat_rate, foreground_livetime)
+        if h_inc_back_num == -1:
+            cstat_fore = f['foreground/stat'][:]
+            ssort = cstat_fore.argsort()
+            cstat_rate = 1.0 / f['foreground/ifar'][:] * args.trials_factor
+            cstat_rate = cstat_rate[ssort]
+            cstat_fore = cstat_fore[ssort]
+            cstat_fap = p_from_far(cstat_rate, foreground_livetime)
+        else :
+            cstat_fore = f['foreground_h%s/stat' % h_inc_back_num][:]
+            ssort = cstat_fore.argsort()
+            cstat_rate = 1.0 / f['foreground_h%s/ifar' % h_inc_back_num][:] * args.trials_factor
+            cstat_rate = cstat_rate[ssort]
+            cstat_fore = cstat_fore[ssort]
+            cstat_fap = p_from_far(cstat_rate, foreground_livetime)
     
     logging.info('Found %s foreground triggers' % len(cstat_fore))
 except:
@@ -81,8 +129,14 @@ except:
 if cstat_fore is not None and len(cstat_fore) == 0:
     cstat_fore = None
 
-back_ifar = f['background/ifar'][:]
-cstat_back = f['background/stat'][:]
+if h_inc_back_num > 0:
+    back_ifar = f['background_h%s/ifar' % h_inc_back_num][:]
+    cstat_back = f['background_h%s/stat' % h_inc_back_num][:]
+
+else :
+    back_ifar = f['background/ifar'][:]
+    cstat_back = f['background/stat'][:]
+
 back_sort = cstat_back.argsort()
 cstat_back = cstat_back[back_sort]
 
@@ -117,8 +171,8 @@ if not args.cumulative:
 
 logging.info('Found %s background (exclusive zerolag) triggers' % len(cstat_back_exc))
 
-# we'll us the background for the xlimits if closed box,
-# foreground otherwise
+# We'll use the background for the xlimits if closed box, foreground
+# otherwise.
 if args.xmin is not None:
     plot_xmin = args.xmin
 elif args.closed_box or cstat_fore is None:
@@ -128,8 +182,8 @@ else:
 
 if args.xmax is not None:
     plot_xmax = args.xmax
-# otherwise, make the furthest point to the right be ~1/10 of the
-# width of the plot from the right axis
+# Otherwise, make the furthest point to the right be ~1/10 of the width of the
+# plot from the right axis.
 else:
     if args.closed_box or cstat_fore is None:
         plot_xmax = cstat_back_exc.max()
@@ -141,21 +195,36 @@ fig = pylab.figure(1)
 back_marker = 'x'
 pylab.scatter(cstat_back_exc, far_back_exc, color='gray', marker=back_marker, s=10, label='Closed Box Background')
 
-def pretty_num(num):
-    exp = numpy.floor(numpy.log10(num))
-    val = num / 10.0 ** exp
-    return '%2.1fe%.0f' % (val, exp)
-
 if not args.closed_box:
     pylab.scatter(cstat_back, far_back, color='black', marker=back_marker, s=10,
         label='Open Box Background')
 
     if cstat_fore is not None and len(cstat_fore):
-        pylab.scatter(cstat_fore, cstat_rate, s=60, color='#ff6600',
-                                  marker=args.fg_marker,
-                                  label='Foreground', zorder=100,
-                                  linewidth=0.5, edgecolors='white')
+        # Remove hierarchically removed foreground triggers from the list
+        # of foreground triggers
+        if h_inc_back_num > 0:
+            cstat_fore_h_rm = numpy.array([], dtype=float)
+            cstat_rate_h_rm = numpy.array([], dtype=float)
 
+            # Since there is only one background bin we can just remove
+            # hierarchically removed triggers from highest ranking statistic
+            # to lower ranking statistic.
+            for i in range(0, h_inc_back_num):
+                rm_idx = cstat_fore.argmax()
+                cstat_fore_h_rm = numpy.append(cstat_fore_h_rm,
+                                               cstat_fore[rm_idx])
+                cstat_rate_h_rm = numpy.append(cstat_rate_h_rm,
+                                                cstat_rate[rm_idx])
+                cstat_fore = numpy.delete(cstat_fore, rm_idx)
+                cstat_rate = numpy.delete(cstat_rate, rm_idx)
+
+            pylab.scatter(cstat_fore_h_rm, cstat_rate_h_rm, s=60, color='#b66dff',
+                          marker=args.fg_marker, label='Hierarchically Removed Foreground',
+                          zorder=100, linewidth=0.5, edgecolors='white')
+
+        pylab.scatter(cstat_fore, cstat_rate, s=60, color='#ff6600',
+                      marker=args.fg_marker, label='Foreground', zorder=100,
+                      linewidth=0.5, edgecolors='white')
 
         if args.cumulative and not args.no_sigma_shading:
             end = sigma_from_p(fap_end)
@@ -181,7 +250,7 @@ if not args.closed_box:
 
                 try:
                     left = cstat_back[high < top].min()
-                    
+
                     if sigmas[i] == end:
                         pylab.text(left, top*1.05, r"\textbf{%1.1f $\sigma$}"  % sigmas[i], fontsize=8)
                     else:
@@ -189,20 +258,22 @@ if not args.closed_box:
                 except ValueError:
                     logging.warn(" Can't find a place for the sigma labels ")
 
-        if args.not_cumulative:
-            # add arrows to any points > the loudest background
-            louder_pts = numpy.where(cstat_fore > cstat_back.max())[0] 
-            for ii in louder_pts:
-                r = cstat_fore[ii]
-                arr_start = cstat_rate[ii]
-                # make the arrow length 1/15 the height of the plot
-                arr_end = arr_start * (plot_ymin / plot_ymax) ** (1./15)
-                pylab.plot([r, r], [arr_start, arr_end], lw=2, color='black',
-                    zorder=99)
-                pylab.plot([r, r], [arr_start, arr_end], lw=2.6, color='white',
-                    zorder=97)
-                pylab.scatter([r], [arr_end], marker='v', c='black',
-                    edgecolors='white', lw=0.5, s=40, zorder=98)
+#        if args.not_cumulative:
+#            # add arrows to any points > the loudest background
+#            far_min_possible = 1. / f.attrs['background_time']
+#            far_min_possible *= 3.15569e7 * args.trials_factor
+#            louder_pts = numpy.where(cstat_rate <= far_min_possible)
+#            for ii in louder_pts:
+#                r = cstat_fore[ii]
+#                arr_start = cstat_rate[ii]
+#                # make the arrow length 1/15 the height of the plot
+#                arr_end = arr_start * (plot_ymin / plot_ymax) ** (1./15)
+#                pylab.plot([r, r], [arr_start, arr_end], lw=2, color='black',
+#                    zorder=99)
+#                pylab.plot([r, r], [arr_start, arr_end], lw=2.6, color='white',
+#                    zorder=97)
+#                pylab.scatter([r], [arr_end], marker='v', c='black',
+#                    edgecolors='white', lw=0.5, s=40, zorder=98)
             
 if not args.cumulative:
     # add second y-axis for probabilities, sigmas
@@ -258,23 +329,22 @@ else:
     ymin, ymax = ax1.get_ylim()
     
     ax2.set_ylim(ymin, ymax)
-    # we'll put ticks at faps of 10^{-x}, where x is an integer
-    # get the ymin, ymax in terms of probability
+    # Put ticks at FAPs of 10^{-x}, where x is an integer get the ymin, ymax
+    # in terms of probability.
     pymin = p_from_far(ymin, foreground_livetime)
     pymax = p_from_far(ymax, foreground_livetime)
-    # figure out the range of values we need to plot: this will be the
-    # floor/ceil of the min/max
-    # values
+    # Figure out the range of values we need to plot: this will be the
+    # floor/ceil of the min/max values.
     tick_min = numpy.ceil(numpy.log10(pymin))
     tick_max = numpy.floor(numpy.log10(pymax))
-    # tick ranges
+    # Tick ranges
     pticks = numpy.arange(tick_min, tick_max+1)
-    # convert back to FAR
+    # Convert back to FAR
     fticks = far_from_p(10**pticks, foreground_livetime, far_back.max())
     ax2.set_yticks(fticks)
-    # set the labels
+    # Set the labels
     ax2.set_yticklabels(['$10^{%i}$' %(val) for val in pticks.astype(int)])
-    # add minor ticks
+    # Add minor ticks
     N_minor_per_decade = 10.
     pminorticks = numpy.zeros(N_minor_per_decade * (pticks.size-1))
     for ii,p in enumerate(10**pticks[:-1]):


### PR DESCRIPTION
This pull request is the work in progress on making more of the hierarchical removal plots.

First, are the cumulative histograms which I believe are exactly as we want them to look.

**Cumulative Histograms**
With no hierarchical removal plot:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/ER10/hierarchical_removal_plots/bulk_bin_cum_0th_background_alt.png

With 1 hierarchical removal plot:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/ER10/hierarchical_removal_plots/bulk_bin_cum_1st_background_alt.png

With 2 hierarchical removals plot:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/ER10/hierarchical_removal_plots/bulk_bin_cum_2nd_background_alt.png

**Non-Cumulative Histograms**
Here comes the tricky part. We should be able to see how the IFARs of foreground triggers change after the hierarchical removals. This currently works that way, but I need to make a patch so that the `pycbc_coinc_statmap` code stores the IFAR values prior to all hierarchical removal as well. Currently it just overwrites those values. Alternatively, one can just run `pycbc_coinc_statmap` twice, once with no hierarchical removals, and a second time with all hierarchical removals, but that seems like a dumb idea. **FIXED: Now use NONE option on `--h_iter_background` for plot everybody hates, and 0 for plot (b)**

(a) With all IFARs updated but with inclusive background from GW150914 [Nobody likes this plot]:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/ER10/hierarchical_removal_plots/bulk_bin_not_cum_None_background.png

(b) With no IFARs updated, with inclusive background from GW150914:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/ER10/hierarchical_removal_plots/bulk_bin_not_cum_0th_background.png

(c) With IFARs only updated as far as with 1 hierarchical removal of GW150914:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/ER10/hierarchical_removal_plots/bulk_bin_not_cum_1st_background.png

(d) With IFARS updated after 2 hierarchical removals:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/ER10/hierarchical_removal_plots/bulk_bin_not_cum_2nd_background.png

**Note! You can see LVT151012 shift IFAR values between plot (c) and (d). Notice too dramatic shift in GW151226 as well between (a) and (b)**