### PR TITLE
Make cyclic boundaries optional

### DIFF
--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -131,32 +131,26 @@ An example configuration file (named ``inference.ini``) is::
     min-spin1_a = 0.0
     max-spin1_a = 0.9
 
-    [prior-spin1_azimuthal]
-    name = uniform
-    min-spin1_azimuthal = 0.
-    max-spin1_azimuthal = 6.283185307179586
-
-    [prior-spin1_polar]
-    name = sin_angle
+    [prior-spin1_polar+spin1_azimuthal]
+    name = uniform_solidangle
+    polar-angle = spin1_polar
+    azimuthal-angle = spin1_azimuthal
 
     [prior-spin2_a]
     name = uniform
     min-spin2_a = 0.0
     max-spin2_a = 0.9
 
-    [prior-spin2_azimuthal]
-    name = uniform
-    min-spin2_azimuthal = 0.
-    max-spin2_azimuthal = 6.283185307179586
-
-    [prior-spin2_polar]
-    name = sin_angle
+    [prior-spin2_polar+spin2_azimuthal]
+    name = uniform_solidangle
+    polar-angle = spin2_polar
+    azimuthal-angle = spin2_azimuthal
 
     [prior-distance]
     ; distance prior
     name = uniform
     min-distance = 10
-    max-distance = 500
+    max-distance = 1000
 
     [prior-coa_phase]
     ; coalescence phase prior

--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -333,10 +333,13 @@ class UniformSolidAngle(bounded.BoundedDist):
     _default_polar_angle = 'theta'
     _default_azimuthal_angle = 'phi'
 
-    def __init__(self, polar_angle=_default_polar_angle,
-                 azimuthal_angle=_default_azimuthal_angle,
+    def __init__(self, polar_angle=None, azimuthal_angle=None,
                  polar_bounds=None, azimuthal_bounds=None,
                  azimuthal_cyclic_domain=False):
+        if polar_angle is None:
+            polar_angle = self._default_polar_angle
+        if azimuthal_angle is None:
+            azimuthal_angle = self._default_azimuthal_angle
         self._polardist = self._polardistcls(**{
             polar_angle: polar_bounds}) 
         self._azimuthaldist = self._azimuthaldistcls(**{

--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -123,9 +123,31 @@ class UniformAngle(uniform.Uniform):
 
     @classmethod
     def from_config(cls, cp, section, variable_args):
-        """Returns a distribution based on a configuration file. The parameters
-        for the distribution are retrieved from the section titled
-        "[`section`-`variable_args`]" in the config file.
+        """Returns a distribution based on a configuration file.
+
+        The parameters for the distribution are retrieved from the section
+        titled "[`section`-`variable_args`]" in the config file. By default,
+        only the name of the distribution (`uniform_angle`) needs to be
+        specified. This will results in a uniform prior on `[0, 2pi)`. To
+        make the domain cyclic, add `cyclic_domain =`. To specify boundaries
+        that are not `[0, 2pi)`, add `(min|max)-var` arguments, where `var`
+        is the name of the variable.
+
+        For example, this will initialize a variable called `theta` with a
+        uniform distribution on `[0, 2pi)` without cyclic boundaries:
+
+        .. code-block:: ini
+
+            [{section}-theta]
+            name = uniform_angle
+
+        This will make the domain cyclic on `[0, 2pi)`:
+
+        .. code-block:: ini
+
+            [{section}-theta]
+            name = uniform_angle
+            cyclic_domain =
 
         Parameters
         ----------
@@ -465,9 +487,10 @@ class UniformSolidAngle(bounded.BoundedDist):
 
     @classmethod
     def from_config(cls, cp, section, variable_args):
-        """Returns a distribution based on a configuration file. The section
-        must have the names of the polar and azimuthal angles in the tag part
-        of the section header. For example:
+        """Returns a distribution based on a configuration file.
+
+        The section must have the names of the polar and azimuthal angles in
+        the tag part of the section header. For example:
 
         .. code-block:: ini
 
@@ -502,6 +525,9 @@ class UniformSolidAngle(bounded.BoundedDist):
 
         This will return a distribution that is uniform in the upper
         hemisphere.
+
+        By default, the domain of the azimuthal angle is `[0, 2pi)`. To make
+        this domain cyclic, add `azimuthal_cyclic_domain =`.
 
         Parameters
         ----------

--- a/pycbc/distributions/boundaries.py
+++ b/pycbc/distributions/boundaries.py
@@ -306,7 +306,7 @@ class Bounds(object):
         except KeyError:
             raise ValueError("unrecognized btype_max {}".format(btype_max))
         # store cyclic conditions
-        self._cyclic = cyclic
+        self._cyclic = bool(cyclic)
         # store reflection conditions; we'll vectorize them here so that they
         # can be used with arrays
         if self._min.name == 'reflected' and self._max.name == 'reflected':

--- a/pycbc/distributions/bounded.py
+++ b/pycbc/distributions/bounded.py
@@ -114,7 +114,7 @@ def get_param_bounds_from_config(cp, section, tag, param):
 
 
 def bounded_from_config(cls, cp, section, variable_args,
-        bounds_required=False):
+        bounds_required=False, additional_opts=None):
     """Returns a bounded distribution based on a configuration file. The
     parameters for the distribution are retrieved from the section titled
     "[`section`-`variable_args`]" in the config file.
@@ -138,6 +138,11 @@ def bounded_from_config(cls, cp, section, variable_args,
        parameter set to None. Even if bounds are not required, a
        ValueError will be raised if only one bound is provided; i.e.,
        either both bounds need to provided or no bounds.
+    additional_opts : {None, dict}
+        Provide additional options to be passed to the distribution class;
+        should be a dictionary specifying option -> value. If an option is
+        provided that also exists in the config file, the value provided will
+        be used instead of being read from the file.
 
     Returns
     -------
@@ -147,13 +152,17 @@ def bounded_from_config(cls, cp, section, variable_args,
     tag = variable_args
     variable_args = variable_args.split(VARARGS_DELIM)
 
+    if additional_opts is None:
+        additional_opts = {}
+
     # list of args that are used to construct distribution
     special_args = ["name"] + \
         ['min-{}'.format(arg) for arg in variable_args] + \
         ['max-{}'.format(arg) for arg in variable_args] + \
         ['btype-min-{}'.format(arg) for arg in variable_args] + \
         ['btype-max-{}'.format(arg) for arg in variable_args] + \
-        ['cyclic-{}'.format(arg) for arg in variable_args]
+        ['cyclic-{}'.format(arg) for arg in variable_args] + \
+        additional_opts.keys()
 
     # get a dict with bounds as value
     dist_args = {}
@@ -177,6 +186,8 @@ def bounded_from_config(cls, cp, section, variable_args,
             pass
         # add option
         dist_args.update({key:val})
+
+    dist_args.update(additional_opts)
 
     # construction distribution and add to list
     return cls(**dist_args)


### PR DESCRIPTION
This makes cyclic boundaries in the angular distributions optional, with the default set to False. This allows us to use `uniform_sky`, `uniform_solidangle`, and `uniform_angle` in the inference config files, instead of having to specify azimuthal angles separately using the uniform distribution. Cyclic boundaries can be turned back on for `uniform_angle` by setting `cyclic_domain = 1` in the ini file; for `uniform_solidangle` and `uniform_sky`, `azimuthal_cyclic_domain = 1`. I've updated the inference docs accordingly.

I also adjusted the upper bound on the distance prior in the BBH example to 1Gpc, since 500Mpc is too close to be used for GW150914.