### PR TITLE
Added ability to specify a dictionary of parameters to generate waveforms

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -312,6 +312,8 @@ def get_obj_attrs(obj):
             for slot in obj.__slots__:
                 if hasattr(obj, slot):
                     pr[slot] = getattr(obj, slot)
+        elif isinstance(obj, dict):
+            pr = obj.copy()
         else:
             for name in dir(obj):
                 try:


### PR DESCRIPTION
When reading parameter estimation results, we sometimes end with a dictionary instead of a numpy record array (for the ability to add fields easily). With this (tiny) patch, one could pass such a dictionary to pycbc's interface to LALSimulation.