### PR TITLE
Use template's f_lower in minifollowups

### DIFF
--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -145,6 +145,7 @@ for num_event in range(num_events):
     params['mass2'] = bank_data['mass2'][bank_id]
     params['spin1z'] = bank_data['spin1z'][bank_id]
     params['spin2z'] = bank_data['spin2z'][bank_id]
+    params['f_lower'] = bank_data['f_lower'][bank_id]
     # don't require precessing template info if not present
     try:
         params['spin1x'] = bank_data['spin1x'][bank_id]

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -218,6 +218,7 @@ for num_event in range(num_events):
         curr_params['mass2'] = hd_sngl.mass2
         curr_params['spin1z'] = hd_sngl.spin1z
         curr_params['spin2z'] = hd_sngl.spin2z
+        curr_params['f_lower'] = hd_sngl.f_lower
         # don't require precessing template info if not present
         try:
             curr_params['spin1x'] = hd_sngl.spin1x

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -197,6 +197,7 @@ for num_event in range(num_events):
     curr_params['mass2'] = trigs.mass2[num_event]
     curr_params['spin1z'] = trigs.spin1z[num_event]
     curr_params['spin2z'] = trigs.spin2z[num_event]
+    curr_params['f_lower'] = trigs.f_lower[num_event]
     curr_params[args.instrument + '_end_time'] = time
     # don't require precessing template info if not present
     try:

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -121,6 +121,10 @@ parser.add_argument("--spin1z", type=float, default=0,
 parser.add_argument("--spin2z", type=float, default=0,
                   help="The aligned pin of the second component object. "
                       "Do not use if using --use-params-of-closest-injection.")
+parser.add_argument("--template-start-frequency", type=float, default=None,
+                  help="If given, use this as a start frequency for "
+                       "generating the template. If not given the "
+                       "--low-frequency-cutoff is used.")
 # Optional arguments for precessing templates
 parser.add_argument("--spin1x", type=float, default=0,
                   help="The non-aligned spin of the first component object. "
@@ -216,6 +220,9 @@ if not opt.use_params_of_closest_injection:
 with ctx:
     fft.from_cli(opt)
     flow = opt.low_frequency_cutoff
+    template_flow = opt.template_start_frequency
+    if template_flow is None:
+        template_flow = flow
     flen = strain_segments.freq_len
     delta_f = strain_segments.delta_f
 
@@ -273,7 +280,7 @@ with ctx:
                                     template=row[0],
                                     inclination=opt.inclination,
                                     taper=opt.taper_template, 
-                                    f_lower=flow, delta_f=delta_f,
+                                    f_lower=template_flow, delta_f=delta_f,
                                     delta_t=gwstrain.delta_t,
                                     distance = 1.0/pycbc.DYN_RANGE_FAC)
         else:
@@ -283,7 +290,7 @@ with ctx:
                                     approximant=approximant,
                                     inclination=opt.inclination,
                                     taper=opt.taper_template,
-                                    f_lower=flow, delta_f=delta_f,
+                                    f_lower=template_flow, delta_f=delta_f,
                                     delta_t=gwstrain.delta_t)
             template = tc.multiply_and_add(tp, opt.u_val)
 
@@ -347,7 +354,7 @@ with ctx:
                                     
         if opt.subtract_template:
             stilde = subtract_template(stilde, template,
-                                snr, opt.trigger_time, opt.low_frequency_cutoff)
+                                       snr, opt.trigger_time, flow)
             snr, corr, norm = filter.matched_filter_core(template, stilde, 
                                 psd=stilde.psd,
                                 low_frequency_cutoff=flow)

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -494,6 +494,11 @@ class SingleDetTriggers(object):
         return np.array(self.bank['inclination'])[self.template_id]
 
     @property
+    def f_lower(self):
+        self.checkbank('f_lower')
+        return np.array(self.bank['f_lower'])[self.template_id]
+
+    @property
     def mtotal(self):
         return self.mass1 + self.mass2
 

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -373,7 +373,7 @@ def make_single_template_plots(workflow, segs, data_read_name, analyzed_name,
                 node.add_opt('--mass2', "%.6f" % params['mass2'])
                 node.add_opt('--spin1z',"%.6f" % params['spin1z'])
                 node.add_opt('--spin2z',"%.6f" % params['spin2z'])
-                node.add_opt('--low-frequency-cutoff',
+                node.add_opt('--template-start-frequency',
                              "%.6f" % params['f_lower'])
                 # Is this precessing?
                 if params.has_key('u_vals') or \

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -373,6 +373,8 @@ def make_single_template_plots(workflow, segs, data_read_name, analyzed_name,
                 node.add_opt('--mass2', "%.6f" % params['mass2'])
                 node.add_opt('--spin1z',"%.6f" % params['spin1z'])
                 node.add_opt('--spin2z',"%.6f" % params['spin2z'])
+                node.add_opt('--low-frequency-cutoff',
+                             "%.6f" % params['flower'])
                 # Is this precessing?
                 if params.has_key('u_vals') or \
                                              params.has_key('u_vals_%s' % ifo):

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -374,7 +374,7 @@ def make_single_template_plots(workflow, segs, data_read_name, analyzed_name,
                 node.add_opt('--spin1z',"%.6f" % params['spin1z'])
                 node.add_opt('--spin2z',"%.6f" % params['spin2z'])
                 node.add_opt('--low-frequency-cutoff',
-                             "%.6f" % params['flower'])
+                             "%.6f" % params['f_lower'])
                 # Is this precessing?
                 if params.has_key('u_vals') or \
                                              params.has_key('u_vals_%s' % ifo):


### PR DESCRIPTION
This patch resolves the issue noted in #1562 by using the value of f_lower stored in the template bank as an input to `pycbc_single_template` in all minifollowups codes. This is tested here:

https://galahad.aei.mpg.de/~spxiwh/LVC/aLIGO/O2/analyses/O2_chunk10/prelim_analyses/run5_TEST

Note that this requires a small change in the configuration file. Currently `--low-frequency-cutoff` is specified in the config file for all `pycbc_single_template` jobs. Now it would be given in the ini file only for jobs where the injection is going to be used as a template. That change should be coordinated with the 1.7.0 release so I am not making it now.

(Fixes #1562 Fix #1562 Close #1562)