### PR TITLE
Fixed variable names in bundle build script and made corrections in docs.

### DIFF
--- a/docs/building_bundled_executables.rst
+++ b/docs/building_bundled_executables.rst
@@ -81,7 +81,7 @@ a git tag of the form ``vX.Y.Z`` (where X, Y, and Z are integers).
     as the **first** argument in the list of arguments.
 
 The minimal set of command line options required to build the ``pycbc_inspiral`` 
-bundle is typically the hash of the versions of LALSuite and PyCBC required::
+bundle is typically the hash of the versions of LALSuite and PyCBC::
 
     pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --pycbc-commit=b68832784969a47fe2658abffb3888ee06cd1be4
 

--- a/docs/building_bundled_executables.rst
+++ b/docs/building_bundled_executables.rst
@@ -128,7 +128,6 @@ Building Releases for CVMFS
 To build a release of ``pycbc_inspiral`` for installation in CVMFS, run the
 script with the arguments::
 
-    pycbc_build_eah.sh --lalsuite-commit=a3a5a476d33f169b8749e2840c306a48df63c936 --pycbc-commit=b68832784969a47fe2658abffb3888ee06cd1be4 --with-extra-libs=file:///home/pycbc/build/composer_xe_2015.0.090.tar.gz
+    pycbc_build_eah.sh --lalsuite-commit=a3a5a476d33f169b8749e2840c306a48df63c936 --pycbc-commit=b68832784969a47fe2658abffb3888ee06cd1be4 --with-extra-libs=file:///home/pycbc/build/composer_xe_2015.0.090.tar.gz --with-lal-data-path=/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/11/share/lalsimulation
 
-changing the ``--lalsuite-commit`` and ``--pycbc-commit`` to the appropriate
-hashes for the release.
+changing the ``--lalsuite-commit``, ``--pycbc-commit``, and ``--with-lal-data-path`` options to the values for the release.

--- a/docs/building_bundled_executables.rst
+++ b/docs/building_bundled_executables.rst
@@ -80,8 +80,8 @@ a git tag of the form ``vX.Y.Z`` (where X, Y, and Z are integers).
     platform, pass the command-line argument ``--force-debian4`` to the script
     as the **first** argument in the list of arguments.
 
-The minimal set of command line options require to ``pycbc_inspiral`` is
-typically the hash of the versions of LALSuite and PyCBC required::
+The minimal set of command line options required to build the ``pycbc_inspiral`` 
+bundle is typically the hash of the versions of LALSuite and PyCBC required::
 
     pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --pycbc-commit=b68832784969a47fe2658abffb3888ee06cd1be4
 
@@ -94,11 +94,12 @@ The script executes ``pycbc_inspiral`` as part of the build process. This may
 require LAL data at build time. The LAL data can be given with the command
 line argument::
     
-    --with-lal-data=/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/11/share/lalsimulation
+    --with-lal-data-path=/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/11/share/lalsimulation
 
 The default command line arguments clone PyCBC from the standard GitHub
 repository.  If you would like to build a bundle using code from your own
-GitHub repository ior branch you can use the arguments::
+GitHub repository or branch you can use the arguments mentioned below. In this 
+case you would not need to specify a ``--pycbc-commit``::
 
     --pycbc-remote=soumide1102 --pycbc-branch=comp_wave_in_search
 
@@ -113,7 +114,7 @@ and bundle different waveform approximants, for example::
 To test with compressed waveform banks, you can provide the following option
 *after* all the other ``--with-extra-approximant`` arguments::
 
-    --with-extra-approx=--use-compressed-waveforms
+    --with-extra-approximant=--use-compressed-waveforms
 
 The weave-compilation step can also be run with additional template banks by
 passing the argument::

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -257,8 +257,8 @@ for i in $*; do
             fi ;;
         --with-extra-libs=*) extra_libs="`echo $i|sed 's/^--with-extra-libs=//'`";;
         --with-extra-bank=*) extra_bank="$extra_bank `echo $i|sed 's/^--with-extra-bank=//'`";;
-        --with-extra-approximant=*) extra_approx="$extra_approx ${extra_approx}`echo $i|sed 's/^--with-extra-approx=//'` ";;
-        --with-lal-data-path=*) lal_data_path="`echo $i|sed 's/^--with-lal-data=//'`";;
+        --with-extra-approximant=*) extra_approx="$extra_approx ${extra_approx}`echo $i|sed 's/^--with-extra-approximant=//'` ";;
+        --with-lal-data-path=*) lal_data_path="`echo $i|sed 's/^--with-lal-data-path=//'`";;
         --help) echo -e "Options:\n$usage">&2; exit 0;;
         *) echo -e "unknown option '$i', valid are:\n$usage">&2; exit 1;;
     esac


### PR DESCRIPTION
Made corrections for the variable names `--with-extra-approximants` and `--with-lal-data-path` in the bundle build script and docs. Also specified in the docs that `--pycbc-commit` is not required to be specified if `--pycbc-branch` is used.