### PR TITLE
Make inverse transforms explicit and other updates

### DIFF
--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -445,7 +445,7 @@ def results_from_cli(opts, load_samples=True, walkers=None):
     if load_samples:
         logging.info("Loading samples")
         # check if need extra parameters for a non-sampling parameter
-        file_parameters, cs = transforms.get_standard_transforms(
+        file_parameters, ts = transforms.get_common_cbc_transforms(
                                                  parameters, fp.variable_args)
         # read samples from file
         samples = fp.read_samples(
@@ -453,8 +453,8 @@ def results_from_cli(opts, load_samples=True, walkers=None):
             thin_start=opts.thin_start, thin_interval=opts.thin_interval,
             thin_end=opts.thin_end, iteration=opts.iteration,
             samples_group=opts.parameters_group)
-        # add a parameters not included in file
-        samples = transforms.apply_transforms(samples, cs)
+        # add parameters not included in file
+        samples = transforms.apply_transforms(samples, ts)
     else:
         samples = None
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -445,7 +445,7 @@ def results_from_cli(opts, load_samples=True, walkers=None):
     if load_samples:
         logging.info("Loading samples")
         # check if need extra parameters for a non-sampling parameter
-        file_parameters, cs = transforms.get_conversions(
+        file_parameters, cs = transforms.get_standard_transforms(
                                                  parameters, fp.variable_args)
         # read samples from file
         samples = fp.read_samples(
@@ -454,7 +454,7 @@ def results_from_cli(opts, load_samples=True, walkers=None):
             thin_end=opts.thin_end, iteration=opts.iteration,
             samples_group=opts.parameters_group)
         # add a parameters not included in file
-        samples = transforms.apply_conversions(samples, cs)
+        samples = transforms.apply_transforms(samples, cs)
     else:
         samples = None
 

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -656,7 +656,7 @@ def get_standard_transforms(requested_params, variable_args,
 
     return list(requested_params), all_c
 
-def apply_transforms_to_samples(samples, cs):
+def apply_transforms(samples, cs):
     """Applies a list of BaseTransform instances on a mapping object.
 
     Parameters

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -106,7 +106,7 @@ class MchirpQToMass1Mass2(BaseTransform):
     _outputs = [parameters.mass1, parameters.mass2]
 
     def transform(self, maps):
-        """ This function transforms from chirp mass and mass ratio to component
+        """This function transforms from chirp mass and mass ratio to component
         masses.
 
         Parameters
@@ -119,10 +119,10 @@ class MchirpQToMass1Mass2(BaseTransform):
 
         >>> import numpy
         >>> from pycbc import transforms
-        >>> from pycbc.waveform import parameters
-        >>> cl = transforms.MchirpQToMass1Mass2()
-        >>> cl.transform({parameters.mchirp : numpy.array([10.]), parameters.q : numpy.array([2.])})
-            {'mass1': array([ 16.4375183]), 'mass2': array([ 8.21875915]), 'mchirp': array([ 10.]), 'q': array([ 2.])}
+        >>> t = transforms.MchirpQToMass1Mass2()
+        >>> t.transform({'mchirp': numpy.array([10.]), 'q': numpy.array([2.])})
+        {'mass1': array([ 16.4375183]), 'mass2': array([ 8.21875915]),
+         'mchirp': array([ 10.]), 'q': array([ 2.])}
 
         Returns
         -------
@@ -140,8 +140,8 @@ class MchirpQToMass1Mass2(BaseTransform):
         return self.format_output(maps, out)
 
     def inverse_transform(self, maps):
-        """ This function transforms from component masses to chirp mass and mass
-        ratio.
+        """This function transforms from component masses to chirp mass and
+        mass ratio.
 
         Parameters
         ----------
@@ -153,11 +153,10 @@ class MchirpQToMass1Mass2(BaseTransform):
 
         >>> import numpy
         >>> from pycbc import transforms
-        >>> from pycbc.waveform import parameters
-        >>> cl = transforms.MchirpQToMass1Mass2()
-        >>> cl.inverse()
-        >>> cl.transform({parameters.mass1 : numpy.array([16.4]), parameters.mass2 : numpy.array([8.2])})
-            {'mass1': array([ 16.4]), 'mass2': array([ 8.2]), 'mchirp': array([ 9.97717521]), 'q': 2.0}
+        >>> t = transforms.MchirpQToMass1Mass2()
+        >>> t.inverse_transform({'mass1': numpy.array([16.4]), 'mass2': numpy.array([8.2])})
+            {'mass1': array([ 16.4]), 'mass2': array([ 8.2]),
+             'mchirp': array([ 9.97717521]), 'q': 2.0}
 
         Returns
         -------
@@ -222,9 +221,8 @@ class SphericalSpin1ToCartesianSpin1(BaseTransform):
 
         >>> import numpy
         >>> from pycbc import transforms
-        >>> from pycbc.waveform import parameters
-        >>> cl = transforms.SphericalSpin1ToCartesianSpin1()
-        >>> cl.transform({parameters.spin1_a : numpy.array([0.1]), parameters.spin1_azimuthal : numpy.array([0.1]), parameters.spin1_polar : numpy.array([0.1])})
+        >>> t = transforms.SphericalSpin1ToCartesianSpin1()
+        >>> t.transform({'spin1_a': numpy.array([0.1]), 'spin1_azimuthal': numpy.array([0.1]), 'spin1_polar': numpy.array([0.1])})
             {'spin1_a': array([ 0.1]), 'spin1_azimuthal': array([ 0.1]), 'spin1_polar': array([ 0.1]),
              'spin2x': array([ 0.00993347]), 'spin2y': array([ 0.00099667]), 'spin2z': array([ 0.09950042])}
 
@@ -322,9 +320,8 @@ class DistanceToRedshift(BaseTransform):
 
         >>> import numpy
         >>> from pycbc import transforms
-        >>> from pycbc.waveform import parameters
-        >>> cl = transforms.DistanceToRedshift()
-        >>> cl.transform({parameters.distance : numpy.array([1000])})
+        >>> t = transforms.DistanceToRedshift()
+        >>> t.transform({'distance': numpy.array([1000])})
             {'distance': array([1000]), 'redshift': 0.19650987609144363}
 
         Returns

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -26,8 +26,8 @@ from pycbc import cosmology
 from pycbc.io import record
 from pycbc.waveform import parameters
 
-class BaseConversion(object):
-    """ A base class for converting between two sets of parameters.
+class BaseTransform(object):
+    """A base class for transforming between two sets of parameters.
     """
     _name = None
     _name_inverse = None
@@ -119,7 +119,7 @@ class BaseConversion(object):
             self.convert = self._convert
             self.jacobian = self._jacobian
 
-class MchirpQToMass1Mass2(BaseConversion):
+class MchirpQToMass1Mass2(BaseTransform):
     """ Converts chirp mass and mass ratio to component masses.
     """
     _name = "mchirp_q_to_mass1_mass2"
@@ -205,7 +205,7 @@ class MchirpQToMass1Mass2(BaseConversion):
         tmp = self._convert(maps)
         return maps["mchirp"] / tmp["mass2"]**2
 
-class SphericalSpin1ToCartesianSpin1(BaseConversion):
+class SphericalSpin1ToCartesianSpin1(BaseTransform):
     """ Converts spherical spin parameters (magnitude and two angles) to
     catesian spin parameters. This class only converts spsins for the first
     component mass.
@@ -275,7 +275,7 @@ class SphericalSpin2ToCartesianSpin2(SphericalSpin1ToCartesianSpin1):
                parameters.spin2_polar]
     _outputs = [parameters.spin2x, parameters.spin2y, parameters.spin2z]
 
-class DistanceToRedshift(BaseConversion):
+class DistanceToRedshift(BaseTransform):
     """ Converts distance to redshift.
     """
     _name = "distance_to_redshift"
@@ -311,7 +311,7 @@ class DistanceToRedshift(BaseConversion):
                                                     maps[parameters.distance])}
         return self.format_output(maps, out)
 
-class AlignedMassSpinToCartesianSpin(BaseConversion):
+class AlignedMassSpinToCartesianSpin(BaseTransform):
     """ Converts mass-weighted spins to cartesian z-axis spins.
     """
     _name = "aligned_mass_spin_to_cartesian_spin"
@@ -370,7 +370,7 @@ class AlignedMassSpinToCartesianSpin(BaseConversion):
         }
         return self.format_output(maps, out)
 
-class PrecessionMassSpinToCartesianSpin(BaseConversion):
+class PrecessionMassSpinToCartesianSpin(BaseTransform):
     """ Converts mass-weighted spins to cartesian x-y plane spins.
     """
     _name = "precession_mass_spin_to_cartesian_spin"
@@ -441,7 +441,7 @@ class PrecessionMassSpinToCartesianSpin(BaseConversion):
                              maps[parameters.spin2x], maps[parameters.spin2y])
         return self.format_output(maps, out)
 
-class ChiPToCartesianSpin(BaseConversion):
+class ChiPToCartesianSpin(BaseTransform):
     """ Converts chi_p to cartesian spins.
     """
     _name = "chi_p_to_cartesian_spin"
@@ -516,7 +516,7 @@ def get_conversions(requested_params, variable_args, valid_params=None):
     requested_params : list
         Updated list of parameters that user wants.
     all_c : list
-        List of BaseConversions to apply.
+        List of BaseTransforms to apply.
     """
 
     # try to parse any equations by putting all strings together
@@ -565,14 +565,14 @@ def get_conversions(requested_params, variable_args, valid_params=None):
     return list(requested_params), all_c
 
 def apply_conversions(samples, cs):
-    """ Applies a list of BaseConversion instances on a mapping object.
+    """ Applies a list of BaseTransform instances on a mapping object.
 
     Parameters
     ----------
     samples : {FieldArray, dict}
         Mapping object to apply conversions to.
     cs : list
-        List of BaseConversion instances to apply.
+        List of BaseTransform instances to apply.
 
     Returns
     -------

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -689,7 +689,7 @@ def apply_transforms(samples, transforms):
     samples : {FieldArray, dict}
         Mapping object with conversions applied. Same type as input.
     """
-    for t in tranforms:
+    for t in transforms:
         try:
             samples = t.transform(samples)
         except NotImplementedError:

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -102,7 +102,6 @@ class MchirpQToMass1Mass2(BaseTransform):
     """ Converts chirp mass and mass ratio to component masses.
     """
     name = "mchirp_q_to_mass1_mass2"
-    inverse = Mass1Mass2ToMchirpQ
     _inputs = [parameters.mchirp, parameters.q]
     _outputs = [parameters.mass1, parameters.mass2]
 
@@ -197,6 +196,8 @@ class Mass1Mass2ToMchirpQ(MchirpQToMass1Mass2):
     jacobian = inverse.inverse_jacobian
     inverse_jacobian = inverse.jacobian
 
+MchirpQToMass1Mass2.inverse = Mass1Mass2ToMchirpQ
+
 
 class SphericalSpin1ToCartesianSpin1(BaseTransform):
     """ Converts spherical spin parameters (magnitude and two angles) to
@@ -204,7 +205,6 @@ class SphericalSpin1ToCartesianSpin1(BaseTransform):
     component mass.
     """
     name = "spherical_spin_1_to_cartesian_spin_1"
-    name_inverse = CartesianSpin1ToSphericalSpin1.name
     _inputs = [parameters.spin1_a, parameters.spin1_azimuthal,
                parameters.spin1_polar]
     _outputs = [parameters.spin1x, parameters.spin1y, parameters.spin1z]
@@ -271,13 +271,15 @@ class CartesianSpin1ToSphericalSpin1(SphericalSpin1ToCartesianSpin1):
     inverse_jacobian = inverse.jacobian
 
 
+SphericalSpin1ToCartesianSpin1.inverse = CartesianSpin1ToSphericalSpin1
+
+
 class SphericalSpin2ToCartesianSpin2(SphericalSpin1ToCartesianSpin1):
     """ Converts spherical spin parameters (magnitude and two angles) to
     catesian spin parameters. This class only transforms spsins for the second
     component mass.
     """
     name = "spherical_spin_2_to_cartesian_spin_2"
-    inverse = CartesianSpin2ToSphericalSpin2
     _inputs = [parameters.spin2_a, parameters.spin2_azimuthal,
                parameters.spin2_polar]
     _outputs = [parameters.spin2x, parameters.spin2y, parameters.spin2z]
@@ -294,6 +296,9 @@ class CartesianSpin2ToSphericalSpin2(SphericalSpin2ToCartesianSpin2):
     inverse_transform = inverse.transform
     jacobian = inverse.inverse_jacobian
     inverse_jacobian = inverse.jacobian
+
+
+SphericalSpin2ToCartesianSpin2.inverse = CartesianSpin2ToSphericalSpin2
 
 
 class DistanceToRedshift(BaseTransform):
@@ -337,7 +342,6 @@ class AlignedMassSpinToCartesianSpin(BaseTransform):
     """ Converts mass-weighted spins to cartesian z-axis spins.
     """
     name = "aligned_mass_spin_to_cartesian_spin"
-    inverse = CartesianSpinToAlignedMassSpin
     _inputs = [parameters.mass1, parameters.mass2, parameters.chi_eff, "chi_a"]
     _outputs = [parameters.mass1, parameters.mass2,
                parameters.spin1z, parameters.spin2z]
@@ -405,11 +409,13 @@ class CartesianSpinToAlignedMassSpin(AlignedMassSpinToCartesianSpin):
     inverse_jacobian = inverse.jacobian
 
 
+AlignedMassSpinToCartesianSpin.inverse = CartesianSpinToAlignedMassSpin
+
+
 class PrecessionMassSpinToCartesianSpin(BaseTransform):
     """ Converts mass-weighted spins to cartesian x-y plane spins.
     """
     name = "precession_mass_spin_to_cartesian_spin"
-    name_inverse = "cartesian_spin_to_precession_mass_spin"
     _inputs = [parameters.mass1, parameters.mass2,
                "xi1", "xi2", "phi_a", "phi_s"]
     _outputs = [parameters.mass1, parameters.mass2,
@@ -490,11 +496,13 @@ class CartesianSpinToPrecessionMassSpin(PrecessionMassSpinToCartesianSpin):
     inverse_jacobian = inverse.jacobian
 
 
+PrecessionMassSpinToCartesianSpin.inverse = CartesianSpinToPrecessionMassSpin
+
+
 class ChiPToCartesianSpin(BaseTransform):
     """Converts chi_p to cartesian spins.
     """
     name = "chi_p_to_cartesian_spin"
-    inverse = CartesianSpinToChiP
     _inputs = ["chi_p"]
     _outputs = [parameters.mass1, parameters.mass2,
                 parameters.spin1x, parameters.spin1y,
@@ -544,6 +552,9 @@ class CartesianSpinToChiP(ChiPToCartesianSpin):
     inverse_transform = inverse.transform
     jacobian = inverse.inverse_jacobian
     inverse_jacobian = inverse.jacobian
+
+
+ChiPToCartesianSpin.inverse = CartesianSpinToChiP
 
 
 # dictionary of all transforms

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -98,6 +98,14 @@ class BaseTransform(object):
             raise TypeError("Input type must be FieldArray or dict.")
 
 
+#
+# =============================================================================
+#
+#                             Forward Transforms
+#
+# =============================================================================
+#
+
 class MchirpQToMass1Mass2(BaseTransform):
     """ Converts chirp mass and mass ratio to component masses.
     """
@@ -183,21 +191,6 @@ class MchirpQToMass1Mass2(BaseTransform):
         return maps["mchirp"] / tmp["mass2"]**2
 
 
-class Mass1Mass2ToMchirpQ(MchirpQToMass1Mass2):
-    """Converts component masses to chirp mass and mass ratio.
-    """
-    name = "mass1_mass2_to_mchirp_q"
-    inverse = MchirpQToMass1Mass2
-    _inputs = inverse._outputs
-    _outputs = inverse._inputs
-    transform = inverse.inverse_transform
-    inverse_transform = inverse.transform
-    jacobian = inverse.inverse_jacobian
-    inverse_jacobian = inverse.jacobian
-
-MchirpQToMass1Mass2.inverse = Mass1Mass2ToMchirpQ
-
-
 class SphericalSpin1ToCartesianSpin1(BaseTransform):
     """ Converts spherical spin parameters (magnitude and two angles) to
     catesian spin parameters. This class only transforms spsins for the first
@@ -256,22 +249,6 @@ class SphericalSpin1ToCartesianSpin1(BaseTransform):
         return self.format_output(maps, out)
 
 
-class CartesianSpin1ToSphericalSpin1(SphericalSpin1ToCartesianSpin1):
-    """The inverse of SphericalSpin1ToCartesianSpin1.
-    """
-    name = "cartesian_spin_1_to_spherical_spin_1"
-    inverse = SphericalSpin1ToCartesianSpin1
-    _inputs = inverse._outputs
-    _outputs = inverse._inputs
-    transform = inverse.inverse_transform
-    inverse_transform = inverse.transform
-    jacobian = inverse.inverse_jacobian
-    inverse_jacobian = inverse.jacobian
-
-
-SphericalSpin1ToCartesianSpin1.inverse = CartesianSpin1ToSphericalSpin1
-
-
 class SphericalSpin2ToCartesianSpin2(SphericalSpin1ToCartesianSpin1):
     """ Converts spherical spin parameters (magnitude and two angles) to
     catesian spin parameters. This class only transforms spsins for the second
@@ -281,22 +258,6 @@ class SphericalSpin2ToCartesianSpin2(SphericalSpin1ToCartesianSpin1):
     _inputs = [parameters.spin2_a, parameters.spin2_azimuthal,
                parameters.spin2_polar]
     _outputs = [parameters.spin2x, parameters.spin2y, parameters.spin2z]
-
-
-class CartesianSpin2ToSphericalSpin2(SphericalSpin2ToCartesianSpin2):
-    """The inverse of SphericalSpin2ToCartesianSpin2.
-    """
-    name = "cartesian_spin_2_to_spherical_spin_2"
-    inverse = SphericalSpin2ToCartesianSpin2
-    _inputs = inverse._outputs
-    _outputs = inverse._inputs
-    transform = inverse.inverse_transform
-    inverse_transform = inverse.transform
-    jacobian = inverse.inverse_jacobian
-    inverse_jacobian = inverse.jacobian
-
-
-SphericalSpin2ToCartesianSpin2.inverse = CartesianSpin2ToSphericalSpin2
 
 
 class DistanceToRedshift(BaseTransform):
@@ -394,21 +355,6 @@ class AlignedMassSpinToCartesianSpin(BaseTransform):
         return self.format_output(maps, out)
 
 
-class CartesianSpinToAlignedMassSpin(AlignedMassSpinToCartesianSpin):
-    """The inverse of AlignedMassSpinToCartesianSpin."""
-    name = "cartesian_spin_to_aligned_mass_spin"
-    inverse = AlignedMassSpinToCartesianSpin
-    _inputs = inverse._outputs
-    _outputs = inverse._inputs
-    transform = inverse.inverse_transform
-    inverse_transform = inverse.transform
-    jacobian = inverse.inverse_jacobian
-    inverse_jacobian = inverse.jacobian
-
-
-AlignedMassSpinToCartesianSpin.inverse = CartesianSpinToAlignedMassSpin
-
-
 class PrecessionMassSpinToCartesianSpin(BaseTransform):
     """ Converts mass-weighted spins to cartesian x-y plane spins.
     """
@@ -480,22 +426,6 @@ class PrecessionMassSpinToCartesianSpin(BaseTransform):
         return self.format_output(maps, out)
 
 
-class CartesianSpinToPrecessionMassSpin(PrecessionMassSpinToCartesianSpin):
-    """The inverse of PrecessionMassSpinToCartesianSpin.
-    """
-    name = "cartesian_spin_to_precession_mass_spin"
-    inverse = PrecessionMassSpinToCartesianSpin
-    _inputs = inverse._outputs
-    _outputs = inverse._inputs
-    transform = inverse.inverse_transform
-    inverse_transform = inverse.transform
-    jacobian = inverse.inverse_jacobian
-    inverse_jacobian = inverse.jacobian
-
-
-PrecessionMassSpinToCartesianSpin.inverse = CartesianSpinToPrecessionMassSpin
-
-
 class ChiPToCartesianSpin(BaseTransform):
     """Converts chi_p to cartesian spins.
     """
@@ -538,6 +468,77 @@ class ChiPToCartesianSpin(BaseTransform):
         return self.format_output(maps, out)
 
 
+#
+# =============================================================================
+#
+#                             Inverse Transforms
+#
+# =============================================================================
+#
+class Mass1Mass2ToMchirpQ(MchirpQToMass1Mass2):
+    """The inverse of MchirpQToMass1Mass2.
+    """
+    name = "mass1_mass2_to_mchirp_q"
+    inverse = MchirpQToMass1Mass2
+    _inputs = inverse._outputs
+    _outputs = inverse._inputs
+    transform = inverse.inverse_transform
+    inverse_transform = inverse.transform
+    jacobian = inverse.inverse_jacobian
+    inverse_jacobian = inverse.jacobian
+
+
+class CartesianSpin1ToSphericalSpin1(SphericalSpin1ToCartesianSpin1):
+    """The inverse of SphericalSpin1ToCartesianSpin1.
+    """
+    name = "cartesian_spin_1_to_spherical_spin_1"
+    inverse = SphericalSpin1ToCartesianSpin1
+    _inputs = inverse._outputs
+    _outputs = inverse._inputs
+    transform = inverse.inverse_transform
+    inverse_transform = inverse.transform
+    jacobian = inverse.inverse_jacobian
+    inverse_jacobian = inverse.jacobian
+
+
+class CartesianSpin2ToSphericalSpin2(SphericalSpin2ToCartesianSpin2):
+    """The inverse of SphericalSpin2ToCartesianSpin2.
+    """
+    name = "cartesian_spin_2_to_spherical_spin_2"
+    inverse = SphericalSpin2ToCartesianSpin2
+    _inputs = inverse._outputs
+    _outputs = inverse._inputs
+    transform = inverse.inverse_transform
+    inverse_transform = inverse.transform
+    jacobian = inverse.inverse_jacobian
+    inverse_jacobian = inverse.jacobian
+
+
+class CartesianSpinToAlignedMassSpin(AlignedMassSpinToCartesianSpin):
+    """The inverse of AlignedMassSpinToCartesianSpin."""
+    name = "cartesian_spin_to_aligned_mass_spin"
+    inverse = AlignedMassSpinToCartesianSpin
+    _inputs = inverse._outputs
+    _outputs = inverse._inputs
+    transform = inverse.inverse_transform
+    inverse_transform = inverse.transform
+    jacobian = inverse.inverse_jacobian
+    inverse_jacobian = inverse.jacobian
+
+
+class CartesianSpinToPrecessionMassSpin(PrecessionMassSpinToCartesianSpin):
+    """The inverse of PrecessionMassSpinToCartesianSpin.
+    """
+    name = "cartesian_spin_to_precession_mass_spin"
+    inverse = PrecessionMassSpinToCartesianSpin
+    _inputs = inverse._outputs
+    _outputs = inverse._inputs
+    transform = inverse.inverse_transform
+    inverse_transform = inverse.transform
+    jacobian = inverse.inverse_jacobian
+    inverse_jacobian = inverse.jacobian
+
+
 class CartesianSpinToChiP(ChiPToCartesianSpin):
     """The inverse of ChiPToCartesianSpin.
     """
@@ -551,8 +552,22 @@ class CartesianSpinToChiP(ChiPToCartesianSpin):
     inverse_jacobian = inverse.jacobian
 
 
+# set the inverse of the forward transforms to the inverse transforms
+MchirpQToMass1Mass2.inverse = Mass1Mass2ToMchirpQ
+SphericalSpin1ToCartesianSpin1.inverse = CartesianSpin1ToSphericalSpin1
+SphericalSpin2ToCartesianSpin2.inverse = CartesianSpin2ToSphericalSpin2
+AlignedMassSpinToCartesianSpin.inverse = CartesianSpinToAlignedMassSpin
+PrecessionMassSpinToCartesianSpin.inverse = CartesianSpinToPrecessionMassSpin
 ChiPToCartesianSpin.inverse = CartesianSpinToChiP
 
+
+#
+# =============================================================================
+#
+#                      Collections of transforms
+#
+# =============================================================================
+#
 
 # dictionary of all transforms
 transforms = {

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -648,7 +648,7 @@ def get_common_cbc_transforms(requested_params, variable_args,
     # find all the transforms for the requested derived parameters
     # calculated from base parameters
     from_base_c = []
-    for converter in common_cbc_forward_transforms:
+    for converter in common_cbc_inverse_transforms:
         if (converter.outputs.issubset(variable_args) or
                 converter.outputs.isdisjoint(requested_params)):
             continue
@@ -661,7 +661,7 @@ def get_common_cbc_transforms(requested_params, variable_args,
     # find all the tranforms for the required base parameters
     # calculated from sampling parameters
     to_base_c = []
-    for converter in common_cbc_inverse_transforms:
+    for converter in common_cbc_forward_transforms:
         if (converter.inputs.issubset(variable_args) and
                 len(converter.outputs.intersection(requested_params)) > 0):
             requested_params.update(converter.inputs)

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -38,34 +38,32 @@ class BaseTransform(object):
         self.name = self._name
         self.inputs = set(self._inputs)
         self.outputs = set(self._outputs)
-        self.convert = self._convert
-        self.jacobian = self._jacobian
 
-    def _convert(self, maps):
+    def convert(self, maps):
         """ This function converts from inputs to outputs.
         """
         raise NotImplementedError("Not added.")
 
-    def _convert_inverse(self, maps):
-        """ The inverse conversions of _convert. This function converts from
+    def convert_inverse(self, maps):
+        """ The inverse conversions of convert. This function converts from
         outputs to inputs.
         """
         raise NotImplementedError("Not added.")
 
-    def _jacobian(self, maps):
+    def jacobian(self, maps):
         """ The Jacobian for the inputs to outputs transformation.
         """
         raise NotImplementedError("Jacobian transform not implemented.")
 
-    def _jacobian_inverse(self, maps):
+    def jacobian_inverse(self, maps):
         """ The Jacobian for the outputs to inputs transformation.
         """
         raise NotImplementedError("Jacobian transform not implemented.")
 
     @staticmethod
     def format_output(old_maps, new_maps):
-        """ This function takes the returned dict from _convert and converts
-        it to the same datatype as the input to _convert.
+        """ This function takes the returned dict from convert and converts
+        it to the same datatype as the input to convert.
 
         Parameters
         ----------
@@ -106,18 +104,18 @@ class BaseTransform(object):
         vice versa. The functions ``convert`` and ``jacobian`` will now call
         the inverse transformation that instance is currently set to.
         """
-        if self.convert == self._convert and self.jacobian == self._jacobian:
+        if self.convert == self.convert and self.jacobian == self.jacobian:
             self.name = self._name_inverse
             self.inputs = set(self._outputs)
             self.outputs = set(self._inputs)
-            self.convert = self._convert_inverse
-            self.jacobian = self._jacobian_inverse
+            self.convert = self.convert_inverse
+            self.jacobian = self.jacobian_inverse
         else:
             self.name = self._name
             self.inputs = set(self._inputs)
             self.outputs = set(self._outputs)
-            self.convert = self._convert
-            self.jacobian = self._jacobian
+            self.convert = self.convert
+            self.jacobian = self.jacobian
 
 class MchirpQToMass1Mass2(BaseTransform):
     """ Converts chirp mass and mass ratio to component masses.
@@ -127,7 +125,7 @@ class MchirpQToMass1Mass2(BaseTransform):
     _inputs = [parameters.mchirp, parameters.q]
     _outputs = [parameters.mass1, parameters.mass2]
 
-    def _convert(self, maps):
+    def convert(self, maps):
         """ This function converts from chirp mass and mass ratio to component
         masses.
 
@@ -161,7 +159,7 @@ class MchirpQToMass1Mass2(BaseTransform):
                                                 maps[parameters.q])
         return self.format_output(maps, out)
 
-    def _convert_inverse(self, maps):
+    def convert_inverse(self, maps):
         """ This function converts from component masses to chirp mass and mass
         ratio.
 
@@ -198,11 +196,11 @@ class MchirpQToMass1Mass2(BaseTransform):
         out[parameters.q] = m_p / m_s
         return self.format_output(maps, out)
 
-    def _jacobian(self, maps):
+    def jacobian(self, maps):
         """ Returns the Jacobian from chirp mass and mass ratio to
         component masses.
         """
-        tmp = self._convert(maps)
+        tmp = self.convert(maps)
         return maps["mchirp"] / tmp["mass2"]**2
 
 class SphericalSpin1ToCartesianSpin1(BaseTransform):
@@ -216,7 +214,7 @@ class SphericalSpin1ToCartesianSpin1(BaseTransform):
                parameters.spin1_polar]
     _outputs = [parameters.spin1x, parameters.spin1y, parameters.spin1z]
 
-    def _convert(self, maps):
+    def convert(self, maps):
         """ This function converts from spherical to cartesian spins.
 
         Parameters
@@ -246,7 +244,7 @@ class SphericalSpin1ToCartesianSpin1(BaseTransform):
         out = {param : val for param, val in zip(self._outputs, data)}
         return self.format_output(maps, out)
 
-    def _convert_inverse(self, maps):
+    def convert_inverse(self, maps):
         """ This function converts from cartesian to spherical spins.
 
         Parameters
@@ -283,7 +281,7 @@ class DistanceToRedshift(BaseTransform):
     _inputs = [parameters.distance]
     _outputs = [parameters.redshift]
 
-    def _convert(self, maps):
+    def convert(self, maps):
         """ This function converts from distance to redshift.
 
         Parameters
@@ -320,7 +318,7 @@ class AlignedMassSpinToCartesianSpin(BaseTransform):
     _outputs = [parameters.mass1, parameters.mass2,
                parameters.spin1z, parameters.spin2z]
 
-    def _convert(self, maps):
+    def convert(self, maps):
         """ This function converts from aligned mass-weighted spins to
         cartesian spins aligned along the z-axis.
 
@@ -346,7 +344,7 @@ class AlignedMassSpinToCartesianSpin(BaseTransform):
                                maps[parameters.chi_eff], maps["chi_a"])
         return self.format_output(maps, out)
 
-    def _convert_inverse(self, maps):
+    def convert_inverse(self, maps):
         """ This function converts from component masses and cartesian spins to
         mass-weighted spin parameters aligned with the angular momentum.
 
@@ -381,7 +379,7 @@ class PrecessionMassSpinToCartesianSpin(BaseTransform):
                 parameters.spin1x, parameters.spin1y,
                 parameters.spin2x, parameters.spin2y]
 
-    def _convert(self, maps):
+    def convert(self, maps):
         """ This function converts from mass-weighted spins to caretsian spins
         in the x-y plane.
 
@@ -410,7 +408,7 @@ class PrecessionMassSpinToCartesianSpin(BaseTransform):
                                maps["xi2"], maps["phi_a"], maps["phi_s"])
         return self.format_output(maps, out)
 
-    def _convert_inverse(self, maps):
+    def convert_inverse(self, maps):
         """ This function converts from component masses and cartesian spins to
         mass-weighted spin parameters perpendicular with the angular momentum.
 
@@ -451,7 +449,7 @@ class ChiPToCartesianSpin(BaseTransform):
                 parameters.spin1x, parameters.spin1y,
                 parameters.spin2x, parameters.spin2y]
 
-    def _convert_inverse(self, maps):
+    def convert_inverse(self, maps):
         """ This function converts from component masses and caretsian spins
         to chi_p.
 


### PR DESCRIPTION
This patch makes the inverse transforms there own classes, rather than a method that changes the behavior of the class. This makes it a bit clearer what each thing is doing (I found it confusing that, e.g., to create a transform from mass1, mass2 to mchirp,q you needed to initialize MchirpQToMass1Mass2), and is needed if a transform takes input arguments, especially if the inverse does not take the same input arguments. This is to pave the way for the logit transform, and any other transform that may take input arguments.

This also defines a dictionary of all of the transform names -> transform classes, similar to what is in distributions. The current `to_/from_` base converters is renamed `standard(_inverse)_transforms`. These are meant to be only transforms that do not need arguments on initialization, as all of the transforms for standard CBC parameters are.

Finally, in keeping with the changing of naming from `sampling_conversions` to `transforms`, I've renamed `convert` to `transform`. Also, I've gotten rid of the preceding `_` in `_name`, `_jacobian`, etc. Having separate `_jacobian` and `jacobian` methods is no longer needed since the inverse transforms are now their own classes.