### PR TITLE
Added psd option to calculate the overlap between waveforms in the function vecdiff

### DIFF
--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -166,7 +166,7 @@ def _vecdiff(htilde, hinterp, fmin, fmax, psd=None):
                           high_frequency_cutoff=fmax,
                           normalized=False, psd=psd))
 
-def vecdiff(htilde, hinterp, sample_points, psd):
+def vecdiff(htilde, hinterp, sample_points, psd=None):
     """Computes a statistic indicating between which sample points a waveform
     and the interpolated waveform differ the most.
     """
@@ -246,7 +246,7 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
                                    low_frequency_cutoff=fmin)
     if mismatch > tolerance:
         # we'll need the difference in the waveforms as a function of frequency
-        vecdiffs = vecdiff(htilde, hdecomp, sample_points, psd)
+        vecdiffs = vecdiff(htilde, hdecomp, sample_points, psd=psd)
 
     # We will find where in the frequency series the interpolated waveform
     # has the smallest overlap with the full waveform, add a sample point
@@ -283,7 +283,7 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
         new_vecdiffs[minpt+2:] = vecdiffs[minpt+1:]
         new_vecdiffs[minpt:minpt+2] = vecdiff(htilde, hdecomp,
                                               sample_points[minpt:minpt+2],
-                                              psd)
+                                              psd=psd)
         vecdiffs = new_vecdiffs
         mismatch = 1. - filter.overlap(hdecomp, htilde, psd=psd,
                                        low_frequency_cutoff=fmin)

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -156,24 +156,24 @@ compression_algorithms = {
         'spa': spa_compression
         }
 
-def _vecdiff(htilde, hinterp, fmin, fmax):
+def _vecdiff(htilde, hinterp, fmin, fmax, psd):
     return abs(filter.overlap_cplx(htilde, htilde,
                           low_frequency_cutoff=fmin,
                           high_frequency_cutoff=fmax,
-                          normalized=False)
+                          normalized=False, psd=psd)
                 - filter.overlap_cplx(htilde, hinterp,
                           low_frequency_cutoff=fmin,
                           high_frequency_cutoff=fmax,
-                          normalized=False))
+                          normalized=False, psd=psd))
 
-def vecdiff(htilde, hinterp, sample_points):
+def vecdiff(htilde, hinterp, sample_points, psd):
     """Computes a statistic indicating between which sample points a waveform
     and the interpolated waveform differ the most.
     """
     vecdiffs = numpy.zeros(sample_points.size-1, dtype=float)
     for kk,thisf in enumerate(sample_points[:-1]):
         nextf = sample_points[kk+1]
-        vecdiffs[kk] = abs(_vecdiff(htilde, hinterp, thisf, nextf))
+        vecdiffs[kk] = abs(_vecdiff(htilde, hinterp, thisf, nextf, psd))
     return vecdiffs
 
 def compress_waveform(htilde, sample_points, tolerance, interpolation,
@@ -246,7 +246,7 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
                                    low_frequency_cutoff=fmin)
     if mismatch > tolerance:
         # we'll need the difference in the waveforms as a function of frequency
-        vecdiffs = vecdiff(htilde, hdecomp, sample_points)
+        vecdiffs = vecdiff(htilde, hdecomp, sample_points, psd)
 
     # We will find where in the frequency series the interpolated waveform
     # has the smallest overlap with the full waveform, add a sample point
@@ -282,7 +282,8 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
         new_vecdiffs[:minpt] = vecdiffs[:minpt]
         new_vecdiffs[minpt+2:] = vecdiffs[minpt+1:]
         new_vecdiffs[minpt:minpt+2] = vecdiff(htilde, hdecomp,
-                                              sample_points[minpt:minpt+2])
+                                              sample_points[minpt:minpt+2],
+                                              psd)
         vecdiffs = new_vecdiffs
         mismatch = 1. - filter.overlap(hdecomp, htilde, psd=psd,
                                        low_frequency_cutoff=fmin)

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -156,7 +156,7 @@ compression_algorithms = {
         'spa': spa_compression
         }
 
-def _vecdiff(htilde, hinterp, fmin, fmax, psd):
+def _vecdiff(htilde, hinterp, fmin, fmax, psd=None):
     return abs(filter.overlap_cplx(htilde, htilde,
                           low_frequency_cutoff=fmin,
                           high_frequency_cutoff=fmax,
@@ -173,7 +173,7 @@ def vecdiff(htilde, hinterp, sample_points, psd):
     vecdiffs = numpy.zeros(sample_points.size-1, dtype=float)
     for kk,thisf in enumerate(sample_points[:-1]):
         nextf = sample_points[kk+1]
-        vecdiffs[kk] = abs(_vecdiff(htilde, hinterp, thisf, nextf, psd))
+        vecdiffs[kk] = abs(_vecdiff(htilde, hinterp, thisf, nextf, psd=psd))
     return vecdiffs
 
 def compress_waveform(htilde, sample_points, tolerance, interpolation,


### PR DESCRIPTION
The psd option should be added to the function `vecdiff` to calculate the overlap between the decompressed and the original waveform, and add sample points based on that, till the tolerance is satisfied. This is consistent with using a psd in `compress_waveform` to calculate the overlap there.

(This doesn't yet fix the infinite loop problem that I saw for at least one template while compressing the O1 bank with precision=single, tolerance=0.0001) 