### PR TITLE
use PyInstaller 3.2.1 also for Cygwin

### DIFF
--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1096,8 +1096,11 @@ if $patch_pyinstaller_bootloader && $build_onefile_bundles; then
 fi
 
 # patch PyInstaller to find the Python library on Cygwin
-if $build_dlls && $pyinstaller21_hacks; then
-    sed -i~ "s|'libpython%d%d.dll'|'libpython%d.%d.dll'|" `find PyInstaller -name bindepend.py`
+# This needs to be applied to compat.py for all PyI versions < 3.1.2
+if $build_dlls; then
+    if ! git log --pretty=oneline --abbrev-commit|grep "^e8c08c" >/dev/null; then
+        sed -i~ "s|'libpython%d%d.dll'|'libpython%d.%d.dll'|" `find PyInstaller -name bindepend.py -or -name compat.py`
+    fi
 fi
 
 # build bootloader (in any case: for Cygwin it wasn't precompiled, for Linux it was patched)

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1164,10 +1164,9 @@ cd $PREFIX
 
 # BUNDLE DIR
 echo -e "\\n\\n>> [`date`] building pyinstaller spec" >&3
-# don't use UPX with PyInstaller 2.x
-if $pyinstaller21_hacks; then
-    upx="--noupx"
-elif $build_dlls; then
+# don't use UPX with PyInstaller
+upx="--noupx"
+if $build_dlls && ! $pyinstaller21_hacks; then
     ext=".exe"
 fi
 # create spec file

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1109,16 +1109,13 @@ cd bootloader
 if $patch_pyinstaller_bootloader; then
     sed -i~ 's/ pid *= *fork()/ pid = 0/' */pyi_utils.c
 fi
-if echo "$pyinstaller_version" | grep '3\.' > /dev/null ||
-   test ".$pyinstaller_version" = ".develop" ||
-   test ".$pyinstaller_version" = ".HEAD"
-then
+if $pyinstaller21_hacks; then
+    python waf configure $pyinstaller_lsb build install
+else
     test "$appendix" = "_OSX64" &&
         sed -i~ /-Wdeclaration-after-statement/d wscript
     pip install future
     python waf distclean configure $pyinstaller_lsb all
-else
-    python waf configure $pyinstaller_lsb build install
 fi
 cd ..
 python setup.py install --prefix="$PREFIX" --record installed-files.txt

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -196,8 +196,8 @@ elif uname -s | grep ^CYGWIN >/dev/null; then # Cygwin (Windows)
     build_freetype=false
     build_gsl=false
     build_swig=false
-    pyinstaller_version=9d0e0ad4
-    pyinstaller21_hacks=true
+#    pyinstaller_version=develop # HEAD # 9d0e0ad4
+#    pyinstaller21_hacks=true
     patch_pyinstaller_bootloader=false
     appendix="_Windows64"
 else

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1079,6 +1079,9 @@ else
         git checkout 3.0 # workaround for misnamed tag
     else
         git checkout $pyinstaller_version
+        if test "$pyinstaller_version" = "develop"; then
+            git pull
+        fi
     fi
 fi
 
@@ -1104,6 +1107,7 @@ if $patch_pyinstaller_bootloader; then
     sed -i~ 's/ pid *= *fork()/ pid = 0/' */pyi_utils.c
 fi
 if echo "$pyinstaller_version" | grep '3\.' > /dev/null ||
+   test ".$pyinstaller_version" = ".develop" ||
    test ".$pyinstaller_version" = ".HEAD"
 then
     test "$appendix" = "_OSX64" &&

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1108,6 +1108,7 @@ if echo "$pyinstaller_version" | grep '3\.' > /dev/null ||
 then
     test "$appendix" = "_OSX64" &&
         sed -i~ /-Wdeclaration-after-statement/d wscript
+    pip install future
     python waf distclean configure $pyinstaller_lsb all
 else
     python waf configure $pyinstaller_lsb build install


### PR DESCRIPTION
This (finally!) enables us to use the same version of PyInstaller on all platforms, and ultimately to get rid of the workarounds required for the previously used PyInstaller 2.1. Note that this is based on #1635.