### PR TITLE
E@H build script: set pipefail

### DIFF
--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -5,6 +5,9 @@
 # FIXME/todo:
 #
 
+# make a pipe fail if any process fails
+set -o pipefail
+
 # check an md5 sum of a file, independent of platform
 # $1 file to check, $2 md5 checksum
 # returns 0 for fail, 1 for success(!)


### PR DESCRIPTION
- hotfix for issue #1522 

Since #1505 analysis test now runs in a pipe, which means that if it fails, the pipe and the script still succeeds, which is exactly what this test is not for.