### PR TITLE
Include a set of basic parameters when reading InferenceFile

### DIFF
--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -23,6 +23,7 @@ from pycbc.io import InferenceFile
 from pycbc.workflow import WorkflowConfigParser
 import pycbc.inference.sampler
 from pycbc.inference import likelihood
+from pycbc.inference import sampling_conversions
 from pycbc.pool import choose_pool
 from pycbc.psd import from_cli_multi_ifos as psd_from_cli_multi_ifos
 from pycbc.strain import from_cli_multi_ifos as strain_from_cli_multi_ifos
@@ -420,10 +421,12 @@ def results_from_cli(opts, load_samples=True, walkers=None):
     samples : {None, FieldArray}
         If load_samples, the samples as a FieldArray; otherwise, None.
     """
+
     logging.info("Reading input file")
     fp = InferenceFile(opts.input_file, "r")
     parameters = fp.variable_args if opts.parameters is None \
                  else opts.parameters
+
     # load the labels
     labels = []
     for ii,p in enumerate(parameters):
@@ -433,13 +436,23 @@ def results_from_cli(opts, load_samples=True, walkers=None):
         else:
             label = fp.read_label(p)
         labels.append(label)
+
+    # load the samples
     if load_samples:
         logging.info("Loading samples")
-        samples = fp.read_samples(parameters, walkers=walkers,
+        # check if need extra parameters for a derived parameter
+        file_parameters = sampling_conversions.get_parameters_set(
+                                                 parameters, fp.variable_args)
+        # read samples from file
+        samples = fp.read_samples(
+            file_parameters, walkers=walkers,
             thin_start=opts.thin_start, thin_interval=opts.thin_interval,
             thin_end=opts.thin_end, iteration=opts.iteration)
+        # add a set of base parameters if not included in InferenceFile
+        samples = sampling_conversions.add_base_parameters(samples)
     else:
         samples = None
+
     return fp, parameters, labels, samples
 
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -440,16 +440,16 @@ def results_from_cli(opts, load_samples=True, walkers=None):
     # load the samples
     if load_samples:
         logging.info("Loading samples")
-        # check if need extra parameters for a derived parameter
-        file_parameters = sampling_conversions.get_parameters_set(
+        # check if need extra parameters for a non-sampling parameter
+        file_parameters, cs = sampling_conversions.get_conversions(
                                                  parameters, fp.variable_args)
         # read samples from file
         samples = fp.read_samples(
             file_parameters, walkers=walkers,
             thin_start=opts.thin_start, thin_interval=opts.thin_interval,
             thin_end=opts.thin_end, iteration=opts.iteration)
-        # add a set of base parameters if not included in InferenceFile
-        samples = sampling_conversions.add_base_parameters(samples)
+        # add a parameters not included in file
+        samples = sampling_conversions.apply_conversions(samples, cs)
     else:
         samples = None
 

--- a/pycbc/inference/sampling_conversions.py
+++ b/pycbc/inference/sampling_conversions.py
@@ -473,10 +473,21 @@ def get_parameters_set(requested_params, variable_args):
     out : list
         List of parameters that user should read from InferenceFile.
     """
-    requested_params = set(requested_params)
+
+    # try to parse any equations by putting all strings together
+    # this will get some garbage but ensures all alphanumeric/underscored
+    # parameter names are added
+    new_params = []
+    for opt in requested_params:
+        s = ""
+        for ch in opt:
+            s += ch if ch.isalnum() or ch == "_" else " "
+        eqn = opt.split(":")[0]
+        new_params += s.split(" ")
+    requested_params = set(requested_params + new_params)
 
     # if asking for a derived parameter add base parameters to request
-    for converter in from_base_converters:#_converters_from_base_parameters():
+    for converter in from_base_converters:
         if (converter.outputs in variable_args or
                 converter.outputs.isdisjoint(requested_params)):
             continue
@@ -484,6 +495,7 @@ def get_parameters_set(requested_params, variable_args):
         if len(intersect) < 1 or intersect.issubset(converter.inputs):
             continue
         requested_params.update(converter.inputs)
+
     # if asking for a base parameter add sampling parameters to request
     for converter in to_base_converters:
         if (converter.outputs in variable_args or 

--- a/pycbc/inference/sampling_conversions.py
+++ b/pycbc/inference/sampling_conversions.py
@@ -265,8 +265,8 @@ class MassSpinToCartesianSpin(BaseConversion):
     (eg. effective spin) to cartesian spin coordinates.
     """
     # mass-spin parameters not in pycbc.waveform.parameters yet
-    _inputs = [parameters.mass1, parameters.mass2, "chi_eff", "chi_a",
-               "xi1", "xi2", "phi_a", "phi_s"]
+    _inputs = [parameters.mass1, parameters.mass2, parameters.chi_eff,
+               "chi_a", "xi1", "xi2", "phi_a", "phi_s"]
     _outputs = [parameters.mass1, parameters.mass2,
                 parameters.spin1x, parameters.spin1y, parameters.spin1z,
                 parameters.spin2x, parameters.spin2y, parameters.spin2z]
@@ -323,7 +323,7 @@ class MassSpinToCartesianSpin(BaseConversion):
 
     @classmethod
     def _convert_inverse(cls, maps):
-        out["chi_eff"] = conversions.chi_eff(
+        out[parmeters.chi_eff] = conversions.chi_eff(
                               maps[parameters.mass1], maps[parameters.mass2],
                               maps[parameters.spin1z], maps[parameters.spin2z])
         out["chi_a"] = conversions.chi_a(
@@ -506,5 +506,6 @@ def get_parameters_set(requested_params, variable_args):
             continue
         if converter.inputs.issubset(set(variable_args)):
             requested_params.update(converter.inputs)
+    print requested_params
     return requested_params
 

--- a/pycbc/inference/sampling_conversions.py
+++ b/pycbc/inference/sampling_conversions.py
@@ -1,0 +1,441 @@
+# Copyright (C) 2017  Christopher M. Biwer
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This modules provides classes and functions for converting sampling parameters
+to a set of base parameters.
+"""
+
+import numpy
+from pycbc import conversions
+from pycbc import coordinates
+from pycbc import cosmology
+from pycbc.io import record
+from pycbc.waveform import parameters
+
+class BaseConversion(object):
+    """ A base class for converting between two sets of parameters.
+    """
+    _inputs = set([])
+    _outputs = set([])
+
+    @property
+    def inputs(self):
+        """ Returns a set of input parameters.
+        """
+        return set(self._inputs)
+
+    @property
+    def outputs(self):
+        """ Returns a set of output parameters.
+        """
+        return set(self._outputs)
+
+    @classmethod
+    def _convert(cls, maps):
+        """ This function converts from inputs to outputs.
+        """
+        raise NotImplementedError("Not added.")
+
+    @classmethod
+    def _convert_inverse(cls, maps):
+        """ The inverse conversions of _convert. This function converts from
+        outputs to inputs.
+        """
+        raise NotImplementedError("Not added.")
+
+    def convert(self, old_maps):
+        """ Convert inputs to outputs. This function accepts either
+        a FieldArray or dict. It will return the same output type as the
+        input mapping object. Internally it calls _convert.
+
+        Parameters
+        ----------
+        old_maps : {FieldArray, dict}
+            Mapping object to add new keys.
+
+        Returns
+        -------
+        {FieldArray, dict}
+            Mapping object with new keys.
+        """
+        new_maps = self._convert(old_maps)
+        return self.format_output(old_maps, new_maps)
+
+    @staticmethod
+    def format_output(old_maps, new_maps):
+        """ This function takes the returned dict from _convert and converts
+        it to the same datatype as the input to _convert.
+
+        Parameters
+        ----------
+        old_maps : {FieldArray, dict}
+            The mapping object to add new maps to.
+        new_maps : dict
+            A dict with key as parameter name and value is numpy.array.
+
+        Returns
+        -------
+        {FieldArray, dict}
+            The old_maps object with new keys from new_maps.
+        """
+
+        # if input is FieldArray then return FieldArray
+        if isinstance(old_maps, record.FieldArray):
+            keys = new_maps.keys()
+            values = [new_maps[key] for key in keys]
+            old_maps = old_maps.add_fields(values, keys)
+            return old_maps
+
+        # if input is dict then return dict
+        elif isinstance(old_maps, dict):
+            out = old_maps.copy()
+            out.update(new_maps)
+            return out
+
+        # else error
+        else:
+            raise TypeError("Input type must be FieldArray or dict.")
+
+    def inverse(self):
+        """ Inverts the conversions being done. Inputs become outputs and
+        vice versa. The function convert will now call the inverse
+        transformation.
+        """
+        self._inputs, self._outputs = self._outputs, self._inputs
+        self._convert, self._convert_inverse = \
+                                      self._convert_inverse, self._convert
+
+class MchirpQToMass1Mass2(BaseConversion):
+    """ Converts chirp mass and mass ratio to component masses.
+    """
+    _inputs = [parameters.mchirp, parameters.q]
+    _outputs = [parameters.mass1, parameters.mass2]
+
+    @classmethod
+    def _convert(cls, maps):
+        """ This function converts from chirp mass and mass ratio to component
+        masses.
+
+        Parameters
+        ----------
+        maps : a mapping object
+
+        Examples
+        --------
+        Convert a dict of numpy.array:
+
+        >>> import numpy
+        >>> from pycbc.inference import sampling_conversions
+        >>> from pycbc.waveform import parameters
+        >>> cl = sampling_conversions.MchirpQToMass1Mass2()
+        >>> cl.convert({parameters.mchirp : numpy.array([10.]), parameters.q : numpy.array([2.])})
+            {'mass1': array([ 16.4375183]), 'mass2': array([ 8.21875915]), 'mchirp': array([ 10.]), 'q': array([ 2.])}
+
+        Returns
+        -------
+        out : dict
+            A dict with key as parameter name and value as numpy.array or float
+            of converted values.
+        """
+        out = {}
+        out[parameters.mass1] = conversions.mass1_from_mchirp_q(
+                                                maps[parameters.mchirp],
+                                                maps[parameters.q])
+        out[parameters.mass2] = conversions.mass2_from_mchirp_q(
+                                                maps[parameters.mchirp],
+                                                maps[parameters.q])
+        return out
+
+    @classmethod
+    def _convert_inverse(cls, maps):
+        """ This function converts from component masses to chirp mass and mass
+        ratio.
+
+        Parameters
+        ----------
+        maps : a mapping object
+
+        Examples
+        --------
+        Convert a dict of numpy.array:
+
+        >>> import numpy
+        >>> from pycbc.inference import sampling_conversions
+        >>> from pycbc.waveform import parameters
+        >>> cl = sampling_conversions.MchirpQToMass1Mass2()
+        >>> cl.inverse()
+        >>> cl.convert({parameters.mass1 : numpy.array([16.4]), parameters.mass2 : numpy.array([8.2])})
+            {'mass1': array([ 16.4]), 'mass2': array([ 8.2]), 'mchirp': array([ 9.97717521]), 'q': 2.0}
+
+        Returns
+        -------
+        out : dict
+            A dict with key as parameter name and value as numpy.array or float
+            of converted values.
+        """
+        out = {}
+        out[parameters.mchirp] = \
+                 conversions.mchirp_from_mass1_mass2(maps[parameters.mass1],
+                                                     maps[parameters.mass2])
+        m_p = conversions.primary_mass(maps[parameters.mass1],
+                                       maps[parameters.mass2])
+        m_s = conversions.secondary_mass(maps[parameters.mass1],
+                                         maps[parameters.mass2])
+        out[parameters.q] = m_p / m_s
+        return out
+
+class SphericalSpin1ToCartesianSpin1(BaseConversion):
+    """ Converts spherical spin parameters (magnitude and two angles) to
+    catesian spin parameters. This class only converts spsins for the first
+    component mass.
+    """
+    _inputs = [parameters.spin1_a, parameters.spin1_azimuthal,
+               parameters.spin1_polar]
+    _outputs = [parameters.spin2x, parameters.spin2y, parameters.spin2z]
+
+    @classmethod
+    def _convert(cls, maps):
+        """ This function converts from spherical to cartesian spins.
+
+        Parameters
+        ----------
+        maps : a mapping object
+
+        Examples
+        --------
+        Convert a dict of numpy.array:
+
+        >>> import numpy
+        >>> from pycbc.inference import sampling_conversions
+        >>> from pycbc.waveform import parameters
+        >>> cl = sampling_conversions.SphericalSpin1ToCartesianSpin1()
+        >>> cl.convert({parameters.spin1_a : numpy.array([0.1]), parameters.spin1_azimuthal : numpy.array([0.1]), parameters.spin1_polar : numpy.array([0.1])})
+            {'spin1_a': array([ 0.1]), 'spin1_azimuthal': array([ 0.1]), 'spin1_polar': array([ 0.1]),
+             'spin2x': array([ 0.00993347]), 'spin2y': array([ 0.00099667]), 'spin2z': array([ 0.09950042])}
+
+        Returns
+        -------
+        out : dict
+            A dict with key as parameter name and value as numpy.array or float
+            of converted values.
+        """
+        a, az, po = cls._inputs
+        data = coordinates.spherical_to_cartesian(maps[a], maps[az], maps[po])
+        out = {param : val for param, val in zip(cls._outputs, data)}
+        return out
+
+    @classmethod
+    def _convert_inverse(cls, maps):
+        sx, sy, sz = cls._inputs
+        data = coordinates.cartesian_to_spherical(maps[sx], maps[sy], maps[sz])
+        out = {param : val for param, val in zip(cls._outputs, data)}
+        return out
+
+class SphericalSpin2ToCartesianSpin2(SphericalSpin1ToCartesianSpin1):
+    """ Converts spherical spin parameters (magnitude and two angles) to
+    catesian spin parameters. This class only converts spsins for the second
+    component mass.
+    """
+    _inputs = [parameters.spin2_a, parameters.spin2_azimuthal,
+               parameters.spin2_polar]
+    _outputs = [parameters.spin2x, parameters.spin2y, parameters.spin2z]
+
+class MassSpinToCartesianSpin(BaseConversion):
+    """ Converts component masses, and mass-weighted spin parameters
+    (eg. effective spin) to cartesian spin coordinates.
+    """
+    # mass-spin parameters not in pycbc.waveform.parameters yet
+    _inputs = ["mass1", "mass2", "chi_eff", "chi_a", "xi1", "xi2",
+               "phi_a", "phi_s"]
+    _outputs = [parameters.mass1, parameters.mass2,
+                parameters.spin1x, parameters.spin1y, parameters.spin1z,
+                parameters.spin2x, parameters.spin2y, parameters.spin2z]
+
+    @classmethod
+    def _convert(cls, maps):
+        """ This function converts from spherical to cartesian spins.
+
+        Parameters
+        ----------
+        maps : a mapping object
+
+        Examples
+        --------
+        Convert a dict of numpy.array:
+
+        >>> import numpy
+        >>> from pycbc.inference import sampling_conversions
+        >>> from pycbc.waveform import parameters
+        >>> cl = sampling_conversions.MassSpinToCartesianSpin()
+        >>> cl.convert({parameters.mass1 : numpy.array([10]), parameters.mass2 : numpy.array([10]), "chi_eff" : numpy.array([0.1]), "chi_a" : numpy.array([0.1]), "xi1" : numpy.array([0.1]), "xi2" : numpy.array([0.1]), "phi_a" : numpy.array([0.1]), "phi_s" : numpy.array([0.1])})
+            {'chi_a': array([ 0.1]), 'chi_eff': array([ 0.1]), 'mass1': array([10]), 'mass2': array([10]), 'phi_a': array([ 0.1]),
+             'phi_s': array([ 0.1]), 'spin1x': array([ 0.09950042]), 'spin1y': array([ 0.00998334]), 'spin1z': array([ 0.]),
+             'spin2x': array([ 0.1]), 'spin2y': array([ 0.]), 'spin2z': array([ 0.2]), 'xi1': array([ 0.1]), 'xi2': array([ 0.1])}
+
+        Returns
+        -------
+        out : dict
+            A dict with key as parameter name and value as numpy.array or float
+            of converted values.
+        """
+        out = {}
+        out[parameters.spin1x] = conversions.spin1x_from_xi1_phi_a_phi_s(
+                               maps["xi1"], maps["phi_a"], maps["phi_s"])
+        out[parameters.spin1y] = conversions.spin1y_from_xi1_phi_a_phi_s(
+                               maps["xi1"], maps["phi_a"], maps["phi_s"])
+        out[parameters.spin1z] = \
+                         conversions.spin1z_from_mass1_mass2_chi_eff_chi_a(
+                               maps[parameters.mass1], maps[parameters.mass2],
+                               maps["chi_eff"], maps["chi_a"])
+        out[parameters.spin2x] = \
+                         conversions.spin2x_from_mass1_mass2_xi2_phi_a_phi_s(
+                               maps[parameters.mass1], maps[parameters.mass2],
+                               maps["xi2"], maps["phi_a"], maps["phi_s"])
+        out[parameters.spin2y] = \
+                         conversions.spin2y_from_mass1_mass2_xi2_phi_a_phi_s(
+                               maps[parameters.mass1], maps[parameters.mass2],
+                               maps["xi2"], maps["phi_a"], maps["phi_s"])
+        out[parameters.spin2z] = \
+                         conversions.spin2z_from_mass1_mass2_chi_eff_chi_a(
+                               maps[parameters.mass1], maps[parameters.mass2],
+                               maps["chi_eff"], maps["chi_a"])
+        return out
+
+    @classmethod
+    def _convert_inverse(cls, maps):
+        out["chi_eff"] = conversions.chi_eff(
+                               maps[parameters.mass1], maps[parameters.mass2,
+                               maps[parameters.spin1z], maps[parameters.spin2z)
+        out["chi_a"] = conversions.chi_a(
+                               maps[parameters.mass1], maps[parameters.mass2,
+                               maps[parameters.spin1x], maps[parameters.spin1y,
+                               maps[parameters.spin2x], maps[parameters.spin2y)
+        out["xi1"] = conversions.primary_xi(
+                               maps[parameters.mass1], maps[parameters.mass2,
+                               maps[parameters.spin1x], maps[parameters.spin1y,
+                               maps[parameters.spin2x], maps[parameters.spin2y)
+        out["xi2"] = conversions.secondary_xi(
+                               maps[parameters.mass1], maps[parameters.mass2,
+                               maps[parameters.spin1x], maps[parameters.spin1y,
+                               maps[parameters.spin2x], maps[parameters.spin2y)
+        out["phi_a"] = conversions.phi_a(
+                               maps[parameters.spin1x], maps[parameters.spin1y],
+                               maps[parameters.spin2x], maps[parameters.spin2y])
+        out["phi_s"] = conversions.phi_s(
+                               maps[parameters.spin1x], maps[parameters.spin1y],
+                               maps[parameters.spin2x], maps[parameters.spin2y])
+       return out
+
+class Xi1Xi2ToChiP(BaseConversion):
+    _inputs = ["x1", "x2"]
+    _outputs = ["chi_p"]
+    @classmethod
+    def _convert(cls, maps):
+
+
+class DistanceToRedshift(BaseConversion):
+    """ Converts distance to redshift.
+    """
+    _inputs = [parameters.distance]
+    _outputs = [parameters.redshift]
+
+    @classmethod
+    def _convert(cls, maps):
+        """ This function converts from distance to redshift.
+
+        Parameters
+        ----------
+        maps : a mapping object
+
+        Examples
+        --------
+        Convert a dict of numpy.array:
+
+        >>> import numpy
+        >>> from pycbc.inference import sampling_conversions
+        >>> from pycbc.waveform import parameters
+        >>> cl = sampling_conversions.DistanceToRedshift()
+        >>> cl.convert({parameters.distance : numpy.array([1000])})
+            {'distance': array([1000]), 'redshift': 0.19650987609144363}
+
+        Returns
+        -------
+        out : dict
+            A dict with key as parameter name and value as numpy.array or float
+            of converted values.
+        """
+        out = {parameters.redshift : cosmology.redshift(maps["distance"])}
+        return out
+
+# list of all Conversions
+converts = [MchirpQToMass1Mass2, SphericalSpin1ToCartesianSpin1,
+            SphericalSpin2ToCartesianSpin2, MassSpinToCartesianSpin,
+            DistanceToRedshift]
+
+def add_base_parameters(sampling_params):
+    """ Adds a standard set of base parameters to a mapping object
+    (ie. FieldArray or dict). The standard set of base parameters includes
+    mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z, and redshift.
+
+    This function loop over all Conversion classes in this module and sees if
+    the conversions is required. If it is required, then the new keys are
+    added.
+
+    Parameters
+    ----------
+    sampling_params : {FieldArray, dict}
+        Mapping object to add new keys.
+
+    Returns
+    -------
+    sampling_params : {FieldArray, dict}
+       Mapping object with new fields.
+    """
+    converters = [converter() for converter in converts]
+    for converter in converters:
+        current_params = set(sampling_params.fieldnames)
+        if (converter.inputs.issubset(current_params) and
+                not converter.outputs.issubset(current_params)):
+            sampling_params = converter.convert(sampling_params)
+    return sampling_params
+
+def get_parameters_set(requested_params, variable_args):
+    """ Determines if any additional parameters from the InferenceFile are
+    needed to get derived parameters that user has asked for.
+
+    Parameters
+    ----------
+    requested_params : list
+        List of parameters that user wants.
+    variable_args : list
+        List of parameters that InferenceFile has.
+
+    Returns
+    -------
+    out : list
+        List of parameters that user should read from InferenceFile.
+    """
+    requested_params = set(requested_params)
+    converters = [converter() for converter in converts]
+    for converter in converters:
+        if (converter.outputs in variable_args or 
+                converter.outputs.isdisjoint(requested_params)):
+            continue
+        intersect = converter.outputs.intersection(requested_params)
+        if len(intersect) < 1:
+            continue
+        requested_params.update(converter.inputs)
+    return requested_params
+

--- a/pycbc/inference/sampling_conversions.py
+++ b/pycbc/inference/sampling_conversions.py
@@ -456,7 +456,7 @@ def add_base_parameters(sampling_params):
                  str(sampling_params.fieldnames))
     return sampling_params
 
-def get_parameters_set(requested_params, variable_args):
+def get_parameters_set(requested_params, variable_args, valid_params=None):
     """ Determines if any additional parameters from the InferenceFile are
     needed to get derived parameters that user has asked for.
 
@@ -484,6 +484,11 @@ def get_parameters_set(requested_params, variable_args):
         eqn = opt.split(":")[0]
         new_params += s.split(" ")
     requested_params = set(requested_params + new_params)
+
+    # can pass a list of valid parameters to remove garbage parameters
+    # from parsing above
+    valid_params = set(valid_params) if valid_params else requested_params
+    requested_params = requested_params.intersection(valid_params)
 
     # if asking for a base parameter add sampling parameters to request
     for converter in to_base_converters:

--- a/pycbc/inference/sampling_conversions.py
+++ b/pycbc/inference/sampling_conversions.py
@@ -384,12 +384,18 @@ class DistanceToRedshift(BaseConversion):
 class BaseToAlignedMassSpin(BaseConversion):
     _inputs = [parameters.mass1, parameters.mass2,
                parameters.spin1z, parameters.spin2z]
-    _outputs = [parameters.chi_eff]
+    _outputs = [parameters.chi_eff, "chi_a"]
     @classmethod
     def _convert(cls, maps):
-        return {parameters.chi_eff : conversions.chi_eff(
+        out = {
+            parameters.chi_eff : conversions.chi_eff(
                              maps[parameters.mass1], maps[parameters.mass2],
-                             maps[parameters.spin1z], maps[parameters.spin2z])}
+                             maps[parameters.spin1z], maps[parameters.spin2z]),
+            "chi_a" : conversions.chi_a(
+                             maps[parameters.mass1], maps[parameters.mass2],
+                             maps[parameters.spin1z], maps[parameters.spin2z]),
+        }
+        return out
 
 class BaseToPrecessionMassSpin(BaseConversion):
     _inputs = [parameters.mass1, parameters.mass2,
@@ -413,14 +419,6 @@ from_base_converters = [
     BaseToAlignedMassSpin(), BaseToPrecessionMassSpin(),
 ]
 converters = to_base_converters + from_base_converters
-
-def _converters_from_base_parameters():
-    # get list of all conversions available from base parameters
-    tmp_converters = []
-    for converter in to_base_converters:
-        converter.inverse()
-        tmp_converters.append(converter)
-    return tmp_converters + from_base_converters
 
 def add_base_parameters(sampling_params):
     """ Adds a standard set of base parameters to a mapping object
@@ -504,8 +502,9 @@ def get_parameters_set(requested_params, variable_args, valid_params=None):
 
     return requested_params
 
-def _add_parameters_from_converters(requested_params, variable_args, converters):
-    for converter in converters:
+def _add_parameters_from_converters(requested_params, variable_args,
+                                    converters_list):
+    for converter in converters_list:
         if (converter.outputs in variable_args or
                 converter.outputs.isdisjoint(requested_params)):
             continue

--- a/pycbc/inference/sampling_conversions.py
+++ b/pycbc/inference/sampling_conversions.py
@@ -211,7 +211,7 @@ class SphericalSpin1ToCartesianSpin1(BaseConversion):
     """
     _inputs = [parameters.spin1_a, parameters.spin1_azimuthal,
                parameters.spin1_polar]
-    _outputs = [parameters.spin2x, parameters.spin2y, parameters.spin2z]
+    _outputs = [parameters.spin1x, parameters.spin1y, parameters.spin1z]
 
     @classmethod
     def _convert(cls, maps):
@@ -401,8 +401,7 @@ class BaseToPrecessionMassSpin(BaseConversion):
         return {"chi_p" : conversions.chi_p(
                       maps[parameters.mass1], maps[parameters.mass2],
                       maps[parameters.spin1x], maps[parameters.spin1y],
-                      maps[parameters.spin1z], maps[parameters.spin2x],
-                      maps[parameters.spin2y], maps[parameters.spin2z])}
+                      maps[parameters.spin2x], maps[parameters.spin2y])}
 
 # list of all Conversions to/from base parameters
 to_base_converters = [
@@ -485,6 +484,17 @@ def get_parameters_set(requested_params, variable_args):
         eqn = opt.split(":")[0]
         new_params += s.split(" ")
     requested_params = set(requested_params + new_params)
+
+    # if asking for a base parameter add sampling parameters to request
+    for converter in to_base_converters:
+        if (converter.outputs in variable_args or
+                converter.outputs.isdisjoint(requested_params)):
+            continue
+        intersect = converter.outputs.intersection(requested_params)
+        if len(intersect) < 1 or intersect.issubset(converter.inputs):
+            continue
+        if converter.inputs.issubset(set(variable_args)):
+            requested_params.update(converter.inputs)
 
     # if asking for a derived parameter add base parameters to request
     for converter in from_base_converters:

--- a/pycbc/inference/sampling_conversions.py
+++ b/pycbc/inference/sampling_conversions.py
@@ -17,6 +17,7 @@ This modules provides classes and functions for converting sampling parameters
 to a set of base parameters.
 """
 
+import logging
 import numpy
 from pycbc import conversions
 from pycbc import coordinates
@@ -422,7 +423,7 @@ def _converters_from_base_parameters():
         tmp_converters.append(converter)
     return tmp_converters + from_base_converters
 
-def add_base_parameters(sampling_params, v):
+def add_base_parameters(sampling_params):
     """ Adds a standard set of base parameters to a mapping object
     (ie. FieldArray or dict). The standard set of base parameters includes
     mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z, and redshift.
@@ -441,7 +442,6 @@ def add_base_parameters(sampling_params, v):
     sampling_params : {FieldArray, dict}
        Mapping object with new fields.
     """
-    print "FIELDNAMES", sampling_params.fieldnames
     # convert sampling parameters into base parameters
     for converter in to_base_converters:
         current_params = set(sampling_params.fieldnames)
@@ -453,6 +453,8 @@ def add_base_parameters(sampling_params, v):
         if (converter.inputs.issubset(current_params) and
                 not converter.outputs.issubset(current_params)):
             sampling_params = converter.convert(sampling_params)
+    logging.info("Found the following parameters in InferenceFile: %s",
+                 str(sampling_params.fieldnames))
     return sampling_params
 
 def get_parameters_set(requested_params, variable_args):
@@ -481,7 +483,6 @@ def get_parameters_set(requested_params, variable_args):
         intersect = converter.outputs.intersection(requested_params)
         if len(intersect) < 1 or intersect.issubset(converter.inputs):
             continue
-        print "USED", converter
         requested_params.update(converter.inputs)
     # if asking for a base parameter add sampling parameters to request
     for converter in to_base_converters:
@@ -493,6 +494,5 @@ def get_parameters_set(requested_params, variable_args):
             continue
         if converter.inputs.issubset(set(variable_args)):
             requested_params.update(converter.inputs)
-    print "REQUEST", requested_params
     return requested_params
 

--- a/pycbc/inference/sampling_conversions.py
+++ b/pycbc/inference/sampling_conversions.py
@@ -316,34 +316,34 @@ class MassSpinToCartesianSpin(BaseConversion):
     @classmethod
     def _convert_inverse(cls, maps):
         out["chi_eff"] = conversions.chi_eff(
-                               maps[parameters.mass1], maps[parameters.mass2,
-                               maps[parameters.spin1z], maps[parameters.spin2z)
+                              maps[parameters.mass1], maps[parameters.mass2],
+                              maps[parameters.spin1z], maps[parameters.spin2z])
         out["chi_a"] = conversions.chi_a(
-                               maps[parameters.mass1], maps[parameters.mass2,
-                               maps[parameters.spin1x], maps[parameters.spin1y,
-                               maps[parameters.spin2x], maps[parameters.spin2y)
+                              maps[parameters.mass1], maps[parameters.mass2],
+                              maps[parameters.spin1x], maps[parameters.spin1y],
+                              maps[parameters.spin2x], maps[parameters.spin2y])
         out["xi1"] = conversions.primary_xi(
-                               maps[parameters.mass1], maps[parameters.mass2,
-                               maps[parameters.spin1x], maps[parameters.spin1y,
-                               maps[parameters.spin2x], maps[parameters.spin2y)
+                              maps[parameters.mass1], maps[parameters.mass2],
+                              maps[parameters.spin1x], maps[parameters.spin1y],
+                              maps[parameters.spin2x], maps[parameters.spin2y])
         out["xi2"] = conversions.secondary_xi(
-                               maps[parameters.mass1], maps[parameters.mass2,
-                               maps[parameters.spin1x], maps[parameters.spin1y,
-                               maps[parameters.spin2x], maps[parameters.spin2y)
+                              maps[parameters.mass1], maps[parameters.mass2],
+                              maps[parameters.spin1x], maps[parameters.spin1y],
+                              maps[parameters.spin2x], maps[parameters.spin2y])
         out["phi_a"] = conversions.phi_a(
-                               maps[parameters.spin1x], maps[parameters.spin1y],
-                               maps[parameters.spin2x], maps[parameters.spin2y])
+                              maps[parameters.spin1x], maps[parameters.spin1y],
+                              maps[parameters.spin2x], maps[parameters.spin2y])
         out["phi_s"] = conversions.phi_s(
-                               maps[parameters.spin1x], maps[parameters.spin1y],
-                               maps[parameters.spin2x], maps[parameters.spin2y])
-       return out
+                              maps[parameters.spin1x], maps[parameters.spin1y],
+                              maps[parameters.spin2x], maps[parameters.spin2y])
+        return out
 
 class Xi1Xi2ToChiP(BaseConversion):
     _inputs = ["x1", "x2"]
     _outputs = ["chi_p"]
     @classmethod
     def _convert(cls, maps):
-
+        return {}
 
 class DistanceToRedshift(BaseConversion):
     """ Converts distance to redshift.


### PR DESCRIPTION
PR #1567 does not solve sampling in spherical coordinates and would require a duplication of all the functions in ``conversions.py``. Also PR #1567 makes these very long command lines. This PR makes ``results_from_cli`` include a set of basic parameters (``mass1``, ``mass2``, ``spin1x``, ``spin1y``, ``spin1z``, ``spin2x``, ``spin2y``, and ``spin2z``). Then you have full access to doing all the conversions.

So even if you sampled in say ``mchirp`` and ``q``, all you need to specify on the command line is ``--parameters mass1 mass2`` and it will plot those parameters.

These classes could probably be used to replace those same types of functions in ``pycbc.waveform.generators``.

Requires #1590.