### PR TITLE
Use samples_group option not default in file for reading samples from emcee sampler

### DIFF
--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -810,7 +810,7 @@ class EmceePTSampler(BaseMCMCSampler):
         if array_class is None:
             array_class = FieldArray
         # get the names of fields needed for the given parameters
-        possible_fields = fp[fp.samples_group].keys()
+        possible_fields = fp[samples_group].keys()
         loadfields = array_class.parse_parameters(parameters, possible_fields)
         return cls._read_fields(
                 fp, samples_group, loadfields, array_class,


### PR DESCRIPTION
If wanting to plot values from ``likelihood_stats`` in ``InferenceFile`` need to use the ``samples_group`` that is passed to the function, not the default set in the class.

For an example of running emcee on sugwg, see: /home/cbiwer/projects/inference_samples_group/test/run_pycbc_inference.sh

And for plotting values from ``likelihood_stats``: /home/cbiwer/projects/inference_samples_group/test/test.sh