### PR TITLE
Turn on sg chisq veto so all code gets built

### DIFF
--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1144,6 +1144,8 @@ do
       "$ENVIRONMENT/dist/pycbc_inspiral/pycbc_inspiral" \
       --fixed-weave-cache \
       --sample-rate 2048 \
+      --sgchisq-snr-threshold 6.0 \
+      --sgchisq-locations 'mtotal>40:20-30,20-45,20-60,20-75,20-90,20-105,20-120' \
       --segment-end-pad 16 \
       --cluster-method window \
       --low-frequency-cutoff 30 \


### PR DESCRIPTION
This prevents the runtime error
```
scipy.weave.build_tools.CompileError: error: Command "g++ -pthread -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/tmp/_MEIRvNMrZ/scipy/weave -I/tmp/_MEIRvNMrZ/scipy/weave/scxx -I/tmp/_MEIRvNMrZ/numpy/core/include -I/tmp/_MEIRvNMrZ/include/python2.7 -c /tmp/_MEIRvNMrZ/sc_8c737c50380e767211ce7dc444fd21df0.cpp -o /tmp/scipy-dbrown-atHCLH/python27_intermediate/compiler_8d209134f2f9c02590a11606fa273eb2/tmp/_MEIRvNMrZ/sc_8c737c50380e767211ce7dc444fd21df0.o -march=native -O3 -w -march=native -O3 -w -fopenmp" failed with exit status 1
```
I have checked that the GW150914 test produces the same results.