### PR TITLE
Move config file loading to option utils

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -34,18 +34,7 @@ from pycbc import strain
 from pycbc import types
 from pycbc.io.inference_hdf import InferenceFile
 from pycbc.waveform import generator
-from pycbc.workflow import WorkflowConfigParser
 from pycbc.inference import option_utils
-
-def convert_liststring_to_list(lstring):
-    """ Checks if an argument of the configuration file is a string of a list
-    and returns the corresponding list (of strings)
-    """
-    if lstring[0]=='[' and lstring[-1]==']':
-        lvalue = [str(lstring[1:-1].split(',')[n].strip().strip("'"))
-                      for n in range(len(lstring[1:-1].split(',')))]
-    return lvalue
-
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
@@ -74,13 +63,7 @@ parser.add_argument("--seed", type=int, default=0,
 option_utils.add_sampler_option_group(parser)
 
 # add config options
-parser.add_argument("--config-files", type=str, nargs="+", required=True,
-                    help="A file parsable by "
-                         "pycbc.workflow.WorkflowConfigParser.")
-parser.add_argument("--config-overrides", type=str, nargs="+", default=None,
-                    metavar="SECTION:OPTION:VALUE",
-                    help="List of section:option:value combinations to add "
-                         "into the configuration file.")
+option_utils.add_config_opts_to_parser(parser)
 
 # output options
 parser.add_argument("--output-file", type=str, required=True,
@@ -153,33 +136,10 @@ low_frequency_cutoff_dict = option_utils.low_frequency_cutoff_from_cli(opts)
 with ctx:
 
     # read configuration file
-    logging.info("Reading configuration file")
-    if opts.config_overrides is not None:
-        overrides = [override.split(":") for override in opts.config_overrides]
-    else:
-        overrides = None
-    cp = WorkflowConfigParser(opts.config_files, overrides)
+    cp = option_utils.config_parser_from_cli(opts)
 
-    # sanity check that each parameter in [variable_args] has a priors section
-    variable_args = cp.options("variable_args")
-    subsections = cp.get_subsections("prior")
-    tags = numpy.concatenate([tag.split("+") for tag in subsections])
-    if not any(param in tags for param in variable_args):
-        raise KeyError("You are missing a priors section in the config file.")
-
-    # get parameters that do not change in sampler
-    static_args = dict([(key,cp.get_opt_tags("static_args",key,[])) \
-                                         for key in cp.options("static_args")])
-    for key,val in static_args.iteritems():
-        try:
-            static_args[key] = float(val)
-            continue
-        except:
-            pass
-        try:
-            static_args[key] = convert_liststring_to_list(val) 
-        except:
-            pass
+    # get the vairable and static arguments from the config file
+    variable_args, static_args = option_utils.read_args_from_config(cp)
 
     # get prior distribution for each variable parameter
     logging.info("Setting up priors for each parameter")

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -18,7 +18,9 @@
 """
 
 import logging
+import numpy
 from pycbc.io import InferenceFile
+from pycbc.workflow import WorkflowConfigParser
 import pycbc.inference.sampler
 from pycbc.inference import likelihood
 from pycbc.pool import choose_pool
@@ -26,6 +28,101 @@ from pycbc.psd import from_cli_multi_ifos as psd_from_cli_multi_ifos
 from pycbc.strain import from_cli_multi_ifos as strain_from_cli_multi_ifos
 from pycbc.gate import gates_from_cli, psd_gates_from_cli, apply_gates_to_td, \
                        apply_gates_to_fd
+
+
+#-----------------------------------------------------------------------------
+#
+#                   Utilities for loading config files
+#
+#-----------------------------------------------------------------------------
+
+def convert_liststring_to_list(lstring):
+    """Checks if an argument of the configuration file is a string of a list
+    and returns the corresponding list (of strings).
+    """
+    if lstring[0]=='[' and lstring[-1]==']':
+        lvalue = [str(lstring[1:-1].split(',')[n].strip().strip("'"))
+                      for n in range(len(lstring[1:-1].split(',')))]
+    return lvalue
+
+
+def add_config_opts_to_parser(parser):
+    """Adds options for the configuration files to the given parser.
+    """
+    parser.add_argument("--config-files", type=str, nargs="+", required=True,
+                        help="A file parsable by "
+                             "pycbc.workflow.WorkflowConfigParser.")
+    parser.add_argument("--config-overrides", type=str, nargs="+",
+                        default=None, metavar="SECTION:OPTION:VALUE",
+                        help="List of section:option:value combinations to "
+                             "add into the configuration file.")
+
+
+def config_parser_from_cli(opts):
+    """Loads a config file from the given options, applying any overrides
+    specified. Specifically, config files are loaded from the `--config-files`
+    options while overrides are loaded from `--config-overrides`.
+    """
+    # read configuration file
+    logging.info("Reading configuration file")
+    if opts.config_overrides is not None:
+        overrides = [override.split(":") for override in opts.config_overrides]
+    else:
+        overrides = None
+    return WorkflowConfigParser(opts.config_files, overrides)
+
+
+def read_args_from_config(cp, section_group=None):
+    """Given an open config file, loads the static and variable arguments to
+    use in the parameter estmation run.
+
+    Parameters
+    ----------
+    cp : WorkflowConfigParser
+        An open config parser to read from.
+    section_group : {None, str}
+        When reading the config file, only read from sections that begin with
+        `{section_group}_`. For example, if `section_group='foo'`, the
+        variable arguments will be retrieved from section
+        `[foo_variable_args]`. If None, no prefix will be appended to section
+        names.
+
+    Returns
+    -------
+    variable_args : list
+        The names of the parameters to vary in the PE run.
+    static_args : dict
+        Dictionary of names -> values giving the parameters to keep fixed.
+    """
+    logging.info("Loading arguments")
+    if section_group is not None:
+        section_prefix = '{}_'.format(section_group)
+    else:
+        section_prefix = ''
+
+    # sanity check that each parameter in [variable_args] has a priors section
+    variable_args = cp.options("{}variable_args".format(section_prefix))
+    subsections = cp.get_subsections("{}prior".format(section_prefix))
+    tags = numpy.concatenate([tag.split("+") for tag in subsections])
+    if not any(param in tags for param in variable_args):
+        raise KeyError("You are missing a priors section in the config file.")
+
+    # get parameters that do not change in sampler
+    static_args = dict([(key,cp.get_opt_tags(
+        "{}static_args".format(section_prefix), key, []))
+        for key in cp.options("{}static_args".format(section_prefix))])
+    for key,val in static_args.iteritems():
+        try:
+            static_args[key] = float(val)
+            continue
+        except:
+            pass
+        try:
+            static_args[key] = convert_liststring_to_list(val) 
+        except:
+            pass
+
+    return variable_args, static_args
 
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Another patch in order to prepare for hierarchical inference, this one moves the blocks of code that load the config file to functions in `option_utils.py`.