### PR TITLE
Move inference data loading/writing to single functions

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -216,11 +216,10 @@ with ctx:
     with InferenceFile(opts.output_file, "w") as fp:
         logging.info("Writing command line and data to output file")
         fp.write_command_line()
-        fp.write_data_to_output(
-            strain_dict=strain_dict if opts.save_strain else None,
-            stilde_dict=stilde_dict if opts.save_stilde else None,
-            psd_dict=psd_dict if opts.save_psd else None,
-            low_frequency_cutoff_dict=low_frequency_cutoff_dict)
+        fp.write_data(strain_dict=strain_dict if opts.save_strain else None,
+                      stilde_dict=stilde_dict if opts.save_stilde else None,
+                      psd_dict=psd_dict if opts.save_psd else None,
+                      low_frequency_cutoff_dict=low_frequency_cutoff_dict)
 
     # get distribution to draw from for each walker initial position
     logging.info("Setting walkers initial conditions for varying parameters")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -201,7 +201,7 @@ with ctx:
                         epoch=stilde_dict.values()[0].epoch,
                         variable_args=variable_args,
                         detectors=opts.instruments,
-                        delta_f=stilde_dict.values()[0], **static_args)
+                        delta_f=stilde_dict.values()[0].delta_f, **static_args)
 
     # construct class that will return the natural logarithm of likelihood
     likelihood = inference.likelihood_evaluators[opts.likelihood_evaluator](

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -146,68 +146,10 @@ logging.info("Using seed %i" %(opts.seed))
 ctx = scheme.from_cli(opts)
 fft.from_cli(opts)
 
-# get gates to apply
-gates = gate.gates_from_cli(opts)
-psd_gates = gate.psd_gates_from_cli(opts)
-
-# get strain time series
-strain_dict = strain.from_cli_multi_ifos(opts, opts.instruments,
-                                         precision="double")
-# apply gates if not waiting to overwhiten
-if not opts.gate_overwhitened:
-    logging.info("Applying gates to strain data")
-    strain_dict = gate.apply_gates_to_td(strain_dict, gates)
-
-# get strain time series to use for PSD estimation
-# if user has not given the PSD time options then use same data as analysis
-if opts.psd_start_time and opts.psd_end_time:
-    logging.info("Will generate a different time series for PSD estimation")
-    psd_opts = opts
-    psd_opts.gps_start_time = psd_opts.psd_start_time
-    psd_opts.gps_end_time = psd_opts.psd_end_time
-    psd_strain_dict = strain.from_cli_multi_ifos(psd_opts, opts.instruments,
-                                                precision="double")
-    # apply any gates
-    logging.info("Applying gates to PSD data")
-    psd_strain_dict = gate.apply_gates_to_td(psd_strain_dict, psd_gates)
-
-elif opts.psd_start_time or opts.psd_end_time:
-    raise ValueError("Must give --psd-start-time and --psd-end-time")
-else:
-    psd_strain_dict = strain_dict
+# get the data and psd
+strain_dict, stilde_dict, psd_dict = option_utils.data_from_cli(opts)
 
 with ctx:
-
-    # FFT strain and save each of the length of the FFT, delta_f, and
-    # low frequency cutoff to a dict
-    logging.info("FFT strain")
-    stilde_dict = {}
-    length_dict = {}
-    delta_f_dict = {}
-    low_frequency_cutoff_dict = {}
-    for ifo in opts.instruments:
-        stilde_dict[ifo] = strain_dict[ifo].to_frequencyseries()
-        length_dict[ifo] = len(stilde_dict[ifo])
-        delta_f_dict[ifo] = stilde_dict[ifo].delta_f
-        low_frequency_cutoff_dict[ifo] = opts.low_frequency_cutoff
-
-    # get PSD as frequency series
-    psd_dict = psd.from_cli_multi_ifos(opts, length_dict, delta_f_dict,
-                               low_frequency_cutoff_dict, opts.instruments,
-                               strain_dict=psd_strain_dict, precision="double")
-
-    # apply any gates to overwhitened data, if desired
-    if opts.gate_overwhitened and opts.gate is not None:
-        logging.info("Applying gates to overwhitened data")
-
-        # overwhiten the data
-        for ifo in gates:
-            stilde_dict[ifo] /= psd_dict[ifo]
-        stilde_dict = gate.apply_gates_to_fd(stilde_dict, gates)
-
-        # unwhiten the data for the likelihood generator
-        for ifo in gates:
-            stilde_dict[ifo] *= psd_dict[ifo]
 
     # read configuration file
     logging.info("Reading configuration file")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -147,6 +147,7 @@ ctx = scheme.from_cli(opts)
 fft.from_cli(opts)
 
 # get the data and psd
+logging.info("Loading data")
 strain_dict, stilde_dict, psd_dict = option_utils.data_from_cli(opts)
 
 with ctx:
@@ -200,7 +201,7 @@ with ctx:
                         epoch=stilde_dict.values()[0].epoch,
                         variable_args=variable_args,
                         detectors=opts.instruments,
-                        delta_f=delta_f_dict.values()[0], **static_args)
+                        delta_f=stilde_dict.values()[0], **static_args)
 
     # construct class that will return the natural logarithm of likelihood
     likelihood = inference.likelihood_evaluators[opts.likelihood_evaluator](

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -212,33 +212,15 @@ with ctx:
     # create sampler that will run
     sampler = option_utils.sampler_from_cli(opts, likelihood)
 
-    # save command line
+    # save command line and data, if desired
     with InferenceFile(opts.output_file, "w") as fp:
+        logging.info("Writing command line and data to output file")
         fp.write_command_line()
-
-    # save PSD
-    if opts.save_psd:
-        # apply dynamic range factor for saving PSDs since
-        # plotting code expects it
-        logging.info("Saving PSDs")
-        psd_dyn_dict = {}
-        for key,val in psd_dict.iteritems():
-             psd_dyn_dict[key] = types.FrequencySeries(
-                                        psd_dict[key] * pycbc.DYN_RANGE_FAC**2,
-                                        delta_f=psd_dict[key].delta_f)
-        with InferenceFile(opts.output_file, "a") as fp:
-            fp.write_psd(psds=psd_dyn_dict,
-                          low_frequency_cutoff=low_frequency_cutoff_dict)
-
-    # save stilde
-    if opts.save_stilde:
-        with InferenceFile(opts.output_file, "a") as fp:
-            fp.write_stilde(stilde_dict)
-
-    # save strain if desired
-    if opts.save_strain:
-        with InferenceFile(opts.output_file, "a") as fp:
-            fp.write_strain(strain_dict)
+        fp.write_data_to_output(
+            strain_dict=strain_dict if opts.save_strain else None,
+            stilde_dict=stilde_dict if opts.save_stilde else None,
+            psd_dict=psd_dict if opts.save_psd else None,
+            low_frequency_cutoff_dict=low_frequency_cutoff_dict)
 
     # get distribution to draw from for each walker initial position
     logging.info("Setting walkers initial conditions for varying parameters")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -54,8 +54,7 @@ parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
 # add data options
 parser.add_argument("--instruments", type=str, nargs="+", required=True,
                     help="IFOs, eg. H1 L1.")
-parser.add_argument("--low-frequency-cutoff", type=float, required=True,
-                    help="Low frequency cutoff for each IFO.")
+option_utils.add_low_frequency_cutoff_opt(parser)
 parser.add_argument("--psd-start-time", type=float, default=None,
                     help="Start time to use for PSD estimation if different "
                          "from analysis.")
@@ -149,6 +148,7 @@ fft.from_cli(opts)
 # get the data and psd
 logging.info("Loading data")
 strain_dict, stilde_dict, psd_dict = option_utils.data_from_cli(opts)
+low_frequency_cutoff_dict = option_utils.low_frequency_cutoff_from_cli(opts)
 
 with ctx:
 
@@ -205,7 +205,8 @@ with ctx:
 
     # construct class that will return the natural logarithm of likelihood
     likelihood = inference.likelihood_evaluators[opts.likelihood_evaluator](
-                        generator, stilde_dict, opts.low_frequency_cutoff,
+                        generator, stilde_dict,
+                        low_frequency_cutoff_dict.values()[0],
                         psds=psd_dict, prior=prior)
 
     # create sampler that will run

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -125,6 +125,29 @@ def sampler_from_cli(opts, likelihood_evaluator, pool=None):
 #
 #-----------------------------------------------------------------------------
 
+def add_low_frequency_cutoff_opt(parser):
+    """Adds the low-frequency-cutoff option to the given parser."""
+    # FIXME: this just uses the same frequency cutoff for every instrument for
+    # now. We should allow for different frequency cutoffs to be used; that
+    # will require (minor) changes to the Likelihood class
+    parser.add_argument("--low-frequency-cutoff", type=float, required=True,
+                        help="Low frequency cutoff for each IFO.")
+
+
+def low_frequency_cutoff_from_cli(opts):
+    """Parses the low frequency cutoff from the given options.
+
+    Returns
+    -------
+    dict
+        Dictionary of instruments -> low frequency cutoff.
+    """
+    # FIXME: this just uses the same frequency cutoff for every instrument for
+    # now. We should allow for different frequency cutoffs to be used; that
+    # will require (minor) changes to the Likelihood class
+    return {ifo: opts.low_frequency_cutoff for ifo in opts.instruments}
+
+
 def data_from_cli(opts):
     """Loads the data needed for a likelihood evaluator from the given
     command-line options. Gates specifed on the command line are also applied.
@@ -183,12 +206,11 @@ def data_from_cli(opts):
     stilde_dict = {}
     length_dict = {}
     delta_f_dict = {}
-    low_frequency_cutoff_dict = {}
+    low_frequency_cutoff_dict = low_frequency_cutoff_from_cli(opts)
     for ifo in opts.instruments:
         stilde_dict[ifo] = strain_dict[ifo].to_frequencyseries()
         length_dict[ifo] = len(stilde_dict[ifo])
         delta_f_dict[ifo] = stilde_dict[ifo].delta_f
-        low_frequency_cutoff_dict[ifo] = opts.low_frequency_cutoff
 
     # get PSD as frequency series
     psd_dict = psd_from_cli_multi_ifos(opts, length_dict, delta_f_dict,

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -550,11 +550,3 @@ def add_density_option_group(parser):
                          "is to use scipy's gaussian_kde.")
 
     return density_group
-
-
-__all__ = ['add_sampler_option_group', 'sampler_from_cli', 'data_from_cli',
-           'add_inference_results_option_group', 'results_from_cli',
-           'get_zvalues', 'add_plot_posterior_option_group',
-           'plot_ranges_from_cli', 'expected_parameters_from_cli',
-           'add_scatter_option_group', 'add_density_option_group',
-           ]

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -321,9 +321,9 @@ class InferenceFile(h5py.File):
             self[group.format(ifo=ifo)] = psds[ifo]
             self[group.format(ifo=ifo)].attrs['delta_f'] = psds[ifo].delta_f
 
-    def write_data_to_output(self, strain_dict=None, stilde_dict=None,
-                             psd_dict=None, low_frequency_cutoff_dict=None,
-                             group=None):
+    def write_data(self, strain_dict=None, stilde_dict=None,
+                   psd_dict=None, low_frequency_cutoff_dict=None,
+                   group=None):
         """Writes the strain/stilde/psd.
 
         Parameters

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -27,7 +27,7 @@ inference samplers generate.
 
 import h5py
 import numpy
-from pycbc import pnutils, DYN_RANGE_FAC
+from pycbc import DYN_RANGE_FAC
 from pycbc.types import FrequencySeries
 from pycbc.waveform import parameters as wfparams
 import pycbc.inference.sampler
@@ -324,11 +324,10 @@ class InferenceFile(h5py.File):
             # plotting code expects it
             psd_dyn_dict = {}
             for key,val in psd_dict.iteritems():
-                 psd_dyn_dict[key] = FrequencySeries(
-                                            psd_dict[key] * DYN_RANGE_FAC**2,
-                                            delta_f=psd_dict[key].delta_f)
+                 psd_dyn_dict[key] = FrequencySeries(val*DYN_RANGE_FAC**2,
+                                                     delta_f=val.delta_f)
             self.write_psd(psds=psd_dyn_dict,
-                         low_frequency_cutoff=low_frequency_cutoff_dict)
+                           low_frequency_cutoff=low_frequency_cutoff_dict)
 
         # save stilde
         if stilde_dict is not None:


### PR DESCRIPTION
This patch moves the block of code that loads the psd, the strain, and FFTs the strain that's currently in `pycbc_inference` to a single function called `data_from_cli` in `option_utils`. The patch also moves the block of code for writing the strain/stilde/psd to a class method of `InferenceFile`.

@cmbiwer: This is unrelated to our patches for the spin priors project. The motivation for this is it is the first in a series of patches to get a hierarchical inference executable I wrote for doing the area theorem on to master. That program is basically a copy of `pycbc_inference`, but it allows you to do a single MCMC on different waveform models and data that share a subset of common parameters. For example, in the area theorem test, the inspiral and ringdown are distinct models looking at different parts of the data, but they share the same sky locations. This may also be useful for doing the no hair theorem test, and, if wish to do it at some point, testing GR. If you're curious, the program is currently on [this branch](https://github.com/cdcapano/pycbc/blob/multievent_inference_dtprior/bin/inference/pycbc_hierarchical_inference). Since that program and `pycbc_inference` have to do a number of common things, the first step is to move those common blocks of code to functions, to make it easier to keep both programs up to date in the future.