### PR TITLE
Fix a few simple test failures

### DIFF
--- a/test/test_injection.py
+++ b/test/test_injection.py
@@ -131,7 +131,7 @@ class TestInjection(unittest.TestCase):
         injections = InjectionSet(self.inj_file.name)
         for det in self.detectors:
             for inj in self.injections:
-                ts = TimeSeries(numpy.zeros(10 * self.sample_rate),
+                ts = TimeSeries(numpy.zeros(int(10 * self.sample_rate)),
                                 delta_t=1/self.sample_rate,
                                 epoch=lal.LIGOTimeGPS(inj.end_time - 5),
                                 dtype=numpy.float64)
@@ -151,7 +151,7 @@ class TestInjection(unittest.TestCase):
         injections = InjectionSet(self.inj_file.name)
         for det in self.detectors:
             for epoch in clear_times:
-                ts = TimeSeries(numpy.zeros(10 * self.sample_rate),
+                ts = TimeSeries(numpy.zeros(int(10 * self.sample_rate)),
                                 delta_t=1/self.sample_rate,
                                 epoch=lal.LIGOTimeGPS(epoch),
                                 dtype=numpy.float64)

--- a/test/test_tmpltbank.py
+++ b/test/test_tmpltbank.py
@@ -133,7 +133,7 @@ class TmpltbankTestClass(unittest.TestCase):
         self.ethincaFreqStep = 10.
 
         self.segLen = 1./self.deltaF
-        self.psdSize = int(self.segLen * self.sampleRate) / 2. + 1
+        self.psdSize = int(self.segLen * self.sampleRate / 2.) + 1
 
         self.psd = pycbc.psd.from_txt('%sZERO_DET_high_P.txt' %(self.dataDir),\
                 self.psdSize, self.deltaF, self.f_low, is_asd_file=True)

--- a/test/test_waveform.py
+++ b/test/test_waveform.py
@@ -24,23 +24,19 @@
 """
 These are the unittests for the pycbc.waveform module
 """
-import sys
 import pycbc
 import unittest
-from pycbc.types import *
-from pycbc.scheme import *
-from pycbc.filter import *
-from pycbc.waveform import *
-import pycbc.fft
 import numpy
 from numpy import sqrt, cos, sin
+from pycbc.scheme import CPUScheme
+from pycbc.waveform import td_approximants, fd_approximants, get_td_waveform, get_fd_waveform
 from utils import parse_args_all_schemes, simple_exit
 
 _scheme, _context = parse_args_all_schemes("Waveform")
 
 failing_wfs = ['PhenSpinTaylor', 'PhenSpinTaylorRD', 'EccentricTD',
               'SpinDominatedWf', 'EOBNRv2HM_ROM', 'EOBNRv2_ROM', 'EccentricFD',
-              'NR_hdf5']
+              'NR_hdf5', 'TEOBResum_ROM', 'Lackey_Tidal_2013_SEOBNRv2_ROM']
 
 class TestWaveform(unittest.TestCase):
     def setUp(self,*args):


### PR DESCRIPTION
* Float indexing with recent numpy
* Unused/dangerous imports
* Blacklist waveform approximants requiring special params