### PR TITLE
Call index first then field in FieldArray

### DIFF
--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -134,8 +134,7 @@ seg_lens = 4*numpy.array([max(4./args.sample_rate,
 
 # generate output file
 logging.info("writing template info to output")
-output = bank.write_to_hdf(args.output, force=args.force,
-    skip_fields='template_duration')
+output = bank.write_to_hdf(args.output, force=args.force)
 
 # get the compressed sample points for each template
 logging.info("getting compressed amplitude and phase")
@@ -157,6 +156,8 @@ for ii in range(imin, imax):
     htilde = bank[ii-imin]
     tmplt = bank.table[ii-imin]
     fmin=tmplt.f_lower
+    template_duration=htilde.chirp_length
+    output['template_duration'][ii-imin]=template_duration
     kmin = int(numpy.ceil(fmin / df))
     if numpy.abs(htilde[kmin]) == 0:
         raise ValueError("""The amplitude of the waveform at the

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -671,10 +671,13 @@ class FilterBank(TemplateBank):
         hdecomp = self.compressed_waveforms[self.table.template_hash[index]].decompress(out=decomp_scratch, f_lower=f_lower, interpolation=decompression_method)
         p = props(self.table[index])
         p.pop('approximant')
-        if hasattr(self.table, 'template_duration'):
-            hdecomp.chirp_length=self.table.template_duration[index]
-        else :
-            hdecomp.chirp_length = get_waveform_filter_length_in_time(approximant, **p)
+        try:
+            tmpltdur = self.table[index].template_duration
+        except AttributeError:
+            tmpltdur = None
+        if tmpltdur is None:
+            tmpltudr = get_waveform_filter_length_in_time(approximant, **p)
+        hdecomp.chirp_length = tmpltdur
         hdecomp.length_in_time = hdecomp.chirp_length
         return hdecomp
 

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -671,7 +671,10 @@ class FilterBank(TemplateBank):
         hdecomp = self.compressed_waveforms[self.table.template_hash[index]].decompress(out=decomp_scratch, f_lower=f_lower, interpolation=decompression_method)
         p = props(self.table[index])
         p.pop('approximant')
-        hdecomp.chirp_length = get_waveform_filter_length_in_time(approximant, **p)
+        if hasattr(self.table, 'template_duration'):
+            hdecomp.chirp_length=self.table.template_duration[index]
+        else :
+            hdecomp.chirp_length = get_waveform_filter_length_in_time(approximant, **p)
         hdecomp.length_in_time = hdecomp.chirp_length
         return hdecomp
 

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -411,7 +411,7 @@ class TemplateBank(object):
         if 'approximant' not in self.table.fieldnames:
             raise ValueError("approximant not found in input file and no "
                 "approximant was specified on initialization")
-        return self.table["approximant"][index]
+        return self.table[index]["approximant"]
 
     def __len__(self):
         return len(self.table)
@@ -486,7 +486,7 @@ class TemplateBank(object):
             if not hasattr(self.table, 'f_lower'):
                 vec = numpy.zeros(len(self.table), dtype=numpy.float32)
                 self.table = self.table.add_fields(vec, 'f_lower')
-            self.table['f_lower'][:] = low_frequency_cutoff
+            self.table[:]['f_lower'] = low_frequency_cutoff
 
         self.min_f_lower = min(self.table['f_lower'])
         if self.f_lower is None and self.min_f_lower == 0.:
@@ -661,14 +661,14 @@ class FilterBank(TemplateBank):
         if self.waveform_decompression_method is not None :
             decompression_method = self.waveform_decompression_method
         else :
-            decompression_method = self.compressed_waveforms[self.table.template_hash[index]].interpolation
+            decompression_method = self.compressed_waveforms[self.table[index].template_hash].interpolation
         logging.info("Decompressing waveform using %s", decompression_method)
 
         # Create memory space for writing the decompressed waveform
         decomp_scratch = FrequencySeries(tempout[0:self.filter_length], delta_f=self.delta_f, copy=False)
 
         # Get the decompressed waveform
-        hdecomp = self.compressed_waveforms[self.table.template_hash[index]].decompress(out=decomp_scratch, f_lower=f_lower, interpolation=decompression_method)
+        hdecomp = self.compressed_waveforms[self.table[index].template_hash].decompress(out=decomp_scratch, f_lower=f_lower, interpolation=decompression_method)
         p = props(self.table[index])
         p.pop('approximant')
         try:

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -657,26 +657,29 @@ class FilterBank(TemplateBank):
         from pycbc.waveform.waveform import props
         from pycbc.waveform import get_waveform_filter_length_in_time
 
+        table_idx = self.table[index]
+        tmplt_hash = table_idx.template_hash
+
         # Get the interpolation method to be used to decompress the waveform
         if self.waveform_decompression_method is not None :
             decompression_method = self.waveform_decompression_method
         else :
-            decompression_method = self.compressed_waveforms[self.table[index].template_hash].interpolation
+            decompression_method = self.compressed_waveforms[tmplt_hash].interpolation
         logging.info("Decompressing waveform using %s", decompression_method)
 
         # Create memory space for writing the decompressed waveform
         decomp_scratch = FrequencySeries(tempout[0:self.filter_length], delta_f=self.delta_f, copy=False)
 
         # Get the decompressed waveform
-        hdecomp = self.compressed_waveforms[self.table[index].template_hash].decompress(out=decomp_scratch, f_lower=f_lower, interpolation=decompression_method)
+        hdecomp = self.compressed_waveforms[tmplt_hash].decompress(out=decomp_scratch, f_lower=f_lower, interpolation=decompression_method)
         p = props(self.table[index])
         p.pop('approximant')
         try:
-            tmpltdur = self.table[index].template_duration
+            tmpltdur = table_idx.template_duration
         except AttributeError:
             tmpltdur = None
         if tmpltdur is None:
-            tmpltudr = get_waveform_filter_length_in_time(approximant, **p)
+            tmpltdur = get_waveform_filter_length_in_time(approximant, **p)
         hdecomp.chirp_length = tmpltdur
         hdecomp.length_in_time = hdecomp.chirp_length
         return hdecomp


### PR DESCRIPTION
This PR makes the index to be called before the field in `self.table` in `TemplateBank` and `FilterBank`. This is to make computation faster when calling a FieldArray.

#1646 would have to be merged before this.