### PR TITLE
Switch Travis to use the Einstein@Home build infrastructure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,22 @@ addons:
             - libssl-dev
 cache:
   directories:
-    - $HOME/build
     - $HOME/.cache/pip
+    - $HOME/build/.cache/pip
+    - $HOME/build/pycbc-sources
+before_cache:
+    - rm -rf $HOME/pycbc-sources/lalsuite
+    - rm -rf $HOME/pycbc-sources/pycbc
+    - rm -rf $HOME/pycbc-sources/pyinstaller
+    - rm -rf $HOME/pycbc-sources/test
+    - rm -f $HOME/pycbc-sources/freetype-*.tar.gz
+    - rm -f $HOME/pycbc-sources/libframe-*.tar.gz
+    - rm -f $HOME/pycbc-sources/metaio-*.tar.gz
+    - rm -f $HOME/pycbc-sources/pegasus-python-source-*.tar.gz
+    - rm -f $HOME/pycbc-sources/Python-*.tgz
+    - rm -f $HOME/pycbc-sources/swig-*.tar.gz
+    - rm -f $HOME/pycbc-sources/zlib-*.tar.gz
+
 install:
   - travis_retry ./tools/install_travis.sh
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ addons:
             - libsqlite3-dev
             - libhdf5-serial-dev
             - libssl-dev
+            - zlib1g-dev
+            - libfreetype6-dev
 cache:
   directories:
     - $HOME/.cache/pip
@@ -20,13 +22,11 @@ before_cache:
     - rm -rf $HOME/pycbc-sources/pycbc
     - rm -rf $HOME/pycbc-sources/pyinstaller
     - rm -rf $HOME/pycbc-sources/test
-    - rm -f $HOME/pycbc-sources/freetype-*.tar.gz
     - rm -f $HOME/pycbc-sources/libframe-*.tar.gz
     - rm -f $HOME/pycbc-sources/metaio-*.tar.gz
     - rm -f $HOME/pycbc-sources/pegasus-python-source-*.tar.gz
     - rm -f $HOME/pycbc-sources/Python-*.tgz
     - rm -f $HOME/pycbc-sources/swig-*.tar.gz
-    - rm -f $HOME/pycbc-sources/zlib-*.tar.gz
 
 install:
   - travis_retry ./tools/install_travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,12 @@ addons:
     apt:
         packages:
             - libfftw3-dev 
-            - libhdf5-serial-dev 
             - liblapack-dev 
             - gfortran 
             - libgsl0-dev
 cache:
   directories:
-    - $HOME/inst
+    - $HOME/build
     - $HOME/.cache/pip
 install:
   - travis_retry ./tools/install_travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache:
     - $HOME/.cache/pip
     - $HOME/build/.cache/pip
     - $HOME/build/pycbc-sources
+  timeout: 600
 before_cache:
     - rm -rf $HOME/pycbc-sources/lalsuite
     - rm -rf $HOME/pycbc-sources/pycbc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ addons:
             - gfortran 
             - libgsl0-dev
             - libsqlite3-dev
+            - libhdf5-serial-dev
+            - libssl-dev
 cache:
   directories:
     - $HOME/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_cache:
     - rm -rf $HOME/pycbc-sources/lalsuite
     - rm -rf $HOME/pycbc-sources/pycbc
     - rm -rf $HOME/pycbc-sources/pyinstaller
-    - rm -rf $HOME/pycbc-sources/test
+    - rm -rf $HOME/pycbc-sources/test/pycbc_inspiral
     - rm -f $HOME/pycbc-sources/libframe-*.tar.gz
     - rm -f $HOME/pycbc-sources/metaio-*.tar.gz
     - rm -f $HOME/pycbc-sources/pegasus-python-source-*.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
             - liblapack-dev 
             - gfortran 
             - libgsl0-dev
+            - libsqlite3-dev
 cache:
   directories:
     - $HOME/build

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -128,16 +128,20 @@ elif [[ v`cat /etc/redhat-release 2>/dev/null` == v"Scientific Linux release 6.8
 elif grep -q "Ubuntu 12" /etc/issue ; then
     link_gcc_version=4.6
     gcc_path="/usr/bin"
-    build_ssl=true
-    build_gsl=false
-    build_lapack=false
-    build_fftw=false
     build_python=true
     build_pcre=true
     pyinstaller_lsb="--no-lsb"
     build_gating_tool=false
-    build_progress_fstab=false
     appendix="_Linux64"
+    if test x$TRAVIS_OS_NAME = xLinux ; then
+        build_fftw=false
+        build_hdf5=false
+        build_ssl=false
+        build_lapack=false
+        build_gsl=false
+        build_wrapper=false
+        build_progress_fstab=false
+    fi
 elif test "`uname -s`" = "Darwin" ; then # OSX
     echo -e "\\n\\n>> [`date`] Using OSX 10.7 settings"
     export FC=gfortran-mp-4.8

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1319,7 +1319,7 @@ do
       --frame-files "$frames" \
       --approximant ${approx_array[$i]} \
       --bank-file ${bank_array[$i]} \
-      --verbose 2>&1 | awk '{if ((!/Filtering template|points above|power chisq|point chisq|Found chisq|generating SEOBNR|generating SPA/) || (/segment 1/ && NR % 100 == 0) || / 0: generating/ || / 1: generating/ ) print}'
+      --verbose 2>&1 | awk '{if ((!/Filtering template|points above|power chisq|point chisq|Found chisq|generating SEOBNR|generating SPA/) || (/segment 1/ && NR % 50 == 0) || / 0: generating/ || / 1: generating/ ) print}'
 done
 
 # test for GW150914

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -502,7 +502,7 @@ else # if $BUILDDIRNAME-preinst.tgz
     fi
 
     # FFTW
-    if $build_fftw
+    if $build_fftw ; then
         p=fftw-3.3.5
         echo -e "\\n\\n>> [`date`] building $p"
         test -r $p.tar.gz ||

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1319,7 +1319,7 @@ do
       --frame-files "$frames" \
       --approximant ${approx_array[$i]} \
       --bank-file ${bank_array[$i]} \
-      --verbose 2>&1 | awk '{if ((!/Filtering template|points above|power chisq|point chisq|Found chisq/) || (/Filtering template/ && NR % 20 == 0)) print}'
+      --verbose 2>&1 | awk '{if ((!/Filtering template|points above|power chisq|point chisq|Found chisq|generating SEOBNR|generating SPA/) || (/segment 1/ && NR % 100 == 0) || /0: generating/ || /1: generating/ ) print}'
 done
 
 # test for GW150914

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -43,6 +43,7 @@ cleanup=true # usually, build directories are removed after a successful build
 verbose_pyinstalled_python=false
 pycbc_branch=master
 pycbc_remote=ligo-cbc
+pycbc_fetch_ref=""
 scratch_pycbc=false
 libgfortran=libgfortran.so
 extra_libs=""
@@ -250,6 +251,8 @@ usage="
     --no-analysis                   for testing, don't run analysis, assume weave cache is already there
 
     --silent-build                  do not brint build messages unless there is an error
+
+    --pycbc-fetch-ref               fetch and use a specific reference for pycbc
 "
 
 # handle command-line arguments, possibly overriding above settings
@@ -271,6 +274,7 @@ for i in $*; do
         --clean-lalsuite) rm -rf "$SOURCE/lalsuite" "$SOURCE/$BUILDDIRNAME-preinst-lalsuite.tgz";;
         --lalsuite-commit=*) lalsuite_branch="`echo $i|sed 's/^--lalsuite-commit=//'`";;
         --pycbc-commit=*) pycbc_commit="`echo $i|sed 's/^--pycbc-commit=//'`";;
+        --pycbc-fetch-ref=*) pycbc_fetch_ref="`echo $i|sed 's/^--pycbc-fetch-ref=//'`";;
         --clean-pycbc) scratch_pycbc=true;;
         --clean-weave-cache) rm -rf "$SOURCE/test/pycbc_inspiral";;
         --clean-sundays)
@@ -924,6 +928,11 @@ else
     git remote update
     git checkout -b $pycbc_branch $pycbc_remote/$pycbc_branch
 fi
+if test "x$pycbc_fetch_ref" != "x" ; then
+    git fetch origin +${pycbc_fetch_ref}
+    git checkout FETCH_HEAD
+fi
+
 echo -e "[`date`] install pkgconfig beforehand"
 pip install `grep -w ^pkgconfig requirements.txt||echo pkgconfig==1.1.0`
 if $pyinstaller21_hacks; then

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -140,6 +140,8 @@ elif grep -q "Ubuntu 12" /etc/issue ; then
         build_ssl=false
         build_lapack=false
         build_gsl=false
+        build_freetype=false
+        build_zlib=false
         build_wrapper=false
         build_progress_fstab=false
     fi

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -73,6 +73,7 @@ build_subprocess32=false
 build_hdf5=true
 build_freetype=true
 build_wrapper=false
+build_progress_fstab=true
 pyinstaller_version=v3.2.1 # 9d0e0ad4, v2.1 .. v3.2.1 -> git, 2.1 .. 3.2.1 -> pypi
 patch_pyinstaller_bootloader=true
 pyinstaller21_hacks=false # use hacks & workarounds necessary for PyInstaller <3.0
@@ -135,6 +136,7 @@ elif grep -q "Ubuntu 12" /etc/issue ; then
     build_pcre=true
     pyinstaller_lsb="--no-lsb"
     build_gating_tool=false
+    build_progress_fstab=false
     appendix="_Linux64"
 elif test "`uname -s`" = "Darwin" ; then # OSX
     echo -e "\\n\\n>> [`date`] Using OSX 10.7 settings"
@@ -927,7 +929,7 @@ else
     git checkout -b $pycbc_branch $pycbc_remote/$pycbc_branch
 fi
 if test "x$pycbc_fetch_ref" != "x" ; then
-    git fetch origin +${pycbc_fetch_ref}
+    git fetch $pycbc_remote +${pycbc_fetch_ref}
     git checkout FETCH_HEAD
 fi
 
@@ -1051,7 +1053,7 @@ if $build_wrapper; then
     gcc -o "$ENVIRONMENT/dist/progress$appendix" $SOURCE/pycbc/tools/einsteinathome/progress.c
     gcc -o "$ENVIRONMENT/dist/fstab" $SOURCE/pycbc/tools/einsteinathome/fstab.c
     gcc -DTEST_WIN32 -o "$ENVIRONMENT/dist/fstab_test" $SOURCE/pycbc/tools/einsteinathome/fstab.c
-else
+elif $build_progress_fstab ; then
     echo -e "\\n\\n>> [`date`] Building 'progress.exe' and 'fstab.exe'"
     if $build_dlls; then
         x86_64-w64-mingw32-gcc -o "$ENVIRONMENT/dist/progress$appendix.exe" $SOURCE/pycbc/tools/einsteinathome/progress.c

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -108,6 +108,14 @@ elif [[ v`cat /etc/redhat-release 2>/dev/null` == v"Scientific Linux release 6.8
     pyinstaller_lsb="--no-lsb"
     build_gating_tool=true
     appendix="_Linux64"
+elif grep -q "Ubuntu 12" /etc/issue ; then
+    link_gcc_version=4.6
+    gcc_path="/usr/bin"
+    build_ssl=true
+    build_python=true
+    pyinstaller_lsb="--no-lsb"
+    build_gating_tool=false
+    appendix="_Linux64"
 elif test "`uname -s`" = "Darwin" ; then # OSX
     echo -e "\\n\\n>> [`date`] Using OSX 10.7 settings"
     export FC=gfortran-mp-4.8

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1314,7 +1314,7 @@ do
       --frame-files "$frames" \
       --approximant ${approx_array[$i]} \
       --bank-file ${bank_array[$i]} \
-      --verbose 2>&1 | egrep -v '(Filtering template|points above|power chisq)'
+      --verbose 2>&1 | egrep -v '(Filtering template|points above|power chisq|point chisq|Found chisq)'
 done
 
 # test for GW150914

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -17,8 +17,8 @@ function exit_on_error {
   rm -f "$PYCBC/lock"
   if $silent_build ; then
       if [ -f $LOG_FILE ] ; then
-          echo "--- Error or interrupt: dumping build log ---------------------" >&4
-          cat $LOG_FILE >&4
+          echo "--- Error or interrupt: dumping last 100 lines of log ---------" >&4
+          tail -n 100 $LOG_FILE >&4
           echo "---------------------------------------------------------------" >&4
           rm -f $LOG_FILE
       fi

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -133,7 +133,7 @@ elif grep -q "Ubuntu 12" /etc/issue ; then
     pyinstaller_lsb="--no-lsb"
     build_gating_tool=false
     appendix="_Linux64"
-    if test x$TRAVIS_OS_NAME = xLinux ; then
+    if test x$TRAVIS_OS_NAME = xlinux ; then
         build_fftw=false
         build_hdf5=false
         build_ssl=false

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1319,7 +1319,7 @@ do
       --frame-files "$frames" \
       --approximant ${approx_array[$i]} \
       --bank-file ${bank_array[$i]} \
-      --verbose 2>&1 | awk '{if ((!/Filtering template|points above|power chisq|point chisq|Found chisq|generating SEOBNR|generating SPA/) || (/segment 1/ && NR % 100 == 0) || /0: generating/ || /1: generating/ ) print}'
+      --verbose 2>&1 | awk '{if ((!/Filtering template|points above|power chisq|point chisq|Found chisq|generating SEOBNR|generating SPA/) || (/segment 1/ && NR % 100 == 0) || / 0: generating/ || / 1: generating/ ) print}'
 done
 
 # test for GW150914

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1319,7 +1319,7 @@ do
       --frame-files "$frames" \
       --approximant ${approx_array[$i]} \
       --bank-file ${bank_array[$i]} \
-      --verbose 2>&1 | awk '!/Filtering template|points above|power chisq|point chisq|Found chisq/ || NR % 20 == 0'
+      --verbose 2>&1 | awk '{if ((!/Filtering template|points above|power chisq|point chisq|Found chisq/) || (/Filtering template/ && NR % 20 == 0)) print}'
 done
 
 # test for GW150914

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -378,7 +378,9 @@ else # if $BUILDDIRNAME-preinst.tgz
 	rm -rf $p
 	tar -xzf $p.tgz
 	cd $p
-	./configure $shared --prefix="$PYTHON_PREFIX"
+	CPPFLAGS=-I/home/dbrown10/include LDFLAGS=-L/home/dbrown10/lib ./configure $shared --prefix="$PYTHON_PREFIX"
+# XXX FIX FOR TRAVIS
+	#./configure $shared --prefix="$PYTHON_PREFIX"
 	make
 	make install
 	cd ..

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1314,7 +1314,7 @@ do
       --frame-files "$frames" \
       --approximant ${approx_array[$i]} \
       --bank-file ${bank_array[$i]} \
-      --verbose 2>&1
+      --verbose 2>&1 | egrep -v '(Filtering template|points above|power chisq)'
 done
 
 # test for GW150914

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -72,6 +72,7 @@ build_preinst_before_lalsuite=true
 build_subprocess32=false
 build_hdf5=true
 build_freetype=true
+build_zlib=true
 build_wrapper=false
 build_progress_fstab=true
 pyinstaller_version=v3.2.1 # 9d0e0ad4, v2.1 .. v3.2.1 -> git, 2.1 .. 3.2.1 -> pypi
@@ -570,17 +571,18 @@ else # if $BUILDDIRNAME-preinst.tgz
     fi
 
     # ZLIB
-    p=zlib-1.2.8
-    echo -e "\\n\\n>> [`date`] building $p" >&3
-    test -r $p.tar.gz || wget $wget_opts $aei/$p.tar.gz
-    rm -rf $p
-    tar -xzf $p.tar.gz
-    cd $p
-    ./configure --prefix=$PREFIX
-    make
-    make install
-    mkdir -p "$PREFIX/lib/pkgconfig"
-    echo 'prefix=
+    if $build_zlib ; then
+        p=zlib-1.2.8
+        echo -e "\\n\\n>> [`date`] building $p" >&3
+        test -r $p.tar.gz || wget $wget_opts $aei/$p.tar.gz
+        rm -rf $p
+        tar -xzf $p.tar.gz
+        cd $p
+        ./configure --prefix=$PREFIX
+        make
+        make install
+        mkdir -p "$PREFIX/lib/pkgconfig"
+        echo 'prefix=
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
@@ -589,9 +591,10 @@ Description: zlib Compression Library
 Version: 1.2.3
 Libs: -L${libdir} -lz
 Cflags: -I${includedir}' |
-    sed "s%^prefix=.*%prefix=$PREFIX%;s/^Version: .*/Version: $p/;s/^Version: zlib-/Version: /" > "$PREFIX/lib/pkgconfig/zlib.pc"
-    cd ..
-    $cleanup && rm -rf $p
+        sed "s%^prefix=.*%prefix=$PREFIX%;s/^Version: .*/Version: $p/;s/^Version: zlib-/Version: /" > "$PREFIX/lib/pkgconfig/zlib.pc"
+        cd ..
+        $cleanup && rm -rf $p
+    fi
 
     # HDF5
     if $build_hdf5; then

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -734,7 +734,7 @@ if test -r "$SOURCE/$BUILDDIRNAME-preinst-lalsuite.tgz"; then
 else
 
     # LALSUITE
-    echo -e "\\n\\n>> [`date`] building lalsuite" >&3
+    echo -e "\\n\\n>> [`date`] Cloning lalsuite" >&3
     if [ ".$no_lalsuite_update" != "." ]; then
 	cd lalsuite
     elif test -d lalsuite/.git; then
@@ -804,11 +804,13 @@ EOF
     if $build_framecpp; then
 	shared="$shared --enable-framec --disable-framel"
     fi
+    echo -e "\\n\\n>> [`date`] Creating lalsuite configure scripts" >&3
     ./00boot
     cd ..
     rm -rf lalsuite-build
     mkdir lalsuite-build
     cd lalsuite-build
+    echo -e "\\n\\n>> [`date`] Configuring lalsuite" >&3
     ../lalsuite/configure CPPFLAGS="$lal_cppflags $CPPFLAGS" --disable-gcc-flags $shared $static --prefix="$PREFIX" --disable-silent-rules \
 	--enable-swig-python --disable-lalxml --disable-lalpulsar --disable-laldetchar --disable-lalstochastic --disable-lalinference \
 	--disable-lalapps --disable-pylal
@@ -817,7 +819,13 @@ EOF
 extern int setenv(const char *name, const char *value, int overwrite);
 extern int unsetenv(const char *name);' > lalsimulation/src/stdlib.h
     fi
-    make
+    echo -e "\\n\\n>> [`date`] Building lalsuite" >&3
+    if $silent_build ; then
+        make 2>&1 | tee >(grep Entering >&3 1>&3 2>&3) 
+    else
+        make
+    fi
+    echo -e "\\n\\n>> [`date`] Installing lalsuite" >&3
     make install
     for i in $PREFIX/etc/*-user-env.sh; do
         source "$i"

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -825,7 +825,7 @@ EOF
     cd lalsuite-build
     echo -e "\\n\\n>> [`date`] Configuring lalsuite" >&3
     ../lalsuite/configure CPPFLAGS="$lal_cppflags $CPPFLAGS" --disable-gcc-flags $shared $static --prefix="$PREFIX" --disable-silent-rules \
-	--enable-swig-python --disable-lalxml --disable-lalpulsar --disable-laldetchar --disable-lalstochastic --disable-lalinference \
+	--enable-swig-python --disable-lalxml --disable-laldetchar --disable-lalstochastic --disable-lalinference \
 	--disable-lalapps --disable-pylal
     if $build_dlls; then
 	echo '#include "/usr/include/stdlib.h"

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -32,7 +32,7 @@ export FC=gfortran
 
 # compilation environment
 BUILDDIRNAME="pycbc-build"
-LOG_FILE=/tmp/$(mktemp -d -t pycbc-build-log.XXXXXXXXXX)
+LOG_FILE=/tmp/$(mktemp -t pycbc-build-log.XXXXXXXXXX)
 
 # defaults, possibly overwritten by command-line arguments
 cleanup=true # usually, build directories are removed after a successful build

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1319,7 +1319,7 @@ do
       --frame-files "$frames" \
       --approximant ${approx_array[$i]} \
       --bank-file ${bank_array[$i]} \
-      --verbose 2>&1 | egrep -v '(Filtering template|points above|power chisq|point chisq|Found chisq)'
+      --verbose 2>&1 | awk '!/Filtering template|points above|power chisq|point chisq|Found chisq/ || NR % 20 == 0'
 done
 
 # test for GW150914

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -130,7 +130,7 @@ elif grep -q "Ubuntu 12" /etc/issue ; then
     build_ssl=true
     build_gsl=false
     build_lapack=false
-    build_fftw=true # XXX CHANGE TO FALSE FOR TRAVIS
+    build_fftw=false
     build_python=true
     build_pcre=true
     pyinstaller_lsb="--no-lsb"
@@ -418,9 +418,7 @@ else # if $BUILDDIRNAME-preinst.tgz
 	rm -rf $p
 	tar -xzf $p.tgz
 	cd $p
-	CPPFLAGS=-I/home/dbrown10/include LDFLAGS=-L/home/dbrown10/lib ./configure $shared --prefix="$PYTHON_PREFIX"
-# XXX FIX FOR TRAVIS
-	#./configure $shared --prefix="$PYTHON_PREFIX"
+	./configure $shared --prefix="$PYTHON_PREFIX"
 	make
 	make install
 	cd ..

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -4,7 +4,8 @@ set -ev
 
 # determine the git branch and origin
 git branch -vvv
-PYCBC_MERGE_REF=`cut -f3 .git/FETCH_HEAD | cut -d " " -f1 | tr -d "'"`
+#PYCBC_MERGE_REF=`cut -f3 .git/FETCH_HEAD | cut -d " " -f1 | tr -d "'"`
+PYCBC_MERGE_REF="refs/pull/1505/merge"
 
 # store the travis test directory
 LOCAL=${PWD}
@@ -15,7 +16,7 @@ mkdir -p ${BUILD}
 
 # run the einstein at home build and test script
 pushd ${BUILD}
-${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --pycbc-fetch-ref ${PYCBC_MERGE_REF} --clean-pycbc --silent-build --no-analysis
+${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --pycbc-fetch-ref=${PYCBC_MERGE_REF} --clean-pycbc --silent-build --no-analysis
 popd
 
 # setup the pycbc environment to run the additional travis tests

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -4,8 +4,7 @@ set -ev
 
 # determine the git branch and origin
 git branch -vvv
-#PYCBC_MERGE_REF=`cut -f3 .git/FETCH_HEAD | cut -d " " -f1 | tr -d "'"`
-PYCBC_MERGE_REF="refs/pull/1505/merge"
+PYCBC_MERGE_REF=`cut -f3 .git/FETCH_HEAD | cut -d " " -f1 | tr -d "'"`
 
 # store the travis test directory
 LOCAL=${PWD}

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -15,10 +15,18 @@ mkdir -p ${BUILD}
 
 # run the einstein at home build and test script
 pushd ${BUILD}
-${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --clean-pycbc --silent-build
+${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --clean-pycbc --silent-build --no-analysis
 popd
 
 # setup the pycbc environment to run the additional travis tests
+BUILDDIRNAME="pycbc-build"
+PYCBC="$BUILD/$BUILDDIRNAME"
+PYTHON_PREFIX="$PYCBC"
+ENVIRONMENT="$PYCBC/environment"
+PREFIX="$ENVIRONMENT"
+PATH="$PREFIX/bin:$PYTHON_PREFIX/bin:$PATH"
+export LD_LIBRARY_PATH="$PREFIX/lib:$PREFIX/bin:$PYTHON_PREFIX/lib:$libgfortran_dir:/usr/local/lib:$LD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PYTHON_PREFIX/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 source ${BUILD}/pycbc-build/environment/etc/lalsuite-user-env.sh
 source ${BUILD}/pycbc-build/environment/bin/activate
 export PYTHONUSERBASE=${BUILD}/.local
@@ -31,7 +39,7 @@ pip install --upgrade pip setuptools
 pip install 'setuptools==18.2' --upgrade
 
 # install pegasus
-pip install http://download.pegasus.isi.edu/pegasus/4.7.2/pegasus-python-source-4.7.4.tar.gz
+pip install http://download.pegasus.isi.edu/pegasus/4.7.4/pegasus-python-source-4.7.4.tar.gz
 
 # re-install pycbc
 python setup.py install

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -4,92 +4,18 @@ set -ev
 
 LOCAL=${PWD}
 
-# working dir for downloaded dependencies
-SRC=${HOME}/src
-mkdir -p ${SRC}
+# working dir for build script
+BUILD=${HOME}/build
+mkdir -p ${BUILD}
 
-# install dir for dependencies
-INST=${HOME}/inst
-
-export LD_LIBRARY_PATH=${INST}/lib:${INST}/lib64
-export PKG_CONFIG_PATH=${INST}/lib/pkgconfig
-export PATH=/usr/lib/ccache:${PATH}:${INST}/bin
+pushd ${BUILD}
+${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --clean-pycbc
+popd
 
 # Update setuptools
-pip install --upgrade pip setuptools
-
-# Install needed version of numpy
-pip install 'numpy==1.9.3' --upgrade 
-
-if [ -f ${INST}/dep_install.done ]
-then
-    echo "Found cache of installed dependencies, using it"
-else
-
-    # install the version of swig that for some reason we have to use
-
-    cd ${SRC}
-    wget -q http://download.sourceforge.net/project/swig/swig/swig-2.0.11/swig-2.0.11.tar.gz
-    tar -xzf swig-2.0.11.tar.gz
-    cd swig-2.0.11
-    ./configure -q --prefix=${INST}
-    make -j
-    make install
-
-    # Install metaio
-
-    cd ${SRC}
-    wget -q https://www.lsc-group.phys.uwm.edu/daswg/download/software/source/metaio-8.2.tar.gz
-    tar -xzf metaio-8.2.tar.gz
-    cd metaio-8.2
-    CPPFLAGS=-std=gnu99 ./configure -q --prefix=${INST}
-    make -j
-    make install
-
-    # install framel
-
-    cd ${SRC}
-    wget -q http://lappweb.in2p3.fr/virgo/FrameL/v8r26.tar.gz
-    tar -xzf v8r26.tar.gz
-    cd v8r26
-    autoreconf
-    ./configure -q --prefix=${INST}
-    make -j
-    make install
-
-    # Install lalsuite
-
-    cd ${SRC}
-    git clone -q https://github.com/lscsoft/lalsuite.git
-    cd lalsuite
-    # This sets the test release to https://versions.ligo.org/cgit/lalsuite/commit/?id=a2a5a476d33f169b8749e2840c306a48df63c936
-    git checkout a2a5a476d33f169b8749e2840c306a48df63c936
-
-    ./00boot
-    ./configure -q --prefix=${INST} --enable-swig-python \
-        --disable-lalstochastic --disable-lalinference --disable-laldetchar \
-        --disable-lalxml --disable-lalburst --disable-lalapps
-    make -j
-    make install
-
-    # run lalsimulation tests
-    cd lalsimulation
-    make check
-
-    touch ${INST}/dep_install.done
-
-    cd ${LOCAL}
-fi
-
-source ${INST}/etc/lal-user-env.sh
-
-# Scipy would be required to build scikit-learn but that does not work with travis currently
-#pip install 'scipy==0.16.0' --upgrade
-
-# Install Pegasus
-pip install http://download.pegasus.isi.edu/pegasus/4.7.2/pegasus-python-source-4.7.2.tar.gz
+#pip install --upgrade pip setuptools
 
 # Needed by mock 
-pip install 'setuptools==18.2' --upgrade
+#pip install 'setuptools==18.2' --upgrade
 
-python setup.py install
+#python setup.py install

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -15,7 +15,7 @@ mkdir -p ${BUILD}
 
 # run the einstein at home build and test script
 pushd ${BUILD}
-${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --clean-pycbc --pycbc-commit=${PYCBC_MERGE_COMMIT}
+${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --silent-build --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --clean-pycbc
 popd
 
 # setup the pycbc environment to run the additional travis tests

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -15,7 +15,7 @@ mkdir -p ${BUILD}
 
 # run the einstein at home build and test script
 pushd ${BUILD}
-${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --pycbc-fetch-ref=${PYCBC_MERGE_REF} --clean-pycbc --silent-build --no-analysis
+${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --pycbc-fetch-ref=${PYCBC_MERGE_REF} --clean-pycbc --silent-build
 popd
 
 # setup the pycbc environment to run the additional travis tests

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -41,6 +41,9 @@ pip install 'setuptools==18.2' --upgrade
 # install pegasus
 pip install http://download.pegasus.isi.edu/pegasus/4.7.4/pegasus-python-source-4.7.4.tar.gz
 
+# install M2Crypto
+SWIG_FEATURES="-cpperraswarn -includeall -I/usr/include/openssl" pip install M2Crypto
+
 # install the segment database tools
 pip install git+https://github.com/ligovirgo/dqsegdb@clean_pip_install_1_4_1#egg=dqsegdb
 

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -3,13 +3,8 @@
 set -ev
 
 # determine the git branch and origin
-GIT_BRANCH=`git name-rev --name-only HEAD`
-echo "Testing branch ${GIT_BRANCH}"
-GIT_ORIGIN=`git config --get remote.origin.url`
-echo "Testing from ${GIT_ORIGIN}"
-
-git remote -vvv
 git branch -vvv
+PYCBC_MERGE_COMMIT=`git rev-parse HEAD`
 
 # store the travis test directory
 LOCAL=${PWD}
@@ -20,7 +15,7 @@ mkdir -p ${BUILD}
 
 # run the einstein at home build and test script
 pushd ${BUILD}
-${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --clean-pycbc
+${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --clean-pycbc --pycbc-commit=${PYCBC_MERGE_COMMIT}
 popd
 
 # setup the pycbc environment to run the additional travis tests

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -12,6 +12,8 @@ LOCAL=${PWD}
 # create working dir for build script
 BUILD=${HOME}/build
 mkdir -p ${BUILD}
+export PYTHONUSERBASE=${BUILD}/.local
+export XDG_CACHE_HOME=${BUILD}/.cache
 
 # run the einstein at home build and test script
 pushd ${BUILD}
@@ -29,8 +31,6 @@ export LD_LIBRARY_PATH="$PREFIX/lib:$PREFIX/bin:$PYTHON_PREFIX/lib:$libgfortran_
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PYTHON_PREFIX/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 source ${BUILD}/pycbc-build/environment/etc/lalsuite-user-env.sh
 source ${BUILD}/pycbc-build/environment/bin/activate
-export PYTHONUSERBASE=${BUILD}/.local
-export XDG_CACHE_HOME=${BUILD}/.cache
 
 # update setuptools
 pip install --upgrade pip setuptools

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -17,7 +17,7 @@ export XDG_CACHE_HOME=${BUILD}/.cache
 
 # run the einstein at home build and test script
 pushd ${BUILD}
-${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --pycbc-fetch-ref=${PYCBC_MERGE_REF} --clean-pycbc --silent-build
+${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --pycbc-fetch-ref=${PYCBC_MERGE_REF} --clean-pycbc --silent-build --clean-lalsuite
 popd
 
 # setup the pycbc environment to run the additional travis tests

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -41,5 +41,8 @@ pip install 'setuptools==18.2' --upgrade
 # install pegasus
 pip install http://download.pegasus.isi.edu/pegasus/4.7.4/pegasus-python-source-4.7.4.tar.gz
 
+# install the segment database tools
+pip install git+https://github.com/ligovirgo/dqsegdb@clean_pip_install_1_4_1#egg=dqsegdb
+
 # re-install pycbc
 python setup.py install

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -27,7 +27,7 @@ PYTHON_PREFIX="$PYCBC"
 ENVIRONMENT="$PYCBC/environment"
 PREFIX="$ENVIRONMENT"
 PATH="$PREFIX/bin:$PYTHON_PREFIX/bin:$PATH"
-export LD_LIBRARY_PATH="$PREFIX/lib:$PREFIX/bin:$PYTHON_PREFIX/lib:$libgfortran_dir:/usr/local/lib:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="$PREFIX/lib:$PREFIX/bin:$PYTHON_PREFIX/lib:/usr/local/lib:$LD_LIBRARY_PATH"
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PYTHON_PREFIX/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 source ${BUILD}/pycbc-build/environment/etc/lalsuite-user-env.sh
 source ${BUILD}/pycbc-build/environment/bin/activate

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -2,20 +2,41 @@
 
 set -ev
 
+# determine the git branch and origin
+GIT_BRANCH=`git name-rev --name-only HEAD`
+echo "Testing branch ${GIT_BRANCH}"
+GIT_ORIGIN=`git config --get remote.origin.url`
+echo "Testing from ${GIT_ORIGIN}"
+
+git remote -vvv
+git branch -vvv
+
+# store the travis test directory
 LOCAL=${PWD}
 
-# working dir for build script
+# create working dir for build script
 BUILD=${HOME}/build
 mkdir -p ${BUILD}
 
+# run the einstein at home build and test script
 pushd ${BUILD}
 ${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --clean-pycbc
 popd
 
-# Update setuptools
-#pip install --upgrade pip setuptools
+# setup the pycbc environment to run the additional travis tests
+source ${BUILD}/pycbc-build/environment/etc/lalsuite-user-env.sh
+source ${BUILD}/pycbc-build/environment/bin/activate
+export PYTHONUSERBASE=${BUILD}/.local
+export XDG_CACHE_HOME=${BUILD}/.cache
 
-# Needed by mock 
-#pip install 'setuptools==18.2' --upgrade
+# update setuptools
+pip install --upgrade pip setuptools
 
-#python setup.py install
+# needed by mock 
+pip install 'setuptools==18.2' --upgrade
+
+# install pegasus
+pip install http://download.pegasus.isi.edu/pegasus/4.7.2/pegasus-python-source-4.7.4.tar.gz
+
+# re-install pycbc
+python setup.py install

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -4,7 +4,7 @@ set -ev
 
 # determine the git branch and origin
 git branch -vvv
-PYCBC_MERGE_COMMIT=`git rev-parse HEAD`
+PYCBC_MERGE_REF=`cut -f3 .git/FETCH_HEAD | cut -d " " -f1 | tr -d "'"`
 
 # store the travis test directory
 LOCAL=${PWD}
@@ -15,7 +15,7 @@ mkdir -p ${BUILD}
 
 # run the einstein at home build and test script
 pushd ${BUILD}
-${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --clean-pycbc --silent-build --no-analysis
+${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --pycbc-fetch-ref ${PYCBC_MERGE_REF} --clean-pycbc --silent-build --no-analysis
 popd
 
 # setup the pycbc environment to run the additional travis tests

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -17,7 +17,7 @@ export XDG_CACHE_HOME=${BUILD}/.cache
 
 # run the einstein at home build and test script
 pushd ${BUILD}
-${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --pycbc-fetch-ref=${PYCBC_MERGE_REF} --clean-pycbc --silent-build --clean-lalsuite
+${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --pycbc-fetch-ref=${PYCBC_MERGE_REF} --clean-pycbc --silent-build
 popd
 
 # setup the pycbc environment to run the additional travis tests

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -15,7 +15,7 @@ mkdir -p ${BUILD}
 
 # run the einstein at home build and test script
 pushd ${BUILD}
-${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --silent-build --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --clean-pycbc
+${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=a2a5a476d33f169b8749e2840c306a48df63c936 --clean-pycbc --silent-build
 popd
 
 # setup the pycbc environment to run the additional travis tests

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -45,11 +45,16 @@ RESULT=0
 #     Some tests fail for reasons not necessarily related to PyCBC
 #     Setup.py seems to returns 0 even when tests fail
 # So we rather run specific tests manually
-for prog in `find test -name '*.py' -print | egrep -v '(autochisq|bankveto|fft|schemes|long)'`
+for prog in `find test -name '*.py' -print | egrep -v '(autochisq|bankveto|fft|schemes|long|lalsim)'`
 do 
     echo -e "\\n\\n>> [`date`] running unit test for $prog" >&3
     python $prog
-    test $? -ne 0 && RESULT=1
+    if test $? -ne 0 ; then
+        RESULT=1
+        echo -e "    FAILED!" >&3
+    else
+        echo -e "    Pass." >&3
+    fi
 done
 
 # check that all executables that do not require
@@ -58,7 +63,12 @@ for prog in `find ${PATH//:/ } -maxdepth 1 -name 'pycbc*' -print | egrep -v '(py
 do
     echo -e "\\n\\n>> [`date`] running $prog --help" >&3
     $prog --help
-    test $? -ne 0 && RESULT=1
+    if test $? -ne 0 ; then
+        RESULT=1
+        echo -e "    FAILED!" >&3
+    else
+        echo -e "    Pass." >&3
+    fi
 done
 
 exit ${RESULT}

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -2,11 +2,17 @@
 
 set -v
 
-INST=${HOME}/inst
-source ${INST}/etc/lal-user-env.sh
-export LD_LIBRARY_PATH=${INST}/lib:${INST}/lib64
-export PKG_CONFIG_PATH=${INST}/lib/pkgconfig:${PKG_CONFIG_PATH}
-export PATH=/usr/lib/ccache:${PATH}:${INST}/bin
+BUILD=${HOME}/build
+BUILDDIRNAME="pycbc-build"
+PYCBC="$BUILD/$BUILDDIRNAME"
+PYTHON_PREFIX="$PYCBC"
+ENVIRONMENT="$PYCBC/environment"
+PREFIX="$ENVIRONMENT"
+PATH="$PREFIX/bin:$PYTHON_PREFIX/bin:$PATH"
+export LD_LIBRARY_PATH="$PREFIX/lib:$PREFIX/bin:$PYTHON_PREFIX/lib:/usr/local/lib:$LD_LIBRARY_PATH"
+export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PYTHON_PREFIX/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
+source ${BUILD}/pycbc-build/environment/etc/lalsuite-user-env.sh
+source ${BUILD}/pycbc-build/environment/bin/activate
 
 # Using python setup.py test has two issues:
 #     Some tests fail for reasons not necessarily related to PyCBC

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -26,6 +26,7 @@ export LD_LIBRARY_PATH="$PREFIX/lib:$PREFIX/bin:$PYTHON_PREFIX/lib:/usr/local/li
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PYTHON_PREFIX/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 source ${BUILD}/pycbc-build/environment/etc/lalsuite-user-env.sh
 source ${BUILD}/pycbc-build/environment/bin/activate
+export LAL_DATA_PATH=$HOME/pycbc-sources/test
 
 # make a copy of stdin and stdout and close them
 exec 3>&1-

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -5,7 +5,6 @@ function exit_on_error {
         echo "--- Error or interrupt: dumping log file ----------------------" >&4
         cat $LOG_FILE >&4
     fi
-fi
 exit 1
 }
 trap exit_on_error ERR INT

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
+echo -e "\\n\\n>> [`date`] Starting PyCBC test suite"
+
+LOG_FILE=$(mktemp -t pycbc-test-log.XXXXXXXXXX)
+echo -e "\\n\\n>> [`date`] writing test log to $LOG_FILE"
+
 function exit_on_error {
+    echo "--- Error or interrupt ----------------------------------------" >&4
     if [ -f $LOG_FILE ] ; then
-        echo "--- Error or interrupt: dumping log file ----------------------" >&4
         cat $LOG_FILE >&4
     fi
+    echo "---------------------------------------------------------------" >&4
 exit 1
 }
 trap exit_on_error ERR INT
@@ -20,9 +26,6 @@ export LD_LIBRARY_PATH="$PREFIX/lib:$PREFIX/bin:$PYTHON_PREFIX/lib:/usr/local/li
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PYTHON_PREFIX/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 source ${BUILD}/pycbc-build/environment/etc/lalsuite-user-env.sh
 source ${BUILD}/pycbc-build/environment/bin/activate
-
-LOG_FILE=$(mktemp -t pycbc-test-log.XXXXXXXXXX)
-echo -e "\\n\\n>> [`date`] writing test log to $LOG_FILE"
 
 # make a copy of stdin and stdout and close them
 exec 3>&1-
@@ -53,8 +56,8 @@ done
 # special environments can return a help message
 for prog in `find ${PATH//:/ } -maxdepth 1 -name 'pycbc*' -print | egrep -v '(pycbc_fit_sngl_trigs|pycbc_live|pycbc_live_nagios_monitor|pycbc_make_grb_summary_page|pycbc_make_offline_grb_workflow|pycbc_mvsc_get_features|pycbc_upload_xml_to_gracedb)'`
 do
-    echo "Checking $prog --help"
-    $prog --help > /dev/null
+    echo -e "\\n\\n>> [`date`] running $prog --help" >&3
+    $prog --help
     test $? -ne 0 && RESULT=1
 done
 

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -75,76 +75,13 @@ test $? -ne 0 && RESULT=1
 python test/test_inference.py
 test $? -ne 0 && RESULT=1
 
-# check for trivial failures of important executables
-
-function test_exec_help {
-    $1 --help > /dev/null
+# check that all executables that do not require
+# special environments can return a help message
+for prog in `find ${PATH//:/ } -maxdepth 1 -name 'pycbc*' -print | egrep -v '(pycbc_fit_sngl_trigs|pycbc_live|pycbc_live_nagios_monitor|pycbc_make_grb_summary_page|pycbc_make_offline_grb_workflow|pycbc_mvsc_get_features|pycbc_upload_xml_to_gracedb)'`
+do
+    echo "Checking $prog --help"
+    $prog --help > /dev/null
     test $? -ne 0 && RESULT=1
-}
-
-test_exec_help pycbc_banksim
-test_exec_help pycbc_make_banksim
-test_exec_help pycbc_faithsim
-test_exec_help pycbc_make_faithsim
-
-#test_exec_help pycbc_coinc_time
-
-test_exec_help pycbc_inspiral
-test_exec_help pycbc_inspiral_skymax
-
-test_exec_help pycbc_geom_nonspinbank
-test_exec_help pycbc_aligned_stoch_bank
-test_exec_help pycbc_geom_aligned_bank
-test_exec_help pycbc_geom_aligned_2dstack
-test_exec_help pycbc_splitbank
-test_exec_help pycbc_bank_verification
-test_exec_help pycbc_tmpltbank_to_chi_params
-
-test_exec_help pycbc_strip_injections
-test_exec_help pycbc_coinc_bank2hdf
-test_exec_help pycbc_coinc_mergetrigs
-test_exec_help pycbc_coinc_findtrigs
-test_exec_help pycbc_coinc_hdfinjfind
-test_exec_help pycbc_coinc_statmap
-test_exec_help pycbc_coinc_statmap_inj
-test_exec_help pycbc_combine_statmap
-test_exec_help pycbc_distribute_background_bins
-test_exec_help pycbc_foreground_censor
-test_exec_help pycbc_plot_singles_vs_params
-test_exec_help pycbc_plot_singles_timefreq
-test_exec_help pycbc_page_snrchi
-test_exec_help pycbc_page_coinc_snrchi
-test_exec_help pycbc_page_sensitivity
-test_exec_help pycbc_page_foreground
-test_exec_help pycbc_page_foundmissed
-test_exec_help pycbc_page_ifar
-test_exec_help pycbc_page_injtable
-test_exec_help pycbc_page_segments
-#test_exec_help pycbc_page_segplot
-#test_exec_help pycbc_page_segtable
-test_exec_help pycbc_page_snrifar
-#test_exec_help pycbc_page_vetotable
-test_exec_help pycbc_plot_bank_bins
-test_exec_help pycbc_plot_hist
-test_exec_help pycbc_calculate_psd
-test_exec_help pycbc_merge_psds
-test_exec_help pycbc_plot_psd_file
-test_exec_help pycbc_plot_range
-test_exec_help pycbc_average_psd
-#test_exec_help pycbc_make_html_page
-test_exec_help pycbc_single_template
-test_exec_help pycbc_single_template_plot
-test_exec_help pycbc_optimal_snr
-test_exec_help pycbc_plot_gating
-test_exec_help pycbc_page_snglinfo
-test_exec_help pycbc_page_injinfo
-test_exec_help pycbc_plot_trigger_timeseries
-test_exec_help pycbc_generate_hwinj
-test_exec_help pycbc_stat_dtphase
-test_exec_help pycbc_condition_strain
-test_exec_help pycbc_plot_waveform
-test_exec_help pycbc_compress_bank
-
-test_exec_help pycbc_inference
+done
 
 exit ${RESULT}

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-echo -e "\\n\\n>> [`date`] Starting PyCBC test suite"
+echo -e "\\n>> [`date`] Starting PyCBC test suite"
 
 LOG_FILE=$(mktemp -t pycbc-test-log.XXXXXXXXXX)
-echo -e "\\n\\n>> [`date`] writing test log to $LOG_FILE"
+echo -e "\\n>> [`date`] writing test log to $LOG_FILE"
 
 function exit_on_error {
     echo "--- Error or interrupt ----------------------------------------" >&4
@@ -48,7 +48,7 @@ RESULT=0
 # So we rather run specific tests manually
 for prog in `find test -name '*.py' -print | egrep -v '(autochisq|bankveto|fft|schemes|long|lalsim|test_waveform)'`
 do 
-    echo -e "\\n\\n>> [`date`] running unit test for $prog" >&3
+    echo -e ">> [`date`] running unit test for $prog" >&3
     python $prog
     if test $? -ne 0 ; then
         RESULT=1
@@ -62,7 +62,7 @@ done
 # special environments can return a help message
 for prog in `find ${PATH//:/ } -maxdepth 1 -name 'pycbc*' -print | egrep -v '(pycbc_fit_sngl_trigs|pycbc_live|pycbc_live_nagios_monitor|pycbc_make_grb_summary_page|pycbc_make_offline_grb_workflow|pycbc_mvsc_get_features|pycbc_upload_xml_to_gracedb)'`
 do
-    echo -e "\\n\\n>> [`date`] running $prog --help" >&3
+    echo -e ">> [`date`] running $prog --help" >&3
     $prog --help
     if test $? -ne 0 ; then
         RESULT=1

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -26,7 +26,7 @@ export LD_LIBRARY_PATH="$PREFIX/lib:$PREFIX/bin:$PYTHON_PREFIX/lib:/usr/local/li
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PYTHON_PREFIX/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 source ${BUILD}/pycbc-build/environment/etc/lalsuite-user-env.sh
 source ${BUILD}/pycbc-build/environment/bin/activate
-export LAL_DATA_PATH=$HOME/pycbc-sources/test
+export LAL_DATA_PATH=$HOME/build/pycbc-sources/test
 
 # make a copy of stdin and stdout and close them
 exec 3>&1-
@@ -46,7 +46,7 @@ RESULT=0
 #     Some tests fail for reasons not necessarily related to PyCBC
 #     Setup.py seems to returns 0 even when tests fail
 # So we rather run specific tests manually
-for prog in `find test -name '*.py' -print | egrep -v '(autochisq|bankveto|fft|schemes|long|lalsim)'`
+for prog in `find test -name '*.py' -print | egrep -v '(autochisq|bankveto|fft|schemes|long|lalsim|test_waveform)'`
 do 
     echo -e "\\n\\n>> [`date`] running unit test for $prog" >&3
     python $prog

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -2,19 +2,6 @@
 
 echo -e "\\n\\n>> [`date`] Starting PyCBC test suite"
 
-LOG_FILE=$(mktemp -t pycbc-test-log.XXXXXXXXXX)
-echo -e "\\n\\n>> [`date`] writing test log to $LOG_FILE"
-
-function exit_on_error {
-    echo "--- Error or interrupt ----------------------------------------" >&4
-    if [ -f $LOG_FILE ] ; then
-        cat $LOG_FILE >&4
-    fi
-    echo "---------------------------------------------------------------" >&4
-exit 1
-}
-trap exit_on_error ERR INT
-
 BUILD=${HOME}/build
 BUILDDIRNAME="pycbc-build"
 PYCBC="$BUILD/$BUILDDIRNAME"
@@ -26,16 +13,6 @@ export LD_LIBRARY_PATH="$PREFIX/lib:$PREFIX/bin:$PYTHON_PREFIX/lib:/usr/local/li
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PYTHON_PREFIX/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 source ${BUILD}/pycbc-build/environment/etc/lalsuite-user-env.sh
 source ${BUILD}/pycbc-build/environment/bin/activate
-
-# make a copy of stdin and stdout and close them
-exec 3>&1-
-exec 4>&2-
-
-# open stdout as $LOG_FILE file for read and write.
-exec 1<>$LOG_FILE
-
-# redirect stderr to stdout
-exec 2>&1
 
 set -v
 

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -45,7 +45,7 @@ RESULT=0
 #     Some tests fail for reasons not necessarily related to PyCBC
 #     Setup.py seems to returns 0 even when tests fail
 # So we rather run specific tests manually
-find test -name '*.py' -print | egrep -v '(test_autochisq.py|test_fft_unthreaded.py|test_schemes.py)'
+for prog in `find test -name '*.py' -print | egrep -v '(autochisq|bankveto|fft|schemes|long)'`
 do 
     echo -e "\\n\\n>> [`date`] running unit test for $prog" >&3
     python $prog

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -2,6 +2,19 @@
 
 echo -e "\\n\\n>> [`date`] Starting PyCBC test suite"
 
+LOG_FILE=$(mktemp -t pycbc-test-log.XXXXXXXXXX)
+echo -e "\\n\\n>> [`date`] writing test log to $LOG_FILE"
+
+function exit_on_error {
+    echo "--- Error or interrupt ----------------------------------------" >&4
+    if [ -f $LOG_FILE ] ; then
+        cat $LOG_FILE >&4
+    fi
+    echo "---------------------------------------------------------------" >&4
+exit 1
+}
+trap exit_on_error ERR INT
+
 BUILD=${HOME}/build
 BUILDDIRNAME="pycbc-build"
 PYCBC="$BUILD/$BUILDDIRNAME"
@@ -13,6 +26,16 @@ export LD_LIBRARY_PATH="$PREFIX/lib:$PREFIX/bin:$PYTHON_PREFIX/lib:/usr/local/li
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PYTHON_PREFIX/lib/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 source ${BUILD}/pycbc-build/environment/etc/lalsuite-user-env.sh
 source ${BUILD}/pycbc-build/environment/bin/activate
+
+# make a copy of stdin and stdout and close them
+exec 3>&1-
+exec 4>&2-
+
+# open stdout as $LOG_FILE file for read and write.
+exec 1<>$LOG_FILE
+
+# redirect stderr to stdout
+exec 2>&1
 
 set -v
 


### PR DESCRIPTION
This pull request switches our Travis build and test infrastructure to use the Einstein@Home build scripts. This synchronizes our testing with @bema-ligo's so any errors in pull requests will be caught by Travis. The E@H build code also simplifies our Travis setup and adds a test that actually runs ``pycbc_inspiral`` and checks that it finds GW150914.

To implement this, I have made a few changes to the E@H build script to:
 * Add an Ubuntu 12 OS target, with an addition check that skips building FFTW, HDF5, OpenSSL, lapack, zlib, freetype, and GSL if the target OS is a Travis Ubuntu machine. We get these libraries via apt in the container, so there is no need to build them.
 * Implement a ``--slient-build`` option. Travis fails if stderr/stdout exceeds 4MB and fails if no output is written to stdout/stderr for 10 minutes. The ``--silent-build`` option is a compromise between too little and too much output. It silences all the build messages from the ``make`` commands and just prints the build script's status to screen. The exception is the lalsuite build, where a ``make|grep`` prints the current build directory to avoid 10 mins of silence. The usual output is sent to a log file in /tmp, which is cleaned up on exit. If the script gets exits ``INT`` or ``ERR`` then the last 100 lines of the log file are printed to the screen.
 * Implement a ``--pycbc-fetch-ref`` option which allows the E@H build script to build from a pull request, rather than a commit hash or branch.
 * Add a variable that makes building FFTW optional.
 * Add a variable that makes building zlib optional.
 * Skip building ``progress.exe`` and ``fstab.exe`` on Travis.

@bema-ligo none of the above changes should affect your normal builds.

In addition, I have made modified ``pycbc_build_eah.sh`` in two ways which should not affect the E@H build, but @bema-ligo may want to double check:
 * Add some filtering to the ``--verbose`` output of ``pycbc_inspiral`` so that it does not fill the screen with garbage. This is always on and reduces the amount of output printed. It should not affect the normal E@H stuff, as long as @bema-ligo is not parsing the stdout from the inspiral code during the build process.
 * Turned off ``--disable-lalpulsar`` in the E@H build as some of the PyCBC template bank code needs the a_n* lattice code from the pulsar package.

On the Travis side, I have:
 * Replace the old build and install code with a call to the E@H script.
 * Automated the ``--help`` test on executables to catch users adding an executable that does not work.
 * Automated testing of the python scripts in the ``test/`` directory.
 * Disabled ``test_waveform.py`` until https://github.com/ligo-cbc/pycbc/issues/1507 is fixed.