### PR TITLE
Allow template_duration to be stored in compressed bank

### DIFF
--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -134,8 +134,7 @@ seg_lens = 4*numpy.array([max(4./args.sample_rate,
 
 # generate output file
 logging.info("writing template info to output")
-output = bank.write_to_hdf(args.output, force=args.force,
-    skip_fields='template_duration')
+output = bank.write_to_hdf(args.output, force=args.force)
 
 # get the compressed sample points for each template
 logging.info("getting compressed amplitude and phase")
@@ -157,6 +156,8 @@ for ii in range(imin, imax):
     htilde = bank[ii-imin]
     tmplt = bank.table[ii-imin]
     fmin=tmplt.f_lower
+    template_duration=htilde.chirp_length
+    output['template_duration'][ii-imin]=template_duration
     kmin = int(numpy.ceil(fmin / df))
     if numpy.abs(htilde[kmin]) == 0:
         raise ValueError("""The amplitude of the waveform at the

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -671,10 +671,13 @@ class FilterBank(TemplateBank):
         hdecomp = self.compressed_waveforms[self.table.template_hash[index]].decompress(out=decomp_scratch, f_lower=f_lower, interpolation=decompression_method)
         p = props(self.table[index])
         p.pop('approximant')
-        if hasattr(self.table, 'template_duration'):
-            hdecomp.chirp_length=self.table.template_duration[index]
-        else :
-            hdecomp.chirp_length = get_waveform_filter_length_in_time(approximant, **p)
+        try:
+            tmpltdur = self.table[index].template_duration
+        except AttributeError:
+            tmpltdur = None
+        if tmpltdur is None:
+            tmpltudr = get_waveform_filter_length_in_time(approximant, **p)
+        hdecomp.chirp_length = tmpltdur
         hdecomp.length_in_time = hdecomp.chirp_length
         return hdecomp
 

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -671,7 +671,10 @@ class FilterBank(TemplateBank):
         hdecomp = self.compressed_waveforms[self.table.template_hash[index]].decompress(out=decomp_scratch, f_lower=f_lower, interpolation=decompression_method)
         p = props(self.table[index])
         p.pop('approximant')
-        hdecomp.chirp_length = get_waveform_filter_length_in_time(approximant, **p)
+        if hasattr(self.table, 'template_duration'):
+            hdecomp.chirp_length=self.table.template_duration[index]
+        else :
+            hdecomp.chirp_length = get_waveform_filter_length_in_time(approximant, **p)
         hdecomp.length_in_time = hdecomp.chirp_length
         return hdecomp
 


### PR DESCRIPTION
This PR allows :
* `template_duration` for waveforms to be stored in compressed bank
* `template_duration` to be read directly from the compressed bank when decompressing. This would save the cost of getting the lengths for templates in a bank using `get_waveform_length_in_time`

@cdcapano Could you please take a look?