### PR TITLE
Changes in pycbc_inspiral and bank.py to use compressed waveforms in the search

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -165,6 +165,10 @@ parser.add_argument("--keep-loudest-interval", type=float,
 parser.add_argument("--keep-loudest-num", type=int,
                     help="Number of triggers to keep from each maximization interval")
 parser.add_argument("--gpu-callback-method", default='none')
+parser.add_argument("--use-compressed-waveforms", action="store_true", default=False,
+                    help='Use compressed waveforms from the bank file.')
+parser.add_argument("--waveform-decompression-method", action='store', default=None,
+                    help='Method to be used decompress waveforms from the bank file.')
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -286,7 +290,10 @@ with ctx:
         low_frequency_cutoff=None if opt.enable_bank_start_frequency else flow,
         dtype=complex64, phase_order=opt.order,
         taper=opt.taper_template, approximant=opt.approximant,
-        out=template_mem, max_template_length=opt.max_template_length)
+        out=template_mem, max_template_length=opt.max_template_length,
+        load_compressed=True if opt.use_compressed_waveforms else False,
+        waveform_decompression_method=
+        opt.waveform_decompression_method if opt.use_compressed_waveforms else None)
 
     sg_chisq = SingleDetSGChisq.from_cli(opt, bank, opt.chisq_bins)
 

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -646,9 +646,42 @@ class FilterBank(TemplateBank):
             **kwds)
         self.ensure_standard_filter_columns(low_frequency_cutoff=low_frequency_cutoff)
 
-    def __getitem__(self, index):
+    def get_decompressed_waveform(self, tempout, index, f_lower=None,
+                                  approximant=None):
+        """Returns a frequency domain decompressed waveform for the template
+        in the bank corresponding to the index taken in as an argument. The
+        decompressed waveform is obtained by interpolating in frequency space,
+        the amplitude and phase points for the compressed template that are
+        read in from the bank."""
+
         from pycbc.waveform.waveform import props
         from pycbc.waveform import get_waveform_filter_length_in_time
+        # Create memory space for writing the decompressed waveform
+        precision_from_bank_file = self.compressed_waveforms[self.table.template_hash[index]].precision
+        waveform_decompression_precision = tempout.precision
+        if waveform_decompression_precision != precision_from_bank_file :
+            raise ValueError("The precision used to compress the "
+                             "waveform was %s, whereas the precision "
+                             "selected to decompress the waveform was "
+                             "%s. Both of theses should be the same. "
+                             "Therefore, use a bank with precision %s."
+                             %(precision_from_bank_file,
+                             waveform_decompression_precision,
+                             waveform_decompression_precision))
+        if self.waveform_decompression_method is not None :
+            decompression_method = self.waveform_decompression_method
+        else :
+            decompression_method = self.compressed_waveforms[self.table.template_hash[index]].interpolation
+        logging.info("Decompressing waveform using %s", decompression_method)
+        decomp_scratch = FrequencySeries(tempout[0:self.filter_length], delta_f=self.delta_f, copy=False)
+        hdecomp = self.compressed_waveforms[self.table.template_hash[index]].decompress(out=decomp_scratch, f_lower=f_lower, interpolation=decompression_method)
+        p = props(self.table[index])
+        p.pop('approximant')
+        hdecomp.chirp_length = get_waveform_filter_length_in_time(approximant, **p)
+        hdecomp.length_in_time = hdecomp.chirp_length
+        return hdecomp
+
+    def __getitem__(self, index):
         # Make new memory for templates if we aren't given output memory
         if self.out is None:
             tempout = zeros(self.filter_length, dtype=self.dtype)
@@ -670,7 +703,6 @@ class FilterBank(TemplateBank):
                                                   self.max_template_length)
         else:
             f_low = self.f_lower
-
         logging.info('%s: generating %s from %s Hz' % (index, approximant, f_low))
 
         # Clear the storage memory
@@ -680,29 +712,8 @@ class FilterBank(TemplateBank):
         # Get the waveform filter
         distance = 1.0 / DYN_RANGE_FAC
         if self.compressed_waveforms is not None :
-            # Create memory space for writing the decompressed waveform
-            precision_from_bank_file = self.compressed_waveforms[self.table.template_hash[index]].precision
-            waveform_decompression_precision = tempout.precision
-            if waveform_decompression_precision != precision_from_bank_file :
-                raise ValueError("The precision used to compress the "
-                                 "waveform was %s, whereas the precision "
-                                 "selected to decompress the waveform was "
-                                 "%s. Both of theses should be the same. "
-                                 "Therefore, use a bank with precision %s."
-                                 %(precision_from_bank_file,
-                                 waveform_decompression_precision,
-                                 waveform_decompression_precision))
-            if self.waveform_decompression_method is not None :
-                decompression_method = self.waveform_decompression_method
-            else :
-                decompression_method = self.compressed_waveforms[self.table.template_hash[index]].interpolation
-            logging.info("Decompressing waveform using %s", decompression_method)
-            decomp_scratch = FrequencySeries(tempout[0:self.filter_length], delta_f=self.delta_f, copy=False)
-            htilde = self.compressed_waveforms[self.table.template_hash[index]].decompress(out=decomp_scratch, f_lower=f_low, interpolation=decompression_method)
-            p = props(self.table[index])
-            p.pop('approximant')
-            htilde.chirp_length = get_waveform_filter_length_in_time(approximant, **p)
-            htilde.length_in_time = htilde.chirp_length
+            htilde = self.get_decompressed_waveform(tempout, index, f_lower=f_low,
+                                                    approximant=approximant)
         else :
             htilde = pycbc.waveform.get_waveform_filter(
                 tempout[0:self.filter_length], self.table[index],

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -657,23 +657,6 @@ class FilterBank(TemplateBank):
         from pycbc.waveform.waveform import props
         from pycbc.waveform import get_waveform_filter_length_in_time
 
-        # Get the precision used to generate the compressed template
-        precision_from_bank_file = self.compressed_waveforms[self.table.template_hash[index]].precision
-
-        # Get the precision that would be used to generate the decompressed
-        # waveform
-        waveform_decompression_precision = tempout.precision
-
-        if waveform_decompression_precision != precision_from_bank_file :
-            raise ValueError("The precision used to compress the "
-                             "waveform was %s, whereas the precision "
-                             "selected to decompress the waveform was "
-                             "%s. Both of theses should be the same. "
-                             "Therefore, use a bank with precision %s."
-                             %(precision_from_bank_file,
-                             waveform_decompression_precision,
-                             waveform_decompression_precision))
-
         # Get the interpolation method to be used to decompress the waveform
         if self.waveform_decompression_method is not None :
             decompression_method = self.waveform_decompression_method

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -628,6 +628,7 @@ class FilterBank(TemplateBank):
                  load_compressed_now=False,
                  low_frequency_cutoff=None,
                  waveform_decompression_method=None,
+                 waveform_decompression_precision=None,
                  **kwds):
         self.out = out
         self.dtype = dtype
@@ -639,6 +640,7 @@ class FilterBank(TemplateBank):
         self.filter_length = filter_length
         self.max_template_length = max_template_length
         self.waveform_decompression_method = waveform_decompression_method
+        self.waveform_decompression_precision = waveform_decompression_precision
 
         super(FilterBank, self).__init__(filename, approximant=approximant,
             parameters=parameters, load_compressed=load_compressed,
@@ -681,6 +683,17 @@ class FilterBank(TemplateBank):
         distance = 1.0 / DYN_RANGE_FAC
         if self.compressed_waveforms is not None :
             # Create memory space for writing the decompressed waveform
+            if self.waveform_decompression_precision is not None :
+                precision_from_bank_file = self.compressed_waveforms[self.table.template_hash[index]].precision
+                if self.waveform_decompression_precision != precision_from_bank_file :
+                    raise ValueError("The precision used to compress the "
+                                     "waveform was %s, whereas the precision "
+                                     "selected to decompress the waveform was "
+                                     "%s. Both of theses should be the same. "
+                                     "Therefore, use a bank with precision %s."
+                                     %(precision_from_bank_file,
+                                     self.waveform_decompression_precision,
+                                     self.waveform_decompression_precision))
             if self.waveform_decompression_method is not None :
                 decompression_method = self.waveform_decompression_method
             else :

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -656,9 +656,14 @@ class FilterBank(TemplateBank):
 
         from pycbc.waveform.waveform import props
         from pycbc.waveform import get_waveform_filter_length_in_time
-        # Create memory space for writing the decompressed waveform
+
+        # Get the precision used to generate the compressed template
         precision_from_bank_file = self.compressed_waveforms[self.table.template_hash[index]].precision
+
+        # Get the precision that would be used to generate the decompressed
+        # waveform
         waveform_decompression_precision = tempout.precision
+
         if waveform_decompression_precision != precision_from_bank_file :
             raise ValueError("The precision used to compress the "
                              "waveform was %s, whereas the precision "
@@ -668,12 +673,18 @@ class FilterBank(TemplateBank):
                              %(precision_from_bank_file,
                              waveform_decompression_precision,
                              waveform_decompression_precision))
+
+        # Get the interpolation method to be used to decompress the waveform
         if self.waveform_decompression_method is not None :
             decompression_method = self.waveform_decompression_method
         else :
             decompression_method = self.compressed_waveforms[self.table.template_hash[index]].interpolation
         logging.info("Decompressing waveform using %s", decompression_method)
+
+        # Create memory space for writing the decompressed waveform
         decomp_scratch = FrequencySeries(tempout[0:self.filter_length], delta_f=self.delta_f, copy=False)
+
+        # Get the decompressed waveform
         hdecomp = self.compressed_waveforms[self.table.template_hash[index]].decompress(out=decomp_scratch, f_lower=f_lower, interpolation=decompression_method)
         p = props(self.table[index])
         p.pop('approximant')

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -258,7 +258,7 @@ class TemplateBank(object):
 
             # inclination stored in xml alpha3 column
             names = list(self.table.dtype.names)
-            names = tuple([n if n != 'alpha3' else 'inclination' for n in names]) 
+            names = tuple([n if n != 'alpha3' else 'inclination' for n in names])
 
             # low frequency cutoff in xml alpha6 column
             names = tuple([n if n!= 'alpha6' else 'f_lower' for n in names])
@@ -463,30 +463,30 @@ class TemplateBank(object):
             indices_combined = np.concatenate(indices)
 
         indices_unique= np.unique(indices_combined)
-        self.table = self.table[indices_unique]   
+        self.table = self.table[indices_unique]
 
 
     def ensure_standard_filter_columns(self, low_frequency_cutoff=None):
         """ Initialize FilterBank common fields
-        
+
         Parameters
         ----------
         low_frequency_cutoff: {float, None}, Optional
             A low frequency cutoff which overrides any given within the
             template bank file.
         """
-        
+
         # Make sure we have a template duration field
         if not hasattr(self.table, 'template_duration'):
             self.table = self.table.add_fields(numpy.zeros(len(self.table),
-                                     dtype=numpy.float32), 'template_duration') 
+                                     dtype=numpy.float32), 'template_duration')
 
         # Make sure we have a f_lower field
         if low_frequency_cutoff is not None:
             if not hasattr(self.table, 'f_lower'):
                 vec = numpy.zeros(len(self.table), dtype=numpy.float32)
                 self.table = self.table.add_fields(vec, 'f_lower')
-            self.table['f_lower'][:] = low_frequency_cutoff        
+            self.table['f_lower'][:] = low_frequency_cutoff
 
         self.min_f_lower = min(self.table['f_lower'])
         if self.f_lower is None and self.min_f_lower == 0.:
@@ -495,7 +495,7 @@ class TemplateBank(object):
 class LiveFilterBank(TemplateBank):
     def __init__(self, filename, sample_rate, minimum_buffer,
                        approximant=None, increment=8, parameters=None,
-                       load_compressed=True, load_compressed_now=False, 
+                       load_compressed=True, load_compressed_now=False,
                        low_frequency_cutoff=None,
                        **kwds):
 
@@ -559,7 +559,7 @@ class LiveFilterBank(TemplateBank):
 
         approximant = self.approximant(index)
         f_end = self.end_frequency(index)
-        flow = self.table[index].f_lower        
+        flow = self.table[index].f_lower
 
         # Determine the length of time of the filter, rounded up to
         # nearest power of two
@@ -569,7 +569,7 @@ class LiveFilterBank(TemplateBank):
         p = props(self.table[index])
         p.pop('approximant')
         buff_size = pycbc.waveform.get_waveform_filter_length_in_time(approximant, **p)
-        
+
         tlen = self.round_up((buff_size + min_buffer) * self.sample_rate)
         flen = int(tlen / 2 + 1)
 

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -628,7 +628,6 @@ class FilterBank(TemplateBank):
                  load_compressed_now=False,
                  low_frequency_cutoff=None,
                  waveform_decompression_method=None,
-                 waveform_decompression_precision=None,
                  **kwds):
         self.out = out
         self.dtype = dtype
@@ -640,7 +639,6 @@ class FilterBank(TemplateBank):
         self.filter_length = filter_length
         self.max_template_length = max_template_length
         self.waveform_decompression_method = waveform_decompression_method
-        self.waveform_decompression_precision = waveform_decompression_precision
 
         super(FilterBank, self).__init__(filename, approximant=approximant,
             parameters=parameters, load_compressed=load_compressed,
@@ -683,17 +681,17 @@ class FilterBank(TemplateBank):
         distance = 1.0 / DYN_RANGE_FAC
         if self.compressed_waveforms is not None :
             # Create memory space for writing the decompressed waveform
-            if self.waveform_decompression_precision is not None :
-                precision_from_bank_file = self.compressed_waveforms[self.table.template_hash[index]].precision
-                if self.waveform_decompression_precision != precision_from_bank_file :
-                    raise ValueError("The precision used to compress the "
-                                     "waveform was %s, whereas the precision "
-                                     "selected to decompress the waveform was "
-                                     "%s. Both of theses should be the same. "
-                                     "Therefore, use a bank with precision %s."
-                                     %(precision_from_bank_file,
-                                     self.waveform_decompression_precision,
-                                     self.waveform_decompression_precision))
+            precision_from_bank_file = self.compressed_waveforms[self.table.template_hash[index]].precision
+            waveform_decompression_precision = tempout.precision
+            if waveform_decompression_precision != precision_from_bank_file :
+                raise ValueError("The precision used to compress the "
+                                 "waveform was %s, whereas the precision "
+                                 "selected to decompress the waveform was "
+                                 "%s. Both of theses should be the same. "
+                                 "Therefore, use a bank with precision %s."
+                                 %(precision_from_bank_file,
+                                 waveform_decompression_precision,
+                                 waveform_decompression_precision))
             if self.waveform_decompression_method is not None :
                 decompression_method = self.waveform_decompression_method
             else :


### PR DESCRIPTION
This PR includes the changes made to `pycbc_inspiral` and `bank.py` to use compressed waveforms in the search to do the matched filtering. The changes primarily are :
* Addition of an argument `--use-compressed-waveforms` to let the user choose whether or not to use compressed waveforms from the template bank, and depending on that load compressed waveforms in `FilterBank` in `bank.py` .
* Tell `FilterBank` that the precision to be used to generate the decompressed waveforms should be `single` and raise an error if the bank was not constructed using the precision that `pycbc_inspiral` specifies.
* If the user chooses to load the compressed waveforms from the bank, read in the `amplitude`, `phase` and `sample_points` for the templates from the bank and decompress them using `decompress` in `compress.py` .
* The waveforms should be decompressed using the `interpolation` method used to generate the compressed waveform points by default, unless some other `interpolation` mechanism is provides to `pycbc_inspiral` via `--waveform-decompression-method`.

I've opened separate PRs for changes to `pycbc_compress_bank`, `compress.py` https://github.com/ligo-cbc/pycbc/pull/1473 and `pycbc_coinc_findtrigs` https://github.com/ligo-cbc/pycbc/pull/1474, which I've assigned to @cdcapano . I'm running test workflows with these changes in. I'll remove the work in progress tag once the results look okay.
