### PR TITLE
Changes in pycbc_compress_bank and compress.py to use compressed waveforms in the search

### DIFF
--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -40,9 +40,9 @@ from pycbc import filter
 
 
 parser = argparse.ArgumentParser(description=__description__)
-parser.add_argument("--bank-file", type=str,
+parser.add_argument("--bank-file", type=str, required=True,
                     help="Bank hdf file to load.")
-parser.add_argument("--output", type=str,
+parser.add_argument("--output", type=str, required=True,
                     help="The hdf file to save the templates and "
                     "compressed waveforms to.")
 parser.add_argument("--low-frequency-cutoff", type=float, required=True,
@@ -73,11 +73,11 @@ parser.add_argument("--tolerance", type=float, default=0.001,
                     "Points will be added to the compressed waveform "
                     "until its interpolation has a mismatch <= this value. "
                     "Default is 0.001.")
-parser.add_argument("--interpolation", type=str, default="linear",
+parser.add_argument("--interpolation", type=str, default="inline_linear",
                     help="The interpolation to use for decompressing the "
                     "waveforms for checking tolerance. Options are "
-                    "'linear', or any interpolation recognized by scipy's "
-                    "interp1d kind argument. Default is linear.")
+                    "'inline_linear', or any interpolation recognized by "
+                    "scipy's interp1d kind argument. Default is inline_linear.")
 parser.add_argument("--precision", type=str, choices=["double", "single"],
                     default="double",
                     help="What precision to generate and store the "

--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -79,7 +79,7 @@ parser.add_argument("--interpolation", type=str, default="inline_linear",
                     "'inline_linear', or any interpolation recognized by "
                     "scipy's interp1d kind argument. Default is inline_linear.")
 parser.add_argument("--precision", type=str, choices=["double", "single"],
-                    default="double",
+                    default="single",
                     help="What precision to generate and store the "
                     "waveforms with; default is double.")
 parser.add_argument("--force", action="store_true", default=False,
@@ -191,7 +191,7 @@ for ii in range(imin, imax):
     # compress
     hcompressed = compress.compress_waveform(
         htilde, sample_points, args.tolerance, args.interpolation,
-        decomp_scratch=decomp_scratch, psd=psd)
+        args.precision, decomp_scratch=decomp_scratch, psd=psd)
 
     # save results
     hcompressed.write_to_hdf(output, tmplt.template_hash)

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -420,9 +420,9 @@ _linear_decompress_code = r"""
                 outptr += 2;
                 findex++;
             }
-            if (next_sfindex == hlen){
-            break;
-            }
+        }
+        if (next_sfindex == hlen){
+        break;
         }
     }
 

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -209,7 +209,7 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
         overlaps.
     precision : str
         The precision being used to generate and store the compressed waveform
-        points. 
+        points.
     decomp_scratch : {None, FrequencySeries}
         Optionally provide scratch space for decompressing the waveform. The
         provided frequency series must have the same `delta_f` and length
@@ -490,7 +490,7 @@ def fd_decompress(amp, phase, sample_frequencies, out=None, df=None,
             _precision_map[phase.dtype.name] != precision:
         raise ValueError("amp, phase, and sample_points must all have the "
             "same precision")
-    
+
     sample_frequencies = numpy.array(sample_frequencies)
     amp = numpy.array(amp)
     phase = numpy.array(phase)
@@ -736,7 +736,7 @@ class CompressedWaveform(object):
         The waveform is written to:
         `fp['[{root}/]compressed_waveforms/{template_hash}/{param}']`,
         where `param` is the `sample_points`, `amplitude`, and `phase`. The
-        `interpolation`, `tolerance`, `mismatch` and `precision` are saved 
+        `interpolation`, `tolerance`, `mismatch` and `precision` are saved
         to the group's attributes.
 
         Parameters

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -177,7 +177,7 @@ def vecdiff(htilde, hinterp, sample_points, psd=None):
     return vecdiffs
 
 def compress_waveform(htilde, sample_points, tolerance, interpolation,
-                      decomp_scratch=None, psd=None):
+                      precision, decomp_scratch=None, psd=None):
     """Retrieves the amplitude and phase at the desired sample points, and adds
     frequency points in order to ensure that the interpolated waveform
     has a mismatch with the full waveform that is <= the desired tolerance. The
@@ -207,6 +207,9 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     interpolation : str
         The interpolation to use for decompressing the waveform when computing
         overlaps.
+    precision : str
+        The precision being used to generate and store the compressed waveform
+        points. 
     decomp_scratch : {None, FrequencySeries}
         Optionally provide scratch space for decompressing the waveform. The
         provided frequency series must have the same `delta_f` and length
@@ -293,7 +296,8 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
 
     return CompressedWaveform(sample_points, comp_amp, comp_phase,
                               interpolation=interpolation,
-                              tolerance=tolerance, mismatch=mismatch)
+                              tolerance=tolerance, mismatch=mismatch,
+                              precision=precision)
 
 
 _linear_decompress_code = r"""
@@ -568,6 +572,9 @@ class CompressedWaveform(object):
     mismatch : {None, float}
         The actual mismatch between the decompressed waveform (using the given
         `interpolation`) and the full waveform.
+    precision : {None, str}
+        The precision used to generate and store the compressed waveform amplitude
+        and phase points.
     load_to_memory : {True, bool}
         If `sample_points`, `amplitude`, and/or `phase` is an hdf dataset, they
         will be cached in memory the first time they are accessed. Default is
@@ -591,11 +598,13 @@ class CompressedWaveform(object):
     mismatch : {None, float}
         The mismatch between the decompressed waveform and the original
         waveform.
+    precision : {None, str}
+        The precision used to generate and store the compressed waveform points.
     """
 
     def __init__(self, sample_points, amplitude, phase,
                  interpolation=None, tolerance=None, mismatch=None,
-                 load_to_memory=True):
+                 precision=None, load_to_memory=True):
         self._sample_points = sample_points
         self._amplitude = amplitude
         self._phase = phase
@@ -618,6 +627,7 @@ class CompressedWaveform(object):
         self.interpolation = interpolation
         self.tolerance = tolerance
         self.mismatch = mismatch
+        self.precision = precision
 
     def _get(self, param):
         val = getattr(self, '_%s' %param)
@@ -726,8 +736,8 @@ class CompressedWaveform(object):
         The waveform is written to:
         `fp['[{root}/]compressed_waveforms/{template_hash}/{param}']`,
         where `param` is the `sample_points`, `amplitude`, and `phase`. The
-        `interpolation`, `tolerance`, and `mismatch` are saved to the group's
-        attributes.
+        `interpolation`, `tolerance`, `mismatch` and `precision` are saved 
+        to the group's attributes.
 
         Parameters
         ----------
@@ -750,6 +760,7 @@ class CompressedWaveform(object):
         fp[group].attrs['mismatch'] = self.mismatch
         fp[group].attrs['interpolation'] = self.interpolation
         fp[group].attrs['tolerance'] = self.tolerance
+        fp[group].attrs['precision'] = self.precision
 
     @classmethod
     def from_hdf(cls, fp, template_hash, root=None, load_to_memory=True,
@@ -798,5 +809,6 @@ class CompressedWaveform(object):
             interpolation=fp[group].attrs['interpolation'],
             tolerance=fp[group].attrs['tolerance'],
             mismatch=fp[group].attrs['mismatch'],
+            precision=fp[group].attrs['precision'],
             load_to_memory=load_to_memory)
 


### PR DESCRIPTION
This PR includes the changes made to `pycbc_compress_bank` and `compress.py` to use compressed waveforms in the search. The changes are :
* Change the default interpolation method from `linear` to `inline_linear`. This is because, scipy's `interpolate.interp1d` requires the `interpolation` argument to be specified as `linear`. So the inline linear decompression method should have a different name.
* Save the `precision` used to generate the compressed bank as metadata in the bank files.
* Includes the bug fix for segmentation fault issue faced while decompressing the compressed waveforms while running `pycbc_inspiral`.

I have test workflows going with the bug fixes. I'll remove the work in progress tag once the results look fine.