### PR TITLE
Allow likelihood_stats group to be plotted on command line

### DIFF
--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -360,6 +360,10 @@ def add_inference_results_option_group(parser):
     # required options
     results_reading_group.add_argument("--input-file", type=str, required=True,
         help="Path to input HDF file.")
+    results_reading_group.add_argument(
+        "--parameters-group", type=str, default=InferenceFile.samples_group,
+        choices=[InferenceFile.samples_group, InferenceFile.stats_group],
+        help="Group in the HDF InferenceFile to look for parameters.")
     results_reading_group.add_argument("--parameters", type=str, nargs="+",
         metavar="PARAM[:LABEL]",
         help="Name of parameters to plot. If none provided will load all of "
@@ -447,7 +451,8 @@ def results_from_cli(opts, load_samples=True, walkers=None):
         samples = fp.read_samples(
             file_parameters, walkers=walkers,
             thin_start=opts.thin_start, thin_interval=opts.thin_interval,
-            thin_end=opts.thin_end, iteration=opts.iteration)
+            thin_end=opts.thin_end, iteration=opts.iteration,
+            samples_group=opts.parameters_group)
         # add a parameters not included in file
         samples = sampling_conversions.apply_conversions(samples, cs)
     else:

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -637,7 +637,7 @@ class BaseMCMCSampler(_BaseSampler):
         if array_class is None:
             array_class = FieldArray
         # get the names of fields needed for the given parameters
-        possible_fields = fp[fp.samples_group].keys()
+        possible_fields = fp[samples_group].keys()
         loadfields = array_class.parse_parameters(parameters, possible_fields)
         return cls._read_fields(fp, samples_group, loadfields, array_class,
                                 thin_start=thin_start,

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -645,63 +645,6 @@ class BaseMCMCSampler(_BaseSampler):
                                 iteration=iteration, walkers=walkers,
                                 flatten=flatten)
 
-    @classmethod
-    def read_likelihood_stats(cls, fp, thin_start=None, thin_interval=None,
-                              thin_end=None, iteration=None, walkers=None,
-                              flatten=True, stats_group=None,
-                              array_class=None):
-        """Reads the likelihood stats from the given file.
-
-        Parameters
-        -----------
-        fp : InferenceFile
-            An open file handler to read the stats from.
-        thin_start : int
-            Index of the sample to begin returning stats. Default is to read
-            stats after burn in. To start from the beginning set thin_start
-            to 0.
-        thin_interval : int
-            Interval to accept every i-th sample. Default is to use the
-            `fp.acl`. If `fp.acl` is not set, then use all stats
-            (set thin_interval to 1).
-        thin_end : int
-            Index of the last sample to read. If not given then
-            `fp.niterations` is used.
-        iteration : int
-            Get a single iteration. If provided, will override the
-            `thin_{start/interval/end}` arguments.
-        walkers : {None, (list of) int}
-            The walker index (or a list of indices) to retrieve. If None,
-            stats from all walkers will be obtained.
-        flatten : {True, bool}
-            The returned array will be one dimensional, with all desired
-            stats from all desired walkers concatenated together. If False,
-            the returned array will have dimension requested walkers
-            x requested iterations.
-        stats_group : {None, str}
-            The group in `fp` from which to retrieve the stats. If
-            None, searches in `fp.stats_group`.
-        array_class : {None, array class}
-            The type of array to return. The class must have a `from_kwargs`
-            class method. If None, will return a FieldArray.
-
-        Returns
-        -------
-        array_class
-            The likelihood stats, as an instance of a the given
-            `array_class` (`FieldArray` if `array_class` is None).
-        """
-        if stats_group is None:
-            stats_group = fp.stats_group
-        if array_class is None:
-            array_class = FieldArray
-        fields = fp[stats_group].keys()
-        return cls._read_fields(fp, stats_group, fields, array_class,
-                                thin_start=thin_start,
-                                thin_interval=thin_interval,
-                                thin_end=thin_end, iteration=iteration,
-                                walkers=walkers, flatten=flatten)
-
     @staticmethod
     def read_acceptance_fraction(fp, thin_start=None, thin_interval=None,
                                  thin_end=None, iteration=None):

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -441,13 +441,12 @@ class BaseMCMCSampler(_BaseSampler):
             The stats that were written, as a FieldArray. If there were no
             stats, returns None.
         """
-        # likelihood_stats is a nwalkers x niterations array
+        # likelihood_stats is a nwalkers x niterations FieldArray
         samples = self.likelihood_stats
         parameters = samples.fieldnames
         if samples is None:
             return None
-        nwalkers, niterations = samples.shape
-        samples = samples.reshape((nwalkers, niterations, 1))
+        samples = samples.to_array(axis=-1)
         samples_group = fp.stats_group
 
         # write data
@@ -457,7 +456,7 @@ class BaseMCMCSampler(_BaseSampler):
                          end_iteration=end_iteration,
                          max_iterations=max_iterations)
 
-        return stats
+        return samples
 
     def write_acceptance_fraction(self, fp, start_iteration=0,
                                   end_iteration=None, max_iterations=None):

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -819,69 +819,6 @@ class EmceePTSampler(BaseMCMCSampler):
                 walkers=walkers, flatten=flatten)
 
     @classmethod
-    def read_likelihood_stats(
-            cls, fp,
-            thin_start=None, thin_interval=None, thin_end=None, iteration=None,
-            temps=None, walkers=None, flatten=True, stats_group=None,
-            array_class=None):
-        """Reads the likelihood stats from the given file.
-
-        Parameters
-        -----------
-        fp : InferenceFile
-            An open file handler to read the stats from.
-        thin_start : int
-            Index of the sample to begin returning stats. Default is to read
-            stats after burn in. To start from the beginning set thin_start
-            to 0.
-        thin_interval : int
-            Interval to accept every i-th sample. Default is to use the
-            `fp.acl`. If `fp.acl` is not set, then use all stats
-            (set thin_interval to 1).
-        thin_end : int
-            Index of the last sample to read. If not given then
-            `fp.niterations` is used.
-        iteration : int
-            Get a single iteration. If provided, will override the
-            `thin_{start/interval/end}` arguments.
-        temps : {None, (list of) int, 'all'}
-            The temperature index (or list of indices) to retrieve. If None,
-            only samples from the coldest (= 0) temperature chain will be
-            retrieved. To retrieve all temperates pass 'all', or a list of
-            all of the temperatures.
-        walkers : {None, (list of) int}
-            The walker index (or a list of indices) to retrieve. If None,
-            stats from all walkers will be obtained.
-        flatten : {True, bool}
-            The returned array will be one dimensional, with all desired
-            stats from all desired walkers concatenated together. If False,
-            the returned array will have dimension requested temps x requested
-            walkers x requested iterations.
-        stats_group : {None, str}
-            The group in `fp` from which to retrieve the stats. If
-            None, searches in `fp.stats_group`.
-        array_class : {None, array class}
-            The type of array to return. The class must have a `from_kwargs`
-            class method. If None, will return a FieldArray.
-
-        Returns
-        -------
-        array_class
-            The likelihood stats, as an instance of the given
-            `array_class` (`FieldArray` if `array_class` is None).
-        """
-        if stats_group is None:
-            stats_group = fp.stats_group
-        if array_class is None:
-            array_class = FieldArray
-        fields = fp[stats_group].keys()
-        return cls._read_fields(fp, stats_group, fields, array_class,
-                                thin_start=thin_start,
-                                thin_interval=thin_interval,
-                                thin_end=thin_end, iteration=iteration,
-                                temps=temps, walkers=walkers, flatten=flatten)
-
-    @classmethod
     def compute_acls(cls, fp, start_index=None, end_index=None):
         """Computes the autocorrleation length for all variable args for all
         walkers for all temps in the given file. If the returned acl is inf,

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -605,13 +605,12 @@ class EmceePTSampler(BaseMCMCSampler):
         max_iterations : {None, int}
             See `write_chain` for details.
         """
-        # likelihood_stats is a ntemps x nwalkers x niterations array
+        # likelihood_stats is a ntemps x nwalkers x niterations FieldArray
         samples = self.likelihood_stats
         parameters = samples.fieldnames
         if samples is None:
             return None
-        nwalkers, niterations = samples.shape
-        samples = samples.reshape((ntemps, nwalkers, niterations, 1))
+        samples = samples.to_array(axis=-1)
         samples_group = fp.stats_group
 
         # write data
@@ -621,7 +620,7 @@ class EmceePTSampler(BaseMCMCSampler):
                          end_iteration=end_iteration,
                          max_iterations=max_iterations)
 
-        return stats
+        return samples
 
     def write_results(self, fp, start_iteration=0, end_iteration=None,
                       max_iterations=None):

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -147,7 +147,7 @@ class InferenceFile(h5py.File):
         """
         return self.attrs["log_evidence"], self.attrs["dlog_evidence"]
 
-    def read_samples(self, parameters, **kwargs):
+    def read_samples(self, parameters, samples_group=None, **kwargs):
         """Reads samples from the file.
 
         Parameters
@@ -158,6 +158,8 @@ class InferenceFile(h5py.File):
             `FieldArray` (as long as the file contains the necessary fields
             to derive the virtual field or method), and/or a function of
             these.
+        samples_group : str
+            Group in HDF InferenceFile that parameters belong to.
         \**kwargs :
             The rest of the keyword args are passed to the sampler's
             `read_samples` method.
@@ -169,8 +171,11 @@ class InferenceFile(h5py.File):
             FieldArray.
         """
         # get the appropriate sampler class
+        samples_group = samples_group if samples_group \
+                             else InferenceFile.samples_group
         sclass = pycbc.inference.sampler.samplers[self.sampler_name]
-        return sclass.read_samples(self, parameters, **kwargs)
+        return sclass.read_samples(self, parameters,
+                                   samples_group=samples_group, **kwargs)
 
     def read_likelihood_stats(self, **kwargs):
         """Reads likelihood stats from self.

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -193,9 +193,7 @@ class InferenceFile(h5py.File):
             array are the names of the stats that are in the `likelihood_stats`
             group.
         """
-        # get the appropriate sampler class
-        sclass = pycbc.inference.sampler.samplers[self.sampler_name]
-        return sclass.read_likelihood_stats(self, **kwargs)
+        return read_samples(parameters, samples_group=fp.stats_group, **kwargs)
 
     def read_acceptance_fraction(self, **kwargs):
         """Returns the acceptance fraction that was written to the file.

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -193,7 +193,9 @@ class InferenceFile(h5py.File):
             array are the names of the stats that are in the `likelihood_stats`
             group.
         """
-        return read_samples(parameters, samples_group=fp.stats_group, **kwargs)
+        parameters = self[self.stats_group].keys()
+        return self.read_samples(
+                          parameters, samples_group=self.stats_group, **kwargs)
 
     def read_acceptance_fraction(self, **kwargs):
         """Returns the acceptance fraction that was written to the file.


### PR DESCRIPTION
This PR:
  * Allows the CLI access to the ``likelihood_stats`` group in the HDF file.
  * Writing ``chain`` and ``likelihood_stats`` now use the same helper function called  ``_write_samples_group``. There is a lot of duplicate code that can be avoided.
  * Fixes bug in ``BaseSampler.write_chain`` that ignored the ``sample_group`` when trying to find what are the possible parameters.

Can plot on command line like:
```
PRECESSING_OPTS="--input-file /home/soumi.de/projects/cbc/inference_for_events/GW150914/H1L1/inference_GW150914_H1L1_100000iter.hdf --output-file /home/cbiwer/public_html/tmp/tmp.png --iteration 5999 --plot-marginal --plot-density --verbose"
pycbc_inference_plot_posterior ${PRECESSING_OPTS} --parameters mchirp
pycbc_inference_plot_posterior ${PRECESSING_OPTS} --parameters loglr --parameters-group likelihood_stats
```

One limitation of this is that you specify the parameters group so you can't plot things from ``samples`` with ``likelihood_stats`` but this is definitely more flexibility than before. And I'm not sure why someone would mix the two. I mainly want this for plotting/displaying convergence using the likelihood.

I tested it with ``kombine`` sampler. I tried with ``emcee_pt`` but it appears to be broken now, see Issue #1625. But I added the code for both.