### PR TITLE
Allow kwargs to be passed to two_column.html from layout

### DIFF
--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -340,7 +340,7 @@ container._adag.addDependency(dep)
 container.save(filename=opts.output_file, output_map_path=opts.output_map)
 
 # write html well
-layout.two_column_layout(rdir.base, layouts)
+layout.two_column_layout(rdir.base, layouts, subtitle="Hello world!")
 
 # save workflow configuration file
 base = rdir["workflow/configuration"]

--- a/bin/workflows/pycbc_make_inference_workflow
+++ b/bin/workflows/pycbc_make_inference_workflow
@@ -340,7 +340,7 @@ container._adag.addDependency(dep)
 container.save(filename=opts.output_file, output_map_path=opts.output_map)
 
 # write html well
-layout.two_column_layout(rdir.base, layouts, subtitle="Hello world!")
+layout.two_column_layout(rdir.base, layouts)
 
 # save workflow configuration file
 base = rdir["workflow/configuration"]

--- a/pycbc/results/layout.py
+++ b/pycbc/results/layout.py
@@ -42,7 +42,7 @@ def single_layout(path, files, **kwargs):
     files: list of pycbc.workflow.core.Files
         This list of images to show in order within the well layout html file.
     """
-    two_column_layout(path, [(f, **kwargs) for f in files])
+    two_column_layout(path, [(f,) for f in files], **kwargs)
 
 def grouper(iterable, n, fillvalue=None):
     """ Group items into chunks of n length

--- a/pycbc/results/layout.py
+++ b/pycbc/results/layout.py
@@ -18,7 +18,7 @@
 import os.path
 from itertools import izip_longest
 
-def two_column_layout(path, cols):
+def two_column_layout(path, cols, **kwargs):
     """ Make a well layout in a two column format
     
     Parameters
@@ -32,9 +32,9 @@ def two_column_layout(path, cols):
     """
     path = os.path.join(os.getcwd(), path, 'well.html')
     from pycbc.results.render import render_workflow_html_template
-    render_workflow_html_template(path, 'two_column.html', cols)
+    render_workflow_html_template(path, 'two_column.html', cols, **kwargs)
 
-def single_layout(path, files):
+def single_layout(path, files, **kwargs):
     """ Make a well layout in  single column format
     
     path: str
@@ -42,7 +42,7 @@ def single_layout(path, files):
     files: list of pycbc.workflow.core.Files
         This list of images to show in order within the well layout html file.
     """
-    two_column_layout(path, [(f,) for f in files])
+    two_column_layout(path, [(f, **kwargs) for f in files])
 
 def grouper(iterable, n, fillvalue=None):
     """ Group items into chunks of n length
@@ -50,7 +50,7 @@ def grouper(iterable, n, fillvalue=None):
     args = [iter(iterable)] * n
     return izip_longest(*args, fillvalue=fillvalue)
     
-def group_layout(path, files):
+def group_layout(path, files, **kwargs):
     """ Make a well layout in chunks of two from a list of files
     
     path: str
@@ -60,7 +60,7 @@ def group_layout(path, files):
         Every two are placed on the same row.
     """
     if len(files) > 0:
-        two_column_layout(path, list(grouper(files, 2)))      
+        two_column_layout(path, list(grouper(files, 2)), **kwargs)      
  
 class SectionNumber(object):
     """ Class to help with numbering sections in an output page.

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -28,7 +28,7 @@ from pycbc.results import unescape_table
 from pycbc.results.metadata import save_html_with_metadata
 from pycbc.workflow.core import SegFile, makedir
 
-def render_workflow_html_template(filename, subtemplate, filelists):
+def render_workflow_html_template(filename, subtemplate, filelists, **kwargs):
     """ Writes a template given inputs from the workflow generator. Takes
     a list of tuples. Each tuple is a pycbc File object. Also the name of the
     subtemplate to render and the filename of the output.
@@ -51,6 +51,7 @@ def render_workflow_html_template(filename, subtemplate, filelists):
     subtemplate = env.get_template(subtemplate)
     context = {'filelists' : filelists,
                'dir' : dirnam}
+    context.update(kwargs)
     output = subtemplate.render(context)
 
     # save as html page

--- a/pycbc/results/static/css/pycbc/orange.css
+++ b/pycbc/results/static/css/pycbc/orange.css
@@ -5,6 +5,10 @@ html, body {
     background-color:#EEEEEE;
 }
 
+p.subtitle{
+    font-size : 18px;
+}
+
 /* add some space to the left upon inserting a caret */
 .caret{
     margin-left : 4px;
@@ -84,3 +88,4 @@ font-size:16px;
 .footer-custom {
     padding : 25px;
 }
+

--- a/pycbc/results/templates/wells/two_column.html
+++ b/pycbc/results/templates/wells/two_column.html
@@ -1,3 +1,8 @@
+<!-- add a subtitle -->
+{% if subtitle %}
+    <p class="subtitle">{{subtitle}}</p>
+{% endif %}
+
 <!-- hold images inside a well -->
 <div class="scaffold well">
 


### PR DESCRIPTION
Allows keyword options to be passed to ``two_column.html`` via ``pycbc.results.layout``. And add a ``{{subtitle}}`` to ``two_column.html``.

So now can do:
```
layout.two_column_layout(rdir.base, layouts, subtitle="Hello World!")
```
to add some text to describe what is in the well.

And you'll get something like this: https://sugwg-jobs.phy.syr.edu/~cbiwer/tmp/inference_workflow/r11/4._samples/