### PR TITLE
pycbc_live: fix float indexing for recent numpy

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -318,6 +318,7 @@ with ctx:
                                      maxelements=args.max_batch_size)
     if args.max_length is not None:
         maxlen = args.max_length
+    maxlen = int(maxlen)
     data_reader = {}
     sngl_estimator = {}
     for ifo in advancing_ifos:


### PR DESCRIPTION
In `pycbc_live`, `maxlen` can turn out to be float, which results in indexing an array with a float. Recent numpy versions throw an error because that is no longer tolerated.