### PR TITLE
Gives error message when there is no proxy

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -263,8 +263,10 @@ else
 fi
 
 #Check that the proxy is valid
+set +e
 grid-proxy-info -exists
 RESULT=$?
+set -e
 if [ ${RESULT} -eq 0 ] ; then
   PROXY_TYPE=`grid-proxy-info -type | tr -d ' '`
   if [ x${PROXY_TYPE} == 'xRFC3820compliantimpersonationproxy' ] ; then


### PR DESCRIPTION
Currently the script exits if the check that the proxy exists fails. Wrap it with set +/-e so that the check doesn't abort the script and an error message can be printed.