### PR TITLE
Read transforms from config file

### DIFF
--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -132,6 +132,56 @@ def read_args_from_config(cp, section_group=None):
     return variable_args, static_args
 
 
+def read_sampling_args_from_config(cp, section_group=None):
+    """Reads sampling parameters from the given config file.
+
+    Parameters are read from the `[({section_group}_)sampling_params]` section.
+    The options should list the variable args to transform; the parameters they
+    point to should list the parameters they are to be transformed to for
+    sampling. If a multiple parameters are transformed together, they should
+    be comma separated. Example:
+
+    .. code-block:: ini
+
+        [sampling_parameters]
+        mass1, mass2 = mchirp, logitq
+        spin1_a = logitspin1_a
+
+    Note that only the final sampling parameters should be listed, even if
+    multiple intermediate transforms are needed. (In the above example, a
+    transform is needed to go from mass1, mass2 to mchirp, q, then another one
+    needed to go from q to logitq.) These transforms should be specified
+    in separate sections; see `transforms.read_transforms_from_config` for
+    details.
+
+    Parameters
+    ----------
+    cp : WorkflowConfigParser
+        An open config parser to read from.
+    section_group : str, optional
+        Append `{section_group}_` to the section name. Default is None.
+
+    Returns
+    -------
+    replaced_params : set
+        The set of variable args to replace in the sampler.
+    sampling_params : set
+        The set of sampling parameters to use instead.
+    """
+    if section_group is not None:
+        section_prefix = '{}_'.format(section_group)
+    else:
+        section_prefix = ''
+    section = section_prefix + 'sampling_parameters'
+    replaced_params = set()
+    sampling_params = set()
+    for args in cp.options(section):
+        map_args = cp.get(section, args)
+        sampling_params.update(set(map(str.strip, map_args.split(','))))
+        replaced_params.update(set(map(str.strip, args.split(',')))) 
+    return replaced_params, sampling_params
+
+
 #-----------------------------------------------------------------------------
 #
 #                    Utilities for setting up a sampler

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -101,7 +101,7 @@ class BaseTransform(object):
 
     @classmethod
     def from_config(cls, cp, section, outputs, skip_opts=None,
-                    additional_opts={}):
+                    additional_opts=None):
         """Initializes a transform from the given section.
 
         Parameters
@@ -129,7 +129,10 @@ class BaseTransform(object):
         tag = outputs
         if skip_opts is None:
             skip_opts = []
-        additional_opts = additional_opts.copy()
+        if additional_opts is None:
+            additional_opts = {}
+        else:
+            additional_opts = additional_opts.copy()
         outputs = set(outputs.split(VARARGS_DELIM))
         special_args = ['name'] + skip_opts + additional_opts.keys()
         # get any extra arguments to pass to init
@@ -740,7 +743,7 @@ class Logit(BaseTransform):
 
     @classmethod
     def from_config(cls, cp, section, outputs, skip_opts=None,
-                    additional_opts={}):
+                    additional_opts=None):
         """Initializes a Logit transform from the given section.
 
         The section must specify an input and output variable name. The domain
@@ -784,6 +787,10 @@ class Logit(BaseTransform):
         opt = 'min-{}'.format(inputvar)
         if skip_opts is None:
             skip_opts = []
+        if additional_opts is None:
+            additional_opts = {}
+        else:
+            additional_opts = additional_opts.copy()
         if cp.has_option(s, opt):
             a = cp.get_opt_tag(section, opt, outputs)
             skip_opts.append(opt)
@@ -922,8 +929,8 @@ class Logistic(Logit):
         return self._bounds
 
     @classmethod
-    def from_config(cls, cp, section, outputs, skip_opts=[],
-                    additional_opts={}):
+    def from_config(cls, cp, section, outputs, skip_opts=None,
+                    additional_opts=None):
         """Initializes a Logistic transform from the given section.
 
         The section must specify an input and output variable name. The
@@ -963,7 +970,12 @@ class Logistic(Logit):
         """
         # pull out the minimum, maximum values of the output variable
         outputvar = cp.get_opt_tag(section, 'output', outputs)
-        additional_opts = additional_opts.copy()
+        if skip_opts is None:
+            skip_opts = []
+        if additional_opts is None:
+            additional_opts = {}
+        else:
+            additional_opts = additional_opts.copy()
         s = '-'.join([section, outputs])
         opt = 'min-{}'.format(outputvar)
         if cp.has_option(s, opt):

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -1104,7 +1104,7 @@ def get_common_cbc_transforms(requested_params, variable_args,
     return list(requested_params), all_c
 
 
-def apply_transforms(samples, transforms):
+def apply_transforms(samples, transforms, inverse=False):
     """Applies a list of BaseTransform instances on a mapping object.
 
     Parameters
@@ -1112,16 +1112,25 @@ def apply_transforms(samples, transforms):
     samples : {FieldArray, dict}
         Mapping object to apply transforms to.
     transforms : list
-        List of BaseTransform instances to apply.
+        List of BaseTransform instances to apply. Nested transforms are assumed
+        to be in order for forward transforms.
+    inverse : bool, optional
+        Apply inverse transforms. In this case transforms will be applied in
+        the opposite order. Default is False.
 
     Returns
     -------
     samples : {FieldArray, dict}
-        Mapping object with conversions applied. Same type as input.
+        Mapping object with transforms applied. Same type as input.
     """
+    if inverse:
+        transforms = transforms[::-1]
     for t in transforms:
         try:
-            samples = t.transform(samples)
+            if inverse:
+                samples = t.inverse_transform(samples)
+            else:
+                samples = t.transform(samples)
         except NotImplementedError:
             continue
     return samples


### PR DESCRIPTION
Adds functions to load transforms from a config file. Also adds the ability to read sampling parameters from the config file that should be used in place of the variable args. (Support in likelihood coming in another patch.)

The syntax is very similar to distributions: separate sections are used for each transformation. Nested transforms can be specified, in which case the transforms are ordered by their nesting. The returned list can the be used with `apply_transforms`.

Example, with config file:
```
[sampling_parameters]
; left side are parameters with priors defined
; right side are parameters to map them to for
; sampling
mass1, mass2 = mchirp, logitq

[sampling_transforms-mchirp+q]
; inputs are mass1, mass2
; outputs are mchirp, q
name = mass1_mass2_to_mchirp_q

[sampling_transforms-logitq]
name = logit
input = q
output = logitq
min-q = 1.
max-q = 8.
```
Get:
```
>>> option_utils.read_sampling_args_from_config(cp)
({'mass1', 'mass2'}, {'logitq', 'mchirp'})
```
```
>>> ts = transforms.read_transforms_from_config(cp, 'sampling_transforms')
>>> m = {'mass1': 40., 'mass2': 30.}
>>> transforms.apply_transforms(m, ts)
{'logitq': -2.9957322735539913,
 'mass1': 40.0,
 'mass2': 30.0,
 'mchirp': 30.09463910461072,
 'q': 1.3333333333333333}
>>> minv = {'logitq': -2.9957322735539913, 'mchirp': 30.09463910461072}
>>> transforms.apply_transforms(minv, ts, inverse=True)
{'logitq': -2.9957322735539913,
 'mass1': 39.999999999999972,
 'mass2': 30.000000000000025,
 'mchirp': 30.09463910461072,
 'q': 1.3333333333333333}
```

Depends on #1681 .