### PR TITLE
Fixing landscape errors

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -6,3 +6,13 @@ ignore-patterns:
     - test/*
     - docs/*
     - tools/*
+
+pylint:
+  disable:
+  - too-many-arguments
+  - too-many-local-variables
+  - too-many-branches
+
+mccabe:
+  disable:
+  - MC0001

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -76,7 +76,7 @@ class ThresholdCluster(object):
     """
     def __new__(cls, *args, **kwargs):
         real_cls = _threshold_cluster_factory(*args, **kwargs)
-        return real_cls(*args, **kwargs)
+        return real_cls(*args, **kwargs) # pylint:disable=not-callable
 
 # The class below should serve as the parent for all schemed classes.
 # The intention is that this class serves simply as the location for

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -39,14 +39,14 @@ from . import coinc
 def threshold(series, value):
     """Return list of values and indices values over threshold in series.
     """
-    return
+    return None, None
     
 @schemed("pycbc.events.threshold_")
 def threshold_only(series, value):
     """Return list of values and indices whose values in series are
        larger (in absolute value) than value
     """
-    return
+    return None, None
 
 #FIXME: This should be under schemed, but I don't understand that yet!
 def threshold_real_numpy(series, value):

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -88,7 +88,7 @@ class Correlator(object):
     """
     def __new__(cls, *args, **kwargs):
         real_cls = _correlate_factory(*args, **kwargs)
-        return real_cls(*args, **kwargs)
+        return real_cls(*args, **kwargs) # pylint:disable=not-callable
 
 # The class below should serve as the parent for all schemed classes.
 # The intention is that this class serves simply as the location for

--- a/pycbc/future.py
+++ b/pycbc/future.py
@@ -54,7 +54,7 @@ def zpk2sos(z, p, k, pairing='nearest'):
     """
 
     import numpy as np
-    from numpy import zeros
+    from numpy import zeros, array
     from scipy.signal import zpk2tf, lfilter
 
     valid_pairings = ['nearest', 'keep_odd']
@@ -158,7 +158,7 @@ def sosfilt(sos, x, axis=-1, zi=None):
     """
 
     import numpy as np
-    from numpy import atleast_1d, atleast_2d, array
+    from numpy import atleast_1d, atleast_2d, array, zeros_like
     from scipy.signal import lfilter
 
     x = np.asarray(x)
@@ -174,7 +174,7 @@ def sosfilt(sos, x, axis=-1, zi=None):
     use_zi = zi is not None
     if use_zi:
         zi = np.asarray(zi)
-        e_zi_shape = list(x.shape)
+        x_zi_shape = list(x.shape)
         x_zi_shape[axis] = 2
         x_zi_shape = tuple([n_sections] + x_zi_shape)
         if zi.shape != x_zi_shape:
@@ -230,9 +230,9 @@ def _cplxreal(z, tol=None):
 
     # Find runs of (approximately) the same real part
     same_real = np.diff(zp.real) <= tol * abs(zp[:-1])
-    diffs = numpy.diff(concatenate(([0], same_real, [0])))
-    run_starts = numpy.where(diffs > 0)[0]
-    run_stops = numpy.where(diffs < 0)[0]
+    diffs = np.diff(concatenate(([0], same_real, [0])))
+    run_starts = np.where(diffs > 0)[0]
+    run_stops = np.where(diffs < 0)[0]
 
     # Sort each run by their imaginary parts
     for i in range(len(run_starts)):

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -34,7 +34,7 @@ import numpy
 # Used to manage a likelihood instance across multiple cores or MPI
 _global_instance = None
 def _call_global_likelihood(*args, **kwds):
-    return _global_instance(*args, **kwds)
+    return _global_instance(*args, **kwds) # pylint:disable=not-callable
 
 class _NoPrior(object):
     """Dummy class to just return 0 if no prior is provided in a

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -238,7 +238,7 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
     if ymax is None:
         ymax = ysamples.max()
     npts = 100
-    X, Y = numpy.mgrid[xmin:xmax:complex(0,npts), ymin:ymax:complex(0,npts)]
+    X, Y = numpy.mgrid[xmin:xmax:complex(0,npts), ymin:ymax:complex(0,npts)] # pylint:disable=invalid-slice-index
     pos = numpy.vstack([X.ravel(), Y.ravel()])
     if use_kombine:
         Z = numpy.exp(kde(pos.T).reshape(X.shape))

--- a/pycbc/tmpltbank/em_progenitors.py
+++ b/pycbc/tmpltbank/em_progenitors.py
@@ -443,7 +443,7 @@ def remnant_mass(eta, ns_g_mass, ns_sequence, chi, incl, shift):
     # Sanity checks
     if not (eta>0. and eta<=0.25 and abs(chi)<=1):
         print('The BH spin magnitude must be <=1 and eta must be between 0 and 0.25')
-        print('This script was launched with ns_mass={0}, eta={1}, chi={2}, inclination={3}\n'.format(ns_b_mass, eta, chi, incl))
+        print('This script was launched with ns_mass={0}, eta={1}, chi={2}, inclination={3}\n'.format(ns_g_mass, eta, chi, incl))
         raise Exception('Unphysical parameters!')
 
     # Binary mass ratio define to be > 1
@@ -668,7 +668,7 @@ def generate_em_constraint_data(mNS_min, mNS_max, delta_mNS, sBH_min, sBH_max, d
     # making sure maxima and minima are included
     mNS_nsamples = complex(0,int(np.ceil((mNS_max-mNS_min)/delta_mNS)+1))
     sBH_nsamples = complex(0,int(np.ceil((sBH_max-sBH_min)/delta_sBH)+1))
-    mNS_vec, sBH_vec = np.mgrid[mNS_min:mNS_max:mNS_nsamples, sBH_min:sBH_max:sBH_nsamples]
+    mNS_vec, sBH_vec = np.mgrid[mNS_min:mNS_max:mNS_nsamples, sBH_min:sBH_max:sBH_nsamples] # pylint:disable=invalid-slice-index
     mNS_locations = np.array(mNS_vec[:,0])
     sBH_locations = np.array(sBH_vec[0])
     mNS_sBH_grid = zip(mNS_vec.ravel(), sBH_vec.ravel())

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -188,10 +188,10 @@ class Array(object):
                     self._data = ArrayWithAligned(_numpy.array(initial_array, 
                                                                dtype=dtype, ndmin=1))
             elif _scheme_matches_base_array(initial_array):
-                self._data = _copy_base_array(initial_array)
+                self._data = _copy_base_array(initial_array) # pylint:disable=assignment-from-no-return
             else:
                 initial_array = _numpy.array(initial_array, dtype=dtype, ndmin=1)
-                self._data = _to_device(initial_array)
+                self._data = _to_device(initial_array) # pylint:disable=assignment-from-no-return
      
     @decorator
     def _memoize_single(fn, self, arg):

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -200,17 +200,17 @@ class Array(object):
         if badh in self._saved:
             return self._saved[badh]
 
-        res = fn(self, arg)
+        res = fn(self, arg) # pylint:disable=not-callable
         self._saved[badh] = res      
         return res
                    
     @decorator
     def _returnarray(fn, self, *args):
-        return Array(fn(self, *args), copy=False)
+        return Array(fn(self, *args), copy=False) # pylint:disable=not-callable
 
     @decorator
     def _returntype(fn, self, *args):
-        ary = fn(self,*args)
+        ary = fn(self,*args) # pylint:disable=not-callable
         if ary is NotImplemented:
             return NotImplemented
         return self._return(ary)
@@ -240,7 +240,7 @@ class Array(object):
             else:
                 return NotImplemented
 
-        return fn(self, *nargs)
+        return fn(self, *nargs) # pylint:disable=not-callable
     
     @decorator  
     def _vcheckother(fn, self, *args):
@@ -258,7 +258,7 @@ class Array(object):
             else:
                 raise TypeError('array argument required')                    
 
-        return fn(self,*nargs)
+        return fn(self,*nargs) # pylint:disable=not-callable
         
     @decorator  
     def _vrcheckother(fn, self,*args):
@@ -275,7 +275,7 @@ class Array(object):
             else:
                 raise TypeError('array argument required')                    
 
-        return fn(self, *nargs)
+        return fn(self, *nargs) # pylint:disable=not-callable
 
     @decorator
     def _icheckother(fn, self, other):
@@ -299,7 +299,7 @@ class Array(object):
         else:
             return NotImplemented
 
-        return fn(self, other)
+        return fn(self, other) # pylint:disable=not-callable
 
     def _typecheck(self, other):
         """ Additional typechecking for other. Placeholder for use by derived

--- a/pycbc/vetoes/chisq.py
+++ b/pycbc/vetoes/chisq.py
@@ -129,7 +129,7 @@ def power_chisq_at_points_from_precomputed(corr, snr, snr_norm, bins, indices):
     """
     logging.info('doing fast point chisq')
     num_bins = len(bins) - 1
-    chisq = shift_sum(corr, indices, bins)
+    chisq = shift_sum(corr, indices, bins) # pylint:disable=assignment-from-no-return
     return (chisq * num_bins - (snr.conj() * snr).real) * (snr_norm ** 2.0)
 
 _q_l = None

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -228,7 +228,7 @@ class BaseGenerator(object):
         def dostuff(self):
             for func in self._pregenerate_functions:
                 func(self)
-            res = generate_func(self)
+            res = generate_func(self) # pylint:disable=not-callable
             return self._postgenerate(res)
         return dostuff
 


### PR DESCRIPTION
So the vulcan main fileserver went down (badly) this morning, meaning I can't access any of my ongoing projects. So what should I do instead for the day? Fix landscape warnings!! This is still work in progress, but I have a question for @ahnitz 

Commit 1:

Disable style messages in the config that we have been telling people to ignore.

https://landscape.io/github/ligo-cbc/pycbc/1795

Commit 2:

Silence false "not callable errors"

https://landscape.io/github/ligo-cbc/pycbc/1796

Commit 3:

Go through all the other errors and either fix it, or silence it. I have not touched issues that other people are already supposed to be fixing, or a few I am unsure of.

https://landscape.io/github/ligo-cbc/pycbc/1797

Remaining points:

Things like this:

https://landscape.io/github/ligo-cbc/pycbc/1797/modules/pycbc/fft/fftw.py#L140

I'm not really certain how the global works. Is it sufficient here to remove the global declaration on line 140? I didn't want to silence this, because the error seems genuine, but don't want to break things!

This looks like a genuine error:

https://landscape.io/github/ligo-cbc/pycbc/1797/modules/pycbc/pool.py#L63

