### PR TITLE
Fix to pycbc_page_segtable

### DIFF
--- a/bin/hdfcoinc/pycbc_page_segtable
+++ b/bin/hdfcoinc/pycbc_page_segtable
@@ -109,7 +109,7 @@ for segment_name in opts.segment_names:
                 # segments to the list and exit this for loop
                 # this is a for loop because the version of the flag may not
                 # be defined by the command line
-                if key.startswith(segment_flag):
+                if key == segment_flag or key.startswith(segment_flag+':'):
                     if not len(base_segs[ifo]) and name == names[0]:
                         base_segs[ifo] = seg_dict[key].coalesce()
                     else:


### PR DESCRIPTION
This fixes #1539 by changing the logic by which segments are identified. We now check if there is an exact match between the two strings or if the key starts with segment_flag followed by a ":". This indicates that a version number is being given.

It seems that the confusion here is because a version number is potentially expected in `seg_dict.keys()`. However, even though a version number *is* present, this simply returns `${IFO}:${CHANNEL_NAME}` ... SO i'm not really sure if this is expected or not, but this patch at least fixes #1539.

(Close #1539 fix #1539)