### PR TITLE
Explain how to publish to github pages

### DIFF
--- a/docs/build_gh_pages.rst
+++ b/docs/build_gh_pages.rst
@@ -32,30 +32,48 @@ These commands create the branch and then remove all of the files from this bran
 Building and pushing the documentation
 ======================================
 
-The documentation should built from the source code on a regular branch and installed into the ``gh-pages`` branch. Since git cannot have two branches checked out simultaneously, you need to make a copy of your repository with just the gh-pages branch checked out. Do this will the following commands (assuming your PyCBC git repository is in a directory named ``pycbc``).
+The documentation should built from the source code on a regular branch and installed into the ``gh-pages`` branch. Since git cannot have two branches checked out simultaneously, you need to check out another copy of the repository with the ``gh-pages`` branch inside your PyCBC source repository. Do this will the following commands (assuming your PyCBC git repository is in a directory named ``pycbc``).
 
 .. code-block:: bash
 
     cd /path/to/your/repo/pycbc
-    git checkout gh-pages
-    cd ..
-    cp -a pycbc pycbc-gh-pages
-    cd pycbc
-    git checkout master
+    git clone git@github.com:github-username/pycbc.git _gh-pages
 
-In this example, we checkout the master branch to build the documentation, but you can change the last command above to checkout any other branch that your are developing.  To generate the documentation, from the top level of the PyCBC source tree run
+Now flush the contents of this directory. We do this, as the documentation is
+not really under version control in the ``gh-pages`` branch. We just use this
+branch to publish to GitHub pages. Run the commands
+
+.. code-block:: bash
+
+    cd _gh-pages
+    git rm -rf *
+    git commit -a -m "flush documentation"
+    cd ..
+
+The last ``cd`` command should put you back at the top level of your PyCBC
+source directory. To build the documentation into the ``_gh-pages`` directory,
+run the command
 
 .. code-block:: bash
 
     python setup.py build_gh_pages
     
-This will build the documentation in the second repository that you created called ``pycbc-gh-pages`` under the directory ``latest/``. To push these changes up to Git Hub
+This will build the documentation in the second repository that you created called ``_gh-pages`` under the directory ``latest/``. To push these changes up to Git Hub
 
 .. code-block:: bash
 
-    cd ../pycbc-gh-pages
+    cd _gh-pages
     git add --all
-    git commit -a -m "updated documentation"
-    git push
+    git commit -a -m "documentation update"
+    git push origin gh-pages
 
 The documentation will then be available under your Git Hub pages at ``http://username.github.io/pycbc/latest/html/`` where you should replace ``username/`` with your Git Hub account name.
+
+In this example, we checkout the master branch to build the documentation, but you can change the last command above to checkout any other branch that your are developing.
+
+.. note::
+
+    Be careful with the ``git rm -rf *`` command as if you run it in the wrong
+    directory you can delete the contents of your git repository. If you do
+    this by accident, you can use ``git reset`` to undo the commit.
+

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -296,19 +296,33 @@ To build the documentation from your virtual environment, first make sure that y
     pip install sphinx-rtd-theme
     pip install git+https://github.com/ligo-cbc/sphinxcontrib-programoutput.git#egg=sphinxcontrib-programoutput
     
-To generate the documentation, from the top level of the PyCBC source tree run
+To generate the documentation and push it to your personal GitHub pages, first create a branch names ``gh-pages``, if you do not already have one. Follow the `GitHub branch <https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/>`_ instructions to do this.
+
+To build and publish the documentation, run the following commands from the
+top-level of your PyCBC source tree, replacing ``github-username`` with your
+GitHub user name:
 
 .. code-block:: bash
 
-    python setup.py build_docs
-    
-This will build the documentation in the directory docs/_build/html which can be copied to a web-accessible directory. For example
+    git clone git@github.com:github-username/pycbc.git _gh-pages
+    cd _gh-pages
+    git checkout gh-pages
+    git rm -rf *
+    git commit -a -m "flush documentation"
+    cd ..
+    python setup.py build_gh_pages
+    cd _gh-pages
+    git add --all
+    git commit -a -m "documentation update"
+    git push origin gh-pages
 
-.. code-block:: bash
+The documentation will then be visible at http://github-username.github.io/pycbc/latest/html where ``github-username`` should be replaced with your GitHub username.
 
-    cp -a docs/_build/html/ ~/public_html/pycbc-docs
-    
-will copy the documentation to a directory called ``pycbc-docs`` under your public html pages.
+.. note::
+
+    Be careful with the ``git rm -rf *`` command as if you run it in the wrong
+    directory you can delete the contents of your git repository. If you do
+    this by accident, you can use ``git reset`` to undo the commit.
 
 To maintain the documentation under GitHub project pages, see
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -324,7 +324,7 @@ The documentation will then be visible at http://github-username.github.io/pycbc
     directory you can delete the contents of your git repository. If you do
     this by accident, you can use ``git reset`` to undo the commit.
 
-To maintain the documentation under GitHub project pages, see
+For more details on building and maintaining the documentation under GitHub project pages, see
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
This commit adds instructions on how to publish to your own GitHub pages, e.g.

http://duncan-brown.github.io/pycbc/latest/html/