### PR TITLE
Remove warning as error for documentation build

### DIFF
--- a/docs/Makefile.std
+++ b/docs/Makefile.std
@@ -45,7 +45,7 @@ clean:
 
 html:
 	python removeGPUmods.py
-	$(SPHINXBUILD) -W -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
Travis now checks that the documentation can build correctly before a merge can happen:

https://github.com/ligo-cbc/pycbc/blob/master/docs/Makefile.gh_pages#L7

This removes the ``-W`` from the non gh_pages build so that users can test the doc build, even if they don't have e.g. MKL. Any documentation failures will be picked up on the pull check in GitHub.