### PR TITLE
Fill in sngl_inspiral.process_id in GraceDB uploads

### DIFF
--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -122,6 +122,7 @@ class SingleCoincForGraceDB(object):
             sngl = return_empty_sngl()
             sngl.event_id = lsctables.SnglInspiralID(sngl_id)
             sngl_event_id_map[ifo] = sngl.event_id
+            sngl.process_id = proc_id
             sngl.ifo = ifo
             for name in names:
                 val = coinc_results['foreground/%s/%s' % (ifo, name)]


### PR DESCRIPTION
Recent GraceDB uploads had `sngl_inspiral` tables whose `process_id` columns are always set to `process:process_id:0` regardless of how PyCBC Live is actually identified in the `process` table.

Note that this has not been tested.