### PR TITLE
pycbc_live: enable followup detectors

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -238,6 +238,8 @@ parser.add_argument('--store-loudest-index', type=int, default=0)
 parser.add_argument('--max-psd-abort-distance', type=float, default=numpy.inf)
 parser.add_argument('--min-psd-abort-distance', type=float, default=-numpy.inf)
 parser.add_argument('--max-triggers-in-batch', type=int)
+parser.add_argument('--max-length', type=float,
+                    help='Maximum duration of templates, used to set the data buffer size')
 
 parser.add_argument('--enable-profiling', type=int, 
                     help="Dump out profiling information from an MPI process at"
@@ -308,6 +310,8 @@ with ctx:
                                      newsnr_threshold=args.newsnr_threshold,
                                      max_triggers_in_batch=args.max_triggers_in_batch,
                                      maxelements=args.max_batch_size)
+    if args.max_length is not None:
+        maxlen = args.max_length
     data_reader = {}
     sngl_estimator = {}
     for ifo in ifos + followup_ifos:
@@ -385,11 +389,11 @@ with ctx:
                 continue
 
             if status is True:
-                logging.info('%s: %s: Filtering', evnt.rank, ifo)
+                logging.info('%s: Filtering: %s', evnt.rank, ifo)
                 if evnt.rank > 0:
                     results[ifo] = mf.process_data(data_reader[ifo])
             else:
-                logging.info('%s: %s: Insufficient data for analysis', evnt.rank, ifo)
+                logging.info('Insufficient data for analysis')
 
         if evnt.rank > 0:
             evnt.commit_results((results, data_end()))

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -301,6 +301,7 @@ with ctx:
         pass
     maxlen = args.psd_segment_length * (args.psd_samples / 2 + 1)
     if evnt.rank > 0:
+        bank.table.sort(order='mchirp')
         waveforms = list(bank[evnt.rank-1::evnt.size-1])
         lengths = numpy.array([1.0 / waveform.delta_f for waveform in waveforms])
         psd_len = args.psd_segment_length * (args.psd_samples / 2 + 1)

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -279,12 +279,6 @@ bank = waveform.LiveFilterBank(args.bank_file, sr, total_pad,
                        approximant=args.approximant,
                        increment=args.increment)
 
-# ifos used for primary analysis (only two at the moment)
-ifos = set(args.channel_name.keys())
-followup_ifos = set(args.followup_detectors)
-ifos -= followup_ifos
-ifos, followup_ifos = list(ifos), list(followup_ifos)
-
 evnt = LiveEventManager(args.output_path, 
                         use_date_prefix=args.day_hour_output_prefix, 
                         ifar_upload_threshold=args.ifar_upload_threshold, 
@@ -292,6 +286,17 @@ evnt = LiveEventManager(args.output_path,
                         gracedb_testing=not args.enable_production_gracedb_upload,
                        )
 
+# ifos used for primary analysis (only two at the moment)
+ifos = set(args.channel_name.keys())
+followup_ifos = set(args.followup_detectors)
+ifos -= followup_ifos
+ifos, followup_ifos = list(ifos), list(followup_ifos)
+
+# the root must also advance followup ifos, other threads don't need to
+if evnt.rank == 0:
+    advancing_ifos = ifos + followup_ifos
+else:
+    advancing_ifos = ifos
 
 # I'm not the root, so do some actually filtering.
 with ctx:
@@ -315,7 +320,7 @@ with ctx:
         maxlen = args.max_length
     data_reader = {}
     sngl_estimator = {}
-    for ifo in ifos + followup_ifos:
+    for ifo in advancing_ifos:
         state = '%s:%s' % (ifo, args.state_channel[ifo]) if args.state_channel else None
         dq ='%s:%s' % (ifo, args.data_quality_channel[ifo]) if args.data_quality_channel else None
 
@@ -371,7 +376,7 @@ with ctx:
         logging.info('%s: Analyzing up to %s', evnt.rank, data_end())
         results = {}
 
-        for ifo in ifos + followup_ifos:
+        for ifo in advancing_ifos:
             results[ifo] = False
             status = data_reader[ifo].advance(valid_pad, timeout=args.frame_read_timeout)
 

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -76,13 +76,15 @@ class LiveEventManager(object):
         else:
             raise TypeError("Not root process")
 
-    def check_coincs(self, ifos, coinc_results, psds, low_frequency_cutoff, data_readers, bank):
+    def check_coincs(self, ifos, coinc_results, psds, low_frequency_cutoff,
+                     data_readers, bank, followup_ifos=None):
         """ Save zerolag triggers to a coinc xml file """
         if 'foreground/ifar' in coinc_results: 
             ifar = coinc_results['foreground/ifar']
             event = SingleCoincForGraceDB(
                     ifos, coinc_results, data_readers=data_readers,
-                    bank=bank, upload_snr_series=args.upload_snr_series)
+                    bank=bank, upload_snr_series=args.upload_snr_series,
+                    followup_ifos=followup_ifos)
 
             time = int(coinc_results['foreground/%s/end_time' % ifos[0]])
             fname = os.path.join(self.path, 'coinc-%s.xml' % time)
@@ -276,12 +278,11 @@ bank = waveform.LiveFilterBank(args.bank_file, sr, total_pad,
                        increment=args.increment)
 
 # ifos used for primary analysis (only two at the moment)
-ifos = args.channel_name.keys()
-followup_ifos = args.followup_detectors
-for ifo in ifos:
-    if ifo in followup_ifos:
-        ifos.pop()
-        
+ifos = set(args.channel_name.keys())
+followup_ifos = set(args.followup_detectors)
+ifos -= followup_ifos
+ifos, followup_ifos = list(ifos), list(followup_ifos)
+
 evnt = LiveEventManager(args.output_path, 
                         use_date_prefix=args.day_hour_output_prefix, 
                         ifar_upload_threshold=args.ifar_upload_threshold, 
@@ -365,7 +366,7 @@ with ctx:
         logging.info('%s: Analyzing up to %s', evnt.rank, data_end())
         results = {}
 
-        for ifo in ifos:
+        for ifo in ifos + followup_ifos:
             results[ifo] = False
             status = data_reader[ifo].advance(valid_pad, timeout=args.frame_read_timeout)
 
@@ -378,13 +379,17 @@ with ctx:
                     logging.info("PSD outside acceptable sensitivity %s - %s, have %s",
                                  args.min_psd_abort_distance, args.max_psd_abort_distance, dist)
                     status = False               
-    
+
+            if ifo in followup_ifos:
+                # we advanced the data and handled the PSD, that's it
+                continue
+
             if status is True:
-                logging.info('%s: Filtering: %s', evnt.rank, ifo)
+                logging.info('%s: %s: Filtering', evnt.rank, ifo)
                 if evnt.rank > 0:
                     results[ifo] = mf.process_data(data_reader[ifo])
             else:
-                logging.info('Insufficient data for analysis')
+                logging.info('%s: %s: Insufficient data for analysis', evnt.rank, ifo)
 
         if evnt.rank > 0:
             evnt.commit_results((results, data_end()))
@@ -410,13 +415,14 @@ with ctx:
                     for key in results[ifo]:
                         if len(results[ifo][key]) > 0:
                             results[ifo][key] = results[ifo][key][idx]
-        
+
             # Look for coincident triggers and do background estimation
             coinc_results = {}
             if args.enable_background_estimation:
                 coinc_results = estimator.add_singles(results, data_reader)
                 evnt.check_coincs(results.keys(), coinc_results,
-                                  psds, args.low_frequency_cutoff, data_reader, bank)
+                                  psds, args.low_frequency_cutoff, data_reader, bank,
+                                  followup_ifos=followup_ifos)
 
             # Check for singles if we don't have coinc time
             if args.enable_single_detector_background:

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1536,12 +1536,12 @@ def compute_followup_snr_series(data_reader, htilde, trig_time,
     onsource_start = onsource_idx - int(snr.sample_rate * duration / 2)
     # FIXME avoid clipping with better handling of past data
     if onsource_start < 0:
-        logging.warn('Clipping start of %s SNR series', ifo)
+        logging.warn('Clipping start of followup SNR time series')
         onsource_start = 0
 
     onsource_end = onsource_idx + int(snr.sample_rate * duration / 2)
     if onsource_end > len(snr):
-        logging.warn('Clipping end of %s SNR series', ifo)
+        logging.warn('Clipping end of followup SNR time series')
         onsource_end = len(snr) - 1
 
     onsource_slice = slice(onsource_start, onsource_end + 1)

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1486,8 +1486,70 @@ class LiveBatchMatchedFilter(object):
 
         return result, veto_info  
 
+def compute_followup_snr_series(data_reader, htilde, trig_time,
+                                duration=0.095):
+    """Given a StrainBuffer, a template frequency series and a trigger time,
+    compute a portion of the SNR time series centered on the trigger for its
+    sky localization and followup.
+
+    Parameters
+    ----------
+    data_reader : StrainBuffer
+        The StrainBuffer object to read strain data from.
+
+    htilde : FrequencySeries
+        The frequency series containing the template waveform.
+
+    trig_time : {float, lal.LIGOTimeGPS}
+        The trigger time.
+
+    duration : float (optional)
+        Duration of the computed SNR series in seconds. If omitted, it defaults
+        to twice the Earth light travel time plus 10 ms of timing uncertainty.
+
+    Returns
+    -------
+    snr : TimeSeries
+        The portion of SNR around the trigger.
+
+    psd : FrequencySeries
+        The noise PSD corresponding to the trigger time.
+    """
+    stilde = data_reader.overwhitened_data(htilde.delta_f)
+
+    norm = 4.0 * htilde.delta_f / (htilde.sigmasq(stilde.psd) ** 0.5)
+
+    qtilde = zeros((len(htilde) - 1) * 2, dtype=htilde.dtype)
+    correlate(htilde, stilde, qtilde)
+    snr = qtilde * 0
+    ifft(qtilde, snr)
+
+    valid_end = int(len(qtilde) - data_reader.trim_padding)
+    valid_start = int(valid_end - data_reader.blocksize * data_reader.sample_rate)
+    snr = snr[slice(valid_start, valid_end)]
+    snr *= norm
+    snr = TimeSeries(snr, delta_t=1./data_reader.sample_rate,
+                     epoch=data_reader.start_time)
+
+    onsource_idx = int(round(float(trig_time - snr.start_time) * snr.sample_rate))
+
+    onsource_start = onsource_idx - int(snr.sample_rate * duration / 2)
+    # FIXME avoid clipping with better handling of past data
+    if onsource_start < 0:
+        logging.warn('Clipping start of %s SNR series', ifo)
+        onsource_start = 0
+
+    onsource_end = onsource_idx + int(snr.sample_rate * duration / 2)
+    if onsource_end > len(snr):
+        logging.warn('Clipping end of %s SNR series', ifo)
+        onsource_end = len(snr) - 1
+
+    onsource_slice = slice(onsource_start, onsource_end + 1)
+    return snr[onsource_slice], stilde.psd
+
 __all__ = ['match', 'matched_filter', 'sigmasq', 'sigma', 'get_cutoff_indices',
            'sigmasq_series', 'make_frequency_series', 'overlap', 'overlap_cplx',
            'matched_filter_core', 'correlate', 'MatchedFilterControl', 'LiveBatchMatchedFilter',
-           'MatchedFilterSkyMaxControl', 'compute_max_snr_over_sky_loc_stat']
+           'MatchedFilterSkyMaxControl', 'compute_max_snr_over_sky_loc_stat',
+           'compute_followup_snr_series']
 

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -86,9 +86,7 @@ class SingleCoincForGraceDB(object):
         self.template_id = coinc_results['foreground/%s/template_id' % self.ifos[0]]
 
         # remember if this should be marked as HWINJ
-        self.is_hardware_injection = False
-        if 'HWINJ' in coinc_results:
-            self.is_hardware_injection = True
+        self.is_hardware_injection = ('HWINJ' in coinc_results)
 
         # Set up the bare structure of the xml document
         outdoc = ligolw.Document()

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -182,9 +182,7 @@ class SingleCoincForGraceDB(object):
             # for detectors which did not trigger, center the SNR series
             # on the mean arrival time at the detectors which *did* trigger
             trig_times = [coinc_results['foreground/%s/end_time' % ifo] for ifo in ifos]
-            logging.info('Trigger times: %s', trig_times)
             subthreshold_center_time = numpy.mean(trig_times)
-            logging.info('Using %s as center time for subthreshold detectors', subthreshold_center_time)
             self.snr_series = {}
             self.snr_series_psd = {}
             for ifo in self.ifos + self.followup_ifos:
@@ -224,7 +222,6 @@ class SingleCoincForGraceDB(object):
                 if onsource_end > len(snr):
                     onsource_end = len(snr) - 1
                 onsource_slice = slice(onsource_start, onsource_end + 1)
-                logging.info('%s len(snr) = %s onsource start %s end %s', ifo, len(snr), onsource_start, onsource_end)
                 snr_lal = snr[onsource_slice].lal()
                 snr_lal.name = 'snr'
                 snr_lal.sampleUnits = ''

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -220,11 +220,7 @@ class SingleCoincForGraceDB(object):
 
                 # store the on-source slice of the series into the XML doc
                 if ifo in ifos:
-                    trig_time = coinc_results['foreground/%s/end_time' % ifo]
-                    if stilde.start_time > trig_time or stilde.end_time < trig_time:
-                        raise RuntimeError('%s trigger time %.3f outside stilde (%.3f-%.3f)' \
-                                % (ifo, trig_time, stilde.start_time, stilde.end_time))
-                    snr_onsource_time = trig_time - snr.start_time
+                    snr_onsource_time = coinc_results['foreground/%s/end_time' % ifo] - snr.start_time
                 else:
                     snr_onsource_time = subthreshold_sngl_time - snr.start_time
                 # the window lasts half an Earth light travel time

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -1390,9 +1390,8 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                 fseries_trimmed = fseries
 
             fseries_trimmed.psd = psd
-
             self.segments[delta_f] = fseries_trimmed
-
+            
         stilde = self.segments[delta_f]
         return stilde  
 

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -1347,8 +1347,6 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         htilde: FrequencySeries
             Overwhited strain data
         """
-        logging.info('StrainBuffer is asked stilde with delta_f=%f', delta_f)
-
         # we haven't alread computed htilde for this delta_f
         if delta_f not in self.segments:
             buffer_length = int(1.0 / delta_f)

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -1347,6 +1347,8 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         htilde: FrequencySeries
             Overwhited strain data
         """
+        logging.info('StrainBuffer is asked stilde with delta_f=%f', delta_f)
+
         # we haven't alread computed htilde for this delta_f
         if delta_f not in self.segments:
             buffer_length = int(1.0 / delta_f)
@@ -1390,7 +1392,17 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                 fseries_trimmed = fseries
 
             fseries_trimmed.psd = psd
+
+            # save start/end times so we can do checks later
+            fseries_trimmed._epoch = lal.LIGOTimeGPS(self.strain[s:e].start_time)
+            fseries_trimmed.start_time = fseries_trimmed._epoch
+            fseries_trimmed.end_time = lal.LIGOTimeGPS(self.strain[s:e].end_time)
+
             self.segments[delta_f] = fseries_trimmed
+            logging.info('StrainBuffer computes stilde spanning (%.3f-%.3f)', fseries_trimmed.start_time, fseries_trimmed.end_time)
+            fseries_trimmed.save('%.3f-correct-stilde-%s-%f.txt' % (fseries_trimmed.start_time, self.channel_name[0:2], delta_f))
+        else:
+            logging.info('StrainBuffer returns preexisting stilde spanning (%.3f-%.3f)', self.segments[delta_f].start_time, self.segments[delta_f].end_time)
             
         stilde = self.segments[delta_f]
         return stilde  

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -1393,17 +1393,8 @@ class StrainBuffer(pycbc.frame.DataBuffer):
 
             fseries_trimmed.psd = psd
 
-            # save start/end times so we can do checks later
-            fseries_trimmed._epoch = lal.LIGOTimeGPS(self.strain[s:e].start_time)
-            fseries_trimmed.start_time = fseries_trimmed._epoch
-            fseries_trimmed.end_time = lal.LIGOTimeGPS(self.strain[s:e].end_time)
-
             self.segments[delta_f] = fseries_trimmed
-            logging.info('StrainBuffer computes stilde spanning (%.3f-%.3f)', fseries_trimmed.start_time, fseries_trimmed.end_time)
-            fseries_trimmed.save('%.3f-correct-stilde-%s-%f.txt' % (fseries_trimmed.start_time, self.channel_name[0:2], delta_f))
-        else:
-            logging.info('StrainBuffer returns preexisting stilde spanning (%.3f-%.3f)', self.segments[delta_f].start_time, self.segments[delta_f].end_time)
-            
+
         stilde = self.segments[delta_f]
         return stilde  
 

--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -10,7 +10,7 @@ from glue.ligolw.utils import process as ligolw_process
 from pycbc import pnutils
 from pycbc.tmpltbank.lambda_mapping import ethinca_order_from_string
 
-def return_empty_sngl():
+def return_empty_sngl(nones=False):
     """
     Function to create a SnglInspiral object where all columns are populated
     but all are set to values that test False (ie. strings to '', floats/ints
@@ -18,6 +18,11 @@ def return_empty_sngl():
     columns you don't care about, but which still need populating. NOTE: This
     will also produce a process_id and event_id with 0 values. For most
     applications these should be set to their correct values.
+
+    Parameters
+    ----------
+    nones : bool (False)
+        If True, just set all columns to None.
 
     Returns
     --------
@@ -27,19 +32,23 @@ def return_empty_sngl():
 
     sngl = lsctables.SnglInspiral()
     cols = lsctables.SnglInspiralTable.validcolumns
-    for entry in cols.keys():
-        if cols[entry] in ['real_4','real_8']:
-            setattr(sngl,entry,0.)
-        elif cols[entry] == 'int_4s':
-            setattr(sngl,entry,0)
-        elif cols[entry] == 'lstring':
-            setattr(sngl,entry,'')
-        elif entry == 'process_id':
-            sngl.process_id = ilwd.ilwdchar("process:process_id:0")
-        elif entry == 'event_id':
-            sngl.event_id = ilwd.ilwdchar("sngl_inspiral:event_id:0")
-        else:
-            raise ValueError("Column %s not recognized" %(entry) )
+    if nones:
+        for entry in cols:
+            setattr(sngl, entry, None)
+    else:
+        for entry in cols.keys():
+            if cols[entry] in ['real_4','real_8']:
+                setattr(sngl,entry,0.)
+            elif cols[entry] == 'int_4s':
+                setattr(sngl,entry,0)
+            elif cols[entry] == 'lstring':
+                setattr(sngl,entry,'')
+            elif entry == 'process_id':
+                sngl.process_id = ilwd.ilwdchar("process:process_id:0")
+            elif entry == 'event_id':
+                sngl.event_id = ilwd.ilwdchar("sngl_inspiral:event_id:0")
+            else:
+                raise ValueError("Column %s not recognized" %(entry) )
     return sngl
 
 def return_search_summary(start_time=0, end_time=0, nevents=0,

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -513,7 +513,6 @@ class LiveFilterBank(TemplateBank):
         for i, p in enumerate(self.table):
             hash_value =  hash((p.mass1, p.mass2, p.spin1z, p.spin2z))
             self.hash_lookup[hash_value] = i
-        self.table.sort(order='mchirp')
 
     def round_up(self, num):
         """Determine the length to use for this waveform by rounding.


### PR DESCRIPTION
This patch starts to implement the `--followup-detectors` option in `pycbc_live`. At the moment, followup detectors are only used for generating the SNR timeseries around triggers found in coincidence in the other detectors.

Note that the state and DQ vetoes of followup detectors are currently ignored, this will be addressed in a future PR.

This patch also fixes a bug caused by templates being sorted at the wrong time and leading to the SNR time series being calculated with an incorrect template.