### PR TITLE
Minor bug fix in calling waveform generator from pycbc_inference

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -156,7 +156,7 @@ with ctx:
                                                     static_args["approximant"])
 
     # construct class that will generate waveforms
-    generator = waveform.FDomainDetFrameGenerator(
+    generated_waveform = generator.FDomainDetFrameGenerator(
                        generator_function, epoch=stilde_dict.values()[0].epoch,
                        variable_args=variable_args, detectors=opts.instruments,
                        delta_f=stilde_dict.values()[0].delta_f,
@@ -165,7 +165,7 @@ with ctx:
 
     # construct class that will return the natural logarithm of likelihood
     likelihood = inference.likelihood_evaluators[opts.likelihood_evaluator](
-                        generator, stilde_dict,
+                        generated_waveform, stilde_dict,
                         low_frequency_cutoff_dict.values()[0],
                         psds=psd_dict, prior=prior)
 


### PR DESCRIPTION
@cdcapano This PR fixes a small bug introduced in #1555. 
I ran into this bug while running the current `pycbc_inference` on master. So thought of filing a patch. 

While generating the waveform, it does `waveform.FDomainDetFrameGenerator(...` but `waveform` is not imported in the code. So it should be `generator.FDomainDetFrameGenerator(...` instead. Also, using the name `generator` for the return value of the class as the module used to generate it creates a bit of confusion. So, I thought using a different name might be helpful. I've renamed `generator` as `generated_waveform` in this PR.