### PR TITLE
Add ChangeOfVariables distribution

### DIFF
--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -27,7 +27,7 @@ from pycbc.distributions.uniform import *
 
 # a dict of all available distributions
 distribs = {
-    ChangeOfVariables.name, ChangeOfVariables,
+    ChangeOfVariables.name : ChangeOfVariables,
     FromFile.name : FromFile,
     Gaussian.name : Gaussian,
     UniformPowerLaw.name : UniformPowerLaw,

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -18,6 +18,7 @@ probability density function of distributions.
 """
 
 from pycbc.distributions.angular import *
+from pycbc.distributions.change_of_variables import *
 from pycbc.distributions.from_file import *
 from pycbc.distributions.gaussian import *
 from pycbc.distributions.power_law import *
@@ -26,6 +27,7 @@ from pycbc.distributions.uniform import *
 
 # a dict of all available distributions
 distribs = {
+    ChangeOfVariables.name, ChangeOfVariables,
     FromFile.name : FromFile,
     Gaussian.name : Gaussian,
     UniformPowerLaw.name : UniformPowerLaw,

--- a/pycbc/distributions/bounded.py
+++ b/pycbc/distributions/bounded.py
@@ -330,7 +330,7 @@ class BoundedDist(object):
         Returns
         -------
         BoundedDist
-            A distribution instance from the pycbc.inference.prior module.
+            A distribution instance from the pycbc.distribution subpackage.
         """
         return bounded_from_config(cls, cp, section, variable_args,
                                     bounds_required=bounds_required)

--- a/pycbc/distributions/change_of_variables.py
+++ b/pycbc/distributions/change_of_variables.py
@@ -42,33 +42,27 @@ class ChangeOfVariables(bounded.BoundedDist):
         self._sampling_dist = sampling_dist
         self._prior_dist = prior_dist
         self._transform = transform
+        self._bounds = self._sampling_dist._bounds
+        self._params = self._sampling_dist._params
 
-    @property
-    def bounds(self):
-        return self._sampling_dist.bounds
-
-    @property
-    def params(self):
-        return self._sampling_dist.params
-
-    def pdf(self, **kwargs):
+    def _pdf(self, **kwargs):
         """Returns the pdf at the given values. The keyword arguments must
         contain all of parameters in self's params. Unrecognized arguments are
         ignored. Any boundary conditions are applied to the values before the
         pdf is evaluated.
         """
         prior_dist_params = self._transform.convert(kwargs)
-        return self._transform.jacobian(**kwargs) \
+        return self._transform.jacobian(kwargs) \
                                * self._prior_dist.pdf(**prior_dist_params)
 
-    def logpdf(self, **kwargs):
+    def _logpdf(self, **kwargs):
         """Returns the log of the pdf at the given values. The keyword
         arguments must contain all of parameters in self's params.
         Unrecognized arguments are ignored. Any boundary conditions are
         applied to the values before the pdf is evaluated.
         """
         prior_dist_params = self._transform.convert(kwargs)
-        return self._transform.jacobian(**kwargs) \
+        return self._transform.jacobian(kwargs) \
                                + self._prior_dist.logpdf(**prior_dist_params)
 
     def rvs(self, size=1, param=None):
@@ -151,6 +145,8 @@ class ChangeOfVariables(bounded.BoundedDist):
         prior_section = "-".join([cov_section, prior_opts["parameters"]])
         for sec, opts in zip([sampling_section, prior_section],
                              [sampling_opts, prior_opts]):
+            if cp.has_section(sec):
+                cp.remove_section(sec)
             cp.add_section(sec)
             sec_opts = [(key, val) for key, val in opts.items()
                         if key not in restricted_opts]
@@ -169,4 +165,4 @@ class ChangeOfVariables(bounded.BoundedDist):
 
         return cls(sampling_dist, prior_dist, transform)
 
-__all__ = [ChangeOfVariables]
+__all__ = ["ChangeOfVariables"]

--- a/pycbc/distributions/change_of_variables.py
+++ b/pycbc/distributions/change_of_variables.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2017  Christopher M. Biwer
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This modules provides classes for evaluating distributions that include
+a change of variables.
+"""
+
+import numpy
+from pycbc.distributions import bounded
+
+class ChangeOfVariables(bounded.BoundedDist):
+    """ Class for sampling in one set of parameters and using a Jacobian
+    transform to another set of parameters to calculate the
+    probability density function.
+    """
+
+    name = "change_of_variables"
+
+    def __init__(self, sampling_dist, prior_dist, transform):
+        self._sampling_dist = sampling_dist
+        self._prior_dist = prior_dist
+        self._transform = transform
+
+    @property
+    def bounds(self):
+        return self._sampling_dist.bounds
+
+    @property
+    def params(self):
+        return self._sampling_dist.params
+
+    def pdf(self, **kwargs):
+        prior_dist_params = self._transform.convert(kwargs)
+        return self._prior_dist.pdf(**prior_dist_params)
+
+    def logpdf(self, **kwargs):
+        prior_dist_params = self._transform.convert(kwargs)
+        return self._prior_dist.logpdf(**prior_dist_params)
+
+    @classmethod
+    def from_config(self, **kwargs):
+        return 0

--- a/pycbc/distributions/change_of_variables.py
+++ b/pycbc/distributions/change_of_variables.py
@@ -60,7 +60,9 @@ class ChangeOfVariables(bounded.BoundedDist):
         from pycbc.distributions import distribs
 
         # a list of restricted options in the configuration file section
-        # used by internally by ChangeOfVariables
+        # used internally by ChangeOfVariables
+        # these options to do get transcribed to the new sections in the
+        # configuration file that are created by from_config
         restricted_opts = ["parameters"]
 
         # get name of Distributions and Transformation

--- a/pycbc/distributions/change_of_variables.py
+++ b/pycbc/distributions/change_of_variables.py
@@ -29,12 +29,12 @@ class ChangeOfVariables(bounded.BoundedDist):
     Examples
     --------
     How to initialize a chirp mass and mass ratio to component mass instance:
-        >> from pycbc import transforms
-        >> from pycbc import distributions
-        >> mchirp_q_dist = distributions.Uniform(mchirp=(7, 40), q=(1, 10))
-        >> mass1_mass2_dist = distributions.Uniform(mass1=(8, 46), mass2=(2, 46))
-        >> cov_dist = distributions.ChangeOfVariables(mchirp_q_dist, mass1_mass2_dist,
-                                                      transforms.MchirpQToMass1Mass2)
+
+    >>> from pycbc import transforms
+    >>> from pycbc import distributions
+    >>> mchirp_q_dist = distributions.Uniform(mchirp=(7, 40), q=(1, 10))
+    >>> mass1_mass2_dist = distributions.Uniform(mass1=(8, 46), mass2=(2, 46))
+    >>> cov_dist = distributions.ChangeOfVariables(mchirp_q_dist, mass1_mass2_dist, transforms.MchirpQToMass1Mass2)
     """
     name = "change_of_variables"
 

--- a/pycbc/distributions/change_of_variables.py
+++ b/pycbc/distributions/change_of_variables.py
@@ -157,12 +157,10 @@ class ChangeOfVariables(bounded.BoundedDist):
             cp.add_options_to_section(sec, sec_opts)
 
         # create Distributions
-        sampling_dist = bounded.bounded_from_config(
-                               distribs[sampling_name], cp,
-                               cov_section, sampling_opts["parameters"])
-        prior_dist = bounded.bounded_from_config(
-                               distribs[prior_name], cp,
-                               cov_section, prior_opts["parameters"])
+        sampling_dist = distribs[sampling_name].from_config(
+                           cp, cov_section, sampling_opts["parameters"])
+        prior_dist = distribs[prior_name].from_config(
+                           cp, cov_section, prior_opts["parameters"])
 
         # create Transformation
         for converter in transforms.all_converters:

--- a/pycbc/distributions/change_of_variables.py
+++ b/pycbc/distributions/change_of_variables.py
@@ -18,6 +18,7 @@ a change of variables.
 """
 
 import numpy
+from pycbc import transforms
 from pycbc.distributions import bounded
 
 class ChangeOfVariables(bounded.BoundedDist):
@@ -60,7 +61,7 @@ class ChangeOfVariables(bounded.BoundedDist):
         # used by internally by ChangeOfVariables
         restricted_opts = ["parameters"]
 
-        # get name of Distributions and Transform
+        # get name of Distributions and Transformation
         sampling_name = cp.get_opt_tag(section, "sampling-name", variable_args)
         prior_name = cp.get_opt_tag(section, "prior-name", variable_args)
         transform_name = cp.get_opt_tag(
@@ -98,4 +99,9 @@ class ChangeOfVariables(bounded.BoundedDist):
                                distribs[prior_name], cp,
                                cov_section, prior_opts["parameters"])
 
-        return 0
+        # create Transformation
+        for converter in transforms.all_converters:
+            if converter.name == transform_name:
+                transform = converter()
+
+        return cls(sampling_dist, prior_dist, transform)

--- a/pycbc/distributions/change_of_variables.py
+++ b/pycbc/distributions/change_of_variables.py
@@ -71,6 +71,27 @@ class ChangeOfVariables(bounded.BoundedDist):
         return self._transform.jacobian(**kwargs) \
                                + self._prior_dist.logpdf(**prior_dist_params)
 
+    def rvs(self, size=1, param=None):
+        """Gives a set of random values drawn from this distribution.
+
+        Parameters
+        ----------
+        size : {1, int}
+            The number of values to generate; default is 1.
+        param : {None, string}
+            If provided, will just return values for the given parameter.
+            Otherwise, returns random values for each parameter.
+
+        Returns
+        -------
+        structured array
+            The random values in a numpy structured array. If a param was
+            specified, the array will only have an element corresponding to the
+            given parameter. Otherwise, the array will have an element for each
+            parameter in self's params.
+        """
+        return self._sampling_dist.rvs(size=size, param=param)
+
     @classmethod
     def from_config(cls, cp, section, variable_args):
         """Returns a distribution based on a configuration file. The parameters

--- a/pycbc/distributions/change_of_variables.py
+++ b/pycbc/distributions/change_of_variables.py
@@ -44,11 +44,13 @@ class ChangeOfVariables(bounded.BoundedDist):
 
     def pdf(self, **kwargs):
         prior_dist_params = self._transform.convert(kwargs)
-        return self._prior_dist.pdf(**prior_dist_params)
+        return self._transform.jacobian(**kwargs) \
+                               * self._prior_dist.pdf(**prior_dist_params)
 
     def logpdf(self, **kwargs):
         prior_dist_params = self._transform.convert(kwargs)
-        return self._prior_dist.logpdf(**prior_dist_params)
+        return self._transform.jacobian(**kwargs) \
+                               + self._prior_dist.logpdf(**prior_dist_params)
 
     @classmethod
     def from_config(cls, cp, section, variable_args):
@@ -102,6 +104,6 @@ class ChangeOfVariables(bounded.BoundedDist):
         # create Transformation
         for converter in transforms.all_converters:
             if converter.name == transform_name:
-                transform = converter()
+                transform = converter
 
         return cls(sampling_dist, prior_dist, transform)

--- a/pycbc/distributions/change_of_variables.py
+++ b/pycbc/distributions/change_of_variables.py
@@ -50,5 +50,23 @@ class ChangeOfVariables(bounded.BoundedDist):
         return self._prior_dist.logpdf(**prior_dist_params)
 
     @classmethod
-    def from_config(self, **kwargs):
+    def from_config(cls, cp, section, variable_args):
+
+        # import mapping for Distributions
+        # cannot be a top-level import because of circular dependencies
+        from pycbc.distributions import distribs
+
+        print variable_args
+
+        sampling_name = cp.get_opt_tag(section, "sampling-name", variable_args)
+
+        cp.add_section("-".join(["cov"])
+
+        sampling_dist = bounded.bounded_from_config(
+                                    distribs[sampling_name], cp, section,
+                                    variable_args, additional_opts=None)
+
+        # get Distributions
+        sampling_dist = distribs[cp.get_opt_tag("prior", key, "")]
+        prior_dist = distribs["prior_name"]
         return 0

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -26,6 +26,8 @@ This modules provides classes and functions for evaluating the prior
 for parameter estimation.
 """
 
+import numpy
+
 class PriorEvaluator(object):
     """
     Callable class that calculates the prior.
@@ -97,6 +99,6 @@ class PriorEvaluator(object):
         """ Evalualate prior for parameters.
         """
         params = dict(zip(self.variable_args, params))
-        return sum([d(**params) for d in self.distributions])
+        return numpy.float64(sum([d(**params) for d in self.distributions]))
 
 

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -458,7 +458,7 @@ class BaseMCMCSampler(_BaseSampler):
         parameters = samples.fieldnames
         if samples is None:
             return None
-        samples = samples.to_array(axis=-1)
+        samples = samples.to_array(axis=-1).astype(numpy.float64)
         samples_group = fp.stats_group
 
         # write data


### PR DESCRIPTION
Depends on #1673 and #1674.

@cdcapano I think this is what you had in mind. That the class gets passed two distributions and a transformation.

At the moment you specify in the configuration file like:
```
[prior-mchirp+q]
name = change_of_variables
transform-name = mchirp_q_to_mass1_mass2
prior-parameters = mass1+mass2
prior-name = uniform
prior-min-mass1 =2.0
prior-max-mass1 =50.0
prior-min-mass2 =2.0
prior-max-mass2 =50.0
sampling-parameters = mchirp+q
sampling-name = uniform
sampling-min-mchirp = 20
sampling-max-mchirp = 22
sampling-min-q = 1.001
sampling-max-q = 2
```

All ``prior-`` options get put in a new section and all ``sampling-`` options get put in a new section. So in the example above. Internally, ``from_config`` creates two new sections ``changeofvariables-mchirp+q`` and ``changeofvariables-mass1+mass2``, then creates distributions from those using their own ``from_config`` functions.

You have to specify the limits of both distributions as normal. Before in my other PR I had it determine the limits of the prior distribution internally. I think that something we want but I think that can be another PR. There's already a bit of stuff here.