### PR TITLE
Set kombine version in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pycbc-glue-obsolete==1.1.0
 weave
 
 # Needed for Parameter Estimation Tasks
-kombine
+kombine==0.8.1
 emcee>=2.2.0
 corner>=2.0.1
 

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'mpld3>=0.3',
                       'pyRXP>=2.1.0',
                       'pycbc-glue-obsolete==1.1.0',
-                      'kombine',
+                      'kombine==0.8.1',
                       'emcee>=2.2.0',
                       'corner>=2.0.1',
                       ]


### PR DESCRIPTION
This sets the kombine version to use in setupy.py to 0.8.1, which is the current most recent version. This is to overcome the current bug in kombine's version history on pypi, in which version 1.1 is older than version 0.8.1. When Ben fixes this, we can go back to just getting the most recent version of kombine.