### PR TITLE
E@H build: always build minimal LALSuite

### DIFF
--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -867,16 +867,8 @@ EOF
     mkdir lalsuite-build
     cd lalsuite-build
     echo -e "\\n\\n>> [`date`] Configuring lalsuite" >&3
-    if $build_minimal_lalsuite ; then
     ../lalsuite/configure CPPFLAGS="$lal_cppflags $CPPFLAGS" --disable-gcc-flags $shared $static --prefix="$PREFIX" --disable-silent-rules \
-	--enable-swig-python --disable-lalxml --disable-laldetchar --disable-lalstochastic --disable-lalinference \
-        --disable-lalburst --disable-lalinspiral --disable-lalpulsar \
-	--disable-lalapps --disable-pylal
-    else
-        ../lalsuite/configure CPPFLAGS="$lal_cppflags $CPPFLAGS" --disable-gcc-flags $shared $static --prefix="$PREFIX" --disable-silent-rules \
-            --enable-swig-python --disable-lalxml --disable-laldetchar --disable-lalstochastic --disable-lalinference \
-	    --disable-lalapps --disable-pylal
-    fi
+        --disable-all-lal --enable-lalframe --enable-lalmetaio --enable-lalsimulation --enable-swig-python
     if $build_dlls; then
 	echo '#include "/usr/include/stdlib.h"
 extern int setenv(const char *name, const char *value, int overwrite);


### PR DESCRIPTION
There is no point in building more of LALSuite for E@H than what is needed for pycbc_inspiral, ie. the command-line switch '--build-minimal-lalsuite' is not necessary. However for configuring LALSuite I suggest to use the "positive" phrasing '--disable-all-lal' '--enable-'... which explicitly lists the parts that are needed instead of explicitly disabling all that is not. For now I'm leaving the '--build-minimal-lalsuite' switch in, so that the current command-lines don't fail.