### PR TITLE
Added code to print loudest events to a wiki table

### DIFF
--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -37,6 +37,13 @@ def to_file(path, ifo=None):
     fil.PFN(path, 'local')
     return fil
 
+def add_wiki_row(outfile, cols):
+    """
+    Adds a wiki-formatted row to an output file from a list or a numpy array.
+    """
+    with open(outfile, 'a') as f:
+        f.write('||%s||\n' % '||'.join(map(str,cols)))
+
 parser = argparse.ArgumentParser(description=__doc__[1:])
 parser.add_argument('--version', action='version', version=pycbc.version.git_verbose_msg) 
 parser.add_argument('--workflow-name', default='my_unamed_run')
@@ -94,7 +101,7 @@ wf.makedir(args.output_dir)
 if args.wiki_file:
     # initialize a wiki table and add the column headers
     wiki_file = os.path.join(args.output_dir, args.wiki_file)
-    mini.add_wiki_row(wiki_file, ['GPS time', 'UTC time', 'newSNR', 'SNR', 
+    add_wiki_row(wiki_file, ['GPS time', 'UTC time', 'newSNR', 'SNR', 
                       'm1', 'm2', 's1', 's2', 'duration', 'omega', 'notes', 
                       'veto'])
 
@@ -207,7 +214,7 @@ for num_event in range(num_events):
         pass
 
     if wiki_file:
-        mini.add_wiki_row(wiki_file, [time, 
+        add_wiki_row(wiki_file, [time, 
                           str(datetime.datetime(*GPSToUTC(int(time))[0:6])),
                           trigs.stat[num_event], trigs.snr[num_event],
                           curr_params['mass1'], curr_params['mass2'],

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -16,8 +16,9 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """ Followup foreground events
 """
-import os, sys, argparse, logging, h5py
+import os, sys, argparse, logging, h5py, datetime
 import numpy
+from lal import GPSToUTC
 from pycbc_glue.ligolw import lsctables, table
 from pycbc_glue.ligolw import utils as ligolw_utils
 from pycbc.results import layout
@@ -73,6 +74,8 @@ parser.add_argument('--minimum-duration', default=None, type=float,
 parser.add_argument('--maximum-duration', default=None, type=float,
                     help="If given only consider single-detector triggers "
                          "with template duration smaller than this.")
+parser.add_argument('--wiki-file',
+                    help="Name of file to save wiki-formatted table in")
 parser.add_argument('--output-map')
 parser.add_argument('--output-file')
 parser.add_argument('--tags', nargs='+', default=[])
@@ -87,7 +90,14 @@ workflow.ifos = [args.instrument]
 workflow.ifo_string = args.instrument
 
 wf.makedir(args.output_dir)
-             
+
+if args.wiki_file:
+    # initialize a wiki table and add the column headers
+    wiki_file = os.path.join(args.output_dir, args.wiki_file)
+    mini.add_wiki_row(wiki_file, ['GPS time', 'UTC time', 'newSNR', 'SNR', 
+                      'm1', 'm2', 's1', 's2', 'duration', 'omega', 'notes', 
+                      'veto'])
+
 # create a FileList that will contain all output files
 layouts = []
 
@@ -195,6 +205,14 @@ for num_event in range(num_events):
         curr_params['u_vals'] = trigs.u_vals[num_event]
     except:
         pass
+
+    if wiki_file:
+        mini.add_wiki_row(wiki_file, [time, 
+                          str(datetime.datetime(*GPSToUTC(int(time))[0:6])),
+                          trigs.stat[num_event], trigs.snr[num_event],
+                          curr_params['mass1'], curr_params['mass2'],
+                          curr_params['spin1z'], curr_params['spin2z'],
+                          trigs.template_duration[num_event], ' ',' ',' '])
 
     files += mini.make_single_template_plots(workflow, insp_segs,
                             args.inspiral_data_read_name,

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -655,10 +655,3 @@ def create_noop_node():
     exe.add_pfn(pfn)
     node = wdax.Node(exe)
     return node
-
-def add_wiki_row(outfile, cols):
-    """
-    Adds a wiki-formatted row to an output file from a list or a numpy array.
-    """
-    with open(outfile, 'a') as f:
-        f.write('||%s||\n' % '||'.join(map(str,cols)))

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -167,6 +167,8 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     exe = Executable(workflow.cp, 'singles_minifollowup',
                      ifos=curr_ifo, out_dir=dax_output, tags=tags)
 
+    wikifile = curr_ifo + '_'.join(tags) + 'loudest_table.txt'
+
     node = exe.create_node()
     node.add_input_opt('--config-files', config_file)
     node.add_input_opt('--bank-file', tmpltbank_file)
@@ -175,6 +177,7 @@ def setup_single_det_minifollowups(workflow, single_trig_file, tmpltbank_file,
     node.add_opt('--inspiral-data-read-name', insp_data_name)
     node.add_opt('--inspiral-data-analyzed-name', insp_anal_name)
     node.add_opt('--instrument', curr_ifo)
+    node.add_opt('--wiki-file', wikifile)
     if veto_file is not None:
         assert(veto_segment_name is not None)
         node.add_input_opt('--veto-file', veto_file)
@@ -652,3 +655,10 @@ def create_noop_node():
     exe.add_pfn(pfn)
     node = wdax.Node(exe)
     return node
+
+def add_wiki_row(outfile, cols):
+    """
+    Adds a wiki-formatted row to an output file from a list or a numpy array.
+    """
+    with open(outfile, 'a') as f:
+        f.write('||%s||\n' % '||'.join(map(str,cols)))


### PR DESCRIPTION
This PR adds the functionality to print the loudest events in `pycbc_sngl_minifollowup` to the output directory of the loudest events.

I added a function to `minifollowups.py` to take a list or a numpy array and print it to a file with wiki table delimiting (`||`). If the `--wiki-file` option is provided to `pycbc_sngl_minifollowup`, this file will be written to the indicated output directory. I added this option to `setup_single_det_minifollowups()` so that the list of loudest events will be built every time `pycbc_sngl_minifollowup` is called.

I grabbed an example call of `pycbc_sngl_minifollowup` from a recent successful workflow and reran it by hand with the `--wiki-file` option and it ran to completion.