### PR TITLE
Unused variables

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -10,7 +10,7 @@ ignore-patterns:
 pylint:
   disable:
   - too-many-arguments
-  - too-many-local-variables
+  - too-many-locals
   - too-many-branches
 
 pyflakes:

--- a/.landscape.yml
+++ b/.landscape.yml
@@ -13,6 +13,10 @@ pylint:
   - too-many-local-variables
   - too-many-branches
 
+pyflakes:
+  disable:
+  - F841
+
 mccabe:
   disable:
   - MC0001

--- a/pycbc/_version_helper.py
+++ b/pycbc/_version_helper.py
@@ -29,15 +29,15 @@ import distutils.version
 
 class GitInfo(object):
     def __init__(self):
-        date = None
-        hash = None
-        branch = None
-        tag = None
-        author = None
-        committer = None
-        status = None
-        builder = None
-        build_date = None
+        self.date = None
+        self.hash = None
+        self.branch = None
+        self.tag = None
+        self.author = None
+        self.committer = None
+        self.status = None
+        self.builder = None
+        self.build_date = None
 
 
 class GitInvocationError(LookupError):

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -132,9 +132,9 @@ def findchirp_cluster_over_window(times, values, window_length):
 
     from weave import inline
     indices = numpy.zeros(len(times), dtype=int)
-    tlen = len(times)
+    tlen = len(times) # pylint:disable=unused-variable
     k = numpy.zeros(1, dtype=int)
-    absvalues = abs(values)
+    absvalues = abs(values) # pylint:disable=unused-variable
     times = times.astype(int)
     code = """
         int j = 0;

--- a/pycbc/events/simd_threshold.py
+++ b/pycbc/events/simd_threshold.py
@@ -703,12 +703,12 @@ class MaxOnlyObject(object):
         self.verbose = verbose
 
     def execute(self):
-        inarr = self.inarr
-        mval = self.mval
-        norm = self.norm
-        mloc = self.mloc
-        nstart = self.nstart
-        howmany = self.howmany
+        inarr = self.inarr # pylint:disable=unused-variable
+        mval = self.mval # pylint:disable=unused-variable
+        norm = self.norm # pylint:disable=unused-variable
+        mloc = self.mloc # pylint:disable=unused-variable
+        nstart = self.nstart # pylint:disable=unused-variable
+        howmany = self.howmany # pylint:disable=unused-variable
         inline(self.code, ['inarr', 'mval', 'norm', 'mloc', 'nstart', 'howmany'],
                extra_compile_args = [WEAVE_FLAGS],
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
@@ -742,12 +742,12 @@ class WindowedMaxObject(object):
 
     def execute(self):
         inarr = self.inarr
-        arrlen = self.arrlen
-        cvals = self.cvals
-        norms = self.norms
-        locs = self.locs
-        winsize = self.winsize
-        startoffset = self.startoffset
+        arrlen = self.arrlen # pylint:disable=unused-variable
+        cvals = self.cvals # pylint:disable=unused-variable
+        norms = self.norms # pylint:disable=unused-variable
+        locs = self.locs # pylint:disable=unused-variable
+        winsize = self.winsize # pylint:disable=unused-variable
+        startoffset = self.startoffset # pylint:disable=unused-variable
         inline(self.code, ['inarr', 'arrlen', 'cvals', 'norms', 'locs', 'winsize', 'startoffset'],
                extra_compile_args = [WEAVE_FLAGS],
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
@@ -795,12 +795,12 @@ class ThreshClusterObject(object):
         self.verbose = verbose
 
     def execute(self, thresh):
-        series = self.series
-        slen = self.slen
-        values = self.values
-        locs = self.locs
-        window = self.window
-        segsize = self.segsize
+        series = self.series # pylint:disable=unused-variable
+        slen = self.slen # pylint:disable=unused-variable
+        values = self.values # pylint:disable=unused-variable
+        locs = self.locs # pylint:disable=unused-variable
+        window = self.window # pylint:disable=unused-variable
+        segsize = self.segsize # pylint:disable=unused-variable
         nthr = inline(self.code, ['series', 'slen', 'values', 'locs', 'thresh', 'window', 'segsize'],
                       extra_compile_args = [WEAVE_FLAGS] + omp_flags,
                       #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],

--- a/pycbc/events/simd_threshold.py
+++ b/pycbc/events/simd_threshold.py
@@ -741,7 +741,7 @@ class WindowedMaxObject(object):
         self.verbose = verbose
 
     def execute(self):
-        inarr = self.inarr
+        inarr = self.inarr # pylint:disable=unused-variable
         arrlen = self.arrlen # pylint:disable=unused-variable
         cvals = self.cvals # pylint:disable=unused-variable
         norms = self.norms # pylint:disable=unused-variable

--- a/pycbc/events/threshold_cpu.py
+++ b/pycbc/events/threshold_cpu.py
@@ -41,15 +41,15 @@ outl = None
 outv = None
 count = None
 def threshold_inline(series, value):
-    arr = numpy.array(series.data.view(dtype=numpy.float32), copy=False)
+    arr = numpy.array(series.data.view(dtype=numpy.float32), copy=False) # pylint:disable=unused-variable
     global outl, outv, count
     if outl is None or len(outl) < len(series):
         outl = numpy.zeros(len(series), dtype=numpy.uint32)
         outv = numpy.zeros(len(series), dtype=numpy.complex64)
         count = numpy.zeros(1, dtype=numpy.uint32)
         
-    N = len(series)
-    threshold = value**2.0
+    N = len(series) # pylint:disable=unused-variable
+    threshold = value**2.0 # pylint:disable=unused-variable
     code = """  
         float v = threshold;
         unsigned int num_parallel_regions = 16;
@@ -109,11 +109,11 @@ class CPUThresholdCluster(_BaseThresholdCluster):
         self.support = thresh_cluster_support
 
     def threshold_and_cluster(self, threshold, window):
-        series = self.series
-        slen = self.slen
+        series = self.series # pylint:disable=unused-variable
+        slen = self.slen # pylint:disable=unused-variable
         values = self.outv
         locs = self.outl
-        segsize = self.segsize
+        segsize = self.segsize # pylint:disable=unused-variable
         self.count = inline(self.code, ['series', 'slen', 'values', 'locs', 'threshold', 'window', 'segsize'],
                             extra_compile_args = [WEAVE_FLAGS] + omp_flags,
                             #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'] + omp_flags,

--- a/pycbc/events/veto.py
+++ b/pycbc/events/veto.py
@@ -206,7 +206,7 @@ def get_segment_definer_comments(xml_file, include_version=True):
     lsctables.use_in(h)
 
     # read segment definer table
-    xmldoc, digest = ligolw_utils.load_fileobj(xml_file,
+    xmldoc, _ = ligolw_utils.load_fileobj(xml_file,
                                         gz=xml_file.name.endswith(".gz"),
                                         contenthandler=h)
     seg_def_table = table.get_table(xmldoc,

--- a/pycbc/fft/core.py
+++ b/pycbc/fft/core.py
@@ -172,7 +172,7 @@ def _check_inv_args(invec, itype, outvec, otype, nbatch, size):
 
 class _BaseFFT(object):
     def __init__(self, invec, outvec, nbatch, size):
-        prec, itype, otype = _check_fft_args(invec, outvec)
+        _, itype, otype = _check_fft_args(invec, outvec)
         _check_fwd_args(invec, itype, outvec, otype, nbatch, size)
         self.forward = True
         self.invec = invec
@@ -225,7 +225,7 @@ class _BaseFFT(object):
 
 class _BaseIFFT(object):
     def __init__(self, invec, outvec, nbatch, size):
-        prec, itype, otype = _check_fft_args(invec, outvec)
+        _, itype, otype = _check_fft_args(invec, outvec)
         _check_inv_args(invec, itype, outvec, otype, nbatch, size)
         self.forward = False
         self.invec = invec

--- a/pycbc/fft/fft_callback.py
+++ b/pycbc/fft/fft_callback.py
@@ -226,7 +226,7 @@ def c2c_correlate_ifft(htilde, stilde, outvec):
         fn, pfn = get_fn_plan(callback=full_corr, parameters = [("void*", "htilde")])
         plan = pfn(len(outvec), int(htilde.data.gpudata))
         _plans[key] = (fn, plan, int(htilde.data.gpudata))
-    fn, plan, h = _plans[key]
+    fn, plan, _ = _plans[key]
     hparam.htilde = htilde.data.gpudata
     fn(plan, int(stilde.data.gpudata), int(outvec.data.gpudata), ctypes.pointer(hparam))
 
@@ -248,7 +248,7 @@ def c2c_half_correlate_ifft(htilde, stilde, outvec):
                               out_callback=zero_out)
         plan = pfn(len(outvec), int(htilde.data.gpudata))
         _plans[key] = (fn, plan, int(htilde.data.gpudata))
-    fn, plan, h = _plans[key]
+    fn, plan, _ = _plans[key]
     hparam_zeros.htilde = htilde.data.gpudata
     hparam_zeros.in_kmax = htilde.end_idx
     hparam_zeros.out_kmin = stilde.analyze.start

--- a/pycbc/fft/fftw_pruned.py
+++ b/pycbc/fft/fftw_pruned.py
@@ -147,7 +147,7 @@ def second_phase(invec, indices, N1, N2):
     out : array of floats
     """
     invec = numpy.array(invec.data, copy=False)
-    NI = len(indices)
+    NI = len(indices) # pylint:disable=unused-variable
     N1=int(N1)
     N2=int(N2)
     out = numpy.zeros(len(indices), dtype=numpy.complex64)
@@ -195,7 +195,7 @@ def fast_second_phase(invec, indices, N1, N2):
     out : array of floats
     """
     invec = numpy.array(invec.data, copy=False)
-    NI = len(indices)
+    NI = len(indices) # pylint:disable=unused-variable
     N1=int(N1)
     N2=int(N2)
     out = numpy.zeros(len(indices), dtype=numpy.complex64)

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1103,7 +1103,7 @@ def matched_filter(template, data, psd=None, low_frequency_cutoff=None,
     snr : TimeSeries
         A time series containing the complex snr.
     """
-    snr, corr, norm = matched_filter_core(template, data, psd=psd,
+    snr, _, norm = matched_filter_core(template, data, psd=psd,
             low_frequency_cutoff=low_frequency_cutoff,
             high_frequency_cutoff=high_frequency_cutoff, h_norm=sigmasq)
     return snr * norm
@@ -1147,7 +1147,7 @@ def match(vec1, vec2, psd=None, low_frequency_cutoff=None,
     global _snr
     if _snr is None or _snr.dtype != htilde.dtype or len(_snr) != N:
         _snr = zeros(N,dtype=complex_same_precision_as(vec1))
-    snr, corr, snr_norm = matched_filter_core(htilde,stilde,psd,low_frequency_cutoff,
+    snr, _, snr_norm = matched_filter_core(htilde,stilde,psd,low_frequency_cutoff,
                              high_frequency_cutoff, v1_norm, out=_snr)
     maxsnr, max_id = snr.abs_max_loc()
     if v2_norm is None:

--- a/pycbc/filter/matchedfilter_cpu.py
+++ b/pycbc/filter/matchedfilter_cpu.py
@@ -48,10 +48,10 @@ batch_correlator_code = """
 """
 
 def batch_correlate_execute(self, y):
-    num_vectors = self.num_vectors
-    size = self.size
-    x = numpy.array(self.x.data, copy=False)
-    z = numpy.array(self.z.data, copy=False)
+    num_vectors = self.num_vectors # pylint:disable=unused-variable
+    size = self.size # pylint:disable=unused-variable
+    x = numpy.array(self.x.data, copy=False) # pylint:disable=unused-variable
+    z = numpy.array(self.z.data, copy=False) # pylint:disable=unused-variable
     y = numpy.array(y.data, copy=False)        
     inline(batch_correlator_code, ['x', 'y', 'z', 'size', 'num_vectors'],
                 extra_compile_args=[WEAVE_FLAGS] + omp_flags,
@@ -90,10 +90,10 @@ def correlate_batch_inline(x, y, z):
     else:
         the_code = double_codeb
         
-    za = numpy.array(z.ptr, copy=False)
-    xa = numpy.array(x.ptr, copy=False)
-    ya = numpy.array(y.ptr, copy=False)
-    N = len(x) 
+    za = numpy.array(z.ptr, copy=False) # pylint:disable=unused-variable
+    xa = numpy.array(x.ptr, copy=False) # pylint:disable=unused-variable
+    ya = numpy.array(y.ptr, copy=False) # pylint:disable=unused-variable
+    N = len(x)  # pylint:disable=unused-variable
     inline(the_code, ['xa', 'ya', 'za', 'N'], 
                     extra_compile_args=[WEAVE_FLAGS] + omp_flags,
                     support_code = support,
@@ -124,10 +124,10 @@ def correlate_inline(x, y, z):
     else:
         the_code = double_code
         
-    za = numpy.array(z.data, copy=False)
-    xa = numpy.array(x.data, copy=False)
-    ya = numpy.array(y.data, copy=False)
-    N = len(x) 
+    za = numpy.array(z.data, copy=False) # pylint:disable=unused-variable
+    xa = numpy.array(x.data, copy=False) # pylint:disable=unused-variable
+    ya = numpy.array(y.data, copy=False) # pylint:disable=unused-variable
+    N = len(x)  # pylint:disable=unused-variable
     inline(the_code, ['xa', 'ya', 'za', 'N'], 
                     extra_compile_args=[WEAVE_FLAGS] + omp_flags,
                     support_code = support,
@@ -148,11 +148,11 @@ class CPUCorrelator(_BaseCorrelator):
         self.segsize = default_segsize
 
     def correlate(self):
-        htilde = self.x
-        stilde = self.y
-        qtilde = self.z
-        arrlen = self.arrlen
-        segsize = self.segsize
+        htilde = self.x # pylint:disable=unused-variable
+        stilde = self.y # pylint:disable=unused-variable
+        qtilde = self.z # pylint:disable=unused-variable
+        arrlen = self.arrlen # pylint:disable=unused-variable
+        segsize = self.segsize # pylint:disable=unused-variable
         inline(self.code, ['htilde', 'stilde', 'qtilde', 'arrlen', 'segsize'],
                extra_compile_args = [WEAVE_FLAGS] + omp_flags,
                #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'] + omp_flags,

--- a/pycbc/filter/resample.py
+++ b/pycbc/filter/resample.py
@@ -286,7 +286,6 @@ def interpolate_complex_frequency(series, delta_f, zeros_offset=0, side='right')
         A new FrequencySeries that has been interpolated.
     """
     new_n = int( (len(series)-1) * series.delta_f / delta_f + 1)
-    samples = numpy.arange(0, new_n) * delta_f
     old_N = int( (len(series)-1) * 2 )
     new_N = int( (new_n - 1) * 2 )
     time_series = TimeSeries(zeros(old_N), delta_t =1.0/(series.delta_f*old_N),

--- a/pycbc/filter/simd_correlate.py
+++ b/pycbc/filter/simd_correlate.py
@@ -421,9 +421,9 @@ ccorrf_simd(htilde, stilde, qtilde, (int64_t) arrlen);
 
 def correlate_simd(ht, st, qt):
     htilde = _np.array(ht.data, copy = False).view(dtype = float32)
-    stilde = _np.array(st.data, copy = False).view(dtype = float32)
-    qtilde = _np.array(qt.data, copy = False).view(dtype = float32)
-    arrlen = len(htilde)
+    stilde = _np.array(st.data, copy = False).view(dtype = float32) # pylint:disable=unused-variable
+    qtilde = _np.array(qt.data, copy = False).view(dtype = float32) # pylint:disable=unused-variable
+    arrlen = len(htilde) # pylint:disable=unused-variable
     inline(corr_simd_code, ['htilde', 'stilde', 'qtilde', 'arrlen'],
            extra_compile_args = [WEAVE_FLAGS],
            #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],
@@ -454,10 +454,10 @@ else:
 
 def correlate_parallel(ht, st, qt):
     htilde = _np.array(ht.data, copy = False)
-    stilde = _np.array(st.data, copy = False)
-    qtilde = _np.array(qt.data, copy = False)
-    arrlen = len(htilde)
-    segsize = default_segsize
+    stilde = _np.array(st.data, copy = False) # pylint:disable=unused-variable
+    qtilde = _np.array(qt.data, copy = False) # pylint:disable=unused-variable
+    arrlen = len(htilde) # pylint:disable=unused-variable
+    segsize = default_segsize # pylint:disable=unused-variable
     inline(corr_parallel_code, ['htilde', 'stilde', 'qtilde', 'arrlen', 'segsize'],
            extra_compile_args = [WEAVE_FLAGS] + omp_flags, libraries = omp_libs,
            #extra_compile_args = ['-mno-avx -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4 -mno-sse4.1 -mno-sse4.2 -mno-sse4a -O2 -w'],

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -98,7 +98,7 @@ def locations_to_cache(locations):
     for source in locations:
         for file_path in glob.glob(source):
             dir_name, file_name = os.path.split(file_path)
-            base_name, file_extension = os.path.splitext(file_name)
+            _, file_extension = os.path.splitext(file_name)
 
             if file_extension in [".lcf", ".cache"]:
                 cache = lal.CacheImport(file_path)
@@ -286,9 +286,8 @@ def frame_paths(frame_type, start_time, end_time, server=None):
     """
     site = frame_type[0]
     connection = datafind_connection(server)
-    times = connection.find_times(site, frame_type, 
-                                  gpsstart=start_time, 
-                                  gpsend=end_time)
+    connection.find_times(site, frame_type, 
+                          gpsstart=start_time, gpsend=end_time)
     cache = connection.find_frame_urls(site, frame_type, start_time, end_time)
     paths = [entry.path for entry in cache]
     return paths    
@@ -470,7 +469,7 @@ class DataBuffer(object):
         sample_rate: int
             The sample rate of the data within this channel
         """
-        data_length = lalframe.FrStreamGetVectorLength(channel_name, stream)
+        lalframe.FrStreamGetVectorLength(channel_name, stream)
         channel_type = lalframe.FrStreamGetTimeSeriesType(channel_name, stream)
         create_series_func = _fr_type_map[channel_type][2]
         get_series_metadata_func = _fr_type_map[channel_type][3]
@@ -505,7 +504,7 @@ class DataBuffer(object):
             return TimeSeries(data.data.data, delta_t=data.deltaT,
                               epoch=self.read_pos, 
                               dtype=dtype)     
-        except Exception as e:
+        except Exception:
             raise RuntimeError('Cannot read requested frame data') 
 
     def null_advance(self, blocksize):

--- a/pycbc/frame/losc.py
+++ b/pycbc/frame/losc.py
@@ -58,7 +58,7 @@ def losc_frame_json(ifo, start_time, end_time):
     
     try:
         return json.loads(urllib.urlopen(url).read())
-    except Exception as err:
+    except Exception:
         raise ValueError('Failed to find gwf files for '
             'ifo=%s, run=%s, between %s-%s' % (ifo, run, start_time, end_time))
            
@@ -115,7 +115,7 @@ def read_frame_losc(channels, start_time, end_time):
     fnames = {ifo:[] for ifo in ifos}
     for ifo in ifos:
         for url in urls[ifo]:
-            fname, meta = urllib.urlretrieve(url)
+            fname, _ = urllib.urlretrieve(url)
             fnames[ifo].append(fname)
     
     ts = [read_frame(fnames[channel[0:2]], channel,

--- a/pycbc/inference/gelman_rubin.py
+++ b/pycbc/inference/gelman_rubin.py
@@ -48,7 +48,7 @@ def walk(chains, start, end, step):
 
     # get number of chains, parameters, and iterations
     chains = numpy.array(chains)
-    nchains, nparameters, niterations = chains.shape
+    _, nparameters, niterations = chains.shape
 
     # get end index of blocks
     ends = numpy.arange(start, end, step)

--- a/pycbc/inference/gelman_rubin.py
+++ b/pycbc/inference/gelman_rubin.py
@@ -48,7 +48,7 @@ def walk(chains, start, end, step):
 
     # get number of chains, parameters, and iterations
     chains = numpy.array(chains)
-    _, nparameters, niterations = chains.shape
+    _, nparameters, _ = chains.shape
 
     # get end index of blocks
     ends = numpy.arange(start, end, step)

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -311,7 +311,7 @@ class SGBurstInjectionSet(object):
                     + str(strain.dtype))
 
         lalstrain = strain.lal()
-        detector = Detector(detector_name)
+        #detector = Detector(detector_name)
         earth_travel_time = lal.REARTH_SI / lal.C_SI
         t0 = float(strain.start_time) - earth_travel_time
         t1 = float(strain.end_time) + earth_travel_time

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -352,7 +352,7 @@ class SingleDetTriggers(object):
             # giving the surviving triggers 
             logging.info('%i triggers before vetoes',
                           len(self.trigs['end_time'][:]))
-            self.veto_mask, segs = events.veto.indices_outside_segments(
+            self.veto_mask, _ = events.veto.indices_outside_segments(
                 self.trigs['end_time'][:], [veto_file],
                 ifo=detector, segment_name=segment_name)
             logging.info('%i triggers remain after vetoes',
@@ -504,13 +504,13 @@ class SingleDetTriggers(object):
 
     @property
     def mchirp(self):
-        mchirp, eta = pnutils.mass1_mass2_to_mchirp_eta(
+        mchirp, _ = pnutils.mass1_mass2_to_mchirp_eta(
             self.mass1, self.mass2)
         return mchirp
 
     @property
     def eta(self):
-        mchirp, eta = pnutils.mass1_mass2_to_mchirp_eta(
+        _, eta = pnutils.mass1_mass2_to_mchirp_eta(
             self.mass1, self.mass2)
         return eta
 
@@ -714,9 +714,8 @@ class ForegroundTriggers(object):
         for name in sngl_col_names:
             sngl_col_vals[name] = self.get_snglfile_array_dict(name)
 
-        for idx, coinc_idx in enumerate(self.sort_arr):
+        for idx in xrange(len(self.sort_arr)):
             # Set up IDs and mapping values
-            curr_tmplt_id = self.template_id[idx]
             coinc_id = lsctables.CoincID(idx)
 
             # Set up sngls
@@ -729,7 +728,6 @@ class ForegroundTriggers(object):
                 sngl = return_empty_sngl()
                 sngl.event_id = event_id
                 sngl.ifo = ifo
-                curr_sngl_file = self.sngl_files[ifo].h5file[ifo]
                 for name in sngl_col_names:
                     val = sngl_col_vals[name][ifo][idx]
                     if name == 'end_time':
@@ -741,7 +739,7 @@ class ForegroundTriggers(object):
                     setattr(sngl, name, val)
                 sngl.mtotal, sngl.eta = pnutils.mass1_mass2_to_mtotal_eta(
                         sngl.mass1, sngl.mass2)
-                sngl.mchirp, junk = pnutils.mass1_mass2_to_mchirp_eta(
+                sngl.mchirp, _ = pnutils.mass1_mass2_to_mchirp_eta(
                         sngl.mass1, sngl.mass2)
                 sngl.eff_distance = (sngl.sigmasq)**0.5 / sngl.snr
                 sngl_combined_mchirp += sngl.mchirp
@@ -804,7 +802,6 @@ def get_chisq_from_file_choice(hdfile, chisq_choice):
         trad_chisq = f['chisq'][:]
         # We now need to handle the case where chisq is not actually calculated
         # 0 is used as a sentinel value
-        l = trad_chisq == 0
         trad_chisq_dof = f['chisq_dof'][:]
         trad_chisq /= (trad_chisq_dof * 2 - 2)
     if chisq_choice in ['cont', 'max_cont_trad', 'max_bank_cont',

--- a/pycbc/libutils.py
+++ b/pycbc/libutils.py
@@ -68,7 +68,7 @@ def pkg_config(pkg_libraries):
 def pkg_config_header_strings(pkg_libraries):
     """ Returns a list of header strings that could be passed to a compiler
     """
-    _, lib_dirs, header_dirs = pkg_config(pkg_libraries)
+    _, _, header_dirs = pkg_config(pkg_libraries)
   
     header_strings = []
 

--- a/pycbc/libutils.py
+++ b/pycbc/libutils.py
@@ -68,7 +68,7 @@ def pkg_config(pkg_libraries):
 def pkg_config_header_strings(pkg_libraries):
     """ Returns a list of header strings that could be passed to a compiler
     """
-    libs, lib_dirs, header_dirs = pkg_config(pkg_libraries)
+    _, lib_dirs, header_dirs = pkg_config(pkg_libraries)
   
     header_strings = []
 

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -135,7 +135,7 @@ def tau0_tau3_to_mass1_mass2(tau0, tau3, f_lower):
 
 def mass1_mass2_spin1z_spin2z_to_beta_sigma_gamma(mass1, mass2,
                                                   spin1z, spin2z):
-    M, eta = mass1_mass2_to_mtotal_eta(mass1, mass2)
+    _, eta = mass1_mass2_to_mtotal_eta(mass1, mass2)
     # get_beta_sigma_from_aligned_spins() takes
     # the spin of the heaviest body first
     heavy_spin = numpy.where(mass2 <= mass1, spin1z, spin2z)
@@ -640,7 +640,7 @@ def meco_velocity(m1, m2, chi1, chi2):
     v : float
         Velocity (dimensionless)
     """
-    energy0, energy2, energy3, energy4, energy5, energy6 = \
+    _, energy2, energy3, energy4, energy5, energy6 = \
         _energy_coeffs(m1, m2, chi1, chi2)
     def eprime(v):
         return 2. + v * v * (4.*energy2 + v * (5.*energy3 \
@@ -667,7 +667,6 @@ def _dtdv_coeffs(m1, m2, chi1, chi2):
     sigmaqm = 81.*m1*m1*chi1*chi1/(16.*mtot*mtot) \
             + 81.*m2*m2*chi2*chi2/(16.*mtot*mtot)
 
-    energy0 = -0.5*eta
     dtdv0 = 1. # FIXME: Wrong but doesn't matter for now.
     dtdv2 = (1./336.) * (743. + 924.*eta)
     dtdv3 = -4. * lal.PI + beta
@@ -680,7 +679,7 @@ def _dtdv_coeffs(m1, m2, chi1, chi2):
     return (dtdv0, dtdv2, dtdv3, dtdv4, dtdv5, dtdv6, dtdv6log, dtdv7)    
 
 def _dtdv_cutoff_velocity(m1, m2, chi1, chi2):
-    dtdv0, dtdv2, dtdv3, dtdv4, dtdv5, dtdv6, dtdv6log, dtdv7 = _dtdv_coeffs(m1, m2, chi1, chi2)
+    _, dtdv2, dtdv3, dtdv4, dtdv5, dtdv6, dtdv6log, dtdv7 = _dtdv_coeffs(m1, m2, chi1, chi2)
 
     def dtdv_func(v):
         x = dtdv7
@@ -722,7 +721,7 @@ def energy_coefficients(m1, m2, s1z=0, s2z=0, phase_order=-1, spin_order=-1):
     s1z = s1z * m1M * m1M
     s2z = s2z * m2M * m2M
       
-    mchirp, eta = mass1_mass2_to_mchirp_eta(m1, m2)
+    _, eta = mass1_mass2_to_mchirp_eta(m1, m2)
 
     ecof = numpy.zeros(phase_order+1)
     # Orbital terms
@@ -750,7 +749,7 @@ def energy_coefficients(m1, m2, s1z=0, s2z=0, phase_order=-1, spin_order=-1):
     ESS2 = 1.0 / eta
     EQM2s1 = qmdef1/2.0/m1M/m1M
     EQM2s1L = -qmdef1*3.0/2.0/m1M/m1M
-    EQM2s2 = qmdef2/2.0/m2M/m2M
+    #EQM2s2 = qmdef2/2.0/m2M/m2M
     EQM2s2L = -qmdef2*3.0/2.0/m2M/m2M
     
     ESO25s1 = 11.0 - 61.0*eta/9.0 + (dm/m1M) * (-3.0 + 10.*eta/3.0)
@@ -773,7 +772,7 @@ def energy_coefficients(m1, m2, s1z=0, s2z=0, phase_order=-1, spin_order=-1):
     
 def energy(v, mass1, mass2, s1z=0, s2z=0, phase_order=-1, spin_order=-1):
     ecof = energy_coefficients(mass1, mass2, s1z, s2z, phase_order, spin_order)
-    mchirp, eta = mass1_mass2_to_mchirp_eta(mass1, mass2)
+    _, eta = mass1_mass2_to_mchirp_eta(mass1, mass2)
     amp = - (1.0/2.0) * eta
     e = 0.0
     for i in numpy.arange(0, len(ecof), 1):

--- a/pycbc/results/legacy_grb.py
+++ b/pycbc/results/legacy_grb.py
@@ -147,7 +147,6 @@ def write_summary(page, args, ifos, skyError=None, ipn=False, ipnError=False):
         td2 = []
         td3 = []
         timedelay = {}
-        deltat = []
         search_file = '../../../S5IPN_GRB%s_search_180deg.txt' % args.grb_name
         for line in open(search_file):
             ra.append(line.split()[0])
@@ -233,7 +232,6 @@ def write_antenna(page, args, seg_plot=None, grid=False, ipn=False):
                                                 ifo)
                 antenna_ifo[ifo].append(round(f_q,3))
         dectKeys = antenna_ifo.keys()
-        newList=[]
 
         for elements in range(len(antenna_ifo.values()[0])):
             newDict={}
@@ -727,7 +725,7 @@ def make_grb_segments_plot(wkflow, science_segs, trigger_time, trigger_name,
 
     xmin, xmax = fig.axes[-1].get_xaxis().get_view_interval()
     ymin, ymax = fig.axes[-1].get_yaxis().get_view_interval()
-    fig.axes[-1].add_artist(Line2D((xmin, xmax), (ymin, ymin), color='black',
+    fig.axes[-1].add_artist(Line2D((xmin, xmax), (ymin, ymax), color='black',
                                 linewidth=2))
     fig.axes[-1].set_xlabel('GPS Time')
 

--- a/pycbc/results/render.py
+++ b/pycbc/results/render.py
@@ -126,14 +126,13 @@ def render_default(path, cp):
 
     if path.endswith('.xml') or path.endswith('.xml.gz'):
         # segment or veto file return a segmentslistdict instance
-        with open(path, 'r') as xmlfile:
-            try:
-                wf_file = SegFile.from_segment_xml(path)
-                # FIXME: This is a dictionary, but the code wants a segmentlist
-                #        for now I just coalesce.
-                seg_dict = wf_file.return_union_seglist()
-            except Exception as e:
-                print('No segment table found in %s : %s' % (path, e))
+        try:
+            wf_file = SegFile.from_segment_xml(path)
+            # FIXME: This is a dictionary, but the code wants a segmentlist
+            #        for now I just coalesce.
+            wf_file.return_union_seglist()
+        except Exception as e:
+            print('No segment table found in %s : %s' % (path, e))
 
     # render template
     template_dir = pycbc.results.__path__[0] + '/templates/files'

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -169,8 +169,8 @@ def get_code_version_numbers(cp):
         version string for each executable.
     """
     code_version_dict = {}
-    for item, value in cp.items('executables'):
-        path, exe_name = os.path.split(value)
+    for _, value in cp.items('executables'):
+        _, exe_name = os.path.split(value)
         version_string = None
         if value.startswith('gsiftp://') or value.startswith('http://'):
            code_version_dict[exe_name] = "Using bundle downloaded from %s" % value

--- a/pycbc/tmpltbank/bank_output_utils.py
+++ b/pycbc/tmpltbank/bank_output_utils.py
@@ -132,7 +132,7 @@ def convert_to_sngl_inspiral_table(params, proc_id):
             setattr(tmplt, colname, value)
         tmplt.mtotal, tmplt.eta = pnutils.mass1_mass2_to_mtotal_eta(
             tmplt.mass1, tmplt.mass2)
-        tmplt.mchirp, junk = pnutils.mass1_mass2_to_mchirp_eta(
+        tmplt.mchirp, _ = pnutils.mass1_mass2_to_mchirp_eta(
             tmplt.mass1, tmplt.mass2)
         tmplt.template_duration = 0 # FIXME
         tmplt.event_id = sngl_inspiral_table.get_next_id()
@@ -390,6 +390,5 @@ def output_sngl_inspiral_table(outputFile, tempBank, metricParams,
     outdoc.childNodes[0].appendChild(search_summary_table)
 
     # write the xml doc to disk
-    proctable = table.get_table(outdoc, lsctables.ProcessTable.tableName)
     ligolw_utils.write_filename(outdoc, outputFile,
                                 gz=outputFile.endswith('.gz'))

--- a/pycbc/tmpltbank/brute_force_methods.py
+++ b/pycbc/tmpltbank/brute_force_methods.py
@@ -485,7 +485,7 @@ def find_xi_extrema_brute(xis, bestMasses, bestXis, direction_num, req_match, \
 
     for _ in xrange(numIterations):
         # Evaluate extrema of the xi direction specified
-        totmass, eta, spin1z, spin2z, mass1, mass2, new_xis = \
+        totmass, eta, spin1z, spin2z, _, _, new_xis = \
             get_mass_distribution([bestChirpmass,bestMasses[1],bestMasses[2],
                                    bestMasses[3]],
                                   scaleFactor, massRangeParams, metricParams,

--- a/pycbc/tmpltbank/brute_force_methods.py
+++ b/pycbc/tmpltbank/brute_force_methods.py
@@ -477,14 +477,13 @@ def find_xi_extrema_brute(xis, bestMasses, bestXis, direction_num, req_match, \
 
     # Setup
     xi_size = len(xis)
-    origMasses = copy.deepcopy(bestMasses)
     bestChirpmass = bestMasses[0] * (bestMasses[1])**(3./5.)
     if find_minimum:
         xiextrema = 10000000000
     else:
         xiextrema = -100000000000
 
-    for i in xrange(numIterations):
+    for _ in xrange(numIterations):
         # Evaluate extrema of the xi direction specified
         totmass, eta, spin1z, spin2z, mass1, mass2, new_xis = \
             get_mass_distribution([bestChirpmass,bestMasses[1],bestMasses[2],
@@ -495,7 +494,6 @@ def find_xi_extrema_brute(xis, bestMasses, bestXis, direction_num, req_match, \
         for j in xrange(1, xi_size):
             cDist += (new_xis[j] - xis[j])**2
         redCDist = cDist[cDist < req_match]
-        redXis = (new_xis[direction_num])[cDist < req_match]
         if len(redCDist):
             if not find_minimum:
                 new_xis[direction_num][cDist > req_match] = -10000000
@@ -512,8 +510,6 @@ def find_xi_extrema_brute(xis, bestMasses, bestXis, direction_num, req_match, \
                 bestMasses[1] = eta[idx]
                 bestMasses[2] = spin1z[idx]
                 bestMasses[3] = spin2z[idx]
-                m1 = mass1[idx]
-                m2 = mass2[idx]
                 bestChirpmass = bestMasses[0] * (bestMasses[1])**(3./5.)
     return xiextrema
 

--- a/pycbc/tmpltbank/coord_utils.py
+++ b/pycbc/tmpltbank/coord_utils.py
@@ -224,7 +224,7 @@ def get_random_mass(numPoints, massRangeParams):
     # only systems that can yield (at least) the desired remnant
     # disk mass and that pass the mass and spin range cuts.
     else:
-        ns_sequence, max_ns_g_mass = load_ns_sequence(massRangeParams.ns_eos)
+        _, max_ns_g_mass = load_ns_sequence(massRangeParams.ns_eos)
 
         # Generate EM constraint surface: minumum eta as a function of BH spin
         # and NS mass required to produce an EM counterpart
@@ -515,17 +515,11 @@ def get_point_distance(point1, point2, metricParams, fUpper):
     aMass2 = point1[1]
     aSpin1 = point1[2]
     aSpin2 = point1[3]
-    try:
-        leng = len(aMass1)
-        aArray = True
-    except:
-        aArray = False
 
     bMass1 = point2[0]
     bMass2 = point2[1]
     bSpin1 = point2[2]
     bSpin2 = point2[3]
-    bArray = False
 
     aXis = get_cov_params(aMass1, aMass2, aSpin1, aSpin2, metricParams, fUpper)
 

--- a/pycbc/tmpltbank/em_progenitors.py
+++ b/pycbc/tmpltbank/em_progenitors.py
@@ -679,7 +679,7 @@ def generate_em_constraint_data(mNS_min, mNS_max, delta_mNS, sBH_min, sBH_max, d
     # Until a numpy v>=1.7 is available everywhere, we have to use a silly
     # vectorization of find_em_constraint_data_point and pass to it a bunch of
     # constant arguments as vectors with one entry repeated several times
-    eos_name_vec=[eos_name for i in range(len(mNS_vec))]
+    eos_name_vec=[eos_name for _ in range(len(mNS_vec))]
     eos_name_vec=np.array(eos_name_vec)
     threshold_vec=np.empty(len(mNS_vec))
     threshold_vec.fill(threshold)

--- a/pycbc/tmpltbank/lattice_utils.py
+++ b/pycbc/tmpltbank/lattice_utils.py
@@ -151,7 +151,6 @@ def generate_anstar_3d_lattice(maxv1, minv1, maxv2, minv2, maxv3, minv3, \
     vs1 = []
     vs2 = []
     vs3 = []
-    count = 0
     curr_point = lal.gsl_vector(3)
     while (lalpulsar.NextLatticeTilingPoint(iterator, curr_point) > 0):
         vs1.append(curr_point.data[0])

--- a/pycbc/tmpltbank/option_utils.py
+++ b/pycbc/tmpltbank/option_utils.py
@@ -931,7 +931,7 @@ class massRangeParameters(object):
                          """
                 raise ValueError(errMsg)
             if use_eos_max_ns_mass:
-                ns_sequence, max_ns_g_mass = load_ns_sequence(self.ns_eos)
+                _, max_ns_g_mass = load_ns_sequence(self.ns_eos)
                 if(self.maxMass2 > max_ns_g_mass):
                     errMsg = """
                              The maximum NS mass supported by this EOS is

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -508,7 +508,6 @@ def get_conversions(requested_params, variable_args, valid_params=None):
         s = ""
         for ch in opt:
             s += ch if ch.isalnum() or ch == "_" else " "
-        eqn = opt.split(":")[0]
         new_params += s.split(" ")
     requested_params = set(requested_params + new_params)
 

--- a/pycbc/types/array.py
+++ b/pycbc/types/array.py
@@ -912,8 +912,8 @@ class Array(object):
         elif ext == '.hdf':
             key = 'data' if group is None else group
             f = h5py.File(path)
-            ds = f.create_dataset(key, data=self.numpy(), compression='gzip',
-                                  compression_opts=9, shuffle=True)
+            f.create_dataset(key, data=self.numpy(), compression='gzip',
+                             compression_opts=9, shuffle=True)
         else:
             raise ValueError('Path must end with .npy, .txt, or .hdf')
            

--- a/pycbc/types/array_cpu.py
+++ b/pycbc/types/array_cpu.py
@@ -68,9 +68,9 @@ def abs_arg_max(self):
         return _np.argmax(self.data)
     else:
         data = _np.array(self._data,
-                         copy=False).view(real_same_precision_as(self))
+                         copy=False).view(real_same_precision_as(self)) # pylint:disable=unused-variable
         loc = _np.array([0])
-        N = len(self)
+        N = len(self) # pylint:disable=unused-variable
         inline(code_abs_arg_max, ['data', 'loc', 'N'], libraries=omp_libs,
                extra_compile_args=code_flags)
         return loc[0]
@@ -127,10 +127,10 @@ total[0] = value;
 
 
 def inner_inline_real(self, other):
-    x = _np.array(self._data, copy=False)
-    y = _np.array(other, copy=False)
+    x = _np.array(self._data, copy=False) # pylint:disable=unused-variable
+    y = _np.array(other, copy=False) # pylint:disable=unused-variable
     total = _np.array([0.], dtype=float64)
-    N = len(self)
+    N = len(self) # pylint:disable=unused-variable
     inline(inner_code, ['x', 'y', 'total', 'N'], libraries=omp_libs,
            extra_compile_args=code_flags)
     return total[0]
@@ -168,7 +168,6 @@ def multiply_and_add(self, other, mult_fac):
     # Sanity checking should have already be done. But we don't know if
     # mult_fac and add_fac are arrays or scalars.
     inpt = _np.array(self.data, copy=False)
-    N = len(inpt)
     # For some reason, _checkother decorator returns other.data so we don't
     # take .data here
     other = _np.array(other, copy=False)

--- a/pycbc/types/array_cpu.py
+++ b/pycbc/types/array_cpu.py
@@ -67,8 +67,8 @@ def abs_arg_max(self):
     if self.kind == 'real':
         return _np.argmax(self.data)
     else:
-        data = _np.array(self._data,
-                         copy=False).view(real_same_precision_as(self)) # pylint:disable=unused-variable
+        data = _np.array(self._data, # pylint:disable=unused-variable
+                         copy=False).view(real_same_precision_as(self))
         loc = _np.array([0])
         N = len(self) # pylint:disable=unused-variable
         inline(code_abs_arg_max, ['data', 'loc', 'N'], libraries=omp_libs,

--- a/pycbc/types/array_cuda.py
+++ b/pycbc/types/array_cuda.py
@@ -84,8 +84,6 @@ class LowerLatencyReductionKernel(ReductionKernel):
 
     def __call__(self, *args, **kwargs):
         f = self.stage1_func
-        arg_types = self.stage1_arg_types
-        stage1_args = args
         s1_invocation_args = [] 
         for arg in args:
             s1_invocation_args.append(arg.gpudata)
@@ -99,7 +97,6 @@ class LowerLatencyReductionKernel(ReductionKernel):
 
         while True:
             f = self.stage2_func
-            arg_types = self.stage2_arg_types
             sz = result.size
             result2 = result
             result, block_count, seq_count, grid_size, block_size = call_prepare(self, sz, args[0].allocator)

--- a/pycbc/types/frequencyseries.py
+++ b/pycbc/types/frequencyseries.py
@@ -467,11 +467,12 @@ def load_frequencyseries(path, group=None):
     if data.ndim == 2:
         delta_f = (data[-1][0] - data[0][0]) / (len(data)-1)
         epoch = _lal.LIGOTimeGPS(data[0][0])
-        return FrequencySeries(data[:,1], delta_f=delta_f)
+        return FrequencySeries(data[:,1], delta_f=delta_f, epoch=epoch)
     elif data.ndim == 3:
         delta_f = (data[-1][0] - data[0][0]) / (len(data)-1)
         epoch = _lal.LIGOTimeGPS(data[0][0])
-        return FrequencySeries(data[:,1] + 1j*data[:,2], delta_f=delta_f)
+        return FrequencySeries(data[:,1] + 1j*data[:,2], delta_f=delta_f,
+                               epoch=epoch)
     else:
         raise ValueError('File has %s dimensions, cannot convert to Array, \
                           must be 2 (real) or 3 (complex)' % data.ndim)

--- a/pycbc/vetoes/autochisq.py
+++ b/pycbc/vetoes/autochisq.py
@@ -67,8 +67,6 @@ def autochisq_from_precomputed(sn, corr_sn, hautocorr, indices,
     """
     Nsnr = len(sn)
 
-    indx = np.array([])
-
     achisq = np.zeros(len(indices))
     num_points_all = int(Nsnr/stride)
     if num_points is None:
@@ -235,14 +233,14 @@ class SingleDetAutoChisq(object):
                 logging.info("Calculating autocorrelation")
 
                 if not self.reverse_template:
-                    Pt, _Ptilde, P_norm = matched_filter_core(htilde,
+                    Pt, _, P_norm = matched_filter_core(htilde,
                               htilde, psd=psd,
                               low_frequency_cutoff=low_frequency_cutoff,
                               high_frequency_cutoff=high_frequency_cutoff)
                     Pt = Pt * (1./ Pt[0])
                     self._autocor = Array(Pt, copy=True)
                 else:
-                    Pt, _Ptilde, P_norm = matched_filter_core(htilde.conj(),
+                    Pt, _, P_norm = matched_filter_core(htilde.conj(),
                               htilde, psd=psd,
                               low_frequency_cutoff=low_frequency_cutoff,
                               high_frequency_cutoff=high_frequency_cutoff)
@@ -260,7 +258,7 @@ class SingleDetAutoChisq(object):
             sn = sn*norm
             if self.reverse_template:
                 assert(stilde is not None)
-                asn, acor, ahnrm = matched_filter_core(htilde.conj(), stilde,
+                asn, _, ahnrm = matched_filter_core(htilde.conj(), stilde,
                                  low_frequency_cutoff=low_frequency_cutoff,
                                  high_frequency_cutoff=high_frequency_cutoff,
                                  h_norm=template.sigmasq(psd))

--- a/pycbc/vetoes/bank_chisq.py
+++ b/pycbc/vetoes/bank_chisq.py
@@ -48,9 +48,9 @@ def segment_snrs(filters, stilde, psd, low_frequency_cutoff):
     snrs = []
     norms = []
 
-    for i, bank_template in enumerate(filters):
+    for bank_template in filters:
         # For every template compute the snr against the stilde segment
-        snr, corr, norm = matched_filter_core(
+        snr, _, norm = matched_filter_core(
                 bank_template, stilde, h_norm=bank_template.sigmasq(psd),
                 psd=None, low_frequency_cutoff=low_frequency_cutoff)
         # SNR time series stored here

--- a/pycbc/vetoes/chisq_cpu.py
+++ b/pycbc/vetoes/chisq_cpu.py
@@ -41,7 +41,7 @@ def chisq_accum_bin_inline(chisq, q):
     
     chisq = numpy.array(chisq.data, copy=False)
     q = numpy.array(q.data, copy=False)
-    N = len(chisq)
+    N = len(chisq) # pylint:disable=unused-variable
     code = """
         #pragma omp parallel for
         for (int i=0; i<N; i++){
@@ -153,9 +153,9 @@ def shift_sum(v1, shifts, bins):
     shifts = numpy.array(shifts, dtype=real_type)
     
     bins = numpy.array(bins, dtype=numpy.uint32)
-    blen = len(bins) - 1
+    blen = len(bins) - 1 # pylint:disable=unused-variable
     v1 = numpy.array(v1.data, copy=False)
-    slen = len(v1)
+    slen = len(v1) # pylint:disable=unused-variable
 
     if v1.dtype.name == 'complex64':
         code = point_chisq_code_single

--- a/pycbc/waveform/SpinTaylorF2.py
+++ b/pycbc/waveform/SpinTaylorF2.py
@@ -290,7 +290,7 @@ def spintaylorf2(**kwds):
     psiJ_C =psiJ + psi + lal.PI/4.
 
     #####Calculate the Coefficients#####
-    quadparam = 1.
+    #quadparam = 1.
     gamma0 = mass1*chi/mass2
     #Calculate the spin corrections
     # FIXME should use pycbc's function, but sigma has different expression

--- a/pycbc/waveform/TaylorF2.py
+++ b/pycbc/waveform/TaylorF2.py
@@ -123,7 +123,6 @@ def taylorf2(**kwds):
     """ Return a TaylorF2 waveform using CUDA to generate the phase and amplitude
     """
     # Pull out the input arguments
-    f_lower = kwds['f_lower']
     delta_f = kwds['delta_f']
     distance = kwds['distance']
     mass1 = kwds['mass1']

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -427,7 +427,6 @@ class TemplateBank(object):
         threshold = inj_filter_rejector.chirp_time_window
         m1= self.table['mass1']
         m2= self.table['mass2']
-        thinning_bank = []
         tau0_temp, _ = pycbc.pnutils.mass1_mass2_to_tau0_tau3(m1, m2, fref)
         indices = []
 
@@ -716,7 +715,7 @@ class FilterBank(TemplateBank):
         logging.info('%s: generating %s from %s Hz' % (index, approximant, f_low))
 
         # Clear the storage memory
-        poke  = tempout.data
+        poke  = tempout.data # pylint:disable=unused-variable
         tempout.clear()
 
         # Get the waveform filter
@@ -825,8 +824,8 @@ class FilterBankSkyMax(TemplateBank):
         logging.info('%s: generating %s from %s Hz', index, approximant, f_low)
 
         # What does this do???
-        poke1 = tempoutplus.data
-        poke2 = tempoutcross.data
+        poke1 = tempoutplus.data # pylint:disable=unused-variable
+        poke2 = tempoutcross.data # pylint:disable=unused-variable
 
         # Clear the storage memory
         tempoutplus.clear()

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -236,7 +236,6 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
         outdf = df
     else:
         outdf = None
-    out = decomp_scratch
     hdecomp = fd_decompress(comp_amp, comp_phase, sample_points,
                             out=decomp_scratch, df=outdf, f_lower=fmin,
                             interpolation=interpolation)
@@ -514,12 +513,12 @@ def fd_decompress(amp, phase, sample_frequencies, out=None, df=None,
         df = out.delta_f
         hlen = len(out)
     if f_lower is None:
-        imin = 0
+        imin = 0 # pylint:disable=unused-variable
         f_lower = sample_frequencies[0]
     else:
         if f_lower >= sample_frequencies.max():
             raise ValueError("f_lower is > than the maximum sample frequency")
-        imin = int(numpy.searchsorted(sample_frequencies, f_lower))
+        imin = int(numpy.searchsorted(sample_frequencies, f_lower)) # pylint:disable=unused-variable
     start_index = int(numpy.floor(f_lower/df))
     if start_index >= hlen:
         raise ValueError('requested f_lower >= largest frequency in out')
@@ -530,9 +529,9 @@ def fd_decompress(amp, phase, sample_frequencies, out=None, df=None,
         else:
             code = _linear_decompress_code
         # use custom interpolation
-        sflen = len(sample_frequencies)
-        h = numpy.array(out.data, copy=False)
-        delta_f = float(df)
+        sflen = len(sample_frequencies) # pylint:disable=unused-variable
+        h = numpy.array(out.data, copy=False) # pylint:disable=unused-variable
+        delta_f = float(df) # pylint:disable=unused-variable
         inline(code, ['h', 'hlen', 'sflen', 'delta_f', 'sample_frequencies',
                       'amp', 'phase', 'start_index', 'imin'],
                extra_compile_args=[WEAVE_FLAGS] +\

--- a/pycbc/waveform/pycbc_phenomC_tmplt.py
+++ b/pycbc/waveform/pycbc_phenomC_tmplt.py
@@ -169,10 +169,6 @@ def imrphenomc_tmplt(**kwds):
     spin1z = float128(kwds['spin1z'])
     spin2z = float128(kwds['spin2z'])
 
-    # phi0, tC are taken to be 0 in the paper, sec V-A, first paragraph.
-    psi0 = 0. #float128(kwds['phi0'])
-    tC= 0. #-1.0 / delta_f 
-
     if 'out' in kwds:
         out = kwds['out']
     else:

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -175,7 +175,7 @@ def lm_tfinal(mass, spin, modes):
     at which the amplitude falls to 1/1000 of the peak amplitude
     """
 
-    f_0, tau = get_lm_f0tau_allmodes(mass, spin, modes)
+    _, tau = get_lm_f0tau_allmodes(mass, spin, modes)
     t_max = {}
     for lmn in modes:
         l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
@@ -229,7 +229,7 @@ def lm_deltaf(mass, spin, modes):
     1/1000 of the peak amplitude.
     """
 
-    f_0, tau = get_lm_f0tau_allmodes(mass, spin, modes)
+    _, tau = get_lm_f0tau_allmodes(mass, spin, modes)
     df = {}
     for lmn in modes:
         l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])

--- a/pycbc/waveform/spa_tmplt.py
+++ b/pycbc/waveform/spa_tmplt.py
@@ -93,9 +93,7 @@ def spa_amplitude_factor(**kwds):
     m1 = kwds['mass1']
     m2 = kwds['mass2']
 
-    dist = 10e6 * lal.PC_SI
-
-    mchirp, eta = pycbc.pnutils.mass1_mass2_to_mchirp_eta(m1, m2)
+    _, eta = pycbc.pnutils.mass1_mass2_to_mchirp_eta(m1, m2)
 
     FTaN = 32.0 * eta*eta / 5.0
     dETaN = 2 * -eta/2.0
@@ -164,7 +162,7 @@ def spa_tmplt(**kwds):
     s1z = kwds['spin1z']
     s2z = kwds['spin2z']
     phase_order = int(kwds['phase_order'])
-    amplitude_order = int(kwds['amplitude_order'])
+    #amplitude_order = int(kwds['amplitude_order'])
     spin_order = int(kwds['spin_order'])
 
     if 'out' in kwds:

--- a/pycbc/waveform/spa_tmplt_cpu.py
+++ b/pycbc/waveform/spa_tmplt_cpu.py
@@ -74,11 +74,11 @@ def spa_tmplt_engine(htilde,  kmin,  phase_order, delta_f, piM,  pfaN,
                     pfa6,  pfl6,  pfa7, amp_factor):
     """ Calculate the spa tmplt phase 
     """
-    kfac = numpy.array(spa_tmplt_precondition(len(htilde), delta_f, kmin).data, copy=False)
+    kfac = numpy.array(spa_tmplt_precondition(len(htilde), delta_f, kmin).data, copy=False) # pylint:disable=unused-variable
     htilde = numpy.array(htilde.data, copy=False)
-    cbrt_vec = numpy.array(get_cbrt(len(htilde)*delta_f + kmin, delta_f).data, copy=False)
-    logv_vec = numpy.array(get_log(len(htilde)*delta_f + kmin, delta_f).data, copy=False)
-    length = len(htilde)
+    cbrt_vec = numpy.array(get_cbrt(len(htilde)*delta_f + kmin, delta_f).data, copy=False) # pylint:disable=unused-variable
+    logv_vec = numpy.array(get_log(len(htilde)*delta_f + kmin, delta_f).data, copy=False) # pylint:disable=unused-variable
+    length = len(htilde) # pylint:disable=unused-variable
     
     code = """ 
     float piM13 = cbrtf(piM);

--- a/pycbc/waveform/utils.py
+++ b/pycbc/waveform/utils.py
@@ -338,8 +338,8 @@ def apply_fseries_time_shift(htilde, dt, kmin=0, copy=True):
     be sampled at equal frequency intervals.
     """
     out = numpy.array(htilde.data, copy=copy)
-    phi = -2 * numpy.pi * dt * htilde.delta_f
-    kmax = len(htilde)
+    phi = -2 * numpy.pi * dt * htilde.delta_f # pylint:disable=unused-variable
+    kmax = len(htilde) # pylint:disable=unused-variable
     if htilde.precision == 'single':
         code = _apply_shift_code32
     else:

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -710,7 +710,7 @@ def get_waveform_filter(out, template=None, **kwargs):
         wav_gen = fd_wav[type(_scheme.mgr.state)]
 
         duration = get_waveform_filter_length_in_time(**input_params)
-        hp, hc = wav_gen[input_params['approximant']](duration=duration,
+        hp, _ = wav_gen[input_params['approximant']](duration=duration,
                                                return_hc=False, **input_params)
 
         hp.resize(n)
@@ -721,8 +721,6 @@ def get_waveform_filter(out, template=None, **kwargs):
         return hp
 
     elif input_params['approximant'] in td_approximants(_scheme.mgr.state):
-        # N: number of time samples required
-        N = (n-1)*2
         wav_gen = td_wav[type(_scheme.mgr.state)]
         hp, hc = wav_gen[input_params['approximant']](**input_params)
         # taper the time series hp if required

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -723,7 +723,6 @@ def get_waveform_filter(out, template=None, **kwargs):
     elif input_params['approximant'] in td_approximants(_scheme.mgr.state):
         # N: number of time samples required
         N = (n-1)*2
-        delta_f = 1.0 / (N * input_params['delta_t'])
         wav_gen = td_wav[type(_scheme.mgr.state)]
         hp, hc = wav_gen[input_params['approximant']](**input_params)
         # taper the time series hp if required

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -722,7 +722,7 @@ def get_waveform_filter(out, template=None, **kwargs):
 
     elif input_params['approximant'] in td_approximants(_scheme.mgr.state):
         wav_gen = td_wav[type(_scheme.mgr.state)]
-        hp, hc = wav_gen[input_params['approximant']](**input_params)
+        hp, _ = wav_gen[input_params['approximant']](**input_params)
         # taper the time series hp if required
         if ('taper' in input_params.keys() and \
             input_params['taper'] is not None):

--- a/pycbc/workflow/coincidence.py
+++ b/pycbc/workflow/coincidence.py
@@ -287,7 +287,7 @@ def convert_trig_to_hdf(workflow, hdfbank, xml_trigger_files, out_dir, tags=None
     for ifo, insp_group in zip(ifos,  insp_groups):
         trig2hdf_exe = PyCBCTrig2HDFExecutable(workflow.cp, 'trig2hdf',
                                        ifos=ifo, out_dir=out_dir, tags=tags)
-        segs, insp_bundles = insp_group.categorize_by_attr('segment')
+        _, insp_bundles = insp_group.categorize_by_attr('segment')
         for insps in  insp_bundles:
             trig2hdf_node =  trig2hdf_exe.create_node(insps, hdfbank[0])
             workflow.add_node(trig2hdf_node)

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -67,8 +67,7 @@ def check_output_error_and_retcode(*popenargs, **kwargs):
     return output, error, retcode
 
 def check_output(*popenargs, **kwargs):
-    output, unused_error, unused_retcode = \
-                           check_output_error_and_retcode(*popenargs, **kwargs)
+    output, _, _ = check_output_error_and_retcode(*popenargs, **kwargs)
     return output
 
 ###############################################################################
@@ -1385,10 +1384,8 @@ class FileList(list):
         
         # Sort the files
 
-        for ix, currFile in enumerate(self):
+        for currFile in self:
             segExtent = currFile.segment_list.extent()
-            segExtStart = float(segExtent[0])
-            segExtEnd = float(segExtent[1])
             startIdx = (segExtent[0] - startTime) / step
             endIdx = (segExtent[1] - startTime) / step
             # Add some small rounding here
@@ -1593,7 +1590,7 @@ class SegFile(File):
             ifo_list.sort()
         if valid_segment is None:
             if seg_summ_dict and \
-                    numpy.any([len(v) for k, v in seg_summ_dict.items()]):
+                    numpy.any([len(v) for _, v in seg_summ_dict.items()]):
                 # Only come here if seg_summ_dict is supplied and it is
                 # not empty.
                 valid_segment = seg_summ_dict.extent_all()
@@ -1634,9 +1631,9 @@ class SegFile(File):
         """
         # load xmldocument and SegmentDefTable and SegmentTables
         fp = open(xml_file, 'r')
-        xmldoc, digest = ligolw_utils.load_fileobj(fp,
-                                            gz=xml_file.endswith(".gz"),
-                                            contenthandler=ContentHandler)
+        xmldoc, _ = ligolw_utils.load_fileobj(fp,
+                                              gz=xml_file.endswith(".gz"),
+                                              contenthandler=ContentHandler)
 
         seg_def_table = table.get_table(xmldoc,
                                         lsctables.SegmentDefTable.tableName)

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -400,7 +400,6 @@ def setup_datafind_runtime_cache_multi_calls_perifo(cp, scienceSegs,
     # Now ready to loop over the input segments
     datafindouts = []
     datafindcaches = []
-    ifos = scienceSegs.keys()
     logging.info("Querying datafind server for all science segments.")
     for ifo, scienceSegsIfo in scienceSegs.items():
         observatory = ifo[0].upper()
@@ -486,7 +485,6 @@ def setup_datafind_runtime_cache_single_call_perifo(cp, scienceSegs, outputDir,
     # Now ready to loop over the input segments
     datafindouts = []
     datafindcaches = []
-    ifos = scienceSegs.keys()
     logging.info("Querying datafind server for all science segments.")
     for ifo, scienceSegsIfo in scienceSegs.items():
         observatory = ifo[0].upper()

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -315,9 +315,6 @@ def multi_ifo_coherent_job_setup(workflow, out_files, curr_exe_job,
     """
     if tags is None:
         tags = []
-    cp = workflow.cp
-    ifos = science_segs.keys()
-    job_tag = curr_exe_job.name.upper()
     data_seg, job_valid_seg = curr_exe_job.get_valid_times()
     curr_out_files = FileList([])
     if 'IPN' in datafind_outs[-1].description \

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -239,7 +239,6 @@ def make_veto_table(workflow, out_dir, vetodef_file=None, tags=None):
     makedir(out_dir)
     node = PlotExecutable(workflow.cp, 'page_vetotable', ifos=workflow.ifos,
                     out_dir=out_dir, tags=tags).create_node()
-    vetodef_files = list(vetodef_file)
     node.add_input_opt('--veto-definer-file', vdf_file)
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow += node

--- a/pycbc/workflow/segment.py
+++ b/pycbc/workflow/segment.py
@@ -1040,7 +1040,6 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
     # Load parsed workflow config options
     cp = workflow.cp
     triggertime = int(os.path.basename(cp.get('workflow', 'trigger-time')))
-    triggername = cp.get('workflow', 'trigger-name')
     minbefore = int(os.path.basename(cp.get('workflow-exttrig_segments',
                                             'min-before')))
     minafter = int(os.path.basename(cp.get('workflow-exttrig_segments',
@@ -1213,11 +1212,11 @@ def get_triggered_coherent_segment(workflow, out_dir, sciencesegs,
         offsource[iifo] = offsrc
 
     # Write off-source to xml file
-    coherent_seg = segments.segmentlistdict()
-    coherent_seg[ifos + ':COH_OFFSOURCE'] = offsrc
-    currFile = SegFile.from_segment_list_dict('COH_OFFSOURCE_SEGMENT',
-                      coherent_seg, ifo_list=ifos, extension="xml",
-                      directory=out_dir)
+    #coherent_seg = segments.segmentlistdict()
+    #coherent_seg[ifos + ':COH_OFFSOURCE'] = offsrc
+    #currFile = SegFile.from_segment_list_dict('COH_OFFSOURCE_SEGMENT',
+    #                  coherent_seg, ifo_list=ifos, extension="xml",
+    #                  directory=out_dir)
     logging.info("Optimal coherent segment calculated.")
 
     offsourceSegfile = os.path.join(out_dir, "offSourceSeg.txt")
@@ -1259,7 +1258,6 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
     # Load parsed workflow config options
     cp = workflow.cp
     triggertime = int(os.path.basename(cp.get('workflow', 'trigger-time')))
-    triggername = cp.get('workflow', 'trigger-name')
     minbefore = int(os.path.basename(cp.get('workflow-exttrig_segments',
                                             'min-before')))
     minafter = int(os.path.basename(cp.get('workflow-exttrig_segments',
@@ -1416,10 +1414,6 @@ def get_triggered_single_ifo_segment(workflow, out_dir, sciencesegs):
     offsource[ifo] = offsrc
 
     # Write off-source to xml file
-    single_seg = segments.segmentlistdict()
-    single_seg[ifo + ':SINGLE_IFO_OFFSOURCE'] = offsrc
-    currFile = SegFile.from_segment_list_dict('SINGLE_IFO_OFFSOURCE_SEGMENT',
-            single_seg, ifo_list=ifo, extension="xml", directory=out_dir)
     logging.info("Optimal single IFO segment calculated for %s." % ifo)
 
     offsourceSegfile = os.path.join(out_dir, "offSourceSeg.txt")


### PR DESCRIPTION
This patch fixes all the "unused variables" issues. One place where this was wrongly being picked up was in the weave code (I don't really understand *how* weave works, but these variables are now given the comment to ignore this warning. I also disable the duplicate pyflakes check, to avoid having to put two "ignore me" comments on the same line.

In all other places I remove the unused variables.