### PR TITLE
Dqsegdb now properly on PyPI, YAY!!

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -197,7 +197,7 @@ To query the new Advanced LIGO and Advanced Virgo Segment Database, you will nee
 
 .. code-block:: bash
 
-    pip install git+https://github.com/ligovirgo/dqsegdb@clean_pip_install_1_4_1#egg=dqsegdb
+    pip install dqsegdb
 
 For uploading triggers to GraceDB at the end of the workflow you will need to have the gracedb client tools installed. The latest release is in pip
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ jinja2
 mpld3>=0.3
 pyRXP>=2.1.0
 pycbc-glue-obsolete==1.1.0
-pycbc-glue==1.0.1
 weave
 
 # Needed for Parameter Estimation Tasks

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -53,10 +53,7 @@ pip install http://download.pegasus.isi.edu/pegasus/4.7.4/pegasus-python-source-
 SWIG_FEATURES="-cpperraswarn -includeall -I/usr/include/openssl" pip install M2Crypto
 
 # install the segment database tools
-pip install git+https://github.com/ligovirgo/dqsegdb@clean_pip_install_1_4_1#egg=dqsegdb
-# FIXME: For now dqsegdb needs a glue, which it does not declare. Please remove
-#        when no longer needed.
-pip install pycbc-glue
+pip install dqsegdb
 
 # install the packges needed to build the documentation
 pip install "Sphinx>=1.4.2"


### PR DESCRIPTION
@duncan-brown This reverts the hack I had to introduce to ensure that old-glue got installed for Travis. I also update both the install instructions and Travis to install dqsegdb "properly" instead of the old hacky thing we had to do because it wasn't on PyPI. Would like this in v1.7.0.

Thanks Ryan Fisher for fixing this for us!