### PR TITLE
Allow InjFilterRejector template waveforms to be generated from compressed waveforms

### DIFF
--- a/pycbc/inject/injfilterrejector.py
+++ b/pycbc/inject/injfilterrejector.py
@@ -293,7 +293,7 @@ class InjFilterRejector(object):
                 # Generate short waveform
                 htilde = bank.generate_with_delta_f_and_max_freq(
                     t_num, self.coarsematch_fmax, self.coarsematch_deltaf,
-                    low_frequency_cutoff=self.f_lower,
+                    low_frequency_cutoff=bank.table[t_num].f_lower,
                     cached_mem=self._short_template_mem)
                 self._short_template_id = t_num
                 self._short_template_wav = htilde


### PR DESCRIPTION
I'll keep this as work in progress till the issue with lesser number of triggers being generated when using compressed waveforms for inj_filter_rejector as compared to when using regular waveforms is resolved.

Also, this depends on #1646 .