### PR TITLE
Allow pycbc_inference to apply multi-dimensional constraints from ini file

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -37,6 +37,7 @@ from pycbc import types
 from pycbc.io.inference_hdf import InferenceFile
 from pycbc.waveform import generator
 from pycbc.inference import option_utils
+from pycbc.inference import prior
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
@@ -155,7 +156,7 @@ with ctx:
     dists = distributions.read_distributions_from_config(cp, "prior")
 
     # construct class that will return the prior
-    prior_eval = inference.PriorEvaluator(variable_args, *dists)
+    prior_eval = prior.PriorEvaluator(variable_args, *dists)
 
     # get sampling transformations
     if cp.has_section('sampling_parameters'):
@@ -217,7 +218,7 @@ with ctx:
     elif len(cp.get_subsections("initial")):
         initial_dists = distributions.read_distributions_from_config(
                                                          cp, section="initial")
-        initial = inference.PriorEvaluator(variable_args, *initial_dists)
+        initial = prior.PriorEvaluator(variable_args, *initial_dists)
         p0 = None
     else:
         initial = None

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -149,14 +149,16 @@ with ctx:
     cp = option_utils.config_parser_from_cli(opts)
 
     # get the vairable and static arguments from the config file
-    variable_args, static_args = option_utils.read_args_from_config(cp)
+    variable_args, static_args, constraints = \
+                                         option_utils.read_args_from_config(cp)
 
     # get prior distribution for each variable parameter
     logging.info("Setting up priors for each parameter")
     dists = distributions.read_distributions_from_config(cp, "prior")
 
     # construct class that will return the prior
-    prior_eval = prior.PriorEvaluator(variable_args, *dists)
+    prior_eval = prior.PriorEvaluator(variable_args, *dists,
+                                      **{"constraints" : constraints})
 
     # get sampling transformations
     if cp.has_section('sampling_parameters'):
@@ -218,7 +220,8 @@ with ctx:
     elif len(cp.get_subsections("initial")):
         initial_dists = distributions.read_distributions_from_config(
                                                          cp, section="initial")
-        init_prior = prior.PriorEvaluator(variable_args, *initial_dists)
+        init_prior = prior.PriorEvaluator(variable_args, *initial_dists,
+                                          **{"constraints" : constraints})
         p0 = None
     else:
         init_prior = None

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -214,16 +214,16 @@ with ctx:
             logging.info("Initial positions taken from iteration %i in %s",
                          iteration, opts.samples_file)
             p0 = fp.read_samples(sampler.variable_args, iteration=iteration)
-        initial = None
+        init_prior = None
     elif len(cp.get_subsections("initial")):
         initial_dists = distributions.read_distributions_from_config(
                                                          cp, section="initial")
-        initial = prior.PriorEvaluator(variable_args, *initial_dists)
+        init_prior = prior.PriorEvaluator(variable_args, *initial_dists)
         p0 = None
     else:
-        initial = None
+        init_prior = None
         p0 = None
-    sampler.set_p0(prior=initial, samples=p0)
+    sampler.set_p0(samples=p0, prior=init_prior)
 
     # setup checkpointing
     if opts.checkpoint_interval:

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -155,7 +155,7 @@ with ctx:
     dists = distributions.read_distributions_from_config(cp, "prior")
 
     # construct class that will return the prior
-    prior = inference.PriorEvaluator(variable_args, *dists)
+    prior_eval = inference.PriorEvaluator(variable_args, *dists)
 
     # get sampling transformations
     if cp.has_section('sampling_parameters'):
@@ -186,7 +186,7 @@ with ctx:
     likelihood = inference.likelihood_evaluators[opts.likelihood_evaluator](
                         generated_waveform, stilde_dict,
                         low_frequency_cutoff_dict.values()[0],
-                        psds=psd_dict, prior=prior,
+                        psds=psd_dict, prior=prior_eval,
                         sampling_parameters=sampling_parameters,
                         replace_parameters=replace_parameters,
                         sampling_transforms=sampling_transforms)

--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -17,8 +17,6 @@ This modules provides classes for evaluating multi-dimensional constraints.
 """
 
 from pycbc import transforms
-from pycbc.distributions import bounded
-from pycbc.workflow import configuration
 
 class Constraint(object):
     """ Creates a constraint that evaluates to True if parameters obey
@@ -70,11 +68,11 @@ class CartesianSpinSpace(Constraint):
     def _constraint(self, params):
         """ Evaluates constraint function.
         """
-        if (params["spin1x"]**2 + params["spin1y"]**2
-            + params["spin1z"]**2)**2 > 1:
+        if (params["spin1x"]**2 + params["spin1y"]**2 +
+                params["spin1z"]**2)**2 > 1:
             return False
-        elif (params["spin2x"]**2 + params["spin2y"]**2
-              + params["spin2z"]**2)**2 > 1:
+        elif (params["spin2x"]**2 + params["spin2y"]**2 +
+                  params["spin2z"]**2)**2 > 1:
             return False
         else:
             return True

--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -1,0 +1,121 @@
+# Copyright (C) 2017 Christopher M. Biwer
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+This modules provides classes for evaluating multi-dimensional constraints.
+"""
+
+from pycbc import transforms
+from pycbc.distributions import bounded
+from pycbc.workflow import configuration
+
+class Constraint(object):
+    """ Creates a constraint that evaluates to True if parameters obey
+    the constraint and False if they do not.
+    """
+    name = "custom"
+    required_parameters = []
+    def __init__(self, variable_args, **kwargs):
+
+        # set any given attributes and get transforms from variable_args
+        # to required parameters
+        for kwarg in kwargs.keys():
+            setattr(self, kwarg, kwargs[kwarg])
+        _, self.transforms = transforms.get_common_cbc_transforms(
+                                       self.required_parameters, variable_args)
+
+    def __call__(self, params):
+        """ Evaluates constraint.
+        """
+        params = transforms.apply_conversions(params, self.transforms) \
+                     if self.transforms else params
+        return self._constraint(params)
+
+    def _constraint(self, params):
+        """ Evaluates constraint function.
+        """
+        return eval(self.func)
+
+
+class MtotalLT(Constraint):
+    """ Pre-defined constraint that check if total mass is less than a value.
+    """
+    name = "mtotal_lt"
+    required_parameters = ["mass1", "mass2"]
+
+    def _constraint(self, params):
+        """ Evaluates constraint function.
+        """
+        return params["mass1"] + params["mass2"] < self.mtotal
+
+class CartesianSpinSpace(Constraint):
+    """ Pre-defined constraint that check if Cartesian parameters
+    are within acceptable values.
+    """
+    name = "cartesian_spin_space"
+    required_parameters = ["mass1", "mass2", "spin1x", "spin1y", "spin1z",
+                           "spin2x", "spin2y", "spin2z"]
+
+    def _constraint(self, params):
+        """ Evaluates constraint function.
+        """
+        if (params["spin1x"]**2 + params["spin1y"]**2
+            + params["spin1z"]**2)**2 > 1:
+            return False
+        elif (params["spin2x"]**2 + params["spin2y"]**2
+              + params["spin2z"]**2)**2 > 1:
+            return False
+        else:
+            return True
+
+class EffectiveSpinSpace(Constraint):
+    """ Pre-defined constraint that check if effective spin parameters
+    are within acceptable values.
+    """
+    name = "effective_spin_space"
+    required_parameters = ["mass1", "mass2", "q", "xi1", "xi2",
+                           "chi_eff", "chi_a"]
+
+    def _constraint(self, params):
+        """ Evaluates constraint function.
+        """
+
+        # ensure that mass1 > mass2
+        if params["mass1"] < params["mass2"]:
+            return False
+
+        # constraint for secondary mass
+        a = ((4.0 * params["q"]**2 + 3.0 * params["q"])
+                 / (4.0 + 3.0 * params["q"]) * params["xi2"])**2
+        b = ((1.0 + params["q"]**2) / 4.0
+                 * (params["chi_eff"] + params["chi_a"])**2)
+        if a + b > 1:
+            return False
+
+        # constraint for primary mass
+        a = params["xi1"]**2
+        b = ((1.0 + params["q"])**2 / (4.0 * params["q"]**2)
+                 * (params["chi_eff"] - params["chi_a"])**2)
+        if a + b > 1:
+            return False
+
+        return True
+
+# list of all constraints
+constraints = {
+    Constraint.name : Constraint,
+    MtotalLT.name : MtotalLT,
+    CartesianSpinSpace.name : CartesianSpinSpace,
+    EffectiveSpinSpace.name : EffectiveSpinSpace,
+}

--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -24,7 +24,8 @@ class Constraint(object):
     """
     name = "custom"
     required_parameters = []
-    def __init__(self, variable_args, **kwargs):
+    def __init__(self, variable_args, func, **kwargs):
+        self.func = func
 
         # set any given attributes and get transforms from variable_args
         # to required parameters

--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -25,8 +25,8 @@ class Constraint(object):
     """
     name = "custom"
     required_parameters = []
-    def __init__(self, variable_args, func, **kwargs):
-        self.func = func
+    def __init__(self, variable_args, constraint_arg, **kwargs):
+        self.constraint_arg = constraint_arg
 
         # set any given attributes and get transforms from variable_args
         # to required parameters
@@ -59,7 +59,7 @@ class Constraint(object):
     def _constraint(self, params):
         """ Evaluates constraint function.
         """
-        return params[self.func]
+        return params[self.constraint_arg]
 
 class MtotalLT(Constraint):
     """ Pre-defined constraint that check if total mass is less than a value.

--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -51,8 +51,8 @@ class Constraint(object):
 
         # apply constraints
         out = self._constraint(params)
-        if out.size == 1:
-            out = out.item()
+        if isinstance(out, record.FieldArray):
+            out = out.item() if params.size == 1 else out
 
         return out
 

--- a/pycbc/distributions/constraints.py
+++ b/pycbc/distributions/constraints.py
@@ -37,7 +37,7 @@ class Constraint(object):
     def __call__(self, params):
         """ Evaluates constraint.
         """
-        params = transforms.apply_conversions(params, self.transforms) \
+        params = transforms.apply_transforms(params, self.transforms) \
                      if self.transforms else params
         return self._constraint(params)
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -22,6 +22,7 @@ import numpy
 import pycbc.inference.sampler
 from pycbc import conversions
 from pycbc import transforms
+from pycbc.distributions import bounded
 from pycbc.distributions import constraints
 from pycbc.io import InferenceFile
 from pycbc.inference import likelihood
@@ -135,7 +136,6 @@ def read_args_from_config(cp, section_group=None):
     cons = []
     section = "{}constraint".format(section_prefix)
     for subsection in cp.get_subsections(section):
-        special_opts = ["name"]
         name = cp.get_opt_tag(section, "name", subsection)
         kwargs = {}
         for key in cp.options(section + "-" + subsection):

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -19,12 +19,13 @@
 
 import logging
 import numpy
+import pycbc.inference.sampler
 from pycbc import conversions
 from pycbc import transforms
+from pycbc.distributions import constraints
 from pycbc.io import InferenceFile
-from pycbc.workflow import WorkflowConfigParser
-import pycbc.inference.sampler
 from pycbc.inference import likelihood
+from pycbc.workflow import WorkflowConfigParser
 from pycbc.pool import choose_pool
 from pycbc.psd import from_cli_multi_ifos as psd_from_cli_multi_ifos
 from pycbc.strain import from_cli_multi_ifos as strain_from_cli_multi_ifos
@@ -131,7 +132,7 @@ def read_args_from_config(cp, section_group=None):
             static_args[key] = convert_liststring_to_list(val) 
 
     # get additional constraints to apply in prior
-    constraints = []
+    cons = []
     section = "{}constraint".format(section_prefix)
     for subsection in cp.get_subsections(section):
         special_opts = ["name"]
@@ -150,10 +151,9 @@ def read_args_from_config(cp, section_group=None):
             except ValueError:
                 pass
             kwargs[key] = val
-        constraints.append(
-                         constraint.constraints[name](variable_args, **kwargs))
+        cons.append(constraints.constraints[name](variable_args, **kwargs))
 
-    return variable_args, static_args, constraints
+    return variable_args, static_args, cons
 
 def read_sampling_args_from_config(cp, section_group=None):
     """Reads sampling parameters from the given config file.

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -137,10 +137,10 @@ def read_args_from_config(cp, section_group=None):
     section = "{}constraint".format(section_prefix)
     for subsection in cp.get_subsections(section):
         name = cp.get_opt_tag(section, "name", subsection)
-        func = cp.get_opt_tag(section, "func", subsection)
+        constraint_arg = cp.get_opt_tag(section, "constraint_arg", subsection)
         kwargs = {}
         for key in cp.options(section + "-" + subsection):
-            if key in ["name", "func"]:
+            if key in ["name", "constraint_arg"]:
                 continue
             val = cp.get_opt_tag(section, key, subsection)
             if key == "required_parameters":
@@ -153,7 +153,7 @@ def read_args_from_config(cp, section_group=None):
                 pass
             kwargs[key] = val
         cons.append(constraints.constraints[name](variable_args,
-                                                  func, **kwargs))
+                                                  constraint_arg, **kwargs))
 
     return variable_args, static_args, cons
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -137,9 +137,10 @@ def read_args_from_config(cp, section_group=None):
     section = "{}constraint".format(section_prefix)
     for subsection in cp.get_subsections(section):
         name = cp.get_opt_tag(section, "name", subsection)
+        func = cp.get_opt_tag(section, "func", subsection)
         kwargs = {}
         for key in cp.options(section + "-" + subsection):
-            if key == "name":
+            if key in ["name", "func"]:
                 continue
             val = cp.get_opt_tag(section, key, subsection)
             if key == "required_parameters":
@@ -151,7 +152,8 @@ def read_args_from_config(cp, section_group=None):
             except ValueError:
                 pass
             kwargs[key] = val
-        cons.append(constraints.constraints[name](variable_args, **kwargs))
+        cons.append(constraints.constraints[name](variable_args,
+                                                  func, **kwargs))
 
     return variable_args, static_args, cons
 

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -88,7 +88,7 @@ class PriorEvaluator(object):
         self.distributions = distributions
 
         # store the constraints
-        self.constraints = kwargs["constraints"] \
+        self._constraints = kwargs["constraints"] \
                                   if "constraints" in kwargs.keys() else []
 
         # check that all of the variable args are described by the given
@@ -112,7 +112,7 @@ class PriorEvaluator(object):
         # of samples rejected
         n_test_samples = kwargs["n_test_samples"] \
                              if "n_test_samples" in kwargs else int(1e6)
-        if self.constraints:
+        if self._constraints:
             logging.info("Renormalizing prior for constraints")
 
             # draw samples
@@ -124,7 +124,7 @@ class PriorEvaluator(object):
 
             # evaluate constraints
             result = numpy.ones(len(samples.values()[0]), dtype=bool)
-            for constraint in self.constraints:
+            for constraint in self._constraints:
                 result = constraint(samples) & result
 
             # set new scaling factor for prior to be
@@ -162,7 +162,7 @@ class PriorEvaluator(object):
     def __call__(self, **params):
         """Evalualate prior for parameters.
         """
-        for constraint in self.constraints:
+        for constraint in self._constraints:
             if not constraint(params):
                 return -numpy.inf
         return sum([d(**params)

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -81,18 +81,18 @@ class PriorEvaluator(object):
 
     def __init__(self, variable_args, *distributions, **kwargs):
 
-        # store the names of the sampling parameters
+        # store the names of the parameters defined in the distributions
         self.variable_args = tuple(variable_args)
 
         # store the distributions
         self.distributions = distributions
 
-        # store the constraints on the sampling parameters
-        # with uniform distributions
+        # store the constraints on the parameters defined inside the
+        # distributions list
         self._constraints = kwargs["constraints"] \
                                   if "constraints" in kwargs.keys() else []
 
-        # check that all of the sampling parameters are described by the given
+        # check that all of the supplied parameters are described by the given
         # distributions
         distparams = set()
         [distparams.update(set(dist.params)) for dist in distributions]

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -81,17 +81,18 @@ class PriorEvaluator(object):
 
     def __init__(self, variable_args, *distributions, **kwargs):
 
-        # store the names of the variable params
+        # store the names of the sampling parameters
         self.variable_args = tuple(variable_args)
 
         # store the distributions
         self.distributions = distributions
 
-        # store the constraints
+        # store the constraints on the sampling parameters
+        # with uniform distributions
         self._constraints = kwargs["constraints"] \
                                   if "constraints" in kwargs.keys() else []
 
-        # check that all of the variable args are described by the given
+        # check that all of the sampling parameters are described by the given
         # distributions
         distparams = set()
         [distparams.update(set(dist.params)) for dist in distributions]

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -83,8 +83,10 @@ class PriorEvaluator(object):
 
         # store the names of the variable params
         self.variable_args = tuple(variable_args)
+
         # store the distributions
         self.distributions = distributions
+
         # store the constraints
         self.constraints = kwargs["constraints"] \
                                   if "constraints" in kwargs.keys() else []

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -130,7 +130,6 @@ class PriorEvaluator(object):
 
             # set new scaling factor for prior to be
             # the fraction of acceptances in random sampling of entire space
-            # times 100
             self._pdf_scale = sum(result) / float(n_test_samples)
 
         else:

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -131,7 +131,7 @@ class PriorEvaluator(object):
             # set new scaling factor for prior to be
             # the fraction of acceptances in random sampling of entire space
             # times 100
-            self._pdf_scale = 100.0 * sum(result) / float(n_test_samples)
+            self._pdf_scale = sum(result) / float(n_test_samples)
 
         else:
             self._pdf_scale = 1.0
@@ -167,7 +167,7 @@ class PriorEvaluator(object):
             if not constraint(params):
                 return -numpy.inf
         return sum([d(**params)
-                    for d in self.distributions]) +  self._logpdf_scale
+                    for d in self.distributions]) - self._logpdf_scale
 
     def rvs(self, size=1):
         """ Rejection samples the prior parameter space.

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -238,18 +238,19 @@ class BaseMCMCSampler(_BaseSampler):
     def pos(self):
         return self._pos
 
-    def set_p0(self, prior=None, samples=None):
-        """Sets the initial position of the walkers.
+    def set_p0(self, samples=None, prior=None):
+        """Sets the initial position of the walkers. Must be supplied a
+        FieldArray of values or a list of Distributions or a PriorEvaluator.
 
         Parameters
         ----------
-        prior : PriorEvaluator, optional
-            Use the given prior to set the initial positions rather than
-            `likelihood_evaultor`'s prior.
         samples : FieldArray, optional
             Use the given samples to set the initial positions. The samples
             will be transformed to the likelihood evaluator's `sampling_args`
             space.
+        prior : PriorEvaluator, optional
+            Use the given prior to set the initial positions rather than
+            `likelihood_evaultor`'s prior.
 
         Returns
         -------
@@ -260,7 +261,7 @@ class BaseMCMCSampler(_BaseSampler):
         nwalkers = self.nwalkers
         ndim = len(self.variable_args)
         p0 = numpy.ones((nwalkers, ndim))
-        # if samples are given then use those as initial poistions
+        # if samples are given then use those as initial positions
         if samples is not None:
             # transform to sampling parameter space
             samples = self.likelihood_evaluator.apply_sampling_transforms(

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -406,18 +406,18 @@ class EmceePTSampler(BaseMCMCSampler):
         # emcee returns ntemps x nwalkers x niterations
         return self._sampler.lnprobability
 
-    def set_p0(self, prior=None, samples=None):
+    def set_p0(self, samples=None, prior=None):
         """Sets the initial position of the walkers.
 
         Parameters
         ----------
-        prior : PriorEvaluator, optional
-            Use the given prior to set the initial positions rather than
-            `likelihood_evaultor`'s prior.
         samples : FieldArray, optional
             Use the given samples to set the initial positions. The samples
             will be transformed to the likelihood evaluator's `sampling_args`
             space.
+        prior : PriorEvaluator, optional
+            Use the given prior to set the initial positions rather than
+            `likelihood_evaultor`'s prior.
 
         Returns
         -------


### PR DESCRIPTION
This PR:
  * Updates ``pycbc_inference``, ``option_utils``, and ``.set_p0`` functions to allow ``PriorEvaluator`` to use passed constraints
  * Fixes to emcee sampler trying ``write_state`` and writing samples.
  * Adds a ``constraint`` module with constraint definitions. The ``custom`` constraint takes a str and evaluates it.

Can use ini file like:
```
[constraint-1]
name = mtotal_lt ; pre-defined constraint
mtotal = 30

[constraint-2]
name = custom ; let's make things up
func = params["mass1"] + params["mass2"] < self.mtotal
mtotal = 30
```