### PR TITLE
Remove files that should not be cached

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ before_cache:
     - rm -rf $HOME/pycbc-sources/pycbc
     - rm -rf $HOME/pycbc-sources/pyinstaller
     - rm -rf $HOME/pycbc-sources/test/pycbc_inspiral
+    - rm -f $HOME/pycbc-sources/test/lal-data-r7.tar.gz
+    - rm -f $HOME/pycbc-sources/test/H1-INSPIRAL-OUT.hdf
     - rm -f $HOME/pycbc-sources/libframe-*.tar.gz
     - rm -f $HOME/pycbc-sources/metaio-*.tar.gz
     - rm -f $HOME/pycbc-sources/pegasus-python-source-*.tar.gz


### PR DESCRIPTION
The E@H script looks for the actual ROM files themselves, so no need to cache the tarball.