### PR TITLE
Avoid reading in compressed waveforms for unused templates

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -291,7 +291,7 @@ with ctx:
         dtype=complex64, phase_order=opt.order,
         taper=opt.taper_template, approximant=opt.approximant,
         out=template_mem, max_template_length=opt.max_template_length,
-        load_compressed=True if opt.use_compressed_waveforms else False,
+        enable_compressed_waveforms=True if opt.use_compressed_waveforms else False,
         waveform_decompression_method=
         opt.waveform_decompression_method if opt.use_compressed_waveforms else None)
 

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -219,8 +219,8 @@ class TemplateBank(object):
         An instance of a WaveformArray containing all of the information about
         the parameters of the bank.
     has_compressed_waveforms : {False, bool}
-        If compressed waveforms are present in the (hdf) file, save True,
-        else False .
+        True if compressed waveforms are present in the the (hdf) file; False
+        otherwise.
     parameters : tuple
         The parameters loaded from the input file. Same as `table.fieldnames`.
     indoc : {None, xmldoc}
@@ -284,8 +284,7 @@ class TemplateBank(object):
             for key in data:
                 self.table[key] = data[key]
             # add the compressed waveforms, if they exist
-            if 'compressed_waveforms' in f:
-                self.has_compressed_waveforms = True
+            self.has_compressed_waveforms = 'compressed_waveforms' in f 
         else:
             raise ValueError("Unsupported template bank file extension %s" %(
                 ext))
@@ -347,6 +346,11 @@ class TemplateBank(object):
         skip_fields : {None, (list of) strings}
             Do not write the given fields to the hdf file. Default is None,
             in which case all fields in self.table.fieldnames are written.
+        write_compressed_waveforms : {True, bool}
+            Write compressed waveforms to the output (hdf) file if this is
+            True, which is the default setting. If False, do not write the
+            compressed waveforms group, but only the template parameters to
+            the output file.
 
         Returns
         -------

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -772,10 +772,11 @@ class CompressedWaveform(object):
         group = '%scompressed_waveforms/%s' %(root, str(template_hash))
         for param in ['amplitude', 'phase', 'sample_points']:
             fp['%s/%s' %(group, param)] = self._get(param).astype(outdtype)
-        fp[group].attrs['mismatch'] = self.mismatch
-        fp[group].attrs['interpolation'] = self.interpolation
-        fp[group].attrs['tolerance'] = self.tolerance
-        fp[group].attrs['precision'] = precision
+        fp_group = fp[group]
+        fp_group.attrs['mismatch'] = self.mismatch
+        fp_group.attrs['interpolation'] = self.interpolation
+        fp_group.attrs['tolerance'] = self.tolerance
+        fp_group.attrs['precision'] = precision
 
     @classmethod
     def from_hdf(cls, fp, template_hash, root=None, load_to_memory=True,
@@ -813,17 +814,18 @@ class CompressedWaveform(object):
         else:
             root = '%s/'%(root)
         group = '%scompressed_waveforms/%s' %(root, str(template_hash))
-        sample_points = fp[group]['sample_points']
-        amp = fp[group]['amplitude']
-        phase = fp[group]['phase']
+        fp_group = fp[group]
+        sample_points = fp_group['sample_points']
+        amp = fp_group['amplitude']
+        phase = fp_group['phase']
         if load_now:
             sample_points = sample_points[:]
             amp = amp[:]
             phase = phase[:]
         return cls(sample_points, amp, phase,
-            interpolation=fp[group].attrs['interpolation'],
-            tolerance=fp[group].attrs['tolerance'],
-            mismatch=fp[group].attrs['mismatch'],
-            precision=fp[group].attrs['precision'],
+            interpolation=fp_group.attrs['interpolation'],
+            tolerance=fp_group.attrs['tolerance'],
+            mismatch=fp_group.attrs['mismatch'],
+            precision=fp_group.attrs['precision'],
             load_to_memory=load_to_memory)
 


### PR DESCRIPTION
This PR changes reading in compressed waveforms for all templates in bank and storing it in a dictionary as part of the `TemplateBank` class. Sample points would be read in only for those templates that are being decompressed in `get_decompressed_waveform` in `FilterBank` or those that are being written to an output hdf file in `write_to_hdf` in `TemplateBank`. This would avoid holding up memory in reading in compressed waveforms and metadata for unused templates.