### PR TITLE
Add logit and logistic transforms

### DIFF
--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -490,7 +490,6 @@ class Logit(BaseTransform):
     name = 'logit'
 
     def __init__(self, input, output, domain=(0., 1.)):
-        super(Logit, self).__init__()
         self._input = input
         self._output = output
         self._inputs = [input]
@@ -500,6 +499,7 @@ class Logit(BaseTransform):
         # shortcuts for quick access later
         self._a = domain[0]
         self._b = domain[1]
+        super(Logit, self).__init__()
 
     @property
     def input(self):

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -474,7 +474,7 @@ class Logit(BaseTransform):
     parameter. This is the inverse of the logistic transform.
 
     Typically, the source of the logit function is assumed to have domain
-    :math:`\in [0, 1)`. However, the `domain` argument can be used to expand
+    :math:`\in (0, 1)`. However, the `domain` argument can be used to expand
     this to any finite real interval.
 
     Parameters
@@ -495,7 +495,8 @@ class Logit(BaseTransform):
         self._target = target
         self._inputs = [source]
         self._outputs = [target]
-        self._bounds = Bounds(domain[0], domain[1])
+        self._bounds = Bounds(domain[0], domain[1],
+                              btype_min='open', btype_max='open')
         # shortcuts for quick access later
         self._a = domain[0]
         self._b = domain[1]
@@ -518,7 +519,7 @@ class Logit(BaseTransform):
 
     @staticmethod
     def logit(x, a=0., b=1.):
-        r"""Computes the logit function with domain :math:`x \in [a, b)`.
+        r"""Computes the logit function with domain :math:`x \in (a, b)`.
 
         This is given by:
 
@@ -527,7 +528,7 @@ class Logit(BaseTransform):
             \mathrm{logit}(x; a, b) = \log\left(\frac{x-a}{b-x}\right).
 
         Note that this is also the inverse of the logistic function with range
-        :math:`[a, b)`.
+        :math:`(a, b)`.
 
         Parameters
         ----------
@@ -547,7 +548,7 @@ class Logit(BaseTransform):
 
     @staticmethod
     def logistic(x, a=0., b=1.):
-        r"""Computes the logistic function with range :math:`\in [a, b)`.
+        r"""Computes the logistic function with range :math:`\in (a, b)`.
 
         This is given by:
 
@@ -556,7 +557,7 @@ class Logit(BaseTransform):
             \mathrm{logistic}(x; a, b) = \frac{a + b e^x}{1 + e^x}.
 
         Note that this is also the inverse of the logit function with domain
-        :math:`[a, b)`.
+        :math:`(a, b)`.
 
         Parameters
         ----------
@@ -634,7 +635,7 @@ class Logit(BaseTransform):
         
             \frac{\mathrm{d}y}{\mathrm{d}x} = \frac{b -a}{(x-a)(b-x)},
 
-        where :math:`x \in [a, b)`.
+        where :math:`x \in (a, b)`.
 
         Parameters
         ----------
@@ -648,6 +649,12 @@ class Logit(BaseTransform):
             The value of the jacobian at the given point(s).
         """
         x = maps[self._source]
+        # check that x is in bounds
+        isin = self._bounds.__contains__(x)
+        if isinstance(isin, numpy.ndarray) and not isin.all():
+            raise ValueError("one or more values are not in bounds")
+        elif not isin:
+            raise ValueError("{} is not in bounds".format(x))
         return (self._b - self._a)/((x - self._a)*(self._b - x))
 
     def inverse_jacobian(self, maps):
@@ -659,7 +666,7 @@ class Logit(BaseTransform):
         
             \frac{\mathrm{d}y}{\mathrm{d}x} = \frac{e^x (b-a)}{(1+e^y)^2},
 
-        where :math:`y \in [a, b)`.
+        where :math:`y \in (a, b)`.
 
         Parameters
         ----------

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -470,31 +470,31 @@ class ChiPToCartesianSpin(BaseTransform):
 
 
 class Logit(BaseTransform):
-    """Applies a logit transform from a `source` parameter to a `target`
+    """Applies a logit transform from an `input` parameter to an `output`
     parameter. This is the inverse of the logistic transform.
 
-    Typically, the source of the logit function is assumed to have domain
+    Typically, the input of the logit function is assumed to have domain
     :math:`\in (0, 1)`. However, the `domain` argument can be used to expand
     this to any finite real interval.
 
     Parameters
     ----------
-    source : str
+    input : str
         The name of the parameter to transform.
-    target : str
+    output : str
         The name of the transformed parameter.
     domain : tuple or distributions.bounds.Bounds, optional
-        The domain of the source parameter. Can be any finite
+        The domain of the input parameter. Can be any finite
         interval. Default is (0., 1.).
     """
     name = 'logit'
 
-    def __init__(self, source, target, domain=(0., 1.)):
+    def __init__(self, input, output, domain=(0., 1.)):
         super(Logit, self).__init__()
-        self._source = source
-        self._target = target
-        self._inputs = [source]
-        self._outputs = [target]
+        self._input = input
+        self._output = output
+        self._inputs = [input]
+        self._outputs = [output]
         self._bounds = Bounds(domain[0], domain[1],
                               btype_min='open', btype_max='open')
         # shortcuts for quick access later
@@ -502,18 +502,18 @@ class Logit(BaseTransform):
         self._b = domain[1]
 
     @property
-    def source(self):
-        """Returns the source parameter."""
-        return self._source
+    def input(self):
+        """Returns the input parameter."""
+        return self._input
 
     @property
-    def target(self):
-        """Returns the target parameter."""
-        return self._target
+    def output(self):
+        """Returns the output parameter."""
+        return self._output
 
     @property
     def bounds(self):
-        """Returns the domain of the source parameter.
+        """Returns the domain of the input parameter.
         """
         return self._bounds
 
@@ -595,14 +595,14 @@ class Logit(BaseTransform):
             A map between the transformed variable name and value(s), along
             with the original variable name and value(s).
         """
-        x = maps[self._source]
+        x = maps[self._input]
         # check that x is in bounds
         isin = self._bounds.__contains__(x)
         if isinstance(isin, numpy.ndarray) and not isin.all():
             raise ValueError("one or more values are not in bounds")
         elif not isin:
             raise ValueError("{} is not in bounds".format(x))
-        out = {self._target : self.logit(x, self._a, self._b)}
+        out = {self._output : self.logit(x, self._a, self._b)}
         return self.format_output(maps, out)
 
     def inverse_transform(self, maps):
@@ -622,8 +622,8 @@ class Logit(BaseTransform):
             A map between the transformed variable name and value(s), along
             with the original variable name and value(s).
         """
-        y = maps[self._target]
-        out = {self._source : self.logistic(y, self._a, self._b)}
+        y = maps[self._output]
+        out = {self._input : self.logistic(y, self._a, self._b)}
         return self.format_output(maps, out)
 
     def jacobian(self, maps):
@@ -648,7 +648,7 @@ class Logit(BaseTransform):
         float
             The value of the jacobian at the given point(s).
         """
-        x = maps[self._source]
+        x = maps[self._input]
         # check that x is in bounds
         isin = self._bounds.__contains__(x)
         if isinstance(isin, numpy.ndarray) and not isin.all():
@@ -679,7 +679,7 @@ class Logit(BaseTransform):
         float
             The value of the jacobian at the given point(s).
         """
-        x = maps[self._target]
+        x = maps[self._output]
         expx = numpy.exp(x)
         return expx * (self._b - self._a) / (1. + expx)**2.
 
@@ -769,21 +769,21 @@ class CartesianSpinToChiP(ChiPToCartesianSpin):
 
 
 class Logistic(Logit):
-    """Applies a logistic transform from a `source` parameter to a `target`
+    """Applies a logistic transform from an `input` parameter to an `output`
     parameter. This is the inverse of the logit transform.
 
-    Typically, the target of the logistic function has range :math:`\in [0,1)`.
+    Typically, the output of the logistic function has range :math:`\in [0,1)`.
     However, the `codomain` argument can be used to expand this to any
     finite real interval.
 
     Parameters
     ----------
-    source : str
+    input : str
         The name of the parameter to transform.
-    target : str
+    output : str
         The name of the transformed parameter.
     frange : tuple or distributions.bounds.Bounds, optional
-        The range of the target parameter. Can be any finite
+        The range of the output parameter. Can be any finite
         interval. Default is (0., 1.).
     """
     name = 'logistic'
@@ -793,12 +793,12 @@ class Logistic(Logit):
     jacobian = inverse.inverse_jacobian
     inverse_jacobian = inverse.jacobian
 
-    def __init__(self, source, target, codomain=(0.,1.)):
-        super(Logistic, self).__init__(target, source, domain=codomain)
+    def __init__(self, input, output, codomain=(0.,1.)):
+        super(Logistic, self).__init__(output, input, domain=codomain)
 
     @property
     def bounds(self):
-        """Returns the range of the target parameter.
+        """Returns the range of the output parameter.
         """
         return self._bounds
 

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -583,14 +583,14 @@ class Logit(BaseTransform):
         Parameters
         ----------
         maps : dict or FieldArray
-            A dictionary or FieldArray which provides the
-            `source -> source value(s)` mapping.
+            A dictionary or FieldArray which provides a map between the
+            parameter name of the variable to transform and its value(s).
 
         Returns
         -------
         out : dict or FieldArray
-            A map with `target -> target value(s)` along with
-            the original `source -> source value(s)`.
+            A map between the transformed variable name and value(s), along
+            with the original variable name and value(s).
         """
         x = maps[self._source]
         out = {self._target : self.logit(x, self._a, self._b)}
@@ -604,14 +604,14 @@ class Logit(BaseTransform):
         Parameters
         ----------
         maps : dict or FieldArray
-            A dictionary or FieldArray which provides the
-            `target -> target value(s)` mapping.
+            A dictionary or FieldArray which provides a map between the
+            parameter name of the variable to transform and its value(s).
 
         Returns
         -------
         out : dict or FieldArray
-            A map with `source -> source value(s)` along with
-            the original `target -> target value(s)`.
+            A map between the transformed variable name and value(s), along
+            with the original variable name and value(s).
         """
         y = maps[self._target]
         out = {self._source : self.logistic(y, self._a, self._b)}
@@ -631,13 +631,13 @@ class Logit(BaseTransform):
         Parameters
         ----------
         maps : dict or FieldArray
-            A dictionary or FieldArray which provides the
-            `source -> source value(s)` mapping.
+            A dictionary or FieldArray which provides a map between the
+            parameter name of the variable to transform and its value(s).
 
         Returns
         -------
         float
-            The value of the jacobian at the given source point.
+            The value of the jacobian at the given point(s).
         """
         x = maps[self._source]
         return (self._b - self._a)/((x - self._a)*(self._b - x))
@@ -656,13 +656,13 @@ class Logit(BaseTransform):
         Parameters
         ----------
         maps : dict or FieldArray
-            A dictionary or FieldArray which provides the
-            `target -> target value(s)` mapping.
+            A dictionary or FieldArray which provides a map between the
+            parameter name of the variable to transform and its value(s).
 
         Returns
         -------
         float
-            The value of the jacobian at the given target point.
+            The value of the jacobian at the given point(s).
         """
         x = maps[self._target]
         expx = numpy.exp(x)

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -468,6 +468,207 @@ class ChiPToCartesianSpin(BaseTransform):
         return self.format_output(maps, out)
 
 
+class Logit(BaseTransform):
+    """Applies a logit transform from a `source` parameter to a `target`
+    parameter. This is the inverse of the logistic transform.
+
+    Typically, the source of the logit function is assumed to have domain
+    :math:`\in [0, 1)`. However, the `domain` argument can be used to expand
+    this to any finite real interval.
+
+    Parameters
+    ----------
+    source : str
+        The name of the parameter to transform.
+    target : str
+        The name of the transformed parameter.
+    domain : tuple or distributions.bounds.Bounds, optional
+        The domain of the source parameter. Can be any finite
+        interval. Default is (0., 1.).
+    """
+    name = 'logit'
+
+    def __init__(self, source, target, domain=(0., 1.)):
+        super(Logit, self).__init__()
+        self._source = source
+        self._target = target
+        self._inputs = [source]
+        self._outputs = [target]
+        self._bounds = domain
+        self._a = bounds[0]
+        self._b = bounds[1]
+
+    @property
+    def source(self):
+        """Returns the source parameter."""
+        return self._source
+
+    @property
+    def target(self):
+        """Returns the target parameter."""
+        return self._target
+
+    @property
+    def bounds(self):
+        """Returns the domain of the source parameter.
+        """
+        return self._bounds
+
+    @staticmethod
+    def logit(x, a=0., b=1.):
+        r"""Computes the logit function with domain :math:`x \in [a, b)`.
+
+        This is given by:
+
+        .. math::
+
+            \mathrm{logit}(x; a, b) = \log\left(\frac{x-a}{b-x}\right).
+
+        Note that this is also the inverse of the logistic function with range
+        :math:`[a, b)`.
+
+        Parameters
+        ----------
+        x : float
+            The value to evaluate.
+        a : float, optional
+            The minimum bound of the domain of x. Default is 0.
+        b : float, optional
+            The maximum bound of the domain of x. Default is 1.
+
+        Returns
+        -------
+        float
+            The logit of x.
+        """
+        return numpy.log(x-a) - numpy.log(b-x)
+
+    @staticmethod
+    def logistic(x, a=0., b=1.):
+        r"""Computes the logistic function with range :math:`\in [a, b)`.
+
+        This is given by:
+
+        .. math::
+
+            \mathrm{logistic}(x; a, b) = \frac{a + b e^x}{1 + e^x}.
+
+        Note that this is also the inverse of the logit function with domain
+        :math:`[a, b)`.
+
+        Parameters
+        ----------
+        x : float
+            The value to evaluate.
+        a : float, optional
+            The minimum bound of the range of the logistic function. Default
+            is 0.
+        b : float, optional
+            The maximum bound of the range of the logistic function. Default
+            is 1.
+
+        Returns
+        -------
+        float
+            The logistic of x.
+        """
+        expx = numpy.exp(x)
+        return (a + b*expx)/(1. + expx)
+
+    def transform(self, maps):
+        r"""Computes :math:`\mathrm{logit}(x; a, b)`.
+        
+        The domain :math:`a, b` of :math:`x` are given by the class's bounds.
+
+        Parameters
+        ----------
+        maps : dict or FieldArray
+            A dictionary or FieldArray which provides the
+            `source -> source value(s)` mapping.
+
+        Returns
+        -------
+        out : dict or FieldArray
+            A map with `target -> target value(s)` along with
+            the original `source -> source value(s)`.
+        """
+        x = maps[self._source]
+        out = {self._target : self.logit(x, self._a, self._b)}
+        return self.format_output(maps, out)
+
+    def inverse_transform(self, maps):
+        r"""Computes :math:`y = \mathrm{logistic}(x; a,b)`.
+
+        The codomain :math:`a, b` of :math:`y` are given by the class's bounds.
+
+        Parameters
+        ----------
+        maps : dict or FieldArray
+            A dictionary or FieldArray which provides the
+            `target -> target value(s)` mapping.
+
+        Returns
+        -------
+        out : dict or FieldArray
+            A map with `source -> source value(s)` along with
+            the original `target -> target value(s)`.
+        """
+        y = maps[self._target]
+        out = {self._source : self.logistic(y, self._a, self._b)}
+        return self.format_output(maps, out)
+
+    def jacobian(self, maps):
+        r"""Computes the Jacobian of :math:`y = \mathrm{logit}(x; a,b)`.
+        
+        This is:
+
+        .. math::
+        
+            \frac{\mathrm{d}y}{\mathrm{d}x} = \frac{b -a}{(x-a)(b-x)},
+
+        where :math:`x \in [a, b)`.
+
+        Parameters
+        ----------
+        maps : dict or FieldArray
+            A dictionary or FieldArray which provides the
+            `source -> source value(s)` mapping.
+
+        Returns
+        -------
+        float
+            The value of the jacobian at the given source point.
+        """
+        x = maps[self._source]
+        return (self._b - self._a)/((x - self._a)*(self._b - x))
+
+    def invese_jacobian(self, maps):
+        r"""Computes the Jacobian of :math:`y = \mathrm{logistic}(x; a,b)`.
+        
+        This is:
+
+        .. math::
+        
+            \frac{\mathrm{d}y}{\mathrm{d}x} = \frac{e^x (b-a)}{(1+e^y)^2},
+
+        where :math:`y \in [a, b)`.
+
+        Parameters
+        ----------
+        maps : dict or FieldArray
+            A dictionary or FieldArray which provides the
+            `target -> target value(s)` mapping.
+
+        Returns
+        -------
+        float
+            The value of the jacobian at the given target point.
+        """
+        x = maps[self._target]
+        expx = numpy.exp(x)
+        return expx * (self._b - self._a) / (1. + expx)**2.
+
+
 #
 # =============================================================================
 #
@@ -552,6 +753,41 @@ class CartesianSpinToChiP(ChiPToCartesianSpin):
     inverse_jacobian = inverse.jacobian
 
 
+class Logistic(Logit):
+    """Applies a logistic transform from a `source` parameter to a `target`
+    parameter. This is the inverse of the logit transform.
+
+    Typically, the target of the logistic function has range :math:`\in [0,1)`.
+    However, the `codomain` argument can be used to expand this to any
+    finite real interval.
+
+    Parameters
+    ----------
+    source : str
+        The name of the parameter to transform.
+    target : str
+        The name of the transformed parameter.
+    frange : tuple or distributions.bounds.Bounds, optional
+        The range of the target parameter. Can be any finite
+        interval. Default is (0., 1.).
+    """
+    name = 'logistic'
+    inverse = Logit
+    transform = inverse.inverse_transform
+    inverse_transform = inverse.transform
+    jacobian = inverse.inverse_jacobian
+    inverse_jacobian = inverse.jacobian
+
+    def __init__(self, source, target, codomain=(0.,1.)):
+        super(Logistic, self).__init__(target, source, domain=codomain)
+
+    @property
+    def bounds(self):
+        """Returns the range of the target parameter.
+        """
+        return self._bounds
+
+
 # set the inverse of the forward transforms to the inverse transforms
 MchirpQToMass1Mass2.inverse = Mass1Mass2ToMchirpQ
 SphericalSpin1ToCartesianSpin1.inverse = CartesianSpin1ToSphericalSpin1
@@ -559,6 +795,7 @@ SphericalSpin2ToCartesianSpin2.inverse = CartesianSpin2ToSphericalSpin2
 AlignedMassSpinToCartesianSpin.inverse = CartesianSpinToAlignedMassSpin
 PrecessionMassSpinToCartesianSpin.inverse = CartesianSpinToPrecessionMassSpin
 ChiPToCartesianSpin.inverse = CartesianSpinToChiP
+Logit.inverse = Logistic
 
 
 #
@@ -584,6 +821,8 @@ transforms = {
     CartesianSpinToPrecessionMassSpin.name : CartesianSpinToPrecessionMassSpin,
     ChiPToCartesianSpin.name : ChiPToCartesianSpin,
     CartesianSpinToChiP.name : CartesianSpinToChiP,
+    Logit.name : Logit,
+    Logistic.name : Logistic,
 }
 
 # standard CBC transforms: these are transforms that do not require input

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -495,8 +495,8 @@ class Logit(BaseTransform):
         self._inputs = [source]
         self._outputs = [target]
         self._bounds = domain
-        self._a = bounds[0]
-        self._b = bounds[1]
+        self._a = domain[0]
+        self._b = domain[1]
 
     @property
     def source(self):


### PR DESCRIPTION
This patch adds the logit and logistic transforms to transforms.py. The logit transform basically movies boundaries to +/- infinity; this is needed for posteriors that peak close to, or at, a boundary. The logistic function is the inverse of the logit.

I'm putting this on hold for now. I realized there are some difficulties fitting these into the current structure for transforms as the logit and logistic function need variables to be specified on initialization. @cmbiwer I'll open another patch to try to deal with that first.