### PR TITLE
Add multi-dimensional constraints to PriorEvaluator.

### DIFF
--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -60,8 +60,8 @@ class PriorEvaluator(object):
         A list of functions to test if parameter values obey multi-dimensional
         constraints.
 
-    Example
-    -------
+    Examples
+    --------
     An example of creating a prior with constraint that total mass must
     be below 30.
 

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -62,7 +62,7 @@ class PriorEvaluator(object):
 
     Example
     -------
-    An example of creating a prior with constraint that componenet masses must
+    An example of creating a prior with constraint that total mass must
     be below 30.
 
     >>> from pycbc.inference import distributions


### PR DESCRIPTION
Allows the user to pass a list of functions that impose multi-dimensional constraints on the prior.

The reason for putting this here is that this transcends parameters in different distributions.

Functions should have the convention that if the parameter values obey the constraint, the function returns ``True``, else if the parameter values disobey the constraint, then the function should return ``False``.