### PR TITLE
Fix tmpltbank workflows

### DIFF
--- a/bin/pycbc_geom_aligned_bank
+++ b/bin/pycbc_geom_aligned_bank
@@ -532,7 +532,8 @@ cp.write(temp_fp)
 temp_fp.close()
 
 opts.config_files=['temp.ini']
-opts.config_overrides=[]
+opts.config_overrides = []
+opts.config_delete = []
 
 # Now setup the workflow
 workflow = wf.Workflow(opts, opts.workflow_name)

--- a/bin/pycbc_geom_aligned_bank
+++ b/bin/pycbc_geom_aligned_bank
@@ -602,7 +602,7 @@ bankverify_exe = BankVerification(workflow.cp, 'bankverify',
 bankverify_node = bankverify_exe.create_node(out_bank, workflow.analysis_time)
 workflow += bankverify_node
 
-workflow.save(filename=opts.dax_filename, output_map=opts.map_filename)
+workflow.save(filename=opts.dax_filename, output_map_path=opts.map_filename)
 
 logging.info("GENERATION SUCCESSFUL.")
 logging.info("Submit the resulting dax file to generate your template bank.")

--- a/bin/workflows/pycbc_create_sbank_workflow
+++ b/bin/workflows/pycbc_create_sbank_workflow
@@ -412,4 +412,4 @@ for cycle_idx in range(num_cycles):
     seed_file = h5add_node.output_files[0]
     bins_inp_file = seed_file
 
-workflow.save(filename=args.dax_filename, output_map=args.map_filename)
+workflow.save(filename=args.dax_filename, output_map_path=args.map_filename)

--- a/bin/workflows/pycbc_create_uberbank_workflow
+++ b/bin/workflows/pycbc_create_uberbank_workflow
@@ -197,13 +197,12 @@ assert(map_file.name.endswith('.map'))
 dax_job = dax.DAX(dax_file)
 dax_job.addArguments('--basename %s' % \
                      os.path.splitext(os.path.basename(dax_file.name))[0])
-wf.Workflow.set_job_properties(dax_job, map_file.name)
+wf.Workflow.set_job_properties(dax_job, map_file)
 
 # Tell the dax job that it needs some input files
 dax_job.uses(metadata_file, link=dax.Link.INPUT, register=False, transfer=True)
 dax_job.uses(intermediate_file, link=dax.Link.INPUT, register=False,
              transfer=True)
-dax_job.uses(map_file, link=dax.Link.INPUT, register=False, transfer=True)
 
 # And this output is used again so declare it. See notes at bottom!!!
 #dax_job.uses(geom_out_file, link=dax.Link.OUTPUT, register=False,
@@ -243,12 +242,7 @@ map_file = sbank_node.output_files[1]
 dax_job = dax.DAX(dax_file)
 dax_job.addArguments('--basename %s' % \
                      os.path.splitext(os.path.basename(dax_file.name))[0])
-wf.Workflow.set_job_properties(dax_job, map_file.name)
-
-#dax_job.uses(sbank_out_file_bbh, link=dax.Link.OUTPUT, register=False,
-#             transfer=False)
-dax_job.uses(map_file, link=dax.Link.INPUT, register=False,
-             transfer=False)
+wf.Workflow.set_job_properties(dax_job, map_file)
 
 workflow._adag.addJob(dax_job)
 dep = dax.Dependency(parent=sbank_node._dax_node, child=dax_job)
@@ -279,10 +273,8 @@ map_file = sbank_node.output_files[1]
 dax_job = dax.DAX(dax_file)
 dax_job.addArguments('--basename %s' % \
                      os.path.splitext(os.path.basename(dax_file.name))[0])
-wf.Workflow.set_job_properties(dax_job, map_file.name)
+wf.Workflow.set_job_properties(dax_job, map_file)
 
-dax_job.uses(map_file, link=dax.Link.INPUT, register=False,
-             transfer=True)
 
 workflow._adag.addJob(dax_job)
 dep = dax.Dependency(parent=sbank_node._dax_node, child=dax_job)

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -657,11 +657,12 @@ class Workflow(pegasus_workflow.Workflow):
         if staging_site:
             job.addArguments('--staging-site %s' % staging_site)
             
-    def save(self, filename=None, output_map=None, staging_site=None):
-        if output_map is None:
-            output_map = self.output_map
-            output_map_file = Pegasus.DAX3.File(os.path.basename(output_map))
-            output_map_file.addPFN(Pegasus.DAX3.PFN(output_map, 'local'))
+    def save(self, filename=None, output_map_path=None, staging_site=None):
+        if output_map_path is None:
+            output_map_path = self.output_map
+        output_map_file = Pegasus.DAX3.File(os.path.basename(output_map_path))
+        output_map_file.addPFN(Pegasus.DAX3.PFN(output_map_path, 'local'))
+        if self.in_workflow is not False:
             self.in_workflow._adag.addFile(output_map_file)
 
         staging_site = self.staging_site
@@ -680,7 +681,7 @@ class Workflow(pegasus_workflow.Workflow):
         super(Workflow, self).save(filename=filename)
         
         # add workflow storage locations to the output mapper
-        f = open(output_map, 'w')
+        f = open(output_map_path, 'w')
         for out in self._outputs:
             try:
                 f.write(out.output_map_str() + '\n')

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -638,11 +638,10 @@ class Workflow(pegasus_workflow.Workflow):
             fil.PFN(fil.storage_path, site='local')
     
     @staticmethod
-    def set_job_properties(job, output_map, staging_site=None):
+    def set_job_properties(job, output_map_file, staging_site=None):
         job.addArguments('-Dpegasus.dir.storage.mapper.replica.file=%s' % 
-                         os.path.basename(output_map))
-        job.uses(Pegasus.DAX3.File(os.path.basename(output_map)), 
-                 link=Pegasus.DAX3.Link.INPUT)
+                         os.path.basename(output_map_file.name))
+        job.uses(output_map_file, link=Pegasus.DAX3.Link.INPUT)
         job.addArguments('-Dpegasus.dir.storage.mapper.replica=File') 
 
         job.addArguments('--output-site local')     
@@ -661,14 +660,13 @@ class Workflow(pegasus_workflow.Workflow):
     def save(self, filename=None, output_map=None, staging_site=None):
         if output_map is None:
             output_map = self.output_map
-            if self.in_workflow is not False:
-                output_map_file = Pegasus.DAX3.File(os.path.basename(output_map))
-                output_map_file.addPFN(Pegasus.DAX3.PFN(output_map, 'local'))
-                self.in_workflow._adag.addFile(output_map_file)
+            output_map_file = Pegasus.DAX3.File(os.path.basename(output_map))
+            output_map_file.addPFN(Pegasus.DAX3.PFN(output_map, 'local'))
+            self.in_workflow._adag.addFile(output_map_file)
 
         staging_site = self.staging_site
             
-        Workflow.set_job_properties(self.as_job, output_map, staging_site)
+        Workflow.set_job_properties(self.as_job, output_map_file, staging_site)
 
         # add executable pfns for local site to dax
         for exe in self._executables:

--- a/pycbc/workflow/inference_followups.py
+++ b/pycbc/workflow/inference_followups.py
@@ -98,7 +98,7 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
     node.add_opt("--workflow-name", name)
 
     # get output map name and use it for the output dir name
-    map_loc = node.output_files[1].name
+    map_file = node.output_files[1]
     node.add_opt("--output-dir", out_dir)
 
     # add this node to the workflow
@@ -109,7 +109,7 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
     fil = node.output_files[0]
     job = dax.DAX(fil)
     job.addArguments("--basename %s" % os.path.splitext(os.path.basename(name))[0])
-    Workflow.set_job_properties(job, map_loc)
+    Workflow.set_job_properties(job, map_file)
     workflow._adag.addJob(job)
 
     # make dax a child of the inference workflow generator node

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -94,7 +94,7 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
     node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map', tags=tags)
 
     name = node.output_files[0].name
-    map_loc = node.output_files[1].name
+    map_file = node.output_files[1]
 
     node.add_opt('--workflow-name', name)
     node.add_opt('--output-dir', out_dir)
@@ -106,7 +106,7 @@ def setup_foreground_minifollowups(workflow, coinc_file, single_triggers,
     
     job = dax.DAX(fil)
     job.addArguments('--basename %s' % os.path.splitext(os.path.basename(name))[0])
-    Workflow.set_job_properties(job, map_loc)
+    Workflow.set_job_properties(job, map_file)
     workflow._adag.addJob(job)
     dep = dax.Dependency(parent=node._dax_node, child=job)
     workflow._adag.addDependency(dep)
@@ -183,7 +183,7 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map', tags=tags)
 
     name = node.output_files[0].name
-    map_loc = node.output_files[1].name
+    map_file = node.output_files[1]
 
     node.add_opt('--workflow-name', name)
     node.add_opt('--output-dir', out_dir)
@@ -196,7 +196,7 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     job = dax.DAX(fil)
     job.addArguments('--basename %s' \
                      % os.path.splitext(os.path.basename(name))[0])
-    Workflow.set_job_properties(job, map_loc)
+    Workflow.set_job_properties(job, map_file)
     workflow._adag.addJob(job)
     dep = dax.Dependency(parent=node._dax_node, child=job)
     workflow._adag.addDependency(dep)
@@ -268,7 +268,7 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
     node.new_output_file_opt(workflow.analysis_time, '.dax.map', '--output-map', tags=tags)
 
     name = node.output_files[0].name
-    map_loc = node.output_files[1].name
+    map_file = node.output_files[1]
     
     node.add_opt('--workflow-name', name)
     node.add_opt('--output-dir', out_dir)
@@ -280,7 +280,7 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
     
     job = dax.DAX(fil)
     job.addArguments('--basename %s' % os.path.splitext(os.path.basename(name))[0])
-    Workflow.set_job_properties(job, map_loc)
+    Workflow.set_job_properties(job, map_file)
     workflow._adag.addJob(job)
     dep = dax.Dependency(parent=node._dax_node, child=job)
     workflow._adag.addDependency(dep)


### PR DESCRIPTION
See #1532 . This fixes that problem by removing the now duplicated output_file_map usage in tmpltbank workflows. I also don't like how this was implemented. The output_map is a File, then a path, then a File. We should pass around Files when possible, so this now requires a File as input (this allows the output_map to be used (or even written by) other jobs if that's ever something we want to do).

The "save" function does want a path, but that is now made clearer.

This fixes #1532. Close #1532 (Trying to make git-hub close the issue automatically when this is merged)