### PR TITLE
Add instructions for non-LIGO members to analyze GW150914

### DIFF
--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -308,19 +308,28 @@ With a minor change to the ``tc`` prior, you can reuse ``inference.ini`` from th
     min-tc = 1126259462.32
     max-tc = 1126259462.52
 
-Next, you need to obtain the real LIGO data containing GW150914. If you are
-a LIGO member and are running on a LIGO Data Grid cluster, set the following
-environment variable::
+Next, you need to obtain the real LIGO data containing GW150914. Do one of
+the following:
 
-    FRAMES="H1:H1_HOFT_C02 L1:L1_HOFT_C02"
+* **If you are a LIGO member and are running on a LIGO Data Grid cluster:**
+  you can use the LIGO data server to automatically obtain the frame files.
+  Simply set the following environment variables::
 
-If you are not a LIGO member, or are not running on a LIGO Data Grid cluster,
-set the following instead::
+    FRAMES="--frame-type H1:H1_HOFT_C02 L1:L1_HOFT_C02"
+    CHANNELS="H1:H1:DCS-CALIB_STRAIN_C02 L1:L1:DCS-CALIB_STRAIN_C02"
 
-    FRAMES="LOSC"
+* **If you are not a LIGO member, or are not running on a LIGO Data Grid
+  cluster:** you need to obtain the data from the
+  `LIGO Open Science Center <https://losc.ligo.org>`_. First run the following
+  commands to download the needed frame files to your working directory::
 
-This will instruct the code to download the frame files from the LIGO Open
-Science Center (https://losc.ligo.org).
+    wget https://losc.ligo.org/s/events/GW150914/H-H1_LOSC_4_V2-1126257414-4096.gwf
+    wget https://losc.ligo.org/s/events/GW150914/L-L1_LOSC_4_V2-1126257414-4096.gwf
+
+  Then set the following enviornment variables::
+
+    FRAMES="--frame-files H1:H-H1_LOSC_4_V2-1126257414-4096.gwf L1:L-L1_LOSC_4_V2-1126257414-4096.gwf"
+    CHANNELS="H1:LOSC-STRAIN L1:LOSC-STRAIN"
 
 Now run::
 
@@ -341,9 +350,6 @@ Now run::
     PSD_SEG_LEN=8
     PSD_STRIDE=4
     PSD_DATA_LEN=1024
-
-    # frame type and channel
-    CHANNELS="H1:H1:DCS-CALIB_STRAIN_C02 L1:L1:DCS-CALIB_STRAIN_C02"
 
     # sampler parameters
     CONFIG_PATH=inference.ini
@@ -386,7 +392,7 @@ Now run::
         --gps-start-time ${GPS_START_TIME} \
         --gps-end-time ${GPS_END_TIME} \
         --channel-name ${CHANNELS} \
-        --frame-type ${FRAMES} \
+        ${FRAMES} \
         --strain-high-pass ${F_HIGHPASS} \
         --pad-data ${PAD_DATA} \
         --psd-estimation ${PSD_ESTIMATION} \

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -305,7 +305,21 @@ With a minor change to the ``tc`` prior, you can reuse ``inference.ini`` from th
     min-tc = 1126259462.32
     max-tc = 1126259462.52
 
-Then run::
+Next, you need to obtain the real LIGO data containing GW150914. If you are
+a LIGO member and are running on a LIGO Data Grid cluster, set the following
+environment variable::
+
+    FRAMES="H1:H1_HOFT_C02 L1:L1_HOFT_C02"
+
+If you are not a LIGO member, or are not running on a LIGO Data Grid cluster,
+set the following instead::
+
+    FRAMES="LOSC"
+
+This will cause the needed frame files to be downloaded from the LIGO Open
+Science Center (https://losc.ligo.org).
+
+Now run::
 
     # trigger parameters
     TRIGGER_TIME=1126259462.42
@@ -326,7 +340,6 @@ Then run::
     PSD_DATA_LEN=1024
 
     # frame type and channel
-    FRAMES="H1:H1_HOFT_C02 L1:L1_HOFT_C02"
     CHANNELS="H1:H1:DCS-CALIB_STRAIN_C02 L1:L1:DCS-CALIB_STRAIN_C02"
 
     # sampler parameters

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -248,6 +248,9 @@ An example of running ``pycbc_inference`` to analyze the injection in fake data:
     N_ITERATIONS=12000
     N_CHECKPOINT=1000
     PROCESSING_SCHEME=cpu
+
+    # the following sets the number of cores to use; adjust as needed to
+    # your computer's capabilities
     NPROCS=12
 
     # get coalescence time as an integer
@@ -316,7 +319,7 @@ set the following instead::
 
     FRAMES="LOSC"
 
-This will cause the needed frame files to be downloaded from the LIGO Open
+This will instruct the code to download the frame files from the LIGO Open
 Science Center (https://losc.ligo.org).
 
 Now run::
@@ -355,6 +358,9 @@ Now run::
     N_ITERATIONS=12000
     N_CHECKPOINT=1000
     PROCESSING_SCHEME=cpu
+
+    # the following sets the number of cores to use; adjust as needed to
+    # your computer's capabilities
     NPROCS=12
 
     # get coalescence time as an integer

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -420,11 +420,6 @@ Now run::
         --save-stilde \
         --force
 
-To get data we used ``--frame-type`` which will query the LIGO Data
-Replicator (LDR) server to locate the frame files for us. You can also
-use ``--frame-files`` or ``--frame-cache`` if you have a list or LAL cache
-file of frames you wish to use.
-
 ----------------------------------------------------
 HDF output file handler (``pycbc.io.InferenceFile``)
 ----------------------------------------------------


### PR DESCRIPTION
This adds instructions to the inference docs for non-LIGO members to analyze GW150914. It uses the frame-type argument's ability to use LOSC data. That functionality appears not to work currently  however (I get an error claiming the gps times are not in public data), so I'm putting on hold until @ahnitz can fix.