### PR TITLE
Sample in different parameter space than variable args

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -163,6 +163,8 @@ with ctx:
             option_utils.read_sampling_args_from_config(cp)
         sampling_transforms = transforms.read_transforms_from_config(cp,
             'sampling_transforms')
+        logging.info("Sampling in {} in place of {}".format(
+            ', '.join(sampling_parameters), ', '.join(replace_parameters)))
     else:
         sampling_parameters = replace_parameters = sampling_transforms = None
 

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -158,10 +158,13 @@ with ctx:
     prior = inference.PriorEvaluator(variable_args, *dists)
 
     # get sampling transformations
-    sampling_parameters, replace_parameters = \
-        option_utils.read_sampling_args_from_config(cp)
-    sampling_transforms = transforms.read_transforms_from_config(cp,
-        'sampling_transforms')
+    if cp.has_section('sampling_parameters'):
+        sampling_parameters, replace_parameters = \
+            option_utils.read_sampling_args_from_config(cp)
+        sampling_transforms = transforms.read_transforms_from_config(cp,
+            'sampling_transforms')
+    else:
+        sampling_parameters = replace_parameters = sampling_transforms = None
 
     # select generator that will generate waveform for a single IFO
     # for likelihood evaluator

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -26,6 +26,7 @@ import pycbc
 import pycbc.opt
 import pycbc.weave
 from pycbc import distributions
+from pycbc import transforms
 from pycbc import fft
 from pycbc import gate
 from pycbc import inference
@@ -155,6 +156,12 @@ with ctx:
 
     # construct class that will return the prior
     prior = inference.PriorEvaluator(variable_args, *dists)
+
+    # get sampling transformations
+    sampling_parameters, replace = \
+        option_utils.read_sampling_args_from_config(cp)
+    sampling_transforms = transforms.read_transforms_from_config(cp,
+        'sampling_transforms')
 
     # select generator that will generate waveform for a single IFO
     # for likelihood evaluator

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -181,11 +181,10 @@ with ctx:
     likelihood = inference.likelihood_evaluators[opts.likelihood_evaluator](
                         generated_waveform, stilde_dict,
                         low_frequency_cutoff_dict.values()[0],
-                        psds=psd_dict, prior=prior
+                        psds=psd_dict, prior=prior,
                         sampling_parameters=sampling_parameters,
                         replace_parameters=replace_parameters,
-                        sampling_transforms=sampling_transforms,
-                        )
+                        sampling_transforms=sampling_transforms)
 
     # create sampler that will run
     sampler = option_utils.sampler_from_cli(opts, likelihood)

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -158,7 +158,7 @@ with ctx:
     prior = inference.PriorEvaluator(variable_args, *dists)
 
     # get sampling transformations
-    sampling_parameters, replace = \
+    sampling_parameters, replace_parameters = \
         option_utils.read_sampling_args_from_config(cp)
     sampling_transforms = transforms.read_transforms_from_config(cp,
         'sampling_transforms')
@@ -181,7 +181,11 @@ with ctx:
     likelihood = inference.likelihood_evaluators[opts.likelihood_evaluator](
                         generated_waveform, stilde_dict,
                         low_frequency_cutoff_dict.values()[0],
-                        psds=psd_dict, prior=prior)
+                        psds=psd_dict, prior=prior
+                        sampling_parameters=sampling_parameters,
+                        replace_parameters=replace_parameters,
+                        sampling_transforms=sampling_transforms,
+                        )
 
     # create sampler that will run
     sampler = option_utils.sampler_from_cli(opts, likelihood)
@@ -205,16 +209,16 @@ with ctx:
             logging.info("Initial positions taken from iteration %i in %s",
                          iteration, opts.samples_file)
             p0 = fp.read_samples(sampler.variable_args, iteration=iteration)
-        initial_dists = None
+        initial = None
     elif len(cp.get_subsections("initial")):
         initial_dists = distributions.read_distributions_from_config(
                                                          cp, section="initial")
+        initial = inference.PriorEvaluator(variable_args, *initial_dists)
         p0 = None
     else:
-        initial_dists = distributions.read_distributions_from_config(
-                                                         cp, section="prior")
+        initial = None
         p0 = None
-    sampler.set_p0(initial_dists, samples=p0)
+    sampler.set_p0(prior=initial, samples=p0)
 
     # setup checkpointing
     if opts.checkpoint_interval:

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -27,8 +27,10 @@ for parameter estimation.
 """
 
 from pycbc import filter
+import pycbc.transforms
 from pycbc.waveform import NoWaveformError
 from pycbc.types import Array
+from pycbc.io import FieldArray
 import numpy
 
 # Used to manage a likelihood instance across multiple cores or MPI
@@ -286,8 +288,9 @@ class _BaseLikelihoodEvaluator(object):
         """
         if self._sampling_transforms is None:
             return samples
-        return transforms.apply_transforms(samples, self._sampling_transforms,
-                                           inverse=inverse)
+        return pycbc.transforms.apply_transforms(samples,
+                                                 self._sampling_transforms,
+                                                 inverse=inverse)
 
     @property
     def data(self):
@@ -341,8 +344,8 @@ class _BaseLikelihoodEvaluator(object):
         if self._sampling_transforms is None:
             return 0.
         else:
-            return numpy.log(abs(transforms.compute_jacobian(params,
-                self._transforms, inverse=True)))
+            return numpy.log(abs(pycbc.transforms.compute_jacobian(params,
+                self._sampling_transforms, inverse=True)))
 
     def prior(self, **params):
         """This function should return the prior of the given params.
@@ -378,9 +381,9 @@ class _BaseLikelihoodEvaluator(object):
         if self._sampling_transforms is not None:
             ptrans = self.apply_sampling_transforms(p0)
             # pull out the sampling args
-            p0 = record.FieldArray.from_arrays([ptrans[arg]
-                                               for arg in self._sampling_args],
-                                               names=self._sampling_args)
+            p0 = FieldArray.from_arrays([ptrans[arg]
+                                         for arg in self._sampling_args],
+                                        names=self._sampling_args)
         return p0
 
     def loglikelihood(self, **params):

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -502,7 +502,7 @@ class _BaseLikelihoodEvaluator(object):
         params = dict(zip(self._sampling_args, params))
         # apply inverse transforms to go from sampling parameters to
         # variable args
-        params = self.apply_sampling_transforms(params, inverse=True) 
+        params = self.apply_sampling_transforms(params, inverse=True)
         # apply any boundary conditions to the parameters before
         # generating/evaluating
         if callfunc is not None:

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -338,7 +338,7 @@ class _BaseLikelihoodEvaluator(object):
         float :
             The value of the jacobian.
         """
-        if self._transforms is None:
+        if self._sampling_transforms is None:
             return 0.
         else:
             return numpy.log(abs(transforms.compute_jacobian(params,
@@ -430,8 +430,12 @@ class _BaseLikelihoodEvaluator(object):
     def logplr(self, **params):
         """Returns the log of the prior-weighted likelihood ratio.
         """
+        if self.return_meta:
+            logp, (_, _, logj) = self.prior(**params)
+        else:
+            logp = self.prior(**params)
+            logj = None
         # if the prior returns -inf, just return
-        logp, _, logj = self.prior(**params)
         if logp == -numpy.inf:
             return self._formatreturn(logp, prior=logp, logjacobian=logj)
         llr = self.loglr(**params)
@@ -441,8 +445,12 @@ class _BaseLikelihoodEvaluator(object):
     def logposterior(self, **params):
         """Returns the log of the posterior of the given params.
         """
+        if self.return_meta:
+            logp, (_, _, logj) = self.prior(**params)
+        else:
+            logp = self.prior(**params)
+            logj = None
         # if the prior returns -inf, just return
-        logp, _, logj = self.prior(**params)
         if logp == -numpy.inf:
             return self._formatreturn(logp, prior=logp, logjacobian=logj)
         ll = self.loglikelihood(**params)
@@ -485,7 +493,7 @@ class _BaseLikelihoodEvaluator(object):
             `return_meta` is True, a tuple of the output of the call function
             and the meta data.
         """
-        params = dict(zip(self._sampling_parameters, params))
+        params = dict(zip(self._sampling_args, params))
         # apply inverse transforms to go from sampling parameters to
         # variable args
         params = self.apply_sampling_transforms(params, inverse=True) 

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -643,11 +643,15 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
     name = 'gaussian'
 
     def __init__(self, waveform_generator, data, f_lower, psds=None,
-            f_upper=None, norm=None, prior=None, return_meta=True):
+                 f_upper=None, norm=None, prior=None,
+                 sampling_parameters=None, replace_parameters=None,
+                 sampling_transforms=None, return_meta=True):
         # set up the boiler-plate attributes; note: we'll compute the
         # log evidence later
         super(GaussianLikelihood, self).__init__(waveform_generator, data,
-            prior=prior, return_meta=return_meta)
+            prior=prior, sampling_parameters=sampling_parameters,
+            replace_parameters=replace_parameters,
+            sampling_transforms=sampling_transforms, return_meta=return_meta)
         # we'll use the first data set for setting values
         d = data.values()[0]
         N = len(d)
@@ -667,9 +671,8 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
         else:
             # temporarily suppress numpy divide by 0 warning
             numpysettings = numpy.seterr(divide='ignore')
-            # FIXME: use the following when we've switched to 2.7
-            #self._weight = {det: Array(numpy.sqrt(norm/psds[det])) for det in data}
-            self._weight = dict([(det, Array(numpy.sqrt(norm/psds[det]))) for det in data])
+            self._weight = {det: Array(numpy.sqrt(norm/psds[det]))
+                            for det in data}
             numpy.seterr(**numpysettings)
         # whiten the data
         for det in self._data:

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -41,10 +41,10 @@ class _NoPrior(object):
     likelihood generator.
     """
     @staticmethod
-    def apply_boundary_conditions(params):
+    def apply_boundary_conditions(**params):
         return params
 
-    def __call__(self, params):
+    def __call__(self, **params):
         return 0.
 
 def snr_from_loglr(loglr):
@@ -443,7 +443,7 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
     >>> fmin = 30.
     >>> m1, m2, s1z, s2z, tsig, ra, dec, pol, dist = 38.6, 29.3, 0., 0., 3.1, 1.37, -1.26, 2.76, 3*500.
     >>> generator = waveform.FDomainDetFrameGenerator(waveform.FDomainCBCGenerator, 0., variable_args=['tc'], detectors=['H1', 'L1'], delta_f=1./seglen, f_lower=fmin, approximant='SEOBNRv2_ROM_DoubleSpin', mass1=m1, mass2=m2, spin1z=s1z, spin2z=s2z, ra=ra, dec=dec, polarization=pol, distance=dist)
-    >>> signal = generator.generate(tsig)
+    >>> signal = generator.generate(tc=tsig)
     >>> psd = pypsd.aLIGOZeroDetHighPower(N, 1./seglen, 20.)
     >>> psds = {'H1': psd, 'L1': psd}
     >>> likelihood_eval = inference.GaussianLikelihood(generator, signal, fmin, psds=psds, return_meta=False)
@@ -451,13 +451,13 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
     Now compute the log likelihood ratio and prior-weighted likelihood ratio;
     since we have not provided a prior, these should be equal to each other:
 
-    >>> likelihood_eval.loglr([tsig]), likelihood_eval.logplr([tsig])
+    >>> likelihood_eval.loglr(tc=tsig), likelihood_eval.logplr(tc=tsig)
         (ArrayWithAligned(277.92945279883855), ArrayWithAligned(277.92945279883855))
 
     Compute the log likelihood and log posterior; since we have not
     provided a prior, these should both be equal to zero:
 
-    >>> likelihood_eval.loglikelihood([tsig]), likelihood_eval.logposterior([tsig])
+    >>> likelihood_eval.loglikelihood(tc=tsig), likelihood_eval.logposterior(tc=tsig)
         (ArrayWithAligned(0.0), ArrayWithAligned(0.0))
 
     Compute the SNR; for this system and PSD, this should be approximately 24:
@@ -578,7 +578,7 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
                 )
         return numpy.float64(lr)
 
-    def loglikelihood(self, params):
+    def loglikelihood(self, **params):
         r"""Computes the log likelihood of the paramaters,
         
         .. math::

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -480,7 +480,7 @@ class _BaseLikelihoodEvaluator(object):
         """
         cls._callfunc = getattr(cls, funcname)
 
-    def evaluate(self, params):
+    def evaluate(self, params, callfunc=None):
         """Evaluates the call function at the given list of parameter values.
 
         Parameters
@@ -488,6 +488,9 @@ class _BaseLikelihoodEvaluator(object):
         params : list
             A list of values. These are assumed to be in the same order as
             variable args.
+        callfunc : str, optional
+            The name of the function to call. If None, will use
+            `self._callfunc`. Default is None.
 
         Returns
         -------
@@ -502,8 +505,11 @@ class _BaseLikelihoodEvaluator(object):
         params = self.apply_sampling_transforms(params, inverse=True) 
         # apply any boundary conditions to the parameters before
         # generating/evaluating
-        return self._callfunc(**self._prior.apply_boundary_conditions(
-                              **params))
+        if callfunc is not None:
+            f = getattr(self, callfunc)
+        else:
+            f = self._callfunc
+        return f(**self._prior.apply_boundary_conditions(**params))
 
     __call__ = evaluate
 

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -328,6 +328,38 @@ class _BaseLikelihoodEvaluator(object):
         logp = self._prior(**params) + logj
         return self._formatreturn(logp, prior=logp, logjacobian=logj)
 
+    def prior_rvs(self, size=1, prior=None):
+        """Returns random variates drawn from the prior.
+
+        If the `sampling_args` are different from the `variable_args`, the
+        variates are transformed to the `sampling_args` parameter space before
+        being returned.
+
+        Parameters
+        ----------
+        size : int, optional
+            Number of random values to return for each parameter. Default is 1.
+        prior : PriorEvaluator, optional
+            Use the given prior to draw values rather than the saved prior.
+
+        Returns
+        -------
+        FieldArray
+            A field array of the random values.
+        """
+        # draw values from the prior
+        if prior is None:
+            prior = self._prior
+        p0 = prior.rvs(size=size)
+        # transform if necessary
+        if self._transforms is not None:
+            ptrans = transforms.apply_transforms(p0, self._transforms)
+            # pull out the sampling args
+            p0 = record.FieldArray.from_arrays([ptrans[arg]
+                                               for arg in self._sampling_args],
+                                               names=self._sampling_args)
+        return p0
+
     def loglikelihood(self, **params):
         """Returns the natural log of the likelihood function.
         """

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -179,7 +179,7 @@ def read_sampling_args_from_config(cp, section_group=None):
         map_args = cp.get(section, args)
         sampling_params.update(set(map(str.strip, map_args.split(','))))
         replaced_params.update(set(map(str.strip, args.split(',')))) 
-    return list(sampling_params), list(replaced_params) 
+    return list(sampling_params), list(replaced_params)
 
 
 #-----------------------------------------------------------------------------

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -163,10 +163,10 @@ def read_sampling_args_from_config(cp, section_group=None):
 
     Returns
     -------
-    replaced_params : set
-        The set of variable args to replace in the sampler.
-    sampling_params : set
-        The set of sampling parameters to use instead.
+    sampling_params : list
+        The list of sampling parameters to use instead.
+    replaced_params : list
+        The list of variable args to replace in the sampler.
     """
     if section_group is not None:
         section_prefix = '{}_'.format(section_group)
@@ -179,7 +179,7 @@ def read_sampling_args_from_config(cp, section_group=None):
         map_args = cp.get(section, args)
         sampling_params.update(set(map(str.strip, map_args.split(','))))
         replaced_params.update(set(map(str.strip, args.split(',')))) 
-    return replaced_params, sampling_params
+    return list(sampling_params), list(replaced_params) 
 
 
 #-----------------------------------------------------------------------------

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -103,31 +103,29 @@ class PriorEvaluator(object):
             raise ValueError("variable_args %s " %(','.join(extra_params)) +
                 "are not in any of the provided distributions")
 
-    def apply_boundary_conditions(self, params):
+    def apply_boundary_conditions(self, **params):
         """Applies each distributions' boundary conditions to the given list
         of parameters, returning a new list with the conditions applied.
 
         Parameters
         ----------
-        params : list
-            List of parameters to apply conditions to. The order of the
-            parameters is assumed to be the same as self.variable_args.
+        **params :
+            Keyword arguments should give the parameters to apply the
+            conditions to.
 
         Returns
         -------
-        list
-            List of the parameters after each distribution's
+        dict
+            A dictionary of the parameters after each distribution's
             `apply_boundary_conditions` function has been applied.
         """
-        params = dict(zip(self.variable_args, params))
         for dist in self.distributions:
             params.update(dist.apply_boundary_conditions(**params))
-        return [params[p] for p in self.variable_args]
+        return params
 
-    def __call__(self, params):
-        """ Evalualate prior for parameters.
+    def __call__(self, **params):
+        """Evalualate prior for parameters.
         """
-        params = dict(zip(self.variable_args, params))
         for constraint in self.constraints:
             if not constraint(params):
                 return -numpy.inf

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -153,7 +153,7 @@ class PriorEvaluator(object):
 
             # determine if all parameter values are in prior space
             # if they are then add to output
-            if self(vals) > -numpy.inf:
+            if self(**dict(zip(self.variable_args, vals))) > -numpy.inf:
                  out[n] = vals
                  n += 1
 

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -94,7 +94,7 @@ class _BaseSampler(object):
         of the sampling args and the variable args.
         """
         return NotImplementedError("samples function not set.")
-        
+ 
     @property
     def clear_chain(self):
         """This function should clear the current chain of samples from memory.
@@ -304,7 +304,6 @@ class BaseMCMCSampler(_BaseSampler):
         """
         # chain is a [additional dimensions x] niterations x ndim array
         samples = self.chain
-        parameters = self.variable_args
         sampling_args = self.sampling_args
         # convert to dictionary to apply boundary conditions
         samples = {param: samples[...,ii]

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -383,7 +383,7 @@ class BaseMCMCSampler(_BaseSampler):
                     # dataset doesn't exist yet
                     fp.create_dataset(dataset_name, (fb,),
                                       maxshape=(max_iterations,),
-                                      dtype=samples.dtype)
+                                      dtype=samples[param].dtype)
                     fp[dataset_name][fa:fb] = samples[param][wi, ma:mb]
 
     def write_chain(self, fp, start_iteration=0, end_iteration=None,

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -154,8 +154,8 @@ class _BaseSampler(object):
         fp.attrs['sampler'] = self.name
         fp.attrs['likelihood_evaluator'] = self.likelihood_evaluator.name
         fp.attrs['ifos'] = self.ifos
-        fp.attrs['variable_args'] = self.variable_args
-        fp.attrs['sampling_args'] = self.sampling_args
+        fp.attrs['variable_args'] = list(self.variable_args)
+        fp.attrs['sampling_args'] = list(self.sampling_args)
         fp.attrs["niterations"] = self.niterations
         fp.attrs["lognl"] = self.likelihood_evaluator.lognl
         sargs = self.likelihood_evaluator.waveform_generator.static_args

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -155,6 +155,7 @@ class _BaseSampler(object):
         fp.attrs['likelihood_evaluator'] = self.likelihood_evaluator.name
         fp.attrs['ifos'] = self.ifos
         fp.attrs['variable_args'] = self.variable_args
+        fp.attrs['sampling_args'] = self.sampling_args
         fp.attrs["niterations"] = self.niterations
         fp.attrs["lognl"] = self.likelihood_evaluator.lognl
         sargs = self.likelihood_evaluator.waveform_generator.static_args

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -80,7 +80,8 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
         self._nwalkers = nwalkers
 
     @classmethod
-    def from_cli(cls, opts, likelihood_evaluator, pool=None, likelihood_call=None):
+    def from_cli(cls, opts, likelihood_evaluator, pool=None,
+                 likelihood_call=None):
         """Create an instance of this sampler from the given command-line
         options.
 
@@ -262,6 +263,7 @@ class _callable(object):
     def __call__(self, *args, **kwds):
         return getattr(self.instance, self.method_name)(*args, **kwds)
 
+
 class EmceePTSampler(BaseMCMCSampler):
     """This class is used to construct a parallel-tempered MCMC sampler from
     the emcee package's PTSampler.
@@ -277,7 +279,8 @@ class EmceePTSampler(BaseMCMCSampler):
         Number of walkers to use in sampler.
     pool : function with map, Optional
         A provider of a map function that allows a function call to be run
-        over multiple sets of arguments and possibly maps them to cores/nodes/etc.
+        over multiple sets of arguments and possibly maps them to
+        cores/nodes/etc.
     burn_in_iterations : {None, int}, Optional
         Set the number of burn in iterations to use. If None,
         `burn_in_ieterations` will be initialized to 0.
@@ -296,7 +299,8 @@ class EmceePTSampler(BaseMCMCSampler):
         # functions separately
         ndim = len(likelihood_evaluator.waveform_generator.variable_args)
         sampler = emcee.PTSampler(ntemps, nwalkers, ndim,
-                                  _callable(likelihood_evaluator, 'loglikelihood'),
+                                  _callable(likelihood_evaluator,
+                                            'loglikelihood'),
                                   likelihood_evaluator._prior,
                                   pool=pool)
         # initialize
@@ -306,7 +310,8 @@ class EmceePTSampler(BaseMCMCSampler):
         self._ntemps = ntemps
 
     @classmethod
-    def from_cli(cls, opts, likelihood_evaluator, pool=None, likelihood_call=None):
+    def from_cli(cls, opts, likelihood_evaluator, pool=None,
+                 likelihood_call=None):
         """Create an instance of this sampler from the given command-line
         options.
 

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -566,7 +566,7 @@ class EmceePTSampler(BaseMCMCSampler):
         """Writes samples to the given file.
 
         Results are written to:
-        
+
             `fp[samples_group/{vararg}/temp{k}/walker{i}]`,
             
         where

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -390,7 +390,7 @@ class EmceePTSampler(BaseMCMCSampler):
         loglr = logl - self.likelihood_evaluator.lognl
         kwargs = {'loglr': loglr, 'prior': logp}
         # if different coordinates were used for sampling, get the jacobian
-        if self.likelihood_evaulator.sampling_transforms is not None:
+        if self.likelihood_evaluator.sampling_transforms is not None:
             samples = self.samples
             # convert to dict
             d = {param: samples[param] for param in samples.fieldnames}
@@ -635,7 +635,7 @@ class EmceePTSampler(BaseMCMCSampler):
                         # dataset doesn't exist yet
                         fp.create_dataset(dataset_name, (fb,),
                                           maxshape=(max_iterations,),
-                                          dtype=samples.dtype)
+                                          dtype=float)
                         fp[dataset_name][fa:fb] = samples[param][tk, wi, ma:mb]
 
     def write_results(self, fp, start_iteration=0, end_iteration=None,
@@ -964,10 +964,12 @@ class EmceePTSampler(BaseMCMCSampler):
         except ImportError:
             raise ImportError("emcee is not installed.")
 
-        logstats = cls.read_likelihood_stats(fp, thin_start=thin_start,
-                                             thin_end=thin_end,
-                                             thin_interval=thin_interval,
-                                             temps='all', flatten=False)
+        stats_group = fp.stats_group
+        parameters = fp[stats_group].keys()
+        logstats = cls.read_samples(fp, parameters, samples_group=stats_group,
+                                    thin_start=thin_start,  thin_end=thin_end,
+                                    thin_interval=thin_interval,
+                                    temps='all', flatten=False)
         # get the likelihoods
         logls = logstats['loglr'] + fp.lognl
         # we need the betas that were used

--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -225,6 +225,22 @@ class KombineSampler(BaseMCMCSampler):
         self.burn_in_iterations = self.niterations
         return p, post, q
 
+    def _write_kde(self, fp, dataset, kde):
+        """Writes the given kde to the file."""
+        shape = kde.data.shape
+        try:
+            if shape != fp[dataset_name].shape:
+                # resize the dataset
+                fp[dataset_name].resize(shape)
+            fp[dataset_name][:] = kde.data
+        except KeyError:
+            # dataset doesn't exist yet
+            fp.create_dataset(dataset_name, shape,
+                              maxshape=(self.nwalkers,
+                                        len(self.variable_args)),
+                              dtype=float)
+            fp[dataset_name][:] = kde.data
+
     def write_state(self, fp):
         """ Saves the state of the sampler in a file.
 
@@ -238,24 +254,18 @@ class KombineSampler(BaseMCMCSampler):
         subgroup = "clustered_kde"
         dataset_name ="/".join([fp.sampler_group, subgroup])
         clustered_kde = self._sampler._kde
-        if dataset_name in fp:
-            fp[dataset_name][:] = clustered_kde.data
-        else:
-            fp[dataset_name] = clustered_kde.data
+        self._write_kde(fp, dataset, clustered_kde)
+        # metadata
         fp[dataset_name].attrs["nclusters"] = clustered_kde.nclusters
         fp[dataset_name].attrs["assignments"] = clustered_kde._assignments
         fp[dataset_name].attrs["centroids"] = clustered_kde.centroids
         fp[dataset_name].attrs["logweights"] = clustered_kde._logweights
         fp[dataset_name].attrs["mean"] = clustered_kde._mean
         fp[dataset_name].attrs["std"] = clustered_kde._std
-
         # save individual KDE data
         for i, kde in enumerate(clustered_kde._kdes):
             dataset_name = "/".join([fp.sampler_group, "kde" + str(i)])
-            if dataset_name in fp:
-                fp[dataset_name][:] = kde.data
-            else:
-                fp[dataset_name] = kde.data
+            self._write_kde(fp, dataset, kde)
 
     def set_state_from_file(self, fp):
         """ Sets the state of the sampler back to the instance saved in a file.

--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -225,7 +225,7 @@ class KombineSampler(BaseMCMCSampler):
         self.burn_in_iterations = self.niterations
         return p, post, q
 
-    def _write_kde(self, fp, dataset, kde):
+    def _write_kde(self, fp, dataset_name, kde):
         """Writes the given kde to the file."""
         shape = kde.data.shape
         try:
@@ -254,7 +254,7 @@ class KombineSampler(BaseMCMCSampler):
         subgroup = "clustered_kde"
         dataset_name ="/".join([fp.sampler_group, subgroup])
         clustered_kde = self._sampler._kde
-        self._write_kde(fp, dataset, clustered_kde)
+        self._write_kde(fp, dataset_name, clustered_kde)
         # metadata
         fp[dataset_name].attrs["nclusters"] = clustered_kde.nclusters
         fp[dataset_name].attrs["assignments"] = clustered_kde._assignments
@@ -265,7 +265,7 @@ class KombineSampler(BaseMCMCSampler):
         # save individual KDE data
         for i, kde in enumerate(clustered_kde._kdes):
             dataset_name = "/".join([fp.sampler_group, "kde" + str(i)])
-            self._write_kde(fp, dataset, kde)
+            self._write_kde(fp, dataset_name, kde)
 
     def set_state_from_file(self, fp):
         """ Sets the state of the sampler back to the instance saved in a file.

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -82,6 +82,17 @@ class InferenceFile(h5py.File):
             for arg in self.attrs["static_args"]])
 
     @property
+    def sampling_args(self):
+        """Returns the parameters that were used to sample.
+
+        Returns
+        -------
+        sampling_args : {list, str}
+            List of the sampling args.
+        """
+        return self.attrs["sampling_args"]
+
+    @property
     def lognl(self):
         """Returns the log noise likelihood."""
         return self.attrs["lognl"]

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -1229,11 +1229,13 @@ def compute_jacobian(samples, transforms, inverse=False):
     float :
         The product of the jacobians of all fo the transforms.
     """
+    j = 1.
     if inverse:
-        j = numpy.array([t.inverse_jacobian(samples)
-                         for t in transforms]).prod()
+        for t in transforms:
+            j *= t.inverse_jacobian(samples)
     else:
-        j = numpy.array([t.jacobian(samples) for t in transforms]).prod()
+        for t in transforms:
+            j *= t.jacobian(samples)
     return j
 
 

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -1210,7 +1210,7 @@ def apply_transforms(samples, transforms, inverse=False):
     return samples
 
 
-def compute_jacobians(samples, transforms, inverse=False):
+def compute_jacobian(samples, transforms, inverse=False):
     """Computes the jacobian of the list of transforms at the given sample
     points.
 

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -1209,6 +1209,34 @@ def apply_transforms(samples, transforms, inverse=False):
             continue
     return samples
 
+
+def compute_jacobians(samples, transforms, inverse=False):
+    """Computes the jacobian of the list of transforms at the given sample
+    points.
+
+    Parameters
+    ----------
+    samples : {FieldArray, dict}
+        Mapping object specifying points at which to compute jacobians.
+    transforms : list
+        List of BaseTransform instances to apply. Nested transforms are assumed
+        to be in order for forward transforms.
+    inverse : bool, optional
+        Compute inverse jacobians. Default is False.
+
+    Returns
+    -------
+    float :
+        The product of the jacobians of all fo the transforms.
+    """
+    if inverse:
+        j = numpy.array([t.inverse_jacobian(samples)
+                         for t in transforms]).prod()
+    else:
+        j = numpy.array([t.jacobian(samples) for t in transforms]).prod()
+    return j
+
+
 def order_transforms(transforms):
     """Orders transforms to ensure proper chaining.
 

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -211,7 +211,7 @@ class FDomainCBCGenerator(BaseCBCGenerator):
     a waveform:
 
     >>> generator = waveform.FDomainCBCGenerator(variable_args=['mchirp', 'eta'], delta_f=1./32, f_lower=30., approximant='TaylorF2')
-    >>> generator.generate(mchirp=1.5, eta=0.25) 
+    >>> generator.generate(mchirp=1.5, eta=0.25)
         (<pycbc.types.frequencyseries.FrequencySeries at 0x109a104d0>,
          <pycbc.types.frequencyseries.FrequencySeries at 0x109a10b50>)
 
@@ -320,7 +320,7 @@ class FDomainMultiModeRingdownGenerator(BaseGenerator):
 
     Create a ringdown with the variable arguments:
 
-    >>> generator.generate(final_mass=65., final_spin=0.7, lmns=['221','211'], amp220=1e-21, amp210=1./10, phi220=0., phi210=0.) 
+    >>> generator.generate(final_mass=65., final_spin=0.7, lmns=['221','211'], amp220=1e-21, amp210=1./10, phi220=0., phi210=0.)
         (<pycbc.types.frequencyseries.FrequencySeries at 0x51614d0>,
          <pycbc.types.frequencyseries.FrequencySeries at 0x5161550>)
 
@@ -466,7 +466,7 @@ class FDomainDetFrameGenerator(object):
     def generate_from_args(self, *args):
         """Generates a waveform, applies a time shift and the detector response
         function from the given args.
-        
+
         The args are assumed to be in the same order as the variable args.
         """
         return self.generate(**dict(zip(self.variable_args, args)))

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -70,8 +70,9 @@ class BaseGenerator(object):
     generator : function
         The function that is called for waveform generation.
     variable_args : tuple
-        The list of names of variable arguments. Values passed to the generate
-        function must be in the same order as the arguments in this list.
+        The list of names of variable arguments. Values passed to the
+        `generate_from_args` function must be in the same order as the
+        arguments in this list.
     frozen_params : dict
         A dictionary of the frozen keyword arguments that are always passed
         to the waveform generator function.
@@ -100,15 +101,15 @@ class BaseGenerator(object):
         """Returns a dictionary of the static arguments."""
         return self.frozen_params
 
-    def generate(self, *args):
+    def generate_from_args(self, *args):
         """Generates a waveform. The list of arguments must be in the same
         order as self's variable_args attribute.
         """
         if len(args) != len(self.variable_args):
             raise ValueError("variable argument length mismatch")
-        return self.generate_from_kwargs(**dict(zip(self.variable_args, args)))
+        return self.generate(**dict(zip(self.variable_args, args)))
 
-    def generate_from_kwargs(self, **kwargs):
+    def generate(self, **kwargs):
         """Generates a waveform from the keyword args. The current params
         are updated with the given kwargs, then the generator is called.
         """
@@ -202,7 +203,7 @@ class FDomainCBCGenerator(BaseCBCGenerator):
 
     Create a waveform with the variable arguments (in this case, mass1, mass2):
 
-    >>> generator.generate(1.4, 1.4)
+    >>> generator.generate(mass1=1.4, mass2=1.4)
         (<pycbc.types.frequencyseries.FrequencySeries at 0x1110c1450>,
          <pycbc.types.frequencyseries.FrequencySeries at 0x1110c1510>)
 
@@ -210,7 +211,7 @@ class FDomainCBCGenerator(BaseCBCGenerator):
     a waveform:
 
     >>> generator = waveform.FDomainCBCGenerator(variable_args=['mchirp', 'eta'], delta_f=1./32, f_lower=30., approximant='TaylorF2')
-    >>> generator.generate(1.5, 0.25)
+    >>> generator.generate(mchirp=1.5, eta=0.25) 
         (<pycbc.types.frequencyseries.FrequencySeries at 0x109a104d0>,
          <pycbc.types.frequencyseries.FrequencySeries at 0x109a10b50>)
 
@@ -254,7 +255,7 @@ class TDomainCBCGenerator(BaseCBCGenerator):
 
     Create a waveform with the variable arguments (in this case, mass1, mass2):
 
-    >>> generator.generate(2., 1.3)
+    >>> generator.generate(mass1=2., mass2=1.3)
         (<pycbc.types.timeseries.TimeSeries at 0x10e546710>,
          <pycbc.types.timeseries.TimeSeries at 0x115f37690>)
 
@@ -262,7 +263,7 @@ class TDomainCBCGenerator(BaseCBCGenerator):
     a waveform:
 
     >>> generator = waveform.TDomainCBCGenerator(variable_args=['mchirp', 'eta'], delta_t=1./4096, f_lower=30., approximant='TaylorT4')
-    >>> generator.generate(1.75, 0.2)
+    >>> generator.generate(mchirp=1.75, eta=0.2)
         (<pycbc.types.timeseries.TimeSeries at 0x116ac6050>,
          <pycbc.types.timeseries.TimeSeries at 0x116ac6950>)
 
@@ -292,11 +293,11 @@ class FDomainRingdownGenerator(BaseGenerator):
     --------
     Initialize a generator:
 
-    >>> generator = waveform.FDomainRingdownGenerator(variable_args=['tau', 'f_0'], delta_f=1./32, f_lower=30., f_final=500)
+    >>> generator = waveform.FDomainRingdownGenerator(variable_args=['tau', 'f_0', 'amp', 'phi'], delta_f=1./32, f_lower=30., f_final=500)
 
     Create a ringdown with the variable arguments (in this case, tau, f_0):
 
-    >>> generator.generate(5, 100)
+    >>> generator.generate(tau=5., f_0=100., amp=1., phi=0.)
         (<pycbc.types.frequencyseries.FrequencySeries at 0x1110c1450>,
          <pycbc.types.frequencyseries.FrequencySeries at 0x1110c1510>)
 
@@ -315,13 +316,11 @@ class FDomainMultiModeRingdownGenerator(BaseGenerator):
     --------
     Initialize a generator:
 
-    >>> generator = waveform.FDomainMultiModeRingdownGenerator(
-            variable_args=['final_mass', 'final_spin', 'lmns','amp220','amp210','phi220','phi210'],
-            delta_f=1./32, f_lower=30., f_final=500)
+    >>> generator = waveform.FDomainMultiModeRingdownGenerator(variable_args=['final_mass', 'final_spin', 'lmns','amp220','amp210','phi220','phi210'], delta_f=1./32, f_lower=30., f_final=500)
 
     Create a ringdown with the variable arguments:
 
-    >>> generator.generate(65., 0.7, ['221','211'], 1e-21, 1./10, 0., 0.)
+    >>> generator.generate(final_mass=65., final_spin=0.7, lmns=['221','211'], amp220=1e-21, amp210=1./10, phi220=0., phi210=0.) 
         (<pycbc.types.frequencyseries.FrequencySeries at 0x51614d0>,
          <pycbc.types.frequencyseries.FrequencySeries at 0x5161550>)
 
@@ -408,7 +407,7 @@ class FDomainDetFrameGenerator(object):
 
     Generate a waveform:
 
-    >>> generator.generate(38.6, 29.3, 0.33, -0.94, 2.43, 1.37, -1.26, 2.76)
+    >>> generator.generate(mass1=38.6, mass2=29.3, spin1z=0.33, spin2z=-0.94, tc=2.43, ra=1.37, dec=-1.26, polarization=2.76)
     {'H1': <pycbc.types.frequencyseries.FrequencySeries at 0x116637350>,
      'L1': <pycbc.types.frequencyseries.FrequencySeries at 0x116637a50>}
 
@@ -464,16 +463,22 @@ class FDomainDetFrameGenerator(object):
     def epoch(self):
         return _lal.LIGOTimeGPS(self._epoch)
 
-    def generate(self, *args):
+    def generate_from_args(self, *args):
         """Generates a waveform, applies a time shift and the detector response
-        function."""
-        self.current_params.update(dict(zip(self.variable_args, args)))
-        # FIXME: use the following when we switch to 2.7
-        #rfparams = {param: self.current_params[param]
-        #    for param in self.rframe_generator.variable_args}
-        rfparams = dict([(param, self.current_params[param])
-            for param in self.rframe_generator.variable_args])
-        hp, hc = self.rframe_generator.generate_from_kwargs(**rfparams)
+        function from the given args.
+        
+        The args are assumed to be in the same order as the variable args.
+        """
+        return self.generate(**dict(zip(self.variable_args, args)))
+
+    def generate(self, **kwargs):
+        """Generates a waveform, applies a time shift and the detector response
+        function from the given kwargs.
+        """
+        self.current_params.update(kwargs)
+        rfparams = {param: self.current_params[param]
+            for param in self.rframe_generator.variable_args}
+        hp, hc = self.rframe_generator.generate(**rfparams)
         if isinstance(hp, TimeSeries):
             df = self.current_params['delta_f']
             hp = hp.to_frequencyseries(delta_f=df)

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -58,7 +58,7 @@ class TestInference(unittest.TestCase):
                        f_lower=fmin, approximant="TaylorF2",
                        mass1=m1, mass2=m2, spin1z=s1z, spin2z=s2z, ra=ra,
                        dec=dec, polarization=pol, distance=dist)
-        signal = gen.generate(tsig)
+        signal = gen.generate(tc=tsig)
 
         # get PSDs
         psd = pypsd.aLIGOZeroDetHighPower(N, 1. / seglen, 20.)


### PR DESCRIPTION
This patch adds the ability to define transforms to sample in a different parameter space than the parameter space of the variable args (which the priors are defined with). Multiple transforms may be used to get from the variable args to the sampling args, and the sampling args need not have a distribution defined for them. This allows, e.g., the sampler to sample in the `logit` of a parameter.

The `LikelihoodEvaluator` controls the transformations between the priors and the sampler. When the initial positions are set, the likelihood evaluator converts them to sampling space before passing to the sampler class. At each iteration, when the sampler passes values to the likelihood evaluator, the values are transformed back to the variable args space before passed to the prior distributions. The log of the Jacobian is added to the `logplr` when passing back to the sampler. When the samples are written to the results file, the likelihood evaluator transforms the chain back to the variable args parameter space. The prior saved to the results file is also saved as it is in the variable args space.

To handle this smoothly, the waveform generator and prior evaluator now take keyword arguments instead of a list of values. The only function that takes a list of values now is the likelihood evaluator's `evaluate` function (which is what `__call__` is set to now). This takes care of converting the list to a dictionary, and does the transform from sampling space to variable args space.

Depends on #1681 and  #1689. Marking as work in progress, as I haven't tested yet, and haven't updated `emcee` yet.