### PR TITLE
pycbc_live: handle edge cases in SNR timeseries

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
-import argparse, numpy, numpy.random, pycbc, logging, cProfile, h5py, lal
-from pycbc import fft, version, waveform, types, filter as pfilter, scheme, psd as pypsd, noise, vetoes, strain, frame
-from pycbc.types import MultiDetOptionAction, zeros
+import argparse, numpy, pycbc, logging, cProfile, h5py, lal
+from pycbc import fft, version, waveform, scheme, frame
+from pycbc.types import MultiDetOptionAction
 from pycbc.filter import LiveBatchMatchedFilter
+from pycbc.strain import StrainBuffer
 from time import time
 import os.path
 from mpi4py import MPI as mpi
@@ -86,8 +87,8 @@ class LiveEventManager(object):
                     bank=bank, upload_snr_series=args.upload_snr_series,
                     followup_ifos=followup_ifos)
 
-            time = int(coinc_results['foreground/%s/end_time' % ifos[0]])
-            fname = os.path.join(self.path, 'coinc-%s.xml' % time)
+            end_time = int(coinc_results['foreground/%s/end_time' % ifos[0]])
+            fname = os.path.join(self.path, 'coinc-%s.xml' % end_time)
 
             comments = ['using ranking statistic: %s' % args.background_statistic]
 
@@ -341,7 +342,7 @@ with ctx:
         if args.enable_single_detector_background and evnt.rank == 0:
             sngl_estimator[ifo] = LiveSingleFarThreshold.from_cli(args, ifo)
 
-        data_reader[ifo] = pycbc.strain.StrainBuffer(frame_src, 
+        data_reader[ifo] = StrainBuffer(frame_src,
                             '%s:%s' % (ifo, args.channel_name[ifo]),
                             args.start_time, max_buffer=maxlen * 2,
                             state_channel=state,


### PR DESCRIPTION
In PyCBC Live, the SNR time series for sky localization is currently truncated early or late when the trigger happens too close to the boundary of the valid SNR segment. Since BAYESTAR does not handle a truncated SNR series, this patch extends the series with samples normally thrown away because of filters and wrap-around. After applying the patch, BAYESTAR completes on all the injections of my test, even the few ones close to the boundary of the valid segment, which were causing BAYESTAR to fail before. I have not reviewed the skymaps or the series themselves yet though.

Some unused imports are also dropped.