### PR TITLE
Move docs to sphinx.ext.napoleon

### DIFF
--- a/docs/conf_std.py
+++ b/docs/conf_std.py
@@ -256,13 +256,6 @@ intersphinx_mapping = {'http://docs.python.org/': None}
 
 napoleon_use_ivar = False
 
-# Ensure that __init__ gets documented for classes ... Not sure why this isn't
-# done by default ...
-def skip(app, what, name, obj, skip, options):
-    if name == "__init__":
-        return False
-    return skip
-
 def setup(app):
     app.connect("autodoc-skip-member", skip)
 

--- a/docs/conf_std.py
+++ b/docs/conf_std.py
@@ -256,7 +256,4 @@ intersphinx_mapping = {'http://docs.python.org/': None}
 
 napoleon_use_ivar = False
 
-def setup(app):
-    app.connect("autodoc-skip-member", skip)
-
 suppress_warnings = ['image.nonlocal_uri']

--- a/docs/conf_std.py
+++ b/docs/conf_std.py
@@ -254,11 +254,6 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None}
 
-# Fix for WARNING: toctree references unknown document
-# http://stackoverflow.com/questions/12206334/sphinx-autosummary-toctree-contains-reference-to-nonexisting-document-warnings
-#numpydoc_show_class_members = False
-#numpydoc_class_members_toctree = False
-
 napoleon_use_ivar = False
 
 # Ensure that __init__ gets documented for classes ... Not sure why this isn't

--- a/docs/conf_std.py
+++ b/docs/conf_std.py
@@ -30,7 +30,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
           'sphinx.ext.intersphinx', 'sphinx.ext.coverage', 
               'sphinx.ext.viewcode', 
             'sphinxcontrib.programoutput',
-         'numpydoc',           'matplotlib.sphinxext.mathmpl',
+         'sphinx.ext.napoleon',           'matplotlib.sphinxext.mathmpl',
           'matplotlib.sphinxext.only_directives',
           'matplotlib.sphinxext.plot_directive', 'sphinx.ext.autosummary']
 
@@ -256,8 +256,10 @@ intersphinx_mapping = {'http://docs.python.org/': None}
 
 # Fix for WARNING: toctree references unknown document
 # http://stackoverflow.com/questions/12206334/sphinx-autosummary-toctree-contains-reference-to-nonexisting-document-warnings
-numpydoc_show_class_members = False
-numpydoc_class_members_toctree = False
+#numpydoc_show_class_members = False
+#numpydoc_class_members_toctree = False
+
+napoleon_use_ivar = False
 
 # Ensure that __init__ gets documented for classes ... Not sure why this isn't
 # done by default ...

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -291,7 +291,7 @@ To build the documentation from your virtual environment, first make sure that y
 
 .. code-block:: bash
 
-    pip install "Sphinx>=1.4.2"
+    pip install "Sphinx>=1.5.0"
     pip install sphinx-rtd-theme
     pip install git+https://github.com/ligo-cbc/sphinxcontrib-programoutput.git#egg=sphinxcontrib-programoutput
     

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -292,7 +292,6 @@ To build the documentation from your virtual environment, first make sure that y
 .. code-block:: bash
 
     pip install "Sphinx>=1.4.2"
-    pip install numpydoc
     pip install sphinx-rtd-theme
     pip install git+https://github.com/ligo-cbc/sphinxcontrib-programoutput.git#egg=sphinxcontrib-programoutput
     

--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -267,13 +267,13 @@ class UniformSolidAngle(bounded.BoundedDist):
         The name of the polar angle.
     azimuthal_angle : {'phi', str}
         The name of the azimuthal angle.
-    polar_bounds : {None, (min, max)}
+    polar_bounds : {None, tuple}
         Limit the polar angle to the given bounds. If None provided, the polar
         angle will vary from 0 (the north pole) to pi (the south pole). The
         bounds should be specified as factors of pi. For example, to limit
         the distribution to the northern hemisphere, set
         `polar_bounds=(0,0.5)`.
-    azimuthal_bounds : {None, (min, max)}
+    azimuthal_bounds : {None, tuple}
         Limit the azimuthal angle to the given bounds. If None provided, the
         azimuthal angle will vary from 0 to 2pi. The
         bounds should be specified as factors of pi. For example, to limit

--- a/pycbc/psd/__init__.py
+++ b/pycbc/psd/__init__.py
@@ -344,7 +344,7 @@ def generate_overlapping_psds(opt, gwstrain, flen, delta_f, flow,
 
     Returns
     --------
-    psd_and_times : list of (start, end, psd) tuples
+    psd_and_times : list of (start, end, PSD) tuples
         This is a list of tuples containing one entry for each PSD. The first
         and second entries (start, end) in each tuple represent the index
         range of the gwstrain data that was used to estimate that PSD. The

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -587,7 +587,7 @@ def select_waveform_generator(approximant):
 
     Returns
     -------
-    generator
+    generator : (PyCBC generator instance)
         A waveform generator object.
 
     Examples

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -563,7 +563,7 @@ def make_singles_timefreq(workflow, single, bank_file, trig_time, out_dir,
         The time of the trigger being followed up.
     out_dir: str
         Location of directory to output to
-    veto_file: File (optional, default=None)
+    veto_file: pycbc.workflow.core.File (optional, default=None)
         If given use this file to veto triggers to determine the loudest event.
         FIXME: Veto files *should* be provided a definer argument and not just
         assume that all segments should be read.

--- a/pycbc/workflow/pegasus_workflow.py
+++ b/pycbc/workflow/pegasus_workflow.py
@@ -311,7 +311,7 @@ class Workflow(object):
         
         Parameters
         ----------
-        node : Node
+        node : pycbc.workflow.pegasus_workflow.Node
             A node that should be executed as part of this workflow.
         """
         node._finalize()

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ git+https://github.com/ligovirgo/dqsegdb@clean_pip_install_1_4_1#egg=dqsegdb
 
 # For building documentation
 Sphinx>=1.4.2
-numpydoc
 sphinx-rtd-theme
 git+https://github.com/ligo-cbc/sphinxcontrib-programoutput.git#egg=sphinxcontrib-programoutput
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ http://download.pegasus.isi.edu/pegasus/4.7.3/pegasus-python-source-4.7.3.tar.gz
 git+https://github.com/ligovirgo/dqsegdb@clean_pip_install_1_4_1#egg=dqsegdb
 
 # For building documentation
-Sphinx>=1.4.2
+Sphinx>=1.5.0
 sphinx-rtd-theme
 git+https://github.com/ligo-cbc/sphinxcontrib-programoutput.git#egg=sphinxcontrib-programoutput
 

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -163,8 +163,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_virtualenv" ] ; then
   pip install pycbc-pylal
 
   echo -e "\\n>> [`date`] Installing modules needed to build documentation"
-  pip install "Sphinx>=1.4.2"
-  pip install numpydoc
+  pip install "Sphinx>=1.5.0"
   pip install sphinx-rtd-theme
   pip install git+https://github.com/ligo-cbc/sphinxcontrib-programoutput.git#egg=sphinxcontrib-programoutput
 

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -57,8 +57,7 @@ SWIG_FEATURES="-cpperraswarn -includeall -I/usr/include/openssl" pip install M2C
 pip install dqsegdb
 
 # install the packges needed to build the documentation
-pip install "Sphinx>=1.4.2"
-pip install numpydoc
+pip install "Sphinx>=1.5.0"
 pip install sphinx-rtd-theme
 pip install git+https://github.com/ligo-cbc/sphinxcontrib-programoutput.git#egg=sphinxcontrib-programoutput
 


### PR DESCRIPTION
This moves our documentation to use the builtin napoleon extension of Sphinx rather than numpydocs. The main reason for this is to trigger the "Warnings are errors" within the numpy-style formatting that are not triggered with numpydocs. This also removes a dependancy from pycbc!

This makes a minor cosmetic effect to the output pages. Example is here:

http://galahad.aei.mpg.de/~spxiwh/pycbc_docs

As one specific difference see here:

http://galahad.aei.mpg.de/~spxiwh/pycbc_docs/pycbc.psd.html?highlight=generate_overlapping_psds#pycbc.psd.generate_overlapping_psds

(especially the `opt` input parameter, which I messed about with), note that *some* of the classes are automatically linked to (probably we would need to edit the config if we wanted to link also to numpy or scipy or something else). One does have to be careful with this, as if you put something like `min` in here, it will try to link to any class/function in pycbc called min (or the builtin function min). As always though, people should really check doc pages they are writing display well.