### PR TITLE
The option "--precision" was igonred in pycbc_insert_frame_hwinj.

### DIFF
--- a/bin/hwinj/pycbc_insert_frame_hwinj
+++ b/bin/hwinj/pycbc_insert_frame_hwinj
@@ -40,7 +40,7 @@ parser.add_argument('--ifo', type=str, required=True,
                      help='IFO.')
 parser.add_argument('--output-file', type=str, required=True,
                     help='Path to output frame file.')
-parser.add_argument('--precision', type=str, default=None,
+parser.add_argument('--precision', type=str, default='double',
                     choices=['single', 'double'],
                     help='Store as a float32 or float64.')
 
@@ -59,7 +59,7 @@ logging_level = logging.DEBUG
 logging.basicConfig(format='%(asctime)s : %(message)s', level=logging_level)
 
 # get strain
-strain = _strain.from_cli(opts,precision=opts.precision)
+strain = _strain.from_cli(opts, precision=opts.precision)
 
 # load data
 logging.info('Reading the hardware injection data')
@@ -73,12 +73,6 @@ start_pad = (opts.hwinj_start_time-opts.gps_start_time) * opts.sample_rate
 logging.info('Summing the two time series')
 for i in range(len(initial_array)):
     strain[start_pad+1+i] += initial_array[i]
-
-# typecast
-if opts.precision == 'single':
-    strain = strain.astype(numpy.float32)
-elif opts.precision == 'double':
-    strain = strain.astype(numpy.float64)
 
 # write frame
 logging.info('Writing data')

--- a/bin/hwinj/pycbc_insert_frame_hwinj
+++ b/bin/hwinj/pycbc_insert_frame_hwinj
@@ -59,7 +59,7 @@ logging_level = logging.DEBUG
 logging.basicConfig(format='%(asctime)s : %(message)s', level=logging_level)
 
 # get strain
-strain = _strain.from_cli(opts)
+strain = _strain.from_cli(opts,precision=opts.precision)
 
 # load data
 logging.info('Reading the hardware injection data')


### PR DESCRIPTION
Previosuly, the command line option was not passed on to from_cli
in strain, which resulted in single precision used regardless of
what was specified.