### PR TITLE
Use the pycbc.version module

### DIFF
--- a/bin/pycbc_banksim_combine_banks
+++ b/bin/pycbc_banksim_combine_banks
@@ -27,17 +27,16 @@ import argparse
 import logging
 from numpy import *
 import pycbc
+import pycbc.version
 
 __author__  = "Ian Harry <ian.harry@astro.cf.ac.uk>"
-__version__ = pycbc.version.git_verbose_msg
-__date__    = pycbc.version.date
 __program__ = "pycbc_banksim_combine_banks"
 
 # Read command line options
 _desc = __doc__[1:]
 parser = argparse.ArgumentParser(description=_desc)
 
-parser.add_argument("--version", action="version", version=__version__)
+parser.add_argument('--version', action=pycbc.version.Version)
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="verbose output")
 parser.add_argument("-I", "--input-files", nargs='+',


### PR DESCRIPTION
Update to use the new ``pycbc.version`` module, as this code currently causes travis to fail with
```
---------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/pycbc-build/environment/bin/pycbc_banksim_combine_banks", line 4, in <module>
    __import__('pkg_resources').run_script('PyCBC===73e4a5', 'pycbc_banksim_combine_banks')
  File "/home/travis/build/pycbc-build/environment/lib/python2.7/site-packages/pkg_resources/__init__.py", line 735, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/home/travis/build/pycbc-build/environment/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1652, in run_script
    exec(code, namespace, namespace)
  File "/home/travis/build/pycbc-build/environment/lib/python2.7/site-packages/PyCBC-73e4a5-py2.7.egg/EGG-INFO/scripts/pycbc_banksim_combine_banks", line 32, in <module>
    __version__ = pycbc.version.git_verbose_msg
AttributeError: 'module' object has no attribute 'version'
---------------------------------------------------------
```