### PR TITLE
fix WEAVE_FLAGS usage

### DIFF
--- a/pycbc/filter/matchedfilter_cpu.py
+++ b/pycbc/filter/matchedfilter_cpu.py
@@ -53,7 +53,7 @@ def batch_correlate_execute(self, y):
     z = numpy.array(self.z.data, copy=False)
     y = numpy.array(y.data, copy=False)        
     inline(batch_correlator_code, ['x', 'y', 'z', 'size', 'num_vectors'],
-                extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
+                extra_compile_args=[WEAVE_FLAGS] + omp_flags,
                 libraries=omp_libs)
 
 support = """
@@ -94,7 +94,7 @@ def correlate_batch_inline(x, y, z):
     ya = numpy.array(y.ptr, copy=False)
     N = len(x) 
     inline(the_code, ['xa', 'ya', 'za', 'N'], 
-                    extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] + omp_flags,
+                    extra_compile_args=[WEAVE_FLAGS] + omp_flags,
                     support_code = support,
                     libraries=omp_libs
           )

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -514,7 +514,7 @@ def fd_decompress(amp, phase, sample_frequencies, out=None, df=None,
         delta_f = float(df)
         inline(code, ['h', 'hlen', 'sflen', 'delta_f', 'sample_frequencies',
                       'amp', 'phase', 'start_index', 'imin'],
-               extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] +\
+               extra_compile_args=[WEAVE_FLAGS] +\
                                   omp_flags,
                libraries=omp_libs)
     else:

--- a/pycbc/waveform/utils.py
+++ b/pycbc/waveform/utils.py
@@ -344,7 +344,7 @@ def apply_fseries_time_shift(htilde, dt, kmin=0, copy=True):
     else:
         code = _apply_shift_code
     inline(code, ['out', 'phi', 'kmin', 'kmax'],
-           extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w']+omp_flags,
+           extra_compile_args=[WEAVE_FLAGS]+omp_flags,
            libraries=omp_libs)
     if copy:
         htilde = FrequencySeries(out, delta_f=htilde.delta_f, epoch=htilde.epoch,


### PR DESCRIPTION
(fix bug introduced in 4d11ed986a842bab489af6e33c2fed026d13fb0b, see #890 )

By default, WEAVE_FLAGS is set to '-march=native -O3 -w',
unless the environment variable WEAVE_FLAGS contains a
-march= specification on its own. ADDING these options
to WEAVE_FLAGS for extra_compile_args in the current way
is dysfunctional, as
- it's superfluous
- it's missing a blank, resulting in the invalid option
  "-w-march=native"
- it prevents the user from overriding the default,
  resulting in failure with compiler versions that
  don't know this architecture.