### PR TITLE
 plot_singles_timefreq: more visible inspiral tracks

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_singles_timefreq
+++ b/bin/hdfcoinc/pycbc_plot_singles_timefreq
@@ -161,7 +161,7 @@ if len(indices) > 0:
                 tmplts.spin1z[tid], tmplts.spin2z[tid],
                 opts.f_low, approximant=bank.approximant(tid))
         if max_rank and rho == max_rank:
-            ax.plot(track_t, track_f, '-', color='#ff0000', zorder=3, lw=2)
+            ax.plot(track_t, track_f, '-', color='#0080ff', zorder=3, lw=2)
         else:
             ax.plot(track_t, track_f, '-', color='#0000ff', zorder=2, lw=0.5, alpha=0.5)
 
@@ -175,12 +175,12 @@ if len(indices) > 0:
             tc - center_time, tmplts.mass1[tid], tmplts.mass2[tid],
             tmplts.spin1z[tid], tmplts.spin2z[tid],
             opts.f_low, approximant=bank.approximant(tid))
-        ax.plot(track_t, track_f, '-', color='#00ff00', zorder=3, lw=2)
+        ax.plot(track_t, track_f, '-', color='#00f000', zorder=3, lw=2)
     else:
         interesting_trig_rank = None
 
     if max_rank:
-        title = '%s - loudest %d triggers by %s - max %s = %.2f (red curve)' \
+        title = '%s - loudest %d triggers by %s - max %s = %.2f (light blue curve)' \
             % (opts.channel_name, opts.num_loudest, opts.rank, opts.rank, max_rank)
     else:
         title = '%s - loudest %d triggers by %s' \


### PR DESCRIPTION
Changes the color of the inspiral tracks in the spectrograms so that it doesn't get confused with the spectrogram color scale.

Old:
https://www.atlas.aei.uni-hannover.de/~tito/LSC/o2/o2-analysis4-full4/3._single_triggers/3.08_H1_loudest_all_time_duration_lt_0.5_sec/H1-PLOT_SINGLES_TIMEFREQ_2-1169107218-1066800.png

New:
https://www.atlas.aei.uni-hannover.de/~tito/LSC/o2/o2-analysis4-full4/blue_spaghetti.png