### PR TITLE
Add ability to do PE with time-domain waveforms

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -194,14 +194,13 @@ with ctx:
     generator_function = generator.select_waveform_generator(
                                                     static_args["approximant"])
 
-    # construct instance that will call single IFO waveform generator
-    # and apply the antenna pattern and timing offsets
-    generator = generator.FDomainDetFrameGenerator(
-                        generator_function,
-                        epoch=stilde_dict.values()[0].epoch,
-                        variable_args=variable_args,
-                        detectors=opts.instruments,
-                        delta_f=stilde_dict.values()[0].delta_f, **static_args)
+    # construct class that will generate waveforms
+    generator = waveform.FDomainDetFrameGenerator(
+                       generator_function, epoch=stilde_dict.values()[0].epoch,
+                       variable_args=variable_args, detectors=opts.instruments,
+                       delta_f=stilde_dict.values()[0].delta_f,
+                       delta_t=strain_dict.values()[0].delta_t,
+                       **static_args)
 
     # construct class that will return the natural logarithm of likelihood
     likelihood = inference.likelihood_evaluators[opts.likelihood_evaluator](

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -242,7 +242,16 @@ class BaseGenerator(object):
 class BaseCBCGenerator(BaseGenerator):
     """Adds ability to convert from various derived parameters to parameters
     needed by the waveform generators.
+
+    Attributes
+    ----------
+    possible_args : set
+        The set of names of arguments that may be used in the `variable_args`
+        or `frozen_params`.
     """
+    possible_args = set(parameters.td_waveform_params +
+                        parameters.fd_waveform_params +
+                        ['taper'])
     def __init__(self, generator, variable_args=(), **frozen_params):
         super(BaseCBCGenerator, self).__init__(generator,
             variable_args=variable_args, **frozen_params)
@@ -258,10 +267,8 @@ class BaseCBCGenerator(BaseGenerator):
                 self._add_pregenerate(func)
                 params_used.update(func.input_params)
         # check that there are no unused parameters
-        all_waveform_input_args = set(parameters.td_waveform_params +
-                                      parameters.fd_waveform_params)
         unused_args = all_args.difference(params_used) \
-                              .difference(all_waveform_input_args)
+                              .difference(self.possible_args)
         if len(unused_args):
             raise ValueError("The following args are not being used: "
                              "{opts}".format(opts=unused_args))

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -573,11 +573,6 @@ class FDomainDetFrameGenerator(object):
             tshift = 0.
         hp._epoch = hc._epoch = self._epoch
         h = {}
-        if 'tc' in self.current_params:
-            try:
-                kmin = int(self.current_params['f_lower']/hp.delta_f)
-            except KeyError:
-                kmin = 0
         if self.detector_names != ['RF']:
             for detname, det in self.detectors.items():
                 # apply detector response function
@@ -590,13 +585,12 @@ class FDomainDetFrameGenerator(object):
                 tc = self.current_params['tc'] + \
                     det.time_delay_from_earth_center(self.current_params['ra'],
                          self.current_params['dec'], self.current_params['tc'])
-                h[detname] = apply_fd_time_shift(thish, tc+tshift, kmin=kmin,
-                                                 copy=False)
+                h[detname] = apply_fd_time_shift(thish, tc+tshift, copy=False)
         else:
             # no detector response, just use the + polarization
             if 'tc' in self.current_params:
-                hp = apply_fd_time_shift(hp, self.current_params['tc'],
-                            kmin=kmin, copy=False)
+                hp = apply_fd_time_shift(hp, self.current_params['tc']+tshift,
+                                         copy=False)
             h['RF'] = hp
         return h
 

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -29,6 +29,7 @@ import functools
 import waveform
 import ringdown
 from pycbc import coordinates
+from pycbc import filter
 from pycbc.waveform import parameters
 from pycbc.waveform.utils import apply_fd_time_shift
 from pycbc.detector import Detector
@@ -547,6 +548,8 @@ class FDomainDetFrameGenerator(object):
         rfparams = dict([(param, self.current_params[param])
             for param in self.rframe_generator.variable_args])
         hp, hc = self.rframe_generator.generate_from_kwargs(**rfparams)
+        hp = filter.make_frequency_series(hp)
+        hc = filter.make_frequency_series(hc)
         hp._epoch = hc._epoch = self._epoch
         h = {}
         if 'tc' in self.current_params:

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -377,6 +377,8 @@ redshift = Parameter("redshift",
 #
 #   Non mandatory flags with default values
 #
+taper = Parameter("taper", dtype=str, default='TAPER_NONE',
+                description="Apply a taper to a time domain waveform.")
 frame_axis = Parameter("frame_axis",
                 dtype=int, default=0,
                 description="Allow to choose among orbital_l, view and total_j")
@@ -437,7 +439,7 @@ fd_waveform_params = cbc_rframe_params + ParameterList([delta_f]) + \
     common_gen_equal_sampled_params + ParameterList([f_final, f_final_func])
 
 # the following are parameters needed to generate a TD waveform
-td_waveform_params = cbc_rframe_params + ParameterList([delta_t]) + \
+td_waveform_params = cbc_rframe_params + ParameterList([delta_t, taper]) + \
     common_gen_equal_sampled_params + ParameterList([numrel_data]) + \
     flags_generation_params
 

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -377,8 +377,6 @@ redshift = Parameter("redshift",
 #
 #   Non mandatory flags with default values
 #
-taper = Parameter("taper", dtype=str, default='TAPER_NONE',
-                description="Apply a taper to a time domain waveform.")
 frame_axis = Parameter("frame_axis",
                 dtype=int, default=0,
                 description="Allow to choose among orbital_l, view and total_j")
@@ -439,7 +437,7 @@ fd_waveform_params = cbc_rframe_params + ParameterList([delta_f]) + \
     common_gen_equal_sampled_params + ParameterList([f_final, f_final_func])
 
 # the following are parameters needed to generate a TD waveform
-td_waveform_params = cbc_rframe_params + ParameterList([delta_t, taper]) + \
+td_waveform_params = cbc_rframe_params + ParameterList([delta_t]) + \
     common_gen_equal_sampled_params + ParameterList([numrel_data]) + \
     flags_generation_params
 


### PR DESCRIPTION
This supersedes #1211. The patch adds the ability to use time domain waveforms in `pycbc_inference`. A taper argument can be added to the ini file to taper the time domain waveform before converting to the frequency domain. It also adds the additional time shift needed to a TD waveform, since they are not generated such that the peak amplitude is at the end of a segment, as a FD waveform is.