### PR TITLE
Fixes towards Python 3 compatibility

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -70,7 +70,8 @@ try:
     # This is a crude check to make sure that the driver is installed
     try:
         loaded_modules = subprocess.Popen(['lsmod'], stdout=subprocess.PIPE).communicate()[0]
-        if str.find(loaded_modules, "nvidia") == -1:
+        loaded_modules = loaded_modules.decode()
+        if 'nvidia' not in loaded_modules:
             raise ImportError("nvidia driver may not be installed correctly")
     except OSError:
         pass

--- a/pycbc/distributions/angular.py
+++ b/pycbc/distributions/angular.py
@@ -17,7 +17,10 @@ This modules provides classes for evaluating angular distributions.
 """
 
 import numpy
-from ConfigParser import Error
+try:
+    from ConfigParser import Error
+except ImportError:
+    from configparser import Error
 from pycbc.distributions import boundaries
 from pycbc.distributions import bounded
 from pycbc.distributions import uniform
@@ -369,8 +372,8 @@ class UniformSolidAngle(bounded.BoundedDist):
             'cyclic_domain': azimuthal_cyclic_domain})
         self._polar_angle = polar_angle
         self._azimuthal_angle = azimuthal_angle
-        self._bounds = dict(self._polardist.bounds.items() +
-                            self._azimuthaldist.bounds.items())
+        self._bounds = self._polardist.bounds.copy()
+        self._bounds.update(self._azimuthaldist.bounds)
         self._params = sorted(self._bounds.keys())
 
 

--- a/pycbc/distributions/bounded.py
+++ b/pycbc/distributions/bounded.py
@@ -17,7 +17,10 @@ This modules provides classes for evaluating distributions with bounds.
 """
 
 import warnings
-from ConfigParser import Error
+try:
+    from ConfigParser import Error
+except ImportError:
+    from configparser import Error
 from pycbc.distributions import boundaries
 
 VARARGS_DELIM = '+'

--- a/pycbc/events/veto.py
+++ b/pycbc/events/veto.py
@@ -1,9 +1,8 @@
 """ This module contains utilities to manipulate trigger lists based on 
 segment.
 """
-import numpy, os.path
-import lal
-from pycbc_glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
+import numpy
+from pycbc_glue.ligolw import table, lsctables, utils as ligolw_utils
 from pycbc_glue.segments import segment, segmentlist
 
 

--- a/pycbc/events/veto.py
+++ b/pycbc/events/veto.py
@@ -1,7 +1,7 @@
 """ This module contains utilities to manipulate trigger lists based on 
 segment.
 """
-import numpy, urlparse, os.path
+import numpy, os.path
 import lal
 from pycbc_glue.ligolw import ligolw, table, lsctables, utils as ligolw_utils
 from pycbc_glue.segments import segment, segmentlist

--- a/pycbc/io/sqlite.py
+++ b/pycbc/io/sqlite.py
@@ -54,16 +54,16 @@ class TableData(SqliteData):
                     self.restriction += " AND " # all subsequent conditions need an AND
                 self.restriction += cond
         if limit: self.restriction += " LIMIT "+str(limit)
-        if self.verbose: print self.restriction
+        if self.verbose: print(self.restriction)
 
     def retrieve_rows(self):
         """
         assigns a list of rows of db content to self.data
         """
-        if self.verbose: print self.command+self.restriction
+        if self.verbose: print(self.command+self.restriction)
         # the result of executing is an *iterator* over rows
         self.data = list(self.curs.execute(self.command+self.restriction))
-        if self.verbose: print "Shape of data is", np.shape(self.data)
+        if self.verbose: print("Shape of data is", np.shape(self.data))
 
     def get_column(self, colname):
         """
@@ -73,13 +73,13 @@ class TableData(SqliteData):
         # data may already be cached as a list
         if self.data is not None:
             colindex = self.indices[colname]
-            if self.verbose: print "    Getting", colname, "data from pre-existing list"
+            if self.verbose: print("    Getting", colname, "data from pre-existing list")
             # allow the list to be of length 0, then return an empty array
             col = np.array([row[colindex] for row in self.data] if len(self.data)>0 else [])
         else:
             column_command = "SELECT "+colname+" FROM "+self.tablen
-            if self.verbose: print column_command+self.restriction
+            if self.verbose: print(column_command+self.restriction)
             col = np.array(val[0] for val in self.curs.execute(column_command+self.restriction))
-            if self.verbose: print "Shape of column", colname, "is", np.shape(col)
+            if self.verbose: print("Shape of column", colname, "is", np.shape(col))
         return col
 

--- a/pycbc/vetoes/chisq_cuda.py
+++ b/pycbc/vetoes/chisq_cuda.py
@@ -163,7 +163,8 @@ def get_cached_bin_layout(bins):
         _bcache[key] = (kmin, kmax, bv) 
     return _bcache[key]
 
-def shift_sum_points(num, (corr, outp, phase, np, nb, N, kmin, kmax, bv, nbins)):
+def shift_sum_points(num, arg_tuple):
+    corr, outp, phase, np, nb, N, kmin, kmax, bv, nbins = arg_tuple
     #fuse = 'fuse' in corr.gpu_callback_method
     fuse = False
     

--- a/setup.py
+++ b/setup.py
@@ -181,8 +181,10 @@ class TestBase(Command):
 
         test_results.append("\n" + (self.scheme + " tests ").rjust(30))
         for test in self.test_modules:
-            test_command = 'python ' + 'test/' + test + '.py -s ' + self.scheme
-            a = subprocess.call(test_command,env=os.environ,shell=True)
+            test_command = [sys.executable,
+                            'test/' + test + '.py',
+                            '-s', self.scheme]
+            a = subprocess.call(test_command, env=os.environ)
             if a != 0:
                 result_str = str(test).ljust(30) + ": Fail : " + str(a)
             else:

--- a/test/test_fftw_openmp.py
+++ b/test/test_fftw_openmp.py
@@ -42,10 +42,10 @@ if 'fftw' in pycbc.fft.get_backend_names():
     try:
         pycbc.fft.fftw.set_threads_backend('openmp')
     except:
-        print "Unable to import openmp threads backend to FFTW; skipping openmp thread tests"
+        print("Unable to import openmp threads backend to FFTW; skipping openmp thread tests")
         _exit(0)
 else:
-    print "FFTW does not seem to be an available CPU backend; skipping openmp thread tests"
+    print("FFTW does not seem to be an available CPU backend; skipping openmp thread tests")
     _exit(0)
 
 # Now set the number of threads to something nontrivial

--- a/test/test_fftw_pthreads.py
+++ b/test/test_fftw_pthreads.py
@@ -42,10 +42,10 @@ if 'fftw' in pycbc.fft.get_backend_names():
     try:
         pycbc.fft.fftw.set_threads_backend('pthreads')
     except:
-        print "Unable to import pthreads threads backend to FFTW; skipping pthreads thread tests"
+        print("Unable to import pthreads threads backend to FFTW; skipping pthreads thread tests")
         _exit(0)
 else:
-    print "FFTW does not seem to be an available CPU backend; skipping pthreads thread tests"
+    print("FFTW does not seem to be an available CPU backend; skipping pthreads thread tests")
     _exit(0)
 
 # Most of the work is now done in fft_base.

--- a/test/test_lalsim.py
+++ b/test/test_lalsim.py
@@ -80,8 +80,8 @@ parser.add_option('--tidal-order', type = int, default=-1, help = "[default: %de
                 
 (opt, args) = parser.parse_args()
 
-print 72*'='
-print "Running {0} unit tests for {1}:".format('CPU', "Lalsimulation Waveforms")
+print(72*'=')
+print("Running {0} unit tests for {1}:".format('CPU', "Lalsimulation Waveforms"))
 
 import matplotlib
 if not opt.show_plots:

--- a/test/test_pnutils.py
+++ b/test/test_pnutils.py
@@ -69,7 +69,7 @@ class TestUtils(unittest.TestCase):
         # with no spin
         result = mass1_mass2_spin1z_spin2z_to_beta_sigma_gamma(1.4, 1.4,
                                                                0., 0.)
-        for i in xrange(3):
+        for i in range(3):
             self.assertAlmostEqual(result[i], 0, places=6)
         # with spin
         result = mass1_mass2_spin1z_spin2z_to_beta_sigma_gamma(10., 1.4,

--- a/test/test_spatmplt.py
+++ b/test/test_spatmplt.py
@@ -24,16 +24,11 @@
 """
 These are the unittests for the pycbc.waveform module
 """
-import sys
 import pycbc
 import unittest
-from pycbc.types import *
-from pycbc.scheme import *
-from pycbc.filter import *
-from pycbc.waveform import *
-import pycbc.fft
-import numpy
-from numpy import sqrt, cos, sin
+from pycbc.types import zeros, complex64
+from pycbc.filter import overlap
+from pycbc.waveform import get_fd_waveform, get_waveform_filter
 from utils import parse_args_all_schemes, simple_exit
 
 _scheme, _context = parse_args_all_schemes("Waveform")

--- a/test/test_spatmplt.py
+++ b/test/test_spatmplt.py
@@ -74,7 +74,7 @@ class TestSPAtmplt(unittest.TestCase):
                             o =  overlap(hp, hpr)
                             self.assertAlmostEqual(1.0, o, places=4)
 
-                            print "checked m1: %s m2:: %s s1z: %s s2z: %s] overlap = %s, diff = %s" % (m1, m2, s1, s2, o, diff)
+                            print("checked m1: %s m2:: %s s1z: %s s2z: %s] overlap = %s, diff = %s" % (m1, m2, s1, s2, o, diff))
 
 
 suite = unittest.TestSuite()

--- a/test/test_threshold.py
+++ b/test/test_threshold.py
@@ -50,14 +50,14 @@ class TestThreshold(unittest.TestCase):
         self.threshold = 1.3
         self.locs, self.vals = trusted_threshold(self.series, self.threshold) 
         self.tolerance = 1e-6
-        print len(self.locs), len(self.vals)
+        print(len(self.locs), len(self.vals))
         
     def test_threshold(self):
         with self.context:
             locs, vals = threshold(self.series, self.threshold)
             self.assertTrue((locs == self.locs).all())
             self.assertTrue((vals == self.vals).all())
-            print len(locs), len(vals)
+            print(len(locs), len(vals))
 suite = unittest.TestSuite()
 suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestThreshold))
 

--- a/test/test_tmpltbank.py
+++ b/test/test_tmpltbank.py
@@ -249,10 +249,10 @@ class TmpltbankTestClass(unittest.TestCase):
                     pass
                 else:
                     err_msg = "Minimum total mass changed unexpectedly."
-                    print self.min_total_mass, curr_min_mass
-                    print self.min_mass1, self.min_mass2, min_comp_mass
-                    print min_eta, self.min_eta, self.max_eta
-                    print min_chirp_mass, self.min_chirp_mass
+                    print(self.min_total_mass, curr_min_mass)
+                    print(self.min_mass1, self.min_mass2, min_comp_mass)
+                    print(min_eta, self.min_eta, self.max_eta)
+                    print(min_chirp_mass, self.min_chirp_mass)
                     self.fail(err_msg)
             if not self.max_total_mass == curr_max_mass:
                 max_comp_mass = self.max_mass1 + self.max_mass2

--- a/test/test_waveform.py
+++ b/test/test_waveform.py
@@ -48,20 +48,20 @@ class TestWaveform(unittest.TestCase):
             for waveform in td_approximants():
                 if waveform in failing_wfs:
                     continue
-                print waveform
+                print(waveform)
                 hc,hp = get_td_waveform(approximant=waveform,mass1=20,mass2=20,delta_t=1.0/4096,f_lower=40)
                 self.assertTrue(len(hc)> 0)
             for waveform in fd_approximants():
                 if waveform in failing_wfs:
                     continue
-                print waveform
+                print(waveform)
                 htilde, g = get_fd_waveform(approximant=waveform,mass1=20,mass2=20,delta_f=1.0/256,f_lower=40)
                 self.assertTrue(len(htilde)> 0)
 
 
     def test_spintaylorf2GPU(self):
     
-        print type(self.context)
+        print(type(self.context))
         if isinstance(self.context, CPUScheme):
             return
             
@@ -109,7 +109,7 @@ class TestWaveform(unittest.TestCase):
                                    self.assertTrue(PhaseDiffP < 0.00001)
                                    self.assertTrue(AmpDiffC < 0.00001)
                                    self.assertTrue(PhaseDiffC < 0.00001)
-                                   print "..checked m1: %s m2:: %s s1x: %s s1y: %s s1z: %s Inclination: %s" % (m1, m2, s1x, s1y, s1z, inclination)
+                                   print("..checked m1: %s m2:: %s s1x: %s s1y: %s s1z: %s Inclination: %s" % (m1, m2, s1x, s1y, s1z, inclination))
 
     def test_errors(self):
         func = get_fd_waveform

--- a/test/utils.py
+++ b/test/utils.py
@@ -102,8 +102,8 @@ def parse_args_all_schemes(feature_str):
 
     _scheme_dict = { 'cpu': 'CPU', 'cuda': 'CUDA'}
 
-    print 72*'='
-    print "Running {0} unit tests for {1}:".format(_scheme_dict[_scheme],feature_str)
+    print(72*'=')
+    print("Running {0} unit tests for {1}:".format(_scheme_dict[_scheme],feature_str))
 
     return [_scheme,_context]
 
@@ -129,8 +129,8 @@ def parse_args_cpu_only(feature_str):
     # a GPU scheme.  So if we get here we're on the CPU, and should print out our message
     # and return.
 
-    print 72*'='
-    print "Running {0} unit tests for {1}:".format('CPU', feature_str)
+    print(72*'=')
+    print("Running {0} unit tests for {1}:".format('CPU', feature_str))
 
     return
 


### PR DESCRIPTION
Some more changes addressing simple Python 3 incompatibilities.

With this patch I am actually able to install PyCBC on my laptop using `python3 setup.py install`. Installing the dependencies fails immediately on pycbc-glue, but at least I get a partially importable PyCBC. The unit test infrastructure works and a couple tests actually pass. The most concerning issues in the failing tests seem to be weave and pycbc-glue.

I split the changes into different commits by topic and amount of possible impact. The first commit is trivial and should have no effect, but you may want to have a look at the other ones.