### PR TITLE
Plot expected values in posterior plots

### DIFF
--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -200,6 +200,10 @@ else:
 
 fp.close()
 
+# get expected parameters
+expected_parameters = option_utils.expected_parameters_from_cli(opts)
+expected_parameters_color = opts.expected_parameters_color
+
 logging.info('Choosing common characteristics for all figures')
 # Set common min and max for axis in all plots
 mins, maxs = option_utils.plot_ranges_from_cli(opts)
@@ -239,7 +243,9 @@ def _make_frame(frame):
                         plot_contours=opts.plot_contours,
                             density_cmap=opts.density_cmap,
                             contour_color=opts.contour_color,
-                            use_kombine=opts.use_kombine_kde)
+                            use_kombine=opts.use_kombine_kde,
+                        expected_parameters=expected_parameters,
+                        expected_parameters_color=expected_parameters_color)
 
     # Write sample number
     if show_colorbar:

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -81,6 +81,8 @@ for p in parameters:
     if p not in maxs:
         maxs[p] = samples[p].max()
 
+expected_parameters = option_utils.expected_parameters_from_cli(opts)
+
 logging.info("Plotting")
 fig, axis_dict = create_multidim_plot(
                 parameters, samples, labels=labels,
@@ -94,7 +96,9 @@ fig, axis_dict = create_multidim_plot(
                     density_cmap=opts.density_cmap,
                     contour_color=opts.contour_color,
                     use_kombine=opts.use_kombine_kde,
-                mins=mins, maxs=maxs)
+                mins=mins, maxs=maxs,
+                expected_parameters=expected_parameters,
+                expected_parameters_color=opts.expected_parameters_color)
 
 # save
 fig.savefig(opts.output_file, bbox_inches='tight', dpi=200)

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -273,6 +273,20 @@ def add_plot_posterior_option_group(parser):
     pgroup.add_argument('--maxs', nargs='+', metavar='PARAM:VAL', default=[],
                         help="Same as mins, but for the maximum values to "
                              "plot.")
+    # add expected parameters options
+    pgroup.add_argument('--expected-parameters', nargs='+', metavar='PARAM:VAL',
+                        default=[],
+                        help="Specify expected parameter values to plot. If "
+                             "provided, a cross will be plotted in each axis "
+                             "that an expected parameter is provided. "
+                             "Parameter names must be "
+                             "the same as the PARAM argument in --parameters "
+                             "(or, if no parameters are provided, the same as "
+                             "the parameter name specified in the variable "
+                             "args in the input file.")
+    pgroup.add_argument('--expected-parameters-color', default='r',
+                        help="What to color the expected-parameters cross. "
+                             "Default is red.")
     return pgroup
 
 
@@ -309,6 +323,32 @@ def plot_ranges_from_cli(opts):
             raise ValueError("option --maxs not specified correctly; see help")
         maxs[x[0]] = float(x[1])
     return mins, maxs
+
+
+def expected_parameters_from_cli(opts):
+    """Parses the --expected-parameters arguments from the `plot_posterior`
+    option group.
+
+    Parameters
+    ----------
+    opts : ArgumentParser
+        The parsed arguments from the command line.
+
+    Returns
+    -------
+    dict
+        Dictionary of parameter name -> expected value. Only parameters that
+        were specified in the --expected-parameters option will be included; if
+        no parameters were provided, will return an empty dictionary.
+    """
+    expected = {}
+    for x in opts.expected_parameters:
+        x = x.split(':')
+        if len(x) != 2:
+            raise ValueError("option --expected-paramters not specified "
+                             "correctly; see help")
+        expected[x[0]] = float(x[1])
+    return expected
 
 
 def add_scatter_option_group(parser):

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -379,7 +379,8 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
 
 
 def create_multidim_plot(parameters, samples, labels=None,
-                mins=None, maxs=None,
+                mins=None, maxs=None, expected_parameters=None,
+                expected_parameters_color='r',
                 plot_marginal=True,
                 plot_scatter=True,
                     zvals=None, show_colorbar=True, cbar_label=None,
@@ -405,6 +406,12 @@ def create_multidim_plot(parameters, samples, labels=None,
         Maximum value for the axis of each variable in `parameters`.
         If None, it will use the maximum of the corresponding variable in
         `samples`.
+    expected_parameters : {None, dict}, optional
+        Expected values of `parameters`, as a dictionary mapping parameter
+        names -> values. A cross will be plotted at the location of the
+        expected parameters on axes that plot any of the expected parameters.
+    expected_parameters_color : {'r', string}, optional
+        What color to make the expected parameters cross.
     plot_marginal : {True, bool}
         Plot the marginalized distribution on the diagonals. If False, the
         diagonal axes will be turned off.
@@ -549,6 +556,18 @@ def create_multidim_plot(parameters, samples, labels=None,
                     ymin=mins[py], ymax=maxs[py],
                     exclude_region=exclude_region, ax=ax,
                     use_kombine=use_kombine)
+
+        if expected_parameters is not None:
+            try:
+                ax.vlines(expected_parameters[px], mins[py], maxs[py],
+                          colors=expected_parameters_color, zorder=5)
+            except KeyError:
+                pass
+            try:
+                ax.hlines(expected_parameters[py], mins[px], maxs[px],
+                          colors=expected_parameters_color, zorder=5)
+            except KeyError:
+                pass
 
         ax.set_xlim(mins[px], maxs[px])
         ax.set_ylim(mins[py], maxs[py])

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -531,9 +531,15 @@ def create_multidim_plot(parameters, samples, labels=None,
             # if only plotting 2 parameters and on the second parameter,
             # rotate the marginal plot
             rotated = nparams == 2 and pi == nparams-1
+            # see if there are expected values
+            if expected_parameters is not None:
+                try:
+                    expected_value = expected_parameters[param]
+                except KeyError:
+                    expected_value = None
             create_marginalized_hist(ax, samples[param], label=labels[param],
                 color='k', fillcolor='gray', linecolor='navy', title=True,
-                expected_value=expected_parameters[param],
+                expected_value=expected_value,
                 expected_color=expected_parameters_color,
                 rotated=rotated, plot_min=mins[param], plot_max=maxs[param])
 

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -338,15 +338,15 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
     values = numpy.percentile(values, percentiles)
     for val in values:
         if rotated:
-            ax.axhline(y=val, ls='dashed', color=linecolor, lw=2)
+            ax.axhline(y=val, ls='dashed', color=linecolor, lw=2, zorder=3)
         else:
-            ax.axvline(x=val, ls='dashed', color=linecolor, lw=2)
+            ax.axvline(x=val, ls='dashed', color=linecolor, lw=2, zorder=3)
     # plot expected
     if expected_value is not None:
         if rotated:
-            ax.axhline(expected_value, color=expected_color, lw=2)
+            ax.axhline(expected_value, color=expected_color, lw=1.5, zorder=2)
         else:
-            ax.axvline(expected_value, color=expected_color, lw=2)
+            ax.axvline(expected_value, color=expected_color, lw=1.5, zorder=2)
     if title:
         values_med = numpy.median(values)
         values_min = values.min()
@@ -576,12 +576,12 @@ def create_multidim_plot(parameters, samples, labels=None,
 
         if expected_parameters is not None:
             try:
-                ax.axvline(expected_parameters[px], lw=2,
+                ax.axvline(expected_parameters[px], lw=1.5,
                            color=expected_parameters_color, zorder=5)
             except KeyError:
                 pass
             try:
-                ax.axhline(expected_parameters[py], lw=2,
+                ax.axhline(expected_parameters[py], lw=1.5,
                            color=expected_parameters_color, zorder=5)
             except KeyError:
                 pass

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -346,7 +346,7 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
         if rotated:
             ax.axhline(expected_value, color=expected_color, lw=2)
         else:
-            ax.axhline(expected_value, color=expected_color, lw=2)
+            ax.axvline(expected_value, color=expected_color, lw=2)
     if title:
         values_med = numpy.median(values)
         values_min = values.min()
@@ -568,13 +568,13 @@ def create_multidim_plot(parameters, samples, labels=None,
 
         if expected_parameters is not None:
             try:
-                ax.vlines(expected_parameters[px], mins[py], maxs[py],
-                          colors=expected_parameters_color, zorder=5)
+                ax.axvline(expected_parameters[px], lw=2,
+                           color=expected_parameters_color, zorder=5)
             except KeyError:
                 pass
             try:
-                ax.hlines(expected_parameters[py], mins[px], maxs[px],
-                          colors=expected_parameters_color, zorder=5)
+                ax.axhline(expected_parameters[py], lw=2,
+                           color=expected_parameters_color, zorder=5)
             except KeyError:
                 pass
 

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -537,6 +537,8 @@ def create_multidim_plot(parameters, samples, labels=None,
                     expected_value = expected_parameters[param]
                 except KeyError:
                     expected_value = None
+            else:
+                expected_value = None
             create_marginalized_hist(ax, samples[param], label=labels[param],
                 color='k', fillcolor='gray', linecolor='navy', title=True,
                 expected_value=expected_value,

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -285,6 +285,7 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
 
 def create_marginalized_hist(ax, values, label, percentiles=None,
         color='k', fillcolor='gray', linecolor='navy', title=True,
+        expected_value=None, expected_color='red',
         rotated=False, plot_min=None, plot_max=None):
     """Plots a 1D marginalized histogram of the given param from the given
     samples.
@@ -340,6 +341,12 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
             ax.axhline(y=val, ls='dashed', color=linecolor, lw=2)
         else:
             ax.axvline(x=val, ls='dashed', color=linecolor, lw=2)
+    # plot expected
+    if expected_value is not None:
+        if rotated:
+            ax.axhline(expected_value, color=expected_color, lw=2)
+        else:
+            ax.axhline(expected_value, color=expected_color, lw=2)
     if title:
         values_med = numpy.median(values)
         values_min = values.min()
@@ -526,6 +533,8 @@ def create_multidim_plot(parameters, samples, labels=None,
             rotated = nparams == 2 and pi == nparams-1
             create_marginalized_hist(ax, samples[param], label=labels[param],
                 color='k', fillcolor='gray', linecolor='navy', title=True,
+                expected_value=expected_parameters[param],
+                expected_color=expected_parameters_color,
                 rotated=rotated, plot_min=mins[param], plot_max=maxs[param])
 
     # Off-diagonals...


### PR DESCRIPTION
This patch adds the ability to plot the expected parameter values on posterior plots in `plot_posterior` and `plot_movie`. A posterior example: [here](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/pycbc_inference/cbc/spin_priors/inj-chieff_0p4-chip_0p1/prior-isotropic_spins/posterior_density-mass1_mass2.png). A movie example: [here](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/pycbc_inference/cbc/spin_priors/inj-chieff_0p4-chip_0p04/prior-uniform_chip_chieff/scatter_movie-1-52000-250.mp4).

The expected values are specified by an `--expected-parameters` option, which expects the name of a parameter which must correspond to one of the parameters, followed by the value. For example, to create the above posterior plot:
```
pycbc_inference_plot_posterior \
    --iteration -1 \
    --plot-density --plot-marginal --plot-contours --verbose \
    --input-file ${input_file} --output-file ${output_file} \
    --parameters \
        'primary_mass(mass1, mass2):$m_1$' 'secondary_mass(mass1, mass2):$m_2$' \
    --expected-parameters \
        "primary_mass(mass1, mass2):40" "secondary_mass(mass1, mass2):30"
```
Expected values do not need to be provided for all of the parameters; any ones not included will simply not have lines on their plot. For example, in the above movie, I did not specify expected values for `t_c`, `phi_c`, and `psi`.