### PR TITLE
Allow user to scale injection in pycbc_insert_frame_hwinj

### DIFF
--- a/bin/hwinj/pycbc_insert_frame_hwinj
+++ b/bin/hwinj/pycbc_insert_frame_hwinj
@@ -42,7 +42,7 @@ parser.add_argument('--output-file', type=str, required=True,
                     help='Path to output frame file.')
 parser.add_argument('--precision', type=str, default=None,
                     choices=['single', 'double'],
-                    help='Store as a numpy.float64.')
+                    help='Store as a float32 or float64.')
 
 # fake data options
 parser.add_argument('--low-frequency-cutoff', type=int, required=False,

--- a/bin/hwinj/pycbc_insert_frame_hwinj
+++ b/bin/hwinj/pycbc_insert_frame_hwinj
@@ -32,18 +32,21 @@ parser.add_argument('--hwinj-file', type=str, required=True,
                     help='Path to single-column ASCII file.')
 parser.add_argument('--hwinj-start-time', type=int, required=True,
                     help='Start time of the single-column ASCII file.')
+parser.add_argument('--scale-factor', type=float, default=1.0,
+                    help='Scales the waveform amplitude by a float.')
 
 # frame options
 parser.add_argument('--ifo', type=str, required=True,
                      help='IFO.')
 parser.add_argument('--output-file', type=str, required=True,
                     help='Path to output frame file.')
+parser.add_argument('--precision', type=str, default=None,
+                    choices=['single', 'double'],
+                    help='Store as a numpy.float64.')
 
 # fake data options
 parser.add_argument('--low-frequency-cutoff', type=int, required=False,
                     help='Low-frequency cutoff for generating fake PSD.')
-parser.add_argument('--scale-factor', type=float, default=1.0,
-                    help='Scales the waveform amplitude by a float.')
 
 # add option groups
 _strain.insert_strain_option_group(parser)
@@ -70,6 +73,12 @@ start_pad = (opts.hwinj_start_time-opts.gps_start_time) * opts.sample_rate
 logging.info('Summing the two time series')
 for i in range(len(initial_array)):
     strain[start_pad+1+i] += initial_array[i]
+
+# typecast
+if opts.precision == 'single':
+    strain = strain.astype(numpy.float32)
+elif opts.precision == 'double':
+    strain = strain.astype(numpy.float64)
 
 # write frame
 logging.info('Writing data')

--- a/bin/hwinj/pycbc_insert_frame_hwinj
+++ b/bin/hwinj/pycbc_insert_frame_hwinj
@@ -24,23 +24,26 @@ from pycbc import strain as _strain
 
 # command line usage
 parser = argparse.ArgumentParser(usage='pycbc_insert_frame_hwinj [--options]',
-             description="Inserts a single-column ASCII file into frame data.")
+                                 description="Inserts a single-column ASCII "
+                                             "file into frame data.")
 
 # injection options
 parser.add_argument('--hwinj-file', type=str, required=True,
-             help='Path to single-column ASCII file.')
+                    help='Path to single-column ASCII file.')
 parser.add_argument('--hwinj-start-time', type=int, required=True,
-             help='Start time of the single-column ASCII file.')
+                    help='Start time of the single-column ASCII file.')
 
 # frame options
 parser.add_argument('--ifo', type=str, required=True,
-             help='IFO.')
+                     help='IFO.')
 parser.add_argument('--output-file', type=str, required=True,
-             help='Path to output frame file.')
+                    help='Path to output frame file.')
 
 # fake data options
 parser.add_argument('--low-frequency-cutoff', type=int, required=False,
-             help='Low-frequency cutoff for generating fake PSD.')
+                    help='Low-frequency cutoff for generating fake PSD.')
+parser.add_argument('--scale-factor', type=float, default=1.0,
+                    help='Scales the waveform amplitude by a float.')
 
 # add option groups
 _strain.insert_strain_option_group(parser)
@@ -58,6 +61,7 @@ strain = _strain.from_cli(opts)
 # load data
 logging.info('Reading the hardware injection data')
 initial_array = numpy.loadtxt(opts.hwinj_file)
+initial_array *= opts.scale_factor
 
 # figure out how much to pad
 start_pad = (opts.hwinj_start_time-opts.gps_start_time) * opts.sample_rate

--- a/docs/distributions.rst
+++ b/docs/distributions.rst
@@ -2,23 +2,26 @@
 Using PyCBC Distributions from PyCBC Inference
 ###################################################
 
-The aim of this page is to demonstrate some simple uses of the distributions available from the distributions.py module available at <https://github.com/ligo-cbc/pycbc/blob/master/pycbc/inference/distributions.py>.
+The aim of this page is to demonstrate some simple uses of the distributions available from the distributions.py module available at :py:mod:`pycbc.inference.distributions`.
 
 =========================================
 Making Mass Distributions in M1 and M2
 =========================================
 
 Here we will demonstrate how to make different mass populations of binaries. This example shows uniform and gaussian mass distributions.
-.. literalinclude:: ../examples/inference/mass_examples.py
-.. command-output:: python ../examples/inference/mass_examples.py
+
+.. plot:: ../examples/distributions/mass_examples.py
+   :include-source:
 
 ========================================================
 Sky Location Distribution as Spin Distribution Example 
 ========================================================
 Here we can make a distribution of spins of unit length with equal distribution in x, y, and z to sample the surface of a unit sphere.
-.. literalinclude:: ../examples/inference/spin_examples.py
-.. command-output:: python ../examples/inference/spin_examples.py
+
+.. plot:: ../examples/distributions/spin_examples.py
+   :include-source:
 
 Using much of the same code we can also show how this sampling accurately covers the surface of a unit sphere.
-.. literalinclude:: ../examples/inferences/spin_spatial_distr_example.py
-.. command-output:: python ../examples/inference/spin_spatial_example.py
+
+.. plot:: ../examples/distributions/spin_spatial_distr_example.py
+   :include-source:


### PR DESCRIPTION
Adds the ``--scale-factor`` option that scales the amplitude of the waveform. And the ``--precision`` option that allows the user to specify the precision.