### PR TITLE
Speed up Travis using PyCBC docker containers and additional caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,20 +81,23 @@ deploy:
     tags: true
     condition: $PYCBC_CONTAINER = build_and_test
 before_cache:
-- rm -rf $HOME/pycbc-sources/lalsuite
-- rm -rf $HOME/pycbc-sources/pycbc
-- rm -rf $HOME/pycbc-sources/pyinstaller
-- rm -rf $HOME/pycbc-sources/test/pycbc_inspiral
-- rm -f $HOME/pycbc-sources/test/lal-data-r7.tar.gz
-- rm -f $HOME/pycbc-sources/test/H1-INSPIRAL-OUT.hdf
-- rm -f $HOME/pycbc-sources/libframe-*.tar.gz
-- rm -f $HOME/pycbc-sources/metaio-*.tar.gz
-- rm -f $HOME/pycbc-sources/pegasus-python-source-*.tar.gz
-- rm -f $HOME/pycbc-sources/Python-*.tgz
-- rm -f $HOME/pycbc-sources/swig-*.tar.gz
+- rm -rf $HOME/build/pycbc-sources/lalsuite
+- rm -rf $HOME/build/pycbc-sources/pycbc
+- rm -rf $HOME/build/pycbc-sources/pyinstaller
+- rm -rf $HOME/build/pycbc-sources/test/pycbc_inspiral
+- rm -f $HOME/build/pycbc-sources/test/lal-data-r7.tar.gz
+- rm -f $HOME/build/pycbc-sources/test/H1-INSPIRAL-OUT.hdf
+- rm -f $HOME/build/pycbc-sources/libframe-*.tar.gz
+- rm -f $HOME/build/pycbc-sources/metaio-*.tar.gz
+- rm -f $HOME/build/pycbc-sources/pegasus-python-source-*.tar.gz
+- rm -f $HOME/build/pycbc-sources/Python-*.tgz
+- rm -f $HOME/build/pycbc-sources/swig-*.tar.gz
+- ls -al $HOME/build/pycbc-sources
+- ls -al $HOME/build/pycbc-sources/test
 cache:
   directories:
   - $HOME/.cache/pip
   - $HOME/build/.cache/pip
   - $HOME/build/pycbc-sources
+  - $HOME/docker-cache
   timeout: 600

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,8 @@ matrix:
     services:
     - docker
 before_install:
-- if [ "x${OS_NAME}" == "xcentos" ] ; then sudo docker pull centos:centos${OS_VERSION} ; fi
-- if [ "x${OS_NAME}" == "xscientific" ] ; then sudo docker pull cern/slc${OS_VERSION}-base ; fi
+- if [ "x${OS_NAME}" == "xcentos" ] ; then sudo docker pull pycbc/ldg-el7; fi
+- if [ "x${OS_NAME}" == "xscientific" ] ; then sudo docker pull pycbc/sl6-travis ; fi
 install:
 - touch ~/.ssh/id_rsa ~/.ssh/ldg_user ~/.ssh/ldg_token
 - chmod 600 ~/.ssh/id_rsa ~/.ssh/ldg_user ~/.ssh/ldg_token

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -48,14 +48,6 @@ fi
 if [ "x${OS_VERSION}" == "x6" ] ; then
   echo -e "\\n>> [`date`] Building pycbc_inspiral bundle for CentOS 6"
 
-  # install requirements into docker container
-  yum install --debuglevel=1 -y gcc gcc-c++ gcc-gfortran python-devel pcre-devel autoconf automake \
-      zlib-devel libpng-devel libjpeg-devel libsqlite3-dev sqlite-devel wget db4-devel git \
-      bzip2 zip python-devel fftw-devel openssl-devel gsl-devel lapack-devel freetype-devel tar
-  ln -s /usr/bin/g++ /usr/bin/g++-4.4.7
-  ln -s /usr/bin/gcc /usr/bin/gcc-4.4.7
-  ln -s /usr/bin/gfortran /usr/bin/gfortran-4.4.7
-
   # create working dir for build script
   BUILD=/pycbc/build
   mkdir -p ${BUILD}
@@ -101,26 +93,6 @@ fi
 
 if [ "x${OS_VERSION}" == "x7" ] ; then
   echo -e "\\n>> [`date`] Building pycbc virtual environment for CentOS 7"
-
-  echo -e "\\n>> [`date`] Installing LDG RPMs"
-  rpm -ivh http://software.ligo.org/lscsoft/scientific/7.2/x86_64/production/lscsoft-production-config-1.3-1.el7.noarch.rpm
-  yum clean all &>/dev/null
-  yum makecache  &>/dev/null
-  yum update &>/dev/null
-  yum -q -y install lscsoft-backports-config
-  yum -q -y install lscsoft-epel-config
-  curl http://download.pegasus.isi.edu/wms/download/rhel/7/pegasus.repo > /etc/yum.repos.d/pegasus.repo
-  yum clean all &>/dev/null
-  yum makecache &>/dev/null
-  yum update &>/dev/null
-  yum -q -y install lscsoft-ius-config
-  yum clean all &>/dev/null
-  yum makecache &>/dev/null
-  yum --debuglevel=1 -y install git2u-all lscsoft-all
-  yum install -q -y zlib-devel libpng-devel libjpeg-devel libsqlite3-dev sqlite-devel db4-devel patch
-  rpm -Uvh https://repo.grid.iu.edu/osg/3.3/osg-3.3-el7-release-latest.rpm
-  yum clean all &>/dev/null
-  yum install -q -y globus-gsi-cert-utils-progs gsi-openssh-clients osg-ca-certs ligo-proxy-utils
 
   echo -e "\\n>> [`date`] Removing LAL RPMs"
   yum -y -q remove "*lal*"

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -22,6 +22,12 @@ if [ "x${OS_NAME}" != "xubuntu" ] ; then
     mkdir -p $HOME/docker-cache
     sudo docker cp buildvm:/pycbc/build/pycbc-sources/pycbc-build-preinst.tgz $HOME/docker-cache/pycbc-build-preinst.tgz
     sudo docker cp buildvm:/pycbc/build/pycbc-sources/pycbc-build-preinst-lalsuite.tgz $HOME/docker-cache/pycbc-build-preinst-lalsuite.tgz
+    sudo docker cp buildvm:/pycbc/build/pycbc-sources/test/H1L1-SBANK_FOR_GW150914ER10.xml.gz $HOME/docker-cache/test/H1L1-SBANK_FOR_GW150914ER10.xml.gz
+    sudo docker cp buildvm:/pycbc/build/pycbc-sources/test/H-H1_LOSC_4_V1-1126257414-4096.gwf $HOME/docker-cache/test/H-H1_LOSC_4_V1-1126257414-4096.gwf
+    ROM_FILES=$(docker run -i -a stdout ${DOCKER_IMG} /bin/bash -c "find /pycbc/build/pycbc-sources/test -name 'SEOB*'")
+    for file in $ROM_FILES; do
+      sudo docker cp buildvm:${file} $HOME/docker-cache/test
+    done
   fi
   exit 0
 fi

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -9,11 +9,14 @@ if [ "x${OS_NAME}" != "xubuntu" ] ; then
     cp -R ~/.ssh .
   fi
   mkdir -p build/pycbc-sources
-  if [ -f $HOME/docker-cache/pycbc-build-preinst.tgz ] ; then
+  if [ -f "$HOME/docker-cache/pycbc-build-preinst.tgz" ] ; then
     cp $HOME/docker-cache/pycbc-build-preinst.tgz build/pycbc-sources
   fi
-  if [ -f $HOME/docker-cache/pycbc-build-preinst-lalsuite.tgz ] ; then
+  if [ -f "$HOME/docker-cache/pycbc-build-preinst-lalsuite.tgz" ] ; then
     cp $HOME/docker-cache/pycbc-build-preinst-lalsuite.tgz build/pycbc-sources
+  fi
+  if [ -f "$HOME/docker-cache/test" ] ; then
+    cp -a $HOME/docker-cache/test build/pycbc-sources/test
   fi
   sudo docker run --name buildvm -v `pwd`:/pycbc:rw ${DOCKER_IMG} /bin/bash -c "bash /pycbc/tools/docker_build_dist.sh --os-version=${OS_VERSION} --pull-request=${TRAVIS_PULL_REQUEST} --commit=${TRAVIS_COMMIT} --secure=${TRAVIS_SECURE_ENV_VARS} --tag=${TRAVIS_TAG}"
   echo -e "\\n>> [`date`] CentOS Docker exited"

--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -3,8 +3,8 @@
 if [ "x${OS_NAME}" != "xubuntu" ] ; then
   set -e
   echo -e "\\n>> [`date`] Starting ${OS_NAME} ${OS_VERSION} docker container"
-  if [ "x${OS_NAME}" == "xcentos" ] ; then DOCKER_IMG="centos:centos${OS_VERSION}" ; fi
-  if [ "x${OS_NAME}" == "xscientific" ] ; then DOCKER_IMG="cern/slc${OS_VERSION}-base" ; fi
+  if [ "x${OS_NAME}" == "xcentos" ] ; then DOCKER_IMG="pycbc/ldg-el7" ; fi
+  if [ "x${OS_NAME}" == "xscientific" ] ; then DOCKER_IMG="pycbc/sl6-travis" ; fi
   if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then
     cp -R ~/.ssh .
   fi


### PR DESCRIPTION
This significantly speeds up the Travis test suite by
 * Using the [SL6](https://hub.docker.com/r/pycbc/sl6-travis/) pre-built Docker container for the ``pycbc_inspiral`` bundle build.
 * Using the [LDG CentOS 7](https://hub.docker.com/r/pycbc/ldg-el7/) pre-built Docker container for the virtual environment build.
 * Caching the E@H build tar balls in the Docker ``pycbc_inspiral`` bundle build.