### PR TITLE
Fix typo in record.py

### DIFF
--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -144,7 +144,7 @@ def default_strlen(strlen=None):
         _default_types_status['default_strlen'] = strlen
         # update the typeDicts as needed
         lstring_as_obj(_default_types_status['lstring_as_obj'])
-        set_ilwd_as_int(_default_types_status['ilwd_as_int'])
+        ilwd_as_int(_default_types_status['ilwd_as_int'])
     return _default_types_status['default_strlen']
 
 # set the defaults


### PR DESCRIPTION
This fixes a typo that was caught by landscape in `record.py`.  At some point I must have changed `set_ilwd_as_int` to `ilwd_as_int` and forgot to update the call to this function in `default_strlen`.