### PR TITLE
Fix weave file locking

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -29,16 +29,6 @@ import subprocess, os, sys, tempfile
 import logging
 import signal
 
-# We need to allow a try/except here to allow for importing during install
-# of pycbc, where we can't guarantee that scipy is installed yet.
-try:
-    import weave.inline_tools
-    from . import weave as pycbc_weave
-    weave.inline_tools._compile_function = weave.inline_tools.compile_function
-    weave.inline_tools.compile_function = pycbc_weave.pycbc_compile_function
-except:
-    pass
-
 try:
     # This will fail when pycbc is imported during the build process,
     # before version.py has been generated.

--- a/pycbc/weave.py
+++ b/pycbc/weave.py
@@ -22,7 +22,9 @@ import os.path, sys
 import logging
 import shutil, atexit, signal
 import fcntl
-import pycbc
+import weave.inline_tools as inline_tools
+
+_compile_function = inline_tools.compile_function
 
 ## Blatently taken from weave to implement a crude file locking scheme
 def pycbc_compile_function(code,arg_names,local_dict,global_dict,
@@ -37,7 +39,6 @@ def pycbc_compile_function(code,arg_names,local_dict,global_dict,
                      **kw):
     """ Dummy wrapper around scipy weave compile to implement file locking
     """
-    from weave.inline_tools import _compile_function
     headers = [] if headers is None else headers
     lockfile_dir = os.environ['PYTHONCOMPILED']
     lockfile_name = os.path.join(lockfile_dir, 'code_lockfile')
@@ -60,6 +61,7 @@ def pycbc_compile_function(code,arg_names,local_dict,global_dict,
 
     return func
 
+inline_tools.compile_function = pycbc_compile_function
 
 def insert_weave_option_group(parser):
     """


### PR DESCRIPTION
This pull request is to restore the custom file locking in weave compilation that PyCBC relies on. Something seems to have broken the previous mechanism; I'm not sure it if happened when weave transitioned to a stand-alone package or not.  It is possible to see from the current master that the correct thing isn't happening: if you import `pycbc.weave` you will see that `pycbc.weave.inline_tools.compile_function` is not pointing at our custom function in `pycbc/weave.py`, but rather at the usual function from the standard package.

This pull request fixes that.  Note that the original approach had a `try/except` block around the imports within `__init__.py` because it said that we couldn't guarantee that `scipy` was available during installation.  I guess I really don't understand that---scipy (and now standalone weave) are dependencies, so I would not expect installation to succeed if the dependencies are not met. So my point being that I've removed anything like that, but I don't know what problem it was supposed to fix, so I may not have run the right test case.