### PR TITLE
Tell pegasus about output map files in the dax

### DIFF
--- a/docs/workflow/hdf_coincidence.rst
+++ b/docs/workflow/hdf_coincidence.rst
@@ -153,19 +153,3 @@ Additional plots can be made by adding a tag. This works similary to the system 
 example you can add  [plot_sensitivity-mchirp], [plot_sensitivity-mtotal], and [plot_sensitivity-spin]
 sections to make three versions of the plot.
 
-===============================================================
-Reusing data from workflow that uses some other post-processing
-===============================================================
-
-Assuming the list of limitations is satisfied by the previous run, then one
-can simply select the 'main.map' file in the '--cache' option to the
-pegasus planner.::
-
-    cd gwanalysis
-    pycbc_basic_pegasus_plan weekly_ahope.dax $LOGPATH --cache /path/to/prior/worklfow/main.map
-
-If the prior workflow did not use the post-processing described on this page, then there is no need
-to edit the map file and it can be used as is.
-
-If you are rerunning a workflow using this post-processing, then select from your weekly_ahope.map file only
-the files you want to reuse, and then point the '--cache' option to it instead.

--- a/docs/workflow/pycbc_make_coinc_search_workflow.rst
+++ b/docs/workflow/pycbc_make_coinc_search_workflow.rst
@@ -731,6 +731,14 @@ below explain how to do this for a few common situations.
     See the documentation under :ref:`workflowconfigparsermod` for more
     details of the ``file-retention-level`` configuration option.
 
+.. note::
+
+    At present you *cannot* re-use ``.dax`` and ``.map`` files from a previous
+    run. A workflow using data reuse must regenerate and re-run any sub-daxes
+    from scratch. If you re-use a ``.map`` file rather than re-generating it,
+    then the new workflow will write results files in the location of the old
+    workflow. All of the examples below use an ``egrep -v '(dax|map)'`` to
+    filter out these files.
 
 .. _workflow_rerun_extend:
 
@@ -845,8 +853,7 @@ directory.
 
 Once in the ``main_ID0000001`` directory, run the command::
 
-    for pfn in `find . -type f | sed 's+^./++g'` ; do echo $pfn file://`pwd`/$pfn pool=\"local\" ; done > /path/to/partial_workflow.map
-
+    for pfn in `find . -type f | sed 's+^./++g'` ; do echo $pfn file://`pwd`/$pfn pool=\"local\" ; done | egrep -v '(dax|map)' > /path/to/partial_workflow.map
 
 changing ``/path/to`` to a location where you want to save the cache.
 
@@ -858,7 +865,7 @@ the ``osg-site-scratch`` directory. In this case::
 and change into the directory that ends with ``main_ID0000001``. Then run the
 same command as above::
 
-    for pfn in `find . -type f | sed 's+^./++g'` ; do echo $pfn file://`pwd`/$pfn pool=\"local\" ; done >> /path/to/partial_workflow.map
+    for pfn in `find . -type f | sed 's+^./++g'` ; do echo $pfn file://`pwd`/$pfn pool=\"local\" ; done | egrep -v '(dax|map)' >> /path/to/partial_workflow.map
 
 but **note** the ``>>`` rather than ``>`` to append to the file ``partial_workflow.map``, rather than deteling the existing file and creating a new file.
  

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -32,6 +32,7 @@ import numpy, cPickle, random
 from itertools import combinations, groupby, permutations
 from operator import attrgetter
 import lal as lalswig
+import Pegasus.DAX3
 from glue import lal, segments
 from glue.ligolw import table, lsctables, ligolw
 from glue.ligolw import utils as ligolw_utils
@@ -580,7 +581,7 @@ class Workflow(pegasus_workflow.Workflow):
  
     @property
     def output_map(self):  
-        if self.in_workflow != False:
+        if self.in_workflow is not False:
             name = self.name + '.map'
         else:
             name = 'output.map'
@@ -589,7 +590,7 @@ class Workflow(pegasus_workflow.Workflow):
         
     @property
     def staging_site(self):  
-        if self.in_workflow != False:
+        if self.in_workflow is not False:
             workflow_section = 'workflow-%s' % self.name 
         else:
             workflow_section = 'workflow'
@@ -638,19 +639,30 @@ class Workflow(pegasus_workflow.Workflow):
     
     @staticmethod
     def set_job_properties(job, output_map, staging_site=None):
-        job.addArguments('-Dpegasus.dir.storage.mapper.replica.file=%s' % output_map) 
+        job.addArguments('-Dpegasus.dir.storage.mapper.replica.file=%s' % 
+                         os.path.basename(output_map))
+        job.uses(Pegasus.DAX3.File(os.path.basename(output_map)), 
+                 link=Pegasus.DAX3.Link.INPUT)
         job.addArguments('-Dpegasus.dir.storage.mapper.replica=File') 
-        job.addArguments('--cache %s' % os.path.join(os.getcwd(), '_reuse.cache')) 
+
         job.addArguments('--output-site local')     
         job.addArguments('--cleanup inplace')
         job.addArguments('--cluster label,horizontal')
         job.addArguments('-vvv')
+
+        # FIXME _reuse_cache needs to be fixed to use PFNs properly. This will
+        # work as pegasus-plan is currently invoked on the local site so has
+        # access to a file in os.getcwd() but this code is fragile.
+        job.addArguments('--cache %s' % os.path.join(os.getcwd(), '_reuse.cache'))
+
         if staging_site:
             job.addArguments('--staging-site %s' % staging_site)
             
     def save(self, filename=None, output_map=None, staging_site=None):
         if output_map is None:
             output_map = self.output_map
+            self.as_job.file.PFN(output_map, site='local')
+            self._adag.addFile(self.as_job.file)
 
         staging_site = self.staging_site
             

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -661,8 +661,10 @@ class Workflow(pegasus_workflow.Workflow):
     def save(self, filename=None, output_map=None, staging_site=None):
         if output_map is None:
             output_map = self.output_map
-            self.as_job.file.PFN(output_map, site='local')
-            self._adag.addFile(self.as_job.file)
+            if self.in_workflow is not False:
+                output_map_file = Pegasus.DAX3.File(os.path.basename(output_map))
+                output_map_file.addPFN(Pegasus.DAX3.PFN(output_map, 'local'))
+                self.in_workflow._adag.addFile(output_map_file)
 
         staging_site = self.staging_site
             

--- a/pycbc/workflow/pegasus_files/local-site-template.xml
+++ b/pycbc/workflow/pegasus_files/local-site-template.xml
@@ -13,5 +13,6 @@
     <profile namespace="condor" key="accounting_group_user">$ACCOUNTING_GROUP_USER</profile>
     <profile namespace="condor" key="should_transfer_files">YES</profile>
     <profile namespace="condor" key="when_to_transfer_output">ON_EXIT_OR_EVICT</profile>
+    <profile namespace="condor" key="use_x509userproxy">True</profile>
     <profile namespace="condor" key="+DESIRED_Sites">&quot;nogrid&quot;</profile>
     <profile namespace="condor" key="+IS_GLIDEIN">&quot;False&quot;</profile>


### PR DESCRIPTION
Pegasus 4.7.3 and above run ``pegasus-plan`` for sub-daxes under the kickstart script for better job management. This means that pegasus needs to be told about output map files in the DAX so that it can manage them. This is implemented by this patch. This should also fix @tdent's observation that data-reuse never seems to work if the reuse cache contains a ``.dax`` or ``.map`` file.

This is a fix for https://github.com/ligo-cbc/pycbc/issues/1448

For top-level workflows, the output map is tagged as a file needed by any sub-dax job and *also* added to the list of PFNs (since it is created by the workflow generation script not within the DAX):
```
<adag xmlns="http://pegasus.isi.edu/schema/DAX" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pegasus.isi.edu/schema/DAX http://pegasus.isi.edu/schema/dax-3.6.xsd" version="3.6" name="o2-analysis-3-vdf_c37d16-p3">
        <file name="o2-analysis-3-vdf_c37d16-p3-finalization.dax">
                <pfn url="/home/dbrown/projects/aligo/o2/analysis-3/o2-analysis-3-vdf_c37d16-p3/output/o2-analysis-3-vdf_c37d16-p3-finalization.dax" site="local"/>
        </file>
        <file name="o2-analysis-3-vdf_c37d16-p3-main.map">
                <pfn url="/home/dbrown/projects/aligo/o2/analysis-3/o2-analysis-3-vdf_c37d16-p3/output/o2-analysis-3-vdf_c37d16-p3-main.map" site="local"/>
        </file>
        <file name="o2-analysis-3-vdf_c37d16-p3-finalization.map">
                <pfn url="/home/dbrown/projects/aligo/o2/analysis-3/o2-analysis-3-vdf_c37d16-p3/output/o2-analysis-3-vdf_c37d16-p3-finalization.map" site="local"/>
        </file>
        <file name="o2-analysis-3-vdf_c37d16-p3-main.dax">
                <pfn url="/home/dbrown/projects/aligo/o2/analysis-3/o2-analysis-3-vdf_c37d16-p3/output/o2-analysis-3-vdf_c37d16-p3-main.dax" site="local"/>
        </file>
        <dax id="ID0000001" file="o2-analysis-3-vdf_c37d16-p3-main.dax">
                <argument>-Dpegasus.dir.storage.mapper.replica.file=o2-analysis-3-vdf_c37d16-p3-main.map -Dpegasus.dir.storage.mapper.replica=File --output-site local --cleanup inplace --cluster label,horizontal -vvv --cache /home/dbrown/projects/aligo/o2/analysis-3/o2-analysis-3-vdf_c37d16-p3/output/_reuse.cache</argument>
                <uses name="o2-analysis-3-vdf_c37d16-p3-main.map" link="input"/>
        </dax>
        <dax id="ID0000002" file="o2-analysis-3-vdf_c37d16-p3-finalization.dax">
                <argument>-Dpegasus.dir.storage.mapper.replica.file=o2-analysis-3-vdf_c37d16-p3-finalization.map -Dpegasus.dir.storage.mapper.replica=File --output-site local --cleanup inplace --cluster label,horizontal -vvv --cache /home/dbrown/projects/aligo/o2/analysis-3/o2-analysis-3-vdf_c37d16-p3/output/_reuse.cache</argument>
                <uses name="o2-analysis-3-vdf_c37d16-p3-finalization.map" link="input"/>
        </dax>
        <child ref="ID0000002">
                <parent ref="ID0000001"/>
        </child>
</adag>
```

For sub-DAXes that are generated within the DAX, the output map is just added to the sub-dax planning job and not included as a PFN, since Pegasus knows which job made it and from whence it came:
```
        <job id="ID0008744" name="foreground_minifollowup-H1L1_ID92">
                <argument>--config-files <file name="FULL_DATA_FULL_CUMULATIVE_CAT_12H_FULL_DATA_FULLforeground_minifollowup.ini"/> --bank-file <file name="H1L1-BANK2HDF-1166486417-2620801.hdf"/> --statmap-file <file name="H1L1-STATMAP_FULL_DATA_FULL_CUMULATIVE_CAT_12H_FULL_DATA_FULL-1166486417-2620801.hdf"/> --inspiral-segments <file name="H1L1-INSP_SEGMENTS-1166486417-2620801.xml"/> --inspiral-data-read-name DATA_ANALYSED --inspiral-data-analyzed-name TRIGGERS_GENERATED --output-file <file name="H1L1-FOREGROUND_MINIFOLLOWUP_FULL_DATA_FULL_CUMULATIVE_CAT_12H-1166486417-2620801.dax"/> --output-map <file name="H1L1-FOREGROUND_MINIFOLLOWUP_FULL_DATA_FULL_CUMULATIVE_CAT_12H-1166486417-2620801.dax.map"/> --workflow-name H1L1-FOREGROUND_MINIFOLLOWUP_FULL_DATA_FULL_CUMULATIVE_CAT_12H-1166486417-2620801.dax --output-dir /home/dbrown/projects/aligo/o2/analysis-3/o2-analysis-3-vdf_c37d16-p3/output/results/7._open_box_result/7.02_loudest_event_followup --single-detector-triggers H1:H1-HDF_TRIGGER_MERGE_FULL_DATA-1166486417-2620801.hdf L1:L1-HDF_TRIGGER_MERGE_FULL_DATA-1166486417-2620801.hdf </argument>
                <profile namespace="dagman" key="category">foreground_minifollowup</profile>
                <profile namespace="hints" key="execution.site">local</profile>
                <profile namespace="condor" key="getenv">True</profile>
                <uses name="H1L1-INSP_SEGMENTS-1166486417-2620801.xml" link="input" register="false" transfer="true"/>
                <uses name="H1L1-BANK2HDF-1166486417-2620801.hdf" link="input" register="false" transfer="true"/>
                <uses name="H1L1-STATMAP_FULL_DATA_FULL_CUMULATIVE_CAT_12H_FULL_DATA_FULL-1166486417-2620801.hdf" link="input" register="false" transfer="true"/>
                <uses name="FULL_DATA_FULL_CUMULATIVE_CAT_12H_FULL_DATA_FULLforeground_minifollowup.ini" link="input" register="false" transfer="true"/>
                <uses name="L1-HDF_TRIGGER_MERGE_FULL_DATA-1166486417-2620801.hdf" link="input" register="false" transfer="true"/>
                <uses name="H1-HDF_TRIGGER_MERGE_FULL_DATA-1166486417-2620801.hdf" link="input" register="false" transfer="true"/>
                <uses name="H1L1-FOREGROUND_MINIFOLLOWUP_FULL_DATA_FULL_CUMULATIVE_CAT_12H-1166486417-2620801.dax" link="output" register="true" transfer="true"/>
                <uses name="H1L1-FOREGROUND_MINIFOLLOWUP_FULL_DATA_FULL_CUMULATIVE_CAT_12H-1166486417-2620801.dax.map" link="output" register="true" transfer="true"/>
        </job>
        <dax id="ID0008745" file="H1L1-FOREGROUND_MINIFOLLOWUP_FULL_DATA_FULL_CUMULATIVE_CAT_12H-1166486417-2620801.dax">
                <argument>--basename H1L1-FOREGROUND_MINIFOLLOWUP_FULL_DATA_FULL_CUMULATIVE_CAT_12H-1166486417-2620801 -Dpegasus.dir.storage.mapper.replica.file=H1L1-FOREGROUND_MINIFOLLOWUP_FULL_DATA_FULL_CUMULATIVE_CAT_12H-1166486417-2620801.dax.map -Dpegasus.dir.storage.mapper.replica=File --output-site local --cleanup inplace --cluster label,horizontal -vvv --cache /home/dbrown/projects/aligo/o2/analysis-3/o2-analysis-3-vdf_c37d16-p3/output/_reuse.cache</argument>
                <uses name="H1L1-FOREGROUND_MINIFOLLOWUP_FULL_DATA_FULL_CUMULATIVE_CAT_12H-1166486417-2620801.dax.map" link="input"/>
        </dax>
```