### PR TITLE
Turn on the HDF5 build on for CERN SL6

### DIFF
--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -69,7 +69,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   # run the einstein at home build and test script
   echo -e "\\n>> [`date`] Running pycbc_build_eah.sh"
   pushd ${BUILD}
-  /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --silent-build --build-minimal-lalsuite --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl
+  /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --silent-build --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl
 
   if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then
     echo -e "\\n>> [`date`] Deploying pycbc_inspiral bundle"

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -138,15 +138,13 @@ elif [[ v`cat /etc/redhat-release 2>/dev/null` == v"Scientific Linux CERN SLC re
     test ".$LC_ALL" = "." && export LC_ALL="$LANG"
     link_gcc_version=4.4.7
     gcc_path="/usr/bin"
-    build_ssl=false
     build_python=true
+    build_hdf5=true
     build_pegasus=false
     build_fftw=false
     build_gsl=false
-    build_hdf5=false
     build_ssl=false
     build_lapack=false
-    build_gsl=false
     build_freetype=false
     build_zlib=false
     build_wrapper=false

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -874,7 +874,7 @@ EOF
     cd lalsuite-build
     echo -e "\\n\\n>> [`date`] Configuring lalsuite" >&3
     ../lalsuite/configure CPPFLAGS="$lal_cppflags $CPPFLAGS" --disable-gcc-flags $shared $static --prefix="$PREFIX" --disable-silent-rules \
-        --disable-all-lal --enable-lalframe --enable-lalmetaio --enable-lalsimulation --enable-lalinspiral --enable-swig-python
+        --disable-all-lal --enable-lalframe --enable-lalmetaio --enable-lalsimulation --enable-lalinspiral --enable-lalpulsar --enable-swig-python
     if $build_dlls; then
 	echo '#include "/usr/include/stdlib.h"
 extern int setenv(const char *name, const char *value, int overwrite);

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -74,7 +74,6 @@ build_pcre=false
 build_fftw=true
 build_framecpp=false
 build_preinst_before_lalsuite=true
-build_minimal_lalsuite=false
 build_subprocess32=false
 build_hdf5=true
 build_freetype=true
@@ -254,8 +253,6 @@ usage="
 
     --clean-lalsuite                checkout and build lalsuite from scratch
 
-    --build-minimal-lalsuite        build as little of lalsuite as possible to make pycbc_inspiral
-
     --clean-sundays                 perform a clean-lalsuite build on sundays
 
     --clean-pycbc                   check out pycbc git repo from scratch
@@ -305,7 +302,6 @@ for i in $*; do
         --print-env) ;;
         --no-pycbc-update) pycbc_branch="HEAD";;
         --no-lalsuite-update) no_lalsuite_update=true;;
-        --build-minimal-lalsuite) build_minimal_lalsuite=true;;
         --bema-testing)
             pycbc_branch=einsteinathome_testing
             pycbc_remote=bema-ligo;;

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -874,7 +874,7 @@ EOF
     cd lalsuite-build
     echo -e "\\n\\n>> [`date`] Configuring lalsuite" >&3
     ../lalsuite/configure CPPFLAGS="$lal_cppflags $CPPFLAGS" --disable-gcc-flags $shared $static --prefix="$PREFIX" --disable-silent-rules \
-        --disable-all-lal --enable-lalframe --enable-lalmetaio --enable-lalsimulation --enable-swig-python
+        --disable-all-lal --enable-lalframe --enable-lalmetaio --enable-lalsimulation --enable-lalinspiral --enable-swig-python
     if $build_dlls; then
 	echo '#include "/usr/include/stdlib.h"
 extern int setenv(const char *name, const char *value, int overwrite);


### PR DESCRIPTION
I accidentally turned the HDF5 build off on the SL6 platform that Travis uses. I didn't notice this, as the E@H test runs SEOBNRv2, which uses txt files. @josh-willis' run failed when using SEOBNRv4 as that reads ROM data from HDF5.

I need to get back to @bema-ligo on https://github.com/ligo-cbc/pycbc/issues/1507 so that we can add a test that uses the v4 ROMs to the E@H test suite.

As part of this pull, I removed the remaining references to ``--build-minimal-lalsuite`` which @bema-ligo deprecated in https://github.com/ligo-cbc/pycbc/pull/1591