### PR TITLE
Clarification in the inference doc

### DIFF
--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -310,7 +310,7 @@ With a minor change to the ``tc`` prior, you can reuse ``inference.ini`` from th
 Then run::
 
     # trigger parameters
-    TRIGGER_TIME=1126259462.0
+    TRIGGER_TIME=1126259462.42
 
     # data to use
     # the longest waveform covered by the prior must fit in these times
@@ -350,8 +350,8 @@ Then run::
     TRIGGER_TIME_INT=${TRIGGER_TIME%.*}
 
     # start and end time of data to read in
-    GPS_START_TIME=$((${TRIGGER_TIME_INT} - ${SEGLEN}))
-    GPS_END_TIME=$((${TRIGGER_TIME_INT} + ${SEGLEN}))
+    GPS_START_TIME=$((${TRIGGER_TIME_INT} - ${SEARCH_BEFORE} - ${PSD_INVLEN}))
+    GPS_END_TIME=$((${TRIGGER_TIME_INT} + ${SEARCH_AFTER} + ${PSD_INVLEN}))
 
     # start and end time of data to read in for PSD estimation
     PSD_START_TIME=$((${GPS_START_TIME} - ${PSD_DATA_LEN}/2))

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -299,7 +299,15 @@ An example of running ``pycbc_inference`` to analyze the injection in fake data:
 GW150914 example
 ----------------
 
-You can reuse ``inference.ini`` from the previous example to analyze a signal in real data::
+With a minor change to the ``tc`` prior, you can reuse ``inference.ini`` from the previous example to analyze the data containing GW150914. Change the ``[prior-tc]`` section to::
+
+    [prior-tc]
+    ; coalescence time prior
+    name = uniform
+    min-tc = 1126259461.8
+    max-tc= 1126259462.2
+
+Then run::
 
     # trigger parameters
     TRIGGER_TIME=1126259462.0
@@ -328,7 +336,6 @@ You can reuse ``inference.ini`` from the previous example to analyze a signal in
     OUTPUT_PATH=inference.hdf
     SEGLEN=8
     IFOS="H1 L1"
-    STRAIN="H1:aLIGOZeroDetHighPower L1:aLIGOZeroDetHighPower"
     SAMPLE_RATE=2048
     F_HIGHPASS=20
     F_MIN=30.

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -114,7 +114,7 @@ An example configuration file (named ``inference.ini``) is::
     ; coalescence time prior
     name = uniform
     min-tc = 1126259461.8
-    max-tc= 1126259462.2
+    max-tc = 1126259462.2
 
     [prior-mchirp]
     name = uniform
@@ -304,8 +304,8 @@ With a minor change to the ``tc`` prior, you can reuse ``inference.ini`` from th
     [prior-tc]
     ; coalescence time prior
     name = uniform
-    min-tc = 1126259461.8
-    max-tc= 1126259462.2
+    min-tc = 1126259462.32
+    max-tc = 1126259462.52
 
 Then run::
 


### PR DESCRIPTION
This clarifies that the tc prior needs to change from the BBH example in order to run on GW150914.