### PR TITLE
Add extended versioning information

### DIFF
--- a/bin/hdfcoinc/pycbc_distribute_background_bins
+++ b/bin/hdfcoinc/pycbc_distribute_background_bins
@@ -1,9 +1,9 @@
 #!/bin/env python
 import h5py, argparse, numpy, pycbc.events, logging, pycbc.events, pycbc.io
-import pycbc.full_version
+import pycbc.version
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--version", action=pycbc.full_version.Version)
+parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--coinc-files', nargs='+',
                     help="List of coinc files to be redistributed")

--- a/bin/hdfcoinc/pycbc_distribute_background_bins
+++ b/bin/hdfcoinc/pycbc_distribute_background_bins
@@ -1,10 +1,9 @@
 #!/bin/env python
 import h5py, argparse, numpy, pycbc.events, logging, pycbc.events, pycbc.io
-import pycbc.version
+import pycbc.full_version
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
+parser.add_argument("--version", action=pycbc.full_version.Version)
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--coinc-files', nargs='+',
                     help="List of coinc files to be redistributed")

--- a/bin/hdfcoinc/pycbc_fit_sngls_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_binned
@@ -27,7 +27,7 @@ from scipy.stats import kstest
 
 from pycbc import io, events, pnutils, bin_utils, results
 from pycbc.events import trigger_fits as trstats
-import pycbc.full_version
+import pycbc.version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
@@ -55,7 +55,7 @@ parser = argparse.ArgumentParser(usage="",
     description="Perform maximum-likelihood fits of single inspiral trigger"
                 " distributions to various functions")
 
-parser.add_argument("--version", action=pycbc.full_version.Version)
+parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("-V", "--verbose", action="store_true",
                     help="Print extra debugging information", default=False)
 parser.add_argument("--trigger-file",

--- a/bin/hdfcoinc/pycbc_fit_sngls_binned
+++ b/bin/hdfcoinc/pycbc_fit_sngls_binned
@@ -27,7 +27,7 @@ from scipy.stats import kstest
 
 from pycbc import io, events, pnutils, bin_utils, results
 from pycbc.events import trigger_fits as trstats
-import pycbc.version
+import pycbc.full_version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
@@ -55,8 +55,7 @@ parser = argparse.ArgumentParser(usage="",
     description="Perform maximum-likelihood fits of single inspiral trigger"
                 " distributions to various functions")
 
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
+parser.add_argument("--version", action=pycbc.full_version.Version)
 parser.add_argument("-V", "--verbose", action="store_true",
                     help="Print extra debugging information", default=False)
 parser.add_argument("--trigger-file",

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -21,7 +21,7 @@ import copy, numpy as np
 
 from pycbc import io, events
 from pycbc.events import trigger_fits as trstats
-import pycbc.full_version
+import pycbc.version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
@@ -48,7 +48,7 @@ parser = argparse.ArgumentParser(usage="",
     description="Perform maximum-likelihood fits of single inspiral trigger"
                 " distributions to various functions")
 
-parser.add_argument("--version", action=pycbc.full_version.Version)
+parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("-V", "--verbose", action="store_true",
                     help="Print extra debugging information", default=False)
 parser.add_argument("--trigger-file",

--- a/bin/hdfcoinc/pycbc_fit_sngls_by_template
+++ b/bin/hdfcoinc/pycbc_fit_sngls_by_template
@@ -21,7 +21,7 @@ import copy, numpy as np
 
 from pycbc import io, events
 from pycbc.events import trigger_fits as trstats
-import pycbc.version
+import pycbc.full_version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
@@ -48,8 +48,7 @@ parser = argparse.ArgumentParser(usage="",
     description="Perform maximum-likelihood fits of single inspiral trigger"
                 " distributions to various functions")
 
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
+parser.add_argument("--version", action=pycbc.full_version.Version)
 parser.add_argument("-V", "--verbose", action="store_true",
                     help="Print extra debugging information", default=False)
 parser.add_argument("--trigger-file",

--- a/bin/hdfcoinc/pycbc_fit_sngls_over_param
+++ b/bin/hdfcoinc/pycbc_fit_sngls_over_param
@@ -20,7 +20,7 @@ import argparse, logging
 import numpy as np
 
 from pycbc import pnutils
-import pycbc.version
+import pycbc.full_version
 
 parser = argparse.ArgumentParser(usage="",
     description="Smooth (regress) the dependence of coefficients describing "
@@ -28,8 +28,7 @@ parser = argparse.ArgumentParser(usage="",
                 "parameter, to suppress random noise in the resulting "
                 "background model.")
 
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
+parser.add_argument("--version", action=pycbc.full_version.Version)
 parser.add_argument("-V", "--verbose", action="store_true",
                     help="Print extra debugging information", default=False)
 parser.add_argument("--template-fit-file",

--- a/bin/hdfcoinc/pycbc_fit_sngls_over_param
+++ b/bin/hdfcoinc/pycbc_fit_sngls_over_param
@@ -20,7 +20,7 @@ import argparse, logging
 import numpy as np
 
 from pycbc import pnutils
-import pycbc.full_version
+import pycbc.version
 
 parser = argparse.ArgumentParser(usage="",
     description="Smooth (regress) the dependence of coefficients describing "
@@ -28,7 +28,7 @@ parser = argparse.ArgumentParser(usage="",
                 "parameter, to suppress random noise in the resulting "
                 "background model.")
 
-parser.add_argument("--version", action=pycbc.full_version.Version)
+parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("-V", "--verbose", action="store_true",
                     help="Print extra debugging information", default=False)
 parser.add_argument("--template-fit-file",

--- a/bin/pycbc_fit_sngl_trigs
+++ b/bin/pycbc_fit_sngl_trigs
@@ -25,7 +25,7 @@ from scipy.stats import kstest
 
 from pycbc import io, events, bin_utils
 from pycbc.events import trstats
-import pycbc.version
+import pycbc.full_version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
@@ -58,8 +58,7 @@ parser = argparse.ArgumentParser(usage="",
     description="Perform maximum-likelihood fits of single inspiral trigger"
                 "distributions to various functions")
 
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg)
+parser.add_argument("--version", action=pycbc.full_version.Version)
 parser.add_argument("-V", "--verbose", action="store_true",
                     help="Print extra debugging information", default=False)
 parser.add_argument("--inputs", nargs="+",

--- a/bin/pycbc_fit_sngl_trigs
+++ b/bin/pycbc_fit_sngl_trigs
@@ -25,7 +25,7 @@ from scipy.stats import kstest
 
 from pycbc import io, events, bin_utils
 from pycbc.events import trstats
-import pycbc.full_version
+import pycbc.version
 
 #### DEFINITIONS AND FUNCTIONS ####
 
@@ -58,7 +58,7 @@ parser = argparse.ArgumentParser(usage="",
     description="Perform maximum-likelihood fits of single inspiral trigger"
                 "distributions to various functions")
 
-parser.add_argument("--version", action=pycbc.full_version.Version)
+parser.add_argument("--version", action=pycbc.version.Version)
 parser.add_argument("-V", "--verbose", action="store_true",
                     help="Print extra debugging information", default=False)
 parser.add_argument("--inputs", nargs="+",

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -19,6 +19,7 @@
 import sys
 import logging, argparse, numpy, itertools
 import pycbc
+import pycbc.full_version
 from pycbc import vetoes, psd, waveform, events, strain, scheme, fft, DYN_RANGE_FAC
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
 from pycbc.filter import MatchedFilterControl, make_frequency_series
@@ -47,8 +48,7 @@ tstart = time.time()
 parser = argparse.ArgumentParser(usage='',
     description="Find single detector gravitational-wave triggers.")
 
-parser.add_argument('--version', action='version',
-                    version=pycbc.version.git_verbose_msg)
+parser.add_argument('--version', action=pycbc.full_version.Version)
 parser.add_argument("-V", "--verbose", action="store_true",
                   help="print extra debugging information", default=False )
 parser.add_argument("--update-progress",

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -19,7 +19,7 @@
 import sys
 import logging, argparse, numpy, itertools
 import pycbc
-import pycbc.full_version
+import pycbc.version
 from pycbc import vetoes, psd, waveform, events, strain, scheme, fft, DYN_RANGE_FAC
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
 from pycbc.filter import MatchedFilterControl, make_frequency_series
@@ -48,7 +48,7 @@ tstart = time.time()
 parser = argparse.ArgumentParser(usage='',
     description="Find single detector gravitational-wave triggers.")
 
-parser.add_argument('--version', action=pycbc.full_version.Version)
+parser.add_argument('--version', action=pycbc.version.Version)
 parser.add_argument("-V", "--verbose", action="store_true",
                   help="print extra debugging information", default=False )
 parser.add_argument("--update-progress",

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -34,7 +34,7 @@ from pycbc.filter import sigma, make_frequency_series
 from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, \
                         MultiDetOptionAction, load_frequencyseries
 from glue.ligolw import lsctables
-import pycbc.version
+import pycbc.full_version
 
 
 class TimeIndependentPSD(object):
@@ -98,8 +98,7 @@ class TimeVaryingPSD(object):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--version", action="version",
-                        version=pycbc.version.git_verbose_msg)
+    parser.add_argument("--version", action=pycbc.full_version.Version)
     parser.add_argument('--input-file', '-i', dest='inj_xml', required=True,
                         help='Input LIGOLW file defining injections')
     parser.add_argument('--output-file', '-o', dest='out_file', required=True,

--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -34,7 +34,7 @@ from pycbc.filter import sigma, make_frequency_series
 from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, \
                         MultiDetOptionAction, load_frequencyseries
 from glue.ligolw import lsctables
-import pycbc.full_version
+import pycbc.version
 
 
 class TimeIndependentPSD(object):
@@ -98,7 +98,7 @@ class TimeVaryingPSD(object):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--version", action=pycbc.full_version.Version)
+    parser.add_argument("--version", action=pycbc.version.Version)
     parser.add_argument('--input-file', '-i', dest='inj_xml', required=True,
                         help='Input LIGOLW file defining injections')
     parser.add_argument('--output-file', '-o', dest='out_file', required=True,

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -18,13 +18,14 @@
 a specific Nth loudest coincident event.
 """
 import sys, logging, argparse, numpy, pycbc, h5py
-from pycbc import vetoes, psd, waveform, version, strain, scheme, fft, filter
+from pycbc import vetoes, psd, waveform, strain, scheme, fft, filter
 from pycbc.io import WaveformArray
 from pycbc import events
 from pycbc.filter import resample_to_delta_t
 from pycbc.types import zeros, complex64
 from pycbc.types import complex_same_precision_as
 import pycbc.waveform.utils
+import pycbc.full_version
 
 def subtract_template(stilde, template, snr, trigger_time, flow):
     idx = int((trigger_time - snr.start_time) / snr.delta_t)
@@ -84,8 +85,7 @@ def select_segments(fname, anal_name, data_name, ifo, time, pad_data):
 
 parser = argparse.ArgumentParser(usage='',
     description="Single template gravitational-wave followup")
-parser.add_argument('--version', action='version', 
-                    version=pycbc.version.git_verbose_msg)
+parser.add_argument('--version', action=pycbc.full_version.Version) 
 parser.add_argument('--output-file', required=True)
 parser.add_argument('--subtract-template', action='store_true')
 parser.add_argument("-V", "--verbose", action="store_true", 

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -25,7 +25,7 @@ from pycbc.filter import resample_to_delta_t
 from pycbc.types import zeros, complex64
 from pycbc.types import complex_same_precision_as
 import pycbc.waveform.utils
-import pycbc.full_version
+import pycbc.version
 
 def subtract_template(stilde, template, snr, trigger_time, flow):
     idx = int((trigger_time - snr.start_time) / snr.delta_t)
@@ -85,7 +85,7 @@ def select_segments(fname, anal_name, data_name, ifo, time, pad_data):
 
 parser = argparse.ArgumentParser(usage='',
     description="Single template gravitational-wave followup")
-parser.add_argument('--version', action=pycbc.full_version.Version) 
+parser.add_argument('--version', action=pycbc.version.Version) 
 parser.add_argument('--output-file', required=True)
 parser.add_argument('--subtract-template', action='store_true')
 parser.add_argument("-V", "--verbose", action="store_true", 

--- a/pycbc/_version.py
+++ b/pycbc/_version.py
@@ -23,7 +23,6 @@ import argparse
 import inspect
 import subprocess
 
-
 def print_link(library):
     err_msg = "Could not execute runtime linker to determine\n" + \
               "shared library paths for library:\n  " + library + "\n"

--- a/pycbc/full_version.py
+++ b/pycbc/full_version.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2017 Duncan Brown
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Generals
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This modules contains a function to provide an argparse action that reports
+extremely verbose version information for PyCBC, lal, and lalsimulation.
+"""
+
+import os, sys
+import argparse
+import inspect
+import subprocess
+
+
+def print_link(library):
+    err_msg = "Could not execute runtime linker to determine\n" + \
+              "shared library paths for library:\n  " + library + "\n"
+    try:
+        link = subprocess.check_output(['ldd', library])
+    except OSError:
+        try:
+            link = subprocess.check_output(['otool', '-L', library])
+        except:
+            link = err_msg
+    except:
+        link = err_msg
+    return link
+
+
+class Version(argparse.Action):
+    """ print the pycbc, lal and lalsimulation versions """
+    def __init__(self, nargs=0, **kw):
+        super(Version, self).__init__(nargs=nargs, **kw)
+
+
+    def __call__(self, parser, namespace, values, option_string=None):
+
+        import pycbc
+        version_str="--- PyCBC Version --------------------------\n" + \
+            pycbc.version.git_verbose_msg + \
+            "\n\nImported from: " + inspect.getfile(pycbc)
+
+        version_str += "\n\n--- LAL Version ----------------------------\n"
+        try:
+            import lal.git_version
+            lal_module = inspect.getfile(lal)
+            lal_library = os.path.join( os.path.dirname(lal_module),
+                '_lal.so')
+            version_str += lal.git_version.verbose_msg + \
+            "\n\nImported from: " + lal_module + \
+            "\n\nRuntime libraries:\n" + print_link(lal_library)
+        except ImportError:
+            version_str += "\nLAL not installed in environment\n"
+
+        version_str += "\n\n--- LALSimulation Version-------------------\n"
+        try:
+            import lalsimulation.git_version
+            lalsimulation_module = inspect.getfile(lalsimulation)
+            lalsimulation_library = os.path.join( os.path.dirname(lalsimulation_module),
+                '_lalsimulation.so')
+            version_str += lalsimulation.git_version.verbose_msg + \
+            "\n\nImported from: " + lalsimulation_module + \
+            "\n\nRuntime libraries:\n" + print_link(lalsimulation_library)
+        except ImportError:
+            version_str += "\nLALSimulation not installed in environment\n"
+
+        print version_str
+        sys.exit(0)

--- a/setup.py
+++ b/setup.py
@@ -257,6 +257,7 @@ def get_version_info():
                                                    vcs_info.build_date,
                                                    vcs_info.status))
             version = vcs_info.version
+            f.write('from pycbc._version import *')
 
     # If this is a release or another kind of source distribution of PyCBC
     except:

--- a/setup.py
+++ b/setup.py
@@ -250,14 +250,14 @@ def get_version_info():
                     'Id: %s\n'
                     'Builder: %s\n'
                     'Build date: %s\n'
-                    'Repository status is %s"""' %(vcs_info.branch,
+                    'Repository status is %s"""\n' %(vcs_info.branch,
                                                    vcs_info.tag,
                                                    vcs_info.hash,
                                                    vcs_info.builder,
                                                    vcs_info.build_date,
                                                    vcs_info.status))
+            f.write('from pycbc._version import *\n')
             version = vcs_info.version
-            f.write('from pycbc._version import *')
 
     # If this is a release or another kind of source distribution of PyCBC
     except:
@@ -283,7 +283,8 @@ def get_version_info():
             f.write('git_builder = \'%s\'\n' % builder)
             f.write('git_build_date = \'%s\'\n' % build_date)
             f.write('git_verbose_msg = """Version: %s Release: %s \n'
-                    ' """' % (version, release))
+                    ' """\n' % (version, release))
+            f.write('from pycbc._version import *\n')
 
     from pycbc import version
     version = version.version


### PR DESCRIPTION
This commit adds a very verbose versioning function and uses it to implement the ``--version`` argument in several programs that depend on PyCBC/LAL/LALSimulation being in sync. It works on Mac OS X and Linux. 

This fixes https://github.com/ligo-cbc/pycbc/issues/1477

Sample output is
```
(pycbc-dev)[dbrown@sugwg-osg ~]$ pycbc_inspiral --version
--- PyCBC Version --------------------------
Branch: hash_check
Tag: None
Id: 6d5326d954c4cb2fe884af8becf945314781f1a3
Builder: Duncan Brown <duncan.brown@ligo.org>
Build date: 2017-02-28 16:21:28 +0000
Repository status is UNCLEAN: Modified working tree

Imported from: /home/dbrown/src/pycbc-dev/lib/python2.7/site-packages/PyCBC-6d5326-py2.7.egg/pycbc/__init__.pyc

--- LAL Version ----------------------------
Branch: None
Tag: None
Id: a2a5a476d33f169b8749e2840c306a48df63c936

Builder: Duncan Brown <duncan.brown@ligo.org>
Repository status: CLEAN: All modifications committed

Imported from: /home/dbrown/src/pycbc-dev/opt/lalsuite/lib64/python2.7/site-packages/lal/__init__.pyc

Runtime libraries:
	linux-vdso.so.1 =>  (0x00007fffc1fa9000)
	liblalsupport.so.9 => /home/dbrown/src/pycbc-dev/opt/lalsuite/lib/liblalsupport.so.9 (0x00007f53cc78e000)
	liblal.so.13 => /home/dbrown/src/pycbc-dev/opt/lalsuite/lib/liblal.so.13 (0x00007f53cc43e000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007f53cc214000)
	libz.so.1 => /lib64/libz.so.1 (0x00007f53cbffe000)
	libhdf5.so.8 => /lib64/libhdf5.so.8 (0x00007f53cba09000)
	libhdf5_hl.so.8 => /lib64/libhdf5_hl.so.8 (0x00007f53cb7d5000)
	libfftw3.so.3 => /lib64/libfftw3.so.3 (0x00007f53cb2e6000)
	libfftw3f.so.3 => /lib64/libfftw3f.so.3 (0x00007f53cadb5000)
	libgsl.so.0 => /lib64/libgsl.so.0 (0x00007f53ca98c000)
	libgslcblas.so.0 => /lib64/libgslcblas.so.0 (0x00007f53ca74f000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f53ca44c000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f53ca230000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f53c9e6f000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f53cd0e6000)
	libsatlas.so.3 => /usr/lib64/atlas/libsatlas.so.3 (0x00007f53c9149000)
	libgfortran.so.3 => /lib64/libgfortran.so.3 (0x00007f53c8e26000)
	libquadmath.so.0 => /lib64/libquadmath.so.0 (0x00007f53c8be9000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f53c89d3000)


--- LALSimulation Version-------------------
Branch: None
Tag: None
Id: a2a5a476d33f169b8749e2840c306a48df63c936

Builder: Duncan Brown <duncan.brown@ligo.org>
Repository status: CLEAN: All modifications committed

Imported from: /home/dbrown/src/pycbc-dev/opt/lalsuite/lib64/python2.7/site-packages/lalsimulation/__init__.pyc

Runtime libraries:
	linux-vdso.so.1 =>  (0x00007fff327bd000)
	liblalsimulation.so.14 => /home/dbrown/src/pycbc-dev/opt/lalsuite/lib/liblalsimulation.so.14 (0x00007fc3df12b000)
	liblalsupport.so.9 => /home/dbrown/src/pycbc-dev/opt/lalsuite/lib/liblalsupport.so.9 (0x00007fc3ded93000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007fc3deb69000)
	libz.so.1 => /lib64/libz.so.1 (0x00007fc3de953000)
	libhdf5.so.8 => /lib64/libhdf5.so.8 (0x00007fc3de35e000)
	libhdf5_hl.so.8 => /lib64/libhdf5_hl.so.8 (0x00007fc3de12a000)
	liblal.so.13 => /home/dbrown/src/pycbc-dev/opt/lalsuite/lib/liblal.so.13 (0x00007fc3ddddb000)
	libfftw3.so.3 => /lib64/libfftw3.so.3 (0x00007fc3dd8eb000)
	libfftw3f.so.3 => /lib64/libfftw3f.so.3 (0x00007fc3dd3bb000)
	libgsl.so.0 => /lib64/libgsl.so.0 (0x00007fc3dcf92000)
	libgslcblas.so.0 => /lib64/libgslcblas.so.0 (0x00007fc3dcd54000)
	libm.so.6 => /lib64/libm.so.6 (0x00007fc3dca52000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fc3dc836000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fc3dc474000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fc3dfd5d000)
	libsatlas.so.3 => /usr/lib64/atlas/libsatlas.so.3 (0x00007fc3db74f000)
	libgfortran.so.3 => /lib64/libgfortran.so.3 (0x00007fc3db42b000)
	libquadmath.so.0 => /lib64/libquadmath.so.0 (0x00007fc3db1ef000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fc3dafd9000)
```