### PR TITLE
Fix two problems with the Travis build

### DIFF
--- a/tools/run_travis.sh
+++ b/tools/run_travis.sh
@@ -23,6 +23,7 @@ if [ "x${OS_NAME}" != "xubuntu" ] ; then
   if [ "x${OS_NAME}" == "xscientific" ] ; then
     echo -e "\\n>> [`date`] Caching E@H build environment"
     mkdir -p $HOME/docker-cache
+    mkdir -p $HOME/docker-cache/test
     sudo docker cp buildvm:/pycbc/build/pycbc-sources/pycbc-build-preinst.tgz $HOME/docker-cache/pycbc-build-preinst.tgz
     sudo docker cp buildvm:/pycbc/build/pycbc-sources/pycbc-build-preinst-lalsuite.tgz $HOME/docker-cache/pycbc-build-preinst-lalsuite.tgz
     sudo docker cp buildvm:/pycbc/build/pycbc-sources/test/H1L1-SBANK_FOR_GW150914ER10.xml.gz $HOME/docker-cache/test/H1L1-SBANK_FOR_GW150914ER10.xml.gz

--- a/tools/test_coinc_search_workflow.sh
+++ b/tools/test_coinc_search_workflow.sh
@@ -58,7 +58,7 @@ pycbc_make_coinc_search_workflow \
   ${CONFIG_PATH}/O2/pipeline/injections.ini \
   ${CONFIG_PATH}/O2/pipeline/plotting.ini \
 --config-overrides \
-  "workflow:datafind-check-frames-exist:warn" \
+  "workflow-datafind:datafind-check-frames-exist:warn" \
   "workflow:start-time:$((1126259462 - 1800))" \
   "workflow:end-time:$((1126259462 + 1800))" \
   "results_page:output-path:${OUTPUT_PATH}" \


### PR DESCRIPTION
This patch fixes this [build error](https://travis-ci.org/ligo-cbc/pycbc/jobs/220413735#L5995) by fixing the section for ``datafind-check-frames-exist`` and this [build error](https://travis-ci.org/ligo-cbc/pycbc/jobs/220419735#L795) by creating the missing directory.