### PR TITLE
pycbc_plot_singles_vs_params: improve autolog

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_singles_vs_params
+++ b/bin/hdfcoinc/pycbc_plot_singles_vs_params
@@ -130,7 +130,9 @@ elif opts.z_var in ['max(snr)', 'max(newsnr)', 'max(newsnr_sgveto)']:
     elif opts.z_var == 'max(newsnr_sgveto)':
         z = trigs.newsnr_sgveto
     z = z[mask]
-    if z.max() / z.min() > 10:
+    min_z = z.min() if opts.min_z is None else opts.min_z
+    max_z = z.max() if opts.max_z is None else opts.max_z
+    if max_z / min_z > 10:
         hexbin_style['norm'] = LogNorm()
         cb_style['ticks'] = LogLocator(subs=range(10))
     hb = ax.hexbin(x, y, C=z, reduce_C_function=max, **hexbin_style)


### PR DESCRIPTION
Fixes the broken color scale of single-trigger hexbin plots when plotting `newsnr_sgveto`. Note that `--min-z` is required, otherwise there is no change.

Without `--min-z`:
https://www.atlas.aei.uni-hannover.de/~tito/LSC/o2/o2-analysis4-full4/H1-PLOT_SINGLES_MTOTAL_EFFSPIN_NEWSNR_FULL_DATA-1169107218-1066800_bad.png

With this patch and `--min-z 6`:
https://www.atlas.aei.uni-hannover.de/~tito/LSC/o2/o2-analysis4-full4/H1-PLOT_SINGLES_MTOTAL_EFFSPIN_NEWSNR_FULL_DATA-1169107218-1066800.png