### PR TITLE
Improved data re-use instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -287,7 +287,7 @@ To build the documentation from your virtual environment, first make sure that y
     pip install "Sphinx>=1.4.2"
     pip install numpydoc
     pip install sphinx-rtd-theme
-    pip install git+https://github.com/ligo-cbc/sphinxcontrib-programoutput.git@pypi_release#egg=sphinxcontrib-programoutput
+    pip install git+https://github.com/ligo-cbc/sphinxcontrib-programoutput.git#egg=sphinxcontrib-programoutput
     
 To generate the documentation, from the top level of the PyCBC source tree run
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -184,7 +184,7 @@ Next install the Pegasus WMS python libraries needed to build the workflows with
 
 .. code-block:: bash
 
-    pip install http://download.pegasus.isi.edu/pegasus/4.7.2/pegasus-python-source-4.7.2.tar.gz
+    pip install http://download.pegasus.isi.edu/pegasus/4.7.3/pegasus-python-source-4.7.3.tar.gz
 
 To query the new Advanced LIGO and Advanced Virgo Segment Database, you will need to install the ``dqsegdb`` tools. Install the 1.4.1 pre-release of these tools, run the command:
 

--- a/docs/workflow/pycbc_make_coinc_search_workflow.rst
+++ b/docs/workflow/pycbc_make_coinc_search_workflow.rst
@@ -608,8 +608,8 @@ If you have a subdax that failed, ``pegasus_analyzer`` will provide you with a c
 Reuse of data from a previous workflow
 ======================================
 
-One of the features of  Pegasus is to reuse the data products of prior runs.
-This can be used to expand an analysis or recover a run with mistaken settings without
+One of the features of Pegasus is reus the data products of prior runs.
+This can be used to e.g. expand an analysis or recover a run with mistaken settings without
 duplicating work. The steps below explain how to do this.
 
 ------------------------------------

--- a/docs/workflow/pycbc_make_coinc_search_workflow.rst
+++ b/docs/workflow/pycbc_make_coinc_search_workflow.rst
@@ -608,7 +608,7 @@ If you have a subdax that failed, ``pegasus_analyzer`` will provide you with a c
 Reuse of data from a previous workflow
 ======================================
 
-One of the features of Pegasus is reus the data products of prior runs.
+One of the features of Pegasus is reuse the data products of prior runs.
 This can be used to e.g. expand an analysis or recover a run with mistaken settings without
 duplicating work. The steps below explain how to do this.
 
@@ -617,7 +617,8 @@ Setting up a workflow for data reuse
 ------------------------------------
 
 The first step is to generate a new workflow that performs the analysis that
-you would like to do. Data reuse happens at the ``pycbc_submit_dax`` step, so
+you would like to do. This workflow should be generated in a new directory so that it does not overwrite data from your previous workflows.
+Data reuse happens at the ``pycbc_submit_dax`` step, so
 first run ``pycbc_make_coinc_search_workflow`` to build a new workflow,
 following the instructions in the section :ref:`coincworkflowgenerate` of this
 page.
@@ -625,7 +626,7 @@ page.
 **Stop** before you plan and submit the workflow with ``pycbc_submit_dax``.
 You will pass an additional file to ``pycbc_submit_dax`` using the
 ``--cache-file`` option with a list of files that Pegasus can re-use from a
-pervious run.  The Pegasus Workflow Planner will try to reduce the workflow
+previous run.  The Pegasus Workflow Planner will reduce the workflow
 using this cache file. Reduction works by deleting jobs from the workflow
 whose output files have been found in some location in this cache file.
 

--- a/docs/workflow/pycbc_make_coinc_search_workflow.rst
+++ b/docs/workflow/pycbc_make_coinc_search_workflow.rst
@@ -635,8 +635,10 @@ The key to data reuse is building the cache file passed to ``pycbc_submit_dax``.
     LOGICAL_FILE_NAME PHYSICAL_FILE_URL pool="SITE"
 
 where ``LOGICAL_FILE_NAME`` is the name of the file as it appears in the
-workflow (including any preceding path), ``PHYSICAL_FILE_URL`` is a URL where
-the file can be found, and ``SITE`` is the site on which that URL resides.
+workflow. This should include any subdirectory path used by the workflow to organize files in the case of, e.g.,
+``INSPIRAL`` files but it should not be the absolute path to the file. ``PHYSICAL_FILE_URL`` is a
+full URL where the file can be found, and ``SITE`` is the site on which that URL
+resides.
 
 The URI in the ``PHYSICAL_FILE_URL`` can be any of the URIs that Pegasus
 recognizes. The URIs ``file://``, ``gsiftp://``, and ``http://`` are likely
@@ -649,7 +651,7 @@ names used by ``pycbc_submit_dax`` to identify the cluster where jobs are run.
 In practice there are only two execution sites used by PyCBC workflows:
 
 1. ``local`` which is the regular Condor pool on the local cluster where the workflow is being run from. This is typically used when re-using data that exists on the filesystem of the local cluster.
-2. ``osg`` which is the Open Science Grid pool, as described in * :ref:`weeklyahopeosg` below. This is only used if the data to be re-used is accessible via the ``/cvmfs`` filesystem.
+2. ``osg`` which is the Open Science Grid pool, as described in :ref:`weeklyahopeosg` below. This is only used if the data to be re-used is accessible via the ``/cvmfs`` filesystem.
 
 If the ``SITE`` string for a file matches the site where a job will be run,
 then Pegasus assumes that the file can be accessed locally via the regular
@@ -677,7 +679,9 @@ To illustrate this, an example of a simple cache file containing four files for 
     116912/H1-INSPIRAL_FULL_DATA_JOB0-1169120586-1662.hdf file://localhost/home/dbrown/projects/aligo/o2/analysis-4/o2-analysis-4/output/full_data/H1-INSPIRAL_FULL_DATA_JOB0-1169120586-1662.hdf pool="local"
     116912/H1-INSPIRAL_FULL_DATA_JOB1-1169120586-1662.hdf file://localhost/home/dbrown/projects/aligo/o2/analysis-4/o2-analysis-4/output/full_data/H1-INSPIRAL_FULL_DATA_JOB1-1169120586-1662.hdf pool="local"
 
-In this case, Pegasus will delete the jobs from the workflow that create the files ``H1-VETOTIME_CAT3-1169107218-1066800.xml``, ``L1-VETOTIME_CAT3-1169107218-1066800.xml``, ``116912/H1-INSPIRAL_FULL_DATA_JOB0-1169120586-1662.hdf``, and ``116912/H1-INSPIRAL_FULL_DATA_JOB1-1169120586-1662.hdf`` when it plans the workflow. Insted, the data will be re-used from the URLs specified in the cache. Since ``site="local"`` for these files, Pegasus expects that the files all exist on the host where the workflow is run from.
+Note that the ``LOGICAL_FILE_NAME`` for the veto files is just the name of the
+file, but for the two inspiral files it contains the subdirectory that the
+workflow uses to organize the files by GPS time. In the case of this file Pegasus will delete from the workflow the jobs that create the files ``H1-VETOTIME_CAT3-1169107218-1066800.xml``, ``L1-VETOTIME_CAT3-1169107218-1066800.xml``, ``116912/H1-INSPIRAL_FULL_DATA_JOB0-1169120586-1662.hdf``, and ``116912/H1-INSPIRAL_FULL_DATA_JOB1-1169120586-1662.hdf`` when it plans the workflow. Insted, the data will be re-used from the URLs specified in the cache. Since ``site="local"`` for these files, Pegasus expects that the files all exist on the host where the workflow is run from.
 
 To re-use data from a remote cluster, the URLs must contain a file transfer
 mechanism and the ``SITE`` should be set to ``remote``. For example, if the


### PR DESCRIPTION
This is a re-write of the data re-use instructions to explain how re-use works and give a few common examples.

A rendered version of the changes can be found [here.](https://github.com/duncan-brown/pycbc/blob/reuse_doc/docs/workflow/pycbc_make_coinc_search_workflow.rst#reuse-of-data-from-a-previous-workflow)

