### PR TITLE
Ability to read in a psd in compress_bank

### DIFF
--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -94,8 +94,15 @@ args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)
 
-psd.verify_psd_options(args, parser)
-strain.verify_strain_options(args, parser)
+# Verify if the input options for calculating the psd are correct, if
+# a PSD is to be used while calculating the overlaps in compress.py . If
+# using a PSD is not desired, this check would prevent raising an error
+# asking for PSD options.
+if args.psd_model or args.psd_file or args.asd_file or args.psd_estimation :
+    psd.verify_psd_options(args, parser)
+
+if args.psd_estimation :
+    strain.verify_strain_options(args, parser)
 
 fmin = args.low_frequency_cutoff
 fmax = args.sample_rate/2.
@@ -159,21 +166,17 @@ for ii in range(imin, imax):
                          is required.""")
     tmplt = bank.table[ii-imin]
     kmax = htilde.end_idx
-    # calculate psd if psd options are provided as input to be used to
-    # compute the overlap between the full waveform and the decompressed
-    # waveform
+    # Calculate psd if psd options are provided as input. The psd would
+    # be used to compute the overlap between the full waveform and the
+    # decompressed waveform.
     try:
         psd = psd_dict[N]
     except KeyError:
         psd_length = int(args.sample_rate / df) / 2  + 1
         psd = pycbc.psd.from_cli(args, length=psd_length, delta_f=df,
                                  low_frequency_cutoff=fmin,
-                                 dyn_range_factor=pycbc.DYN_RANGE_FAC)
-        if args.precision == 'single' :
-            psd_dtype=numpy.float32
-        elif args.precision == 'double' :
-            psd_dtype=numpy.float64
-        psd = FrequencySeries(psd, delta_f=psd.delta_f, dtype=psd_dtype)
+                                 dyn_range_factor=pycbc.DYN_RANGE_FAC,
+                                 precision=args.precision)
         psd_dict[N] = psd
 
     # get the compressed sample points

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -31,7 +31,7 @@ import numpy
 import h5py
 import logging
 import pycbc
-from pycbc import psd, strain, DYN_RANGE_FAC
+from pycbc import psd, DYN_RANGE_FAC
 from pycbc.waveform import compress
 from pycbc import waveform
 from pycbc.types import FrequencySeries, real_same_precision_as
@@ -98,8 +98,8 @@ pycbc.init_logging(args.verbose)
 # a PSD is to be used while calculating the overlaps in compress.py . If
 # using a PSD is not desired, this check would prevent raising an error
 # asking for PSD options.
-if args.psd_model or args.psd_file or args.asd_file or args.psd_estimation :
-    psd.verify_psd_options(args, parser)
+if args.psd_model or args.psd_file or args.asd_file :
+psd.verify_psd_options(args, parser)
 
 fmin = args.low_frequency_cutoff
 fmax = args.sample_rate/2.
@@ -169,7 +169,7 @@ for ii in range(imin, imax):
     try:
         psd = psd_dict[N]
     except KeyError:
-        psd_length = int(args.sample_rate / df) / 2  + 1
+        psd_length = N / 2  + 1
         psd = pycbc.psd.from_cli(args, length=psd_length, delta_f=df,
                                  low_frequency_cutoff=fmin,
                                  dyn_range_factor=pycbc.DYN_RANGE_FAC,

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -99,7 +99,7 @@ pycbc.init_logging(args.verbose)
 # using a PSD is not desired, this check would prevent raising an error
 # asking for PSD options.
 if args.psd_model or args.psd_file or args.asd_file :
-psd.verify_psd_options(args, parser)
+    psd.verify_psd_options(args, parser)
 
 fmin = args.low_frequency_cutoff
 fmax = args.sample_rate/2.

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -31,6 +31,7 @@ import numpy
 import h5py
 import logging
 import pycbc
+import pycbc.psd
 from pycbc.waveform import compress
 from pycbc import waveform
 from pycbc.types import FrequencySeries, real_same_precision_as
@@ -40,50 +41,54 @@ from pycbc import filter
 
 parser = argparse.ArgumentParser(description=__description__)
 parser.add_argument("--bank-file", type=str,
-                help="Bank hdf file to load.")
+                    help="Bank hdf file to load.")
 parser.add_argument("--output", type=str,
-                help="The hdf file to save the templates and compressed "
-                     "waveforms to.")
+                    help="The hdf file to save the templates and "
+                    "compressed waveforms to.")
 parser.add_argument("--low-frequency-cutoff", type=float, required=True,
-                help="The low frequency cutoff to use for generating "
-                     "the waveforms (Hz)")
+                    help="The low frequency cutoff to use for generating "
+                    "the waveforms (Hz).")
 # add approximant arg
 pycbc.waveform.bank.add_approximant_arg(parser)
 parser.add_argument("--sample-rate", type=int, required=True,
-                help="Half this value sets the maximum frequency of the "
-                     "compressed waveforms.")
+                    help="Half this value sets the maximum frequency of the "
+                    "compressed waveforms.")
 parser.add_argument("--tmplt-index", nargs=2, type=int, default=None,
-                help="Only generate compressed waveforms for the given "
-                     "indices in the bank file. Must provide both a start "
-                     "and a stop index. Default is to compress all of the "
-                     "templates in the bank file.")
+                    help="Only generate compressed waveforms for the given "
+                    "indices in the bank file. Must provide both a start "
+                    "and a stop index. Default is to compress all of the "
+                    "templates in the bank file.")
 parser.add_argument("--compression-algorithm", type=str, required=True,
-                choices=compress.compression_algorithms.keys(),
-                help="The compression algorithm to use for selecting "
-                     "frequency points.")
+                    choices=compress.compression_algorithms.keys(),
+                    help="The compression algorithm to use for selecting "
+                    "frequency points.")
 parser.add_argument("--t-pad", type=float, default=0.001,
-                help="The minimum duration used for t(f) in seconds. The "
-                     "inverse of this gives the maximum frequency step that "
-                     "will be used in the compressed waveforms. Default is "
-                     "0.001.")
+                    help="The minimum duration used for t(f) in seconds. "
+                    "The inverse of this gives the maximum frequency "
+                    "step that will be used in the compressed waveforms. "
+                    "Default is 0.001.")
 parser.add_argument("--tolerance", type=float, default=0.001,
-                help="The maximum mismatch to allow between the interpolated "
-                     "waveform must and the full waveform. Points will be "
-                     "added to the compressed waveform until its "
-                     "interpolation has a mismatch <= this value. Default is "
-                     "0.001.")
+                    help="The maximum mismatch to allow between the "
+                    "interpolated waveform must and the full waveform. "
+                    "Points will be added to the compressed waveform "
+                    "until its interpolation has a mismatch <= this value. "
+                    "Default is 0.001.")
 parser.add_argument("--interpolation", type=str, default="linear",
-                help="The interpolation to use for decompressing the "
-                     "waveforms for checking tolerance. Options are 'linear', "
-                     "or any interpolation recognized by scipy's interp1d "
-                     "kind argument. Default is linear.")
+                    help="The interpolation to use for decompressing the "
+                    "waveforms for checking tolerance. Options are "
+                    "'linear', or any interpolation recognized by scipy's "
+                    "interp1d kind argument. Default is linear.")
 parser.add_argument("--precision", type=str, choices=["double", "single"],
-                default="double",
-                help="What precision to generate and store the waveforms with;"
-                     " default is double.")
+                    default="double",
+                    help="What precision to generate and store the "
+                    "waveforms with; default is double.")
+parser.add_argument("--psd-from-file", type=str,
+                    help="File from which psd would be read in to used "
+                    "in compress.py for calculating the overlap/match "
+                    "between the compressed and full waveforms. ")
 parser.add_argument("--force", action="store_true", default=False,
                     help="Overwrite the given hdf file if it exists. "
-                         "Otherwise, an error is raised.")
+                    "Otherwise, an error is raised.")
 parser.add_argument("--verbose", action="store_true", default=False)
 
 
@@ -104,8 +109,9 @@ if args.precision == "single":
 else:
     dtype = numpy.complex128
 # we'll just use dummy values for N, df for now
-bank = waveform.FilterBank(args.bank_file, 5, 0.25, fmin, dtype,
-    approximant=args.approximant)
+bank = waveform.FilterBank(args.bank_file, 5, 0.25, dtype,
+                           low_frequency_cutoff=fmin,
+                           approximant=args.approximant)
 templates = bank.table
 if args.tmplt_index is not None:
     imin, imax = args.tmplt_index
@@ -136,17 +142,31 @@ for ii in range(imin, imax):
     bank.delta_f = df
     bank.N = N
     bank.filter_length = N/2 + 1
-    # We'll budge the waveform starting frequency down by 1df to ensure 
-    # the first point is correct
-    bank.f_lower = fmin-df
+    bank.f_lower = fmin
     bank.kmin = int(bank.f_lower / df)
     # scratch space
     decomp_scratch = FrequencySeries(numpy.zeros(N, dtype=dtype), delta_f=df)
     # generate the waveform
     htilde = bank[ii-imin]
+    if numpy.abs(htilde[bank.kmin]) == 0:
+        raise ValueError("""The amplitude of the waveform at the
+                         low_frequency_cutoff is zero. A non-zero value
+                         is required.""")
     tmplt = bank.table[ii-imin]
     kmax = htilde.end_idx
-    
+    if args.psd_from_file :
+        logging.info("Generating psd for %d'th template", (ii-imin))
+        psd_length = int(args.sample_rate / df) / 2  + 1
+        psd = pycbc.psd.from_txt(args.psd_from_file, psd_length,
+                                 df, fmin, is_asd_file=False)
+        if args.precision == 'single' :
+            psd_dtype=numpy.float32
+        elif args.precision == 'double' :
+            psd_dtype=numpy.float64
+        psd = FrequencySeries(psd, delta_f=psd.delta_f, dtype=psd_dtype)
+    else :
+        psd = None
+
     # get the compressed sample points
     if args.compression_algorithm == 'mchirp':
         sample_points = compress.mchirp_compression(tmplt.mass1, tmplt.mass2,
@@ -158,11 +178,11 @@ for ii in range(imin, imax):
     else:
         raise ValueError("unrecognized compression algorithm %s" %(
             args.compression_algorithm))
-            
+
     # compress
     hcompressed = compress.compress_waveform(
         htilde, sample_points, args.tolerance, args.interpolation,
-        decomp_scratch=decomp_scratch)
+        decomp_scratch=decomp_scratch, psd=psd)
 
     # save results
     hcompressed.write_to_hdf(output, tmplt.template_hash)

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -31,7 +31,7 @@ import numpy
 import h5py
 import logging
 import pycbc
-import pycbc.psd
+from pycbc import psd, strain, DYN_RANGE_FAC
 from pycbc.waveform import compress
 from pycbc import waveform
 from pycbc.types import FrequencySeries, real_same_precision_as
@@ -50,9 +50,6 @@ parser.add_argument("--low-frequency-cutoff", type=float, required=True,
                     "the waveforms (Hz).")
 # add approximant arg
 pycbc.waveform.bank.add_approximant_arg(parser)
-parser.add_argument("--sample-rate", type=int, required=True,
-                    help="Half this value sets the maximum frequency of the "
-                    "compressed waveforms.")
 parser.add_argument("--tmplt-index", nargs=2, type=int, default=None,
                     help="Only generate compressed waveforms for the given "
                     "indices in the bank file. Must provide both a start "
@@ -82,19 +79,23 @@ parser.add_argument("--precision", type=str, choices=["double", "single"],
                     default="double",
                     help="What precision to generate and store the "
                     "waveforms with; default is double.")
-parser.add_argument("--psd-from-file", type=str,
-                    help="File from which psd would be read in to used "
-                    "in compress.py for calculating the overlap/match "
-                    "between the compressed and full waveforms. ")
 parser.add_argument("--force", action="store_true", default=False,
                     help="Overwrite the given hdf file if it exists. "
                     "Otherwise, an error is raised.")
 parser.add_argument("--verbose", action="store_true", default=False)
 
+# Insert the PSD options
+pycbc.psd.insert_psd_option_group(parser)
+
+# Insert the data reading options
+pycbc.strain.insert_strain_option_group(parser)
 
 args = parser.parse_args()
 
 pycbc.init_logging(args.verbose)
+
+psd.verify_psd_options(args, parser)
+strain.verify_strain_options(args, parser)
 
 fmin = args.low_frequency_cutoff
 fmax = args.sample_rate/2.
@@ -135,6 +136,10 @@ output = bank.write_to_hdf(args.output, force=args.force,
 # get the compressed sample points for each template
 logging.info("getting compressed amplitude and phase")
 mismatches = numpy.zeros(imax-imin, dtype=float)
+
+# Create a dictionary to store the psd for every value of N that is used
+psd_dict = {}
+
 for ii in range(imin, imax):
     # update the N, df to use based on this waveform
     N = int(args.sample_rate*seg_lens[ii-imin])
@@ -154,18 +159,22 @@ for ii in range(imin, imax):
                          is required.""")
     tmplt = bank.table[ii-imin]
     kmax = htilde.end_idx
-    if args.psd_from_file :
-        logging.info("Generating psd for %d'th template", (ii-imin))
+    # calculate psd if psd options are provided as input to be used to
+    # compute the overlap between the full waveform and the decompressed
+    # waveform
+    try:
+        psd = psd_dict[N]
+    except KeyError:
         psd_length = int(args.sample_rate / df) / 2  + 1
-        psd = pycbc.psd.from_txt(args.psd_from_file, psd_length,
-                                 df, fmin, is_asd_file=False)
+        psd = pycbc.psd.from_cli(args, length=psd_length, delta_f=df,
+                                 low_frequency_cutoff=fmin,
+                                 dyn_range_factor=pycbc.DYN_RANGE_FAC)
         if args.precision == 'single' :
             psd_dtype=numpy.float32
         elif args.precision == 'double' :
             psd_dtype=numpy.float64
         psd = FrequencySeries(psd, delta_f=psd.delta_f, dtype=psd_dtype)
-    else :
-        psd = None
+        psd_dict[N] = psd
 
     # get the compressed sample points
     if args.compression_algorithm == 'mchirp':

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -50,6 +50,9 @@ parser.add_argument("--low-frequency-cutoff", type=float, required=True,
                     "the waveforms (Hz).")
 # add approximant arg
 pycbc.waveform.bank.add_approximant_arg(parser)
+parser.add_argument("--sample-rate", type=int, required=True,
+                    help="Half this value sets the maximum frequency of "
+                    "the compressed waveforms.")
 parser.add_argument("--tmplt-index", nargs=2, type=int, default=None,
                     help="Only generate compressed waveforms for the given "
                     "indices in the bank file. Must provide both a start "
@@ -85,10 +88,7 @@ parser.add_argument("--force", action="store_true", default=False,
 parser.add_argument("--verbose", action="store_true", default=False)
 
 # Insert the PSD options
-pycbc.psd.insert_psd_option_group(parser)
-
-# Insert the data reading options
-pycbc.strain.insert_strain_option_group(parser)
+pycbc.psd.insert_psd_option_group(parser, include_data_options=False)
 
 args = parser.parse_args()
 
@@ -100,9 +100,6 @@ pycbc.init_logging(args.verbose)
 # asking for PSD options.
 if args.psd_model or args.psd_file or args.asd_file or args.psd_estimation :
     psd.verify_psd_options(args, parser)
-
-if args.psd_estimation :
-    strain.verify_strain_options(args, parser)
 
 fmin = args.low_frequency_cutoff
 fmax = args.sample_rate/2.

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -170,17 +170,22 @@ def insert_psd_option_group(parser, output=True, include_data_options=True):
                              help="Get PSD using given PSD ASCII file")
     psd_options.add_argument("--asd-file",
                              help="Get PSD using given ASD ASCII file")
-    psd_options.add_argument("--psd-estimation",
-                             help="Measure PSD from the data, using given "
-                             "average method.",
-                             choices=["mean", "median", "median-mean"])
-    psd_options.add_argument("--psd-segment-length", type=float,
-                             help="(Required for --psd-estimation) The "
-                             "segment length for PSD estimation (s)")
-    psd_options.add_argument("--psd-segment-stride", type=float,
-                             help="(Required for --psd-estimation) The "
-                             "separation between consecutive segments (s)")
+    psd_options.add_argument("--psd-inverse-length", type=float,
+                             help="(Optional) The maximum length of the "
+                             "impulse response of the overwhitening "
+                             "filter (s)")
     if include_data_options :
+        psd_options.add_argument("--psd-estimation",
+                                 help="Measure PSD from the data, using "
+                                 "given average method.",
+                                 choices=["mean", "median", "median-mean"])
+        psd_options.add_argument("--psd-segment-length", type=float,
+                                 help="(Required for --psd-estimation) The "
+                                 "segment length for PSD estimation (s)")
+        psd_options.add_argument("--psd-segment-stride", type=float,
+                                 help="(Required for --psd-estimation) "
+                                 "The separation between consecutive "
+                                 "segments (s)")
         psd_options.add_argument("--psd-num-segments", type=int, default=None,
                                  help="(Optional, used only with "
                                  "--psd-estimation). If given, PSDs will "
@@ -190,10 +195,6 @@ def insert_psd_option_group(parser, output=True, include_data_options=True):
                                  "then excess data will not be used in "
                                  "the PSD estimate. If not enough data "
                                  "is given, the code will fail.")
-    psd_options.add_argument("--psd-inverse-length", type=float,
-                             help="(Optional) The maximum length of the "
-                             "impulse response of the overwhitening "
-                             "filter (s)")
     if output:
         psd_options.add_argument("--psd-output",
                           help="(Optional) Write PSD to specified file")


### PR DESCRIPTION
This PR adds in the ability in to implement the use of a psd in compress_bank and then use it in compress.py to calculate overlaps between the decompressed and full waveforms. This PR also makes the options in insert_psd_option_group to do a Welch estimate from data optional. 
@cdcapano This is the new PR. Please could you take a look.