### PR TITLE
Add option to ringdown module for tapering time-domain ringdowns

### DIFF
--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -323,10 +323,10 @@ def get_td_qnm(template=None, taper=None, **kwargs):
         hplus = TimeSeries(zeros(window+kmax), delta_t=delta_t)
         hcross = TimeSeries(zeros(window+kmax), delta_t=delta_t)
         hplus.data[:window] = taper_hp
-        hplus.data[window:window+kmax] = hp
+        hplus.data[window:] = hp
         hplus._epoch = taper_times[0]
         hcross.data[:window] = taper_hc
-        hcross.data[window:window+kmax] = hc
+        hcross.data[window:] = hc
         hcross._epoch = taper_times[0]
 
         return hplus, hcross
@@ -489,8 +489,7 @@ def get_td_lm(template=None, taper=None, **kwargs):
     # Find maximum window size to create long enough output vector
     if taper is not None:
         taper_window = [int(taper*tau[n]/delta_t) + 1 for n in range(nmodes)]
-        max_window = max(taper_window)
-        kmax += max_window
+        kmax += max(taper_window)
 
     outplus = TimeSeries(zeros(kmax, dtype=float64), delta_t=delta_t)
     outcross = TimeSeries(zeros(kmax, dtype=float64), delta_t=delta_t)

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -676,7 +676,7 @@ def get_td_lm_allmodes(template=None, taper=None, **kwargs):
         t_final = lm_tfinal(final_mass, final_spin, lmns)
 
     kmax = int(t_final / delta_t) + 1
-    f_0, tau = get_lm_f0tau_allmodes(final_mass, final_spin, lmns)
+    _, tau = get_lm_f0tau_allmodes(final_mass, final_spin, lmns)
     # Different overtones will have different tapering window-size
     # Find maximum window size to create long enough output vector
     if taper is not None:

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -312,7 +312,7 @@ def get_td_qnm(template=None, taper=None, **kwargs):
         return hplus, hcross
 
     else:
-        taper_times = -numpy.arange(0, taper*tau, delta_t)
+        taper_times = -numpy.arange(delta_t, taper*tau, delta_t)
         taper_times.sort()
         window = len(taper_times)
         taper_hp = amp * numpy.exp(10*taper_times/tau) * \


### PR DESCRIPTION
When doing the multi-mode PE on time-domain ringdown (only) injections, we noticed that we were having issues due to the sharp turn on of the ringdown. This PR adds an option to taper the ringdown with a rapid exponential ringup.
Comparisons between the tapered and the non-tapered ringdown are [here](https://www.atlas.aei.uni-hannover.de/~miriam.cabero/LSC/tests/ringdown_taper/)
After this is accepted, I will make the corresponding changes to pycbc_ringinj to incorporate this option.