### PR TITLE
Fix mathjax rendering on HTML pages

### DIFF
--- a/pycbc/results/templates/orange.html
+++ b/pycbc/results/templates/orange.html
@@ -19,6 +19,13 @@
     <script type="text/javascript" src="{{dot_dot_str}}static/js/fancybox/2.1.5/jquery.fancybox.js"></script>
     <link rel="stylesheet" type="text/css" href="{{dot_dot_str}}static/css/fancybox/2.1.5/jquery.fancybox.css" media="screen" />
 
+    <!-- add mathjax -->
+    <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$']]}});
+    </script>
+    <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+    </script>
+
     <!-- add orange stylization -->
     <script type="text/javascript" src="{{dot_dot_str}}static/js/fancybox/2.1.5/fancybox-orange.js"></script> 
     <link media="all" href="{{dot_dot_str}}static/css/pycbc/orange.css" type="text/css" rel="stylesheet">


### PR DESCRIPTION
No one ever added this to the HTML pages. Its only because the posterior table is on there, is why the labels loaded before.