### PR TITLE
Fixes to versioning in results pages

### DIFF
--- a/bin/pycbc_hdf5_splitbank
+++ b/bin/pycbc_hdf5_splitbank
@@ -32,8 +32,8 @@ from numpy import random
 __author__  = "Soumi De <soumi.de@ligo.org>"
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
-parser.add_argument("--version", action=version,
-                    version=pycbc.version.git_verbose_msg) 
+parser.add_argument("--version", action="version",
+                  version=pycbc.version.git_verbose_msg)
 parser.add_argument("--bank-file", type=str,
                     help="Bank hdf file to load.")
 parser.add_argument('--templates-per-bank', type = int,

--- a/bin/pycbc_hdf5_splitbank
+++ b/bin/pycbc_hdf5_splitbank
@@ -28,13 +28,12 @@ import logging
 import pycbc, pycbc.version
 from pycbc.waveform import bank
 from numpy import random
-__author__  = "Soumi De <soumi.de@ligo.org>"
-__version__ = pycbc.version.git_verbose_msg
-__date__    = pycbc.version.date
-__program__ = "pycbc_hdf5_splitbank"
 
+__author__  = "Soumi De <soumi.de@ligo.org>"
 
 parser = argparse.ArgumentParser(description=__doc__[1:])
+parser.add_argument("--version", action=version,
+                    version=pycbc.version.git_verbose_msg) 
 parser.add_argument("--bank-file", type=str,
                     help="Bank hdf file to load.")
 parser.add_argument('--templates-per-bank', type = int,

--- a/bin/pycbc_inj_cut
+++ b/bin/pycbc_inj_cut
@@ -25,8 +25,6 @@ The two sets are stored into two separate output files.
 
 __author__ = "Stephen Fairhurst"
 __email__ = "stephen.fairhurst@ligo.org"
-__version__ = "0.0"
-__date__ = "31.10.2015"
 
 import argparse
 import logging
@@ -36,8 +34,10 @@ import pycbc.inject
 import glue.ligolw.utils
 from pycbc.types import MultiDetOptionAction
 from glue.ligolw import lsctables
+import pycbc.version
 
 parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--version', action=pycbc.version.Version)
 parser.add_argument('--input', dest='inj_xml', required=True, help='Input LIGOLW injections file.')
 parser.add_argument('--output-missed', dest='output_missed', required=False,
                   help="Output LIGOLW file containing injections we expect to miss.")

--- a/pycbc/_version.py
+++ b/pycbc/_version.py
@@ -26,11 +26,14 @@ import subprocess
 def print_link(library):
     err_msg = "Could not execute runtime linker to determine\n" + \
               "shared library paths for library:\n  " + library + "\n"
+    FNULL = open(os.devnull, 'w')
     try:
-        link = subprocess.check_output(['ldd', library])
+        link = subprocess.check_output(['ldd', library],
+                                       stderr=FNULL)
     except OSError:
         try:
-            link = subprocess.check_output(['otool', '-L', library])
+            link = subprocess.check_output(['otool', '-L', library],
+                                           stderr=FNULL)
         except:
             link = err_msg
     except:

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -168,7 +168,6 @@ def get_code_version_numbers(cp):
         A dictionary keyed by the executable name with values giving the
         version string for each executable.
     """
-    from pycbc.workflow.core import check_output_error_and_retcode
     code_version_dict = {}
     for item, value in cp.items('executables'):
         path, exe_name = os.path.split(value)

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -177,29 +177,12 @@ def get_code_version_numbers(cp):
            code_version_dict[exe_name] = "Using bundle downloaded from %s" % value
         else:
             try:
-                # FIXME: Replace with this version when python 2.7 is guaranteed
-                # version_output = subprocess.check_output([value, '--version'],
-                #                                         stderr=subprocess.STDOUT) 
-                # Start of legacy block
                 if value.startswith('file://'):
                     value = value[7:]
-                output, error, retcode = \
-                               check_output_error_and_retcode([value, '--version'])
-                if not retcode == 0:
-                    raise subprocess.CalledProcessError(retcode, '')
-                # End of legacy block
-                version_output = (output + error).replace('\n', ' ').split()
-                # Look for a version
-                if "Id:" in version_output:
-                    index = version_output.index("Id:") + 1
-                    version_string = 'Version is %s.' %(version_output[index],)
-                elif "LALApps:" in version_output:
-                    index = version_output.index("LALApps:") + 3
-                    version_string = 'Version (lalapps) is %s.' %(version_output[index],)
-                if version_string is None:
-                    version_string = "Cannot identify version string in output."
+                version_string = subprocess.check_output([value, '--version'],
+                                                        stderr=subprocess.STDOUT) 
             except subprocess.CalledProcessError:
-                version_string = "Executable fails on %s --version" %(value)
+                version_string = "Executable fails on %s --version" % (value)
             except OSError:
                 version_string = "Executable doesn't seem to exist(!)"
             code_version_dict[exe_name] = version_string
@@ -209,7 +192,7 @@ def write_code_versions(path, cp):
     code_version_dict = get_code_version_numbers(cp)
     html_text = ''
     for key,value in code_version_dict.items():
-        html_text+= '<li><b>%s</b>: %s </li>\n' %(key,value.replace('@', '&#64;'))
+        html_text+= '<li><b>%s</b>:<br><pre>%s</pre></li><hr><br><br>\n' %(key,value.replace('@', '&#64;'))
     kwds = {'render-function' : 'render_text',
             'title' : 'Version Information from Executables',
     }


### PR DESCRIPTION
This fixes three issues:

 * Fix a couple of executables that did not implement ``--version``
 * Fix the versioning module to use python 2.7 subprocess
 * Fix the versioning module to work with PyPI released code

I also suppressed a spurious error message that happens when trying to ``ldd`` libraries in a bundle.