### PR TITLE
Fixed bad import in pycbc_fit_sngl_trigs

### DIFF
--- a/bin/pycbc_fit_sngl_trigs
+++ b/bin/pycbc_fit_sngl_trigs
@@ -24,7 +24,7 @@ import numpy as np
 from scipy.stats import kstest
 
 from pycbc import io, events, bin_utils
-from pycbc.events import trstats
+from pycbc.events import trigger_fits as trstats
 import pycbc.version
 
 #### DEFINITIONS AND FUNCTIONS ####


### PR DESCRIPTION
Found while testing travis:
```
(pycbc-dev)[dbrown@sugwg-osg ~]$ pycbc_fit_sngl_trigs --help
Traceback (most recent call last):
  File "/home/dbrown/src/pycbc-dev/bin/pycbc_fit_sngl_trigs", line 4, in <module>
    __import__('pkg_resources').run_script('PyCBC==770rc47', 'pycbc_fit_sngl_trigs')
  File "/home/dbrown/src/pycbc-dev/lib/python2.7/site-packages/pkg_resources/__init__.py", line 738, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/home/dbrown/src/pycbc-dev/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1499, in run_script
    exec(code, namespace, namespace)
  File "/home/dbrown/src/pycbc-dev/lib/python2.7/site-packages/PyCBC-770rc47-py2.7.egg/EGG-INFO/scripts/pycbc_fit_sngl_trigs", line 27, in <module>
    from pycbc.events import trstats
ImportError: cannot import name trstats
```