### PR TITLE
Replace generator.py functions with transforms

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -383,10 +383,12 @@ def chi_p(mass1, mass2, spin1x, spin1y, spin2x, spin2y):
     xi2 = primary_xi(mass1, mass2, spin1x, spin1y, spin2x, spin2y)
     return chi_p_from_xi1_xi2(xi1, xi2)
 
-def phi_a(spin1x, spin1y, spin2x, spin2y):
+def phi_a(mass1, mass2, spin1x, spin1y, spin2x, spin2y):
     """ Returns the angle between the in-plane perpendicular spins."""
-    phi1 = phi_from_spinx_spiny(spin1x, spin1y)
-    phi2 = phi_from_spinx_spiny(spin2x, spin2y)
+    phi1 = phi_from_spinx_spiny(primary_spin(mass1, mass2, spin1x, spin2x),
+                                primary_spin(mass1, mass2, spin1y, spin2y))
+    phi2 = phi_from_spinx_spiny(secondary_spin(mass1, mass2, spin1x, spin2x),
+                                secondary_spin(mass1, mass2, spin1y, spin2y))
     return phi1 - phi2
 
 def phi_s(spin1x, spin1y, spin2x, spin2y):

--- a/pycbc/distributions/bounded.py
+++ b/pycbc/distributions/bounded.py
@@ -333,7 +333,7 @@ class BoundedDist(object):
         Returns
         -------
         BoundedDist
-            A distribution instance from the pycbc.inference.prior module.
+            A distribution instance from the pycbc.distribution subpackage.
         """
         return bounded_from_config(cls, cp, section, variable_args,
                                     bounds_required=bounds_required)

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -587,7 +587,7 @@ class EmceePTSampler(BaseMCMCSampler):
         tidx = numpy.arange(ntemps)
 
         # loop over number of dimensions
-        for pi, param in enumerate(self.variable_args):
+        for pi, param in enumerate(parameters):
             # loop over number of temps
             for tk in tidx:
                 # loop over number of walkers

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -1076,6 +1076,8 @@ def get_common_cbc_transforms(requested_params, variable_args,
     all_c : list
         List of BaseTransforms to apply.
     """
+    variable_args = set(variable_args) if not isinstance(variable_args, set) \
+                                    else variable_args
 
     # try to parse any equations by putting all strings together
     # this will get some garbage but ensures all alphanumeric/underscored
@@ -1114,6 +1116,7 @@ def get_common_cbc_transforms(requested_params, variable_args,
                 len(converter.outputs.intersection(requested_params)) > 0):
             requested_params.update(converter.inputs)
             to_base_c.append(converter)
+            variable_args.update(converter.outputs)
 
     # get list of transforms that converts sampling parameters to the base
     # parameters and then converts base parameters to the derived parameters

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -438,20 +438,59 @@ class PrecessionMassSpinToCartesianSpin(BaseTransform):
             A dict with key as parameter name and value as numpy.array or float
             of transformed values.
         """
-        out = {}
-        out[parameters.spin1x] = conversions.spin1x_from_xi1_phi_a_phi_s(
-                               maps["xi1"], maps["phi_a"], maps["phi_s"])
-        out[parameters.spin1y] = conversions.spin1y_from_xi1_phi_a_phi_s(
-                               maps["xi1"], maps["phi_a"], maps["phi_s"])
-        out[parameters.spin2x] = \
-                         conversions.spin2x_from_mass1_mass2_xi2_phi_a_phi_s(
-                               maps[parameters.mass1], maps[parameters.mass2],
-                               maps["xi2"], maps["phi_a"], maps["phi_s"])
-        out[parameters.spin2y] = \
-                         conversions.spin2y_from_mass1_mass2_xi2_phi_a_phi_s(
-                               maps[parameters.mass1], maps[parameters.mass2],
-                               maps["xi2"], maps["phi_a"], maps["phi_s"])
+
+        # find primary and secondary masses
+        # since functions in conversions.py map to primary/secondary masses
+        m_p = conversions.primary_mass(maps["mass1"], maps["mass2"])
+        m_s = conversions.secondary_mass(maps["mass1"], maps["mass2"])
+
+        # find primary and secondary xi
+        # can re-purpose spin functions for just a generic variable
+        xi_p = conversions.primary_spin(maps["mass1"], maps["mass2"],
+                                        maps["xi1"], maps["xi2"])
+        xi_s = conversions.secondary_spin(maps["mass1"], maps["mass2"],
+                                          maps["xi1"], maps["xi2"])
+
+        # convert using convention of conversions.py that is mass1 > mass2
+        spinx_p = conversions.spin1x_from_xi1_phi_a_phi_s(
+                           xi_p, maps["phi_a"], maps["phi_s"])
+        spiny_p = conversions.spin1y_from_xi1_phi_a_phi_s(
+                           xi_p, maps["phi_a"], maps["phi_s"])
+        spinx_s = conversions.spin2x_from_mass1_mass2_xi2_phi_a_phi_s(
+                           m_p, m_s, xi_s, maps["phi_a"], maps["phi_s"])
+        spiny_s = conversions.spin2y_from_mass1_mass2_xi2_phi_a_phi_s(
+                           m_p, m_s, xi_s, maps["phi_a"], maps["phi_s"])
+
+        # map parameters from primary/secondary to indices
+        if isinstance(m_p, numpy.ndarray):
+            mass1, mass2 = map(numpy.array, [maps["mass1"], maps["mass2"]])
+            mask_mass1_gte_mass2 = mass1 >= mass2
+            mask_mass1_lt_mass2 = mass1 < mass2
+            out[parameters.spin1x] = numpy.concatenate(
+                                        spinx_p[mask_mass1_gte_mass2],
+                                        spinx_s[mask_mass1_lt_mass2])
+            out[parameters.spin1y] = numpy.concatenate(
+                                        spiny_p[mask_mass1_gte_mass2],
+                                        spiny_s[mask_mass1_lt_mass2])
+            out[parameters.spin2x] = numpy.concatenate(
+                                        spinx_p[mask_mass1_lt_mass2],
+                                        spinx_s[mask_mass1_gte_mass2])
+            out[parameters.spin2y] = numpy.concatenate(
+                                        spinx_p[mask_mass1_lt_mass2],
+                                        spinx_s[mask_mass1_gte_mass2])
+        elif maps["mass1"] > maps["mass2"]:
+            out[parameters.spin1x] = spinx_p
+            out[parameters.spin1y] = spiny_p
+            out[parameters.spin2x] = spinx_s
+            out[parameters.spin2y] = spiny_s
+        else:
+            out[parameters.spin1x] = spinx_s
+            out[parameters.spin1y] = spiny_s
+            out[parameters.spin2x] = spinx_p
+            out[parameters.spin2y] = spiny_p
+
         return self.format_output(maps, out)
+
 
     def inverse_transform(self, maps):
         """ This function transforms from component masses and cartesian spins to

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -477,6 +477,7 @@ class PrecessionMassSpinToCartesianSpin(BaseTransform):
                              maps[parameters.spin1x], maps[parameters.spin1y],
                              maps[parameters.spin2x], maps[parameters.spin2y])
         out["phi_a"] = conversions.phi_a(
+                             maps[parameters.mass1], maps[parameters.mass2],
                              maps[parameters.spin1x], maps[parameters.spin1y],
                              maps[parameters.spin2x], maps[parameters.spin2y])
         out["phi_s"] = conversions.phi_s(

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -465,6 +465,7 @@ class PrecessionMassSpinToCartesianSpin(BaseTransform):
                            m_p, m_s, xi_s, maps["phi_a"], maps["phi_s"])
 
         # map parameters from primary/secondary to indices
+        out = {}
         if isinstance(m_p, numpy.ndarray):
             mass1, mass2 = map(numpy.array, [maps["mass1"], maps["mass2"]])
             mask_mass1_gte_mass2 = mass1 >= mass2

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -39,6 +39,9 @@ class BaseTransform(object):
         self.inputs = set(self._inputs)
         self.outputs = set(self._outputs)
 
+    def __call__(self, maps):
+        return self.transform(maps)
+
     def transform(self, maps):
         """ This function transforms from inputs to outputs.
         """

--- a/pycbc/waveform/__init__.py
+++ b/pycbc/waveform/__init__.py
@@ -1,6 +1,5 @@
 from pycbc.waveform.waveform import *
 from pycbc.waveform.utils import *
 from pycbc.waveform.bank import *
-from pycbc.waveform.generator import *
 from pycbc.waveform.ringdown import *
 from pycbc.waveform.parameters import *

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -134,7 +134,7 @@ class BaseGenerator(object):
         """
         def dostuff(self):
             for func in self._pregenerate_functions:
-                self.current_params = func(self.current_params)
+                self.current_params = func.transform(self.current_params)
             res = generate_func(self) # pylint:disable=not-callable
             return self._postgenerate(res)
         return dostuff
@@ -171,7 +171,7 @@ class BaseCBCGenerator(BaseGenerator):
         params_used, cs = transforms.get_common_cbc_transforms(
                                        list(self.possible_args), variable_args)
         for c in cs:
-            self._add_pregenerate(c.transform)
+            self._add_pregenerate(c)
         # check that there are no unused parameters
         unused_args = all_args.difference(params_used) \
                               .difference(self.possible_args)

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -30,106 +30,13 @@ import waveform
 import ringdown
 from pycbc import coordinates
 from pycbc import filter
+from pycbc import transforms
 from pycbc.types import TimeSeries
 from pycbc.waveform import parameters
 from pycbc.waveform.utils import apply_fd_time_shift, taper_timeseries
 from pycbc.detector import Detector
 from pycbc import pnutils
 import lal as _lal
-
-#
-#   Pregenerator functions for generator
-#
-
-
-def add_attrs(**func_attrs):
-    """ Decorator for adding attributes to a function.
-    """
-    def add_attr_decorator(fn):
-        # wraps is a decorator for updating the attributes of the
-        # wrapping function to those of the original function
-        # ie. __name__, __doc__, and __module__ will point to the
-        # original function instead of the wrapped function
-        @functools.wraps(fn)
-        def wrapper(*args, **kwargs):
-            return fn(*args, **kwargs)
-        # update with attributes
-        for attr, value in func_attrs.iteritems():
-            setattr(wrapper, attr, value)
-        return wrapper
-    return add_attr_decorator
-
-
-@add_attrs(input_params=[parameters.mchirp, parameters.eta],
-           output_params=[parameters.mass1, parameters.mass2])
-def generator_mchirp_eta_to_mass1_mass2(generator):
-    """Converts mchirp and eta in `current_params`, to mass1 and mass2.
-    """
-    mchirp = generator.current_params['mchirp']
-    eta = generator.current_params['eta']
-    m1, m2 = pnutils.mchirp_eta_to_mass1_mass2(mchirp, eta)
-    generator.current_params['mass1'] = m1
-    generator.current_params['mass2'] = m2
-
-
-@add_attrs(input_params=[parameters.mtotal, parameters.eta],
-           output_params=[parameters.mass1, parameters.mass2])
-def generator_mtotal_eta_to_mass1_mass2(generator):
-    """Converts mtotal and eta in `current_params`, to mass1 and mass2.
-    """
-    mtotal = generator.current_params['mtotal']
-    eta = generator.current_params['eta']
-    m1, m2 = pnutils.mtotal_eta_to_mass1_mass2(mtotal, eta)
-    generator.current_params['mass1'] = m1
-    generator.current_params['mass2'] = m2
-
-
-@add_attrs(input_params=[parameters.mchirp, parameters.q],
-           output_params=[parameters.mass1, parameters.mass2])
-def generator_mchirp_q_to_mass1_mass2(generator):
-    """Converts mchirp and q in `current_params`, to mass1 and mass2.
-    """
-    mchirp = generator.current_params['mchirp']
-    q = generator.current_params['q']
-    m1, m2 = pnutils.mchirp_q_to_mass1_mass2(mchirp, q)
-    generator.current_params['mass1'] = m1
-    generator.current_params['mass2'] = m2
-
-
-@add_attrs(input_params=[parameters.spin1_a, parameters.spin2_a,
-                         parameters.spin1_azimuthal,
-                         parameters.spin2_azimuthal,
-                         parameters.spin1_polar, parameters.spin2_polar],
-           output_params=[parameters.spin1x, parameters.spin2x,
-                          parameters.spin1y, parameters.spin2y,
-                          parameters.spin1z, parameters.spin2z])
-def generator_spin_spherical_to_spin_cartesian(generator):
-    """Converts spherical spin magnitude and angles in `current_params`,
-    to cartesian component spins.
-    """
-    x, y, z = coordinates.spherical_to_cartesian(
-                                   generator.current_params["spin1_a"],
-                                   generator.current_params["spin1_azimuthal"],
-                                   generator.current_params["spin1_polar"])
-    generator.current_params["spin1x"] = x
-    generator.current_params["spin1y"] = y
-    generator.current_params["spin1z"] = z
-    x, y, z = coordinates.spherical_to_cartesian(
-                                   generator.current_params["spin2_a"],
-                                   generator.current_params["spin2_azimuthal"],
-                                   generator.current_params["spin2_polar"])
-    generator.current_params["spin2x"] = x
-    generator.current_params["spin2y"] = y
-    generator.current_params["spin2z"] = z
-
-
-# a list of all generator functions
-generator_functions = [
-    generator_mchirp_eta_to_mass1_mass2,
-    generator_mtotal_eta_to_mass1_mass2,
-    generator_mchirp_q_to_mass1_mass2,
-    generator_spin_spherical_to_spin_cartesian,
-]
 
 #
 #   Generator for CBC waveforms
@@ -227,7 +134,7 @@ class BaseGenerator(object):
         """
         def dostuff(self):
             for func in self._pregenerate_functions:
-                func(self)
+                self.current_params = func(self.current_params)
             res = generate_func(self) # pylint:disable=not-callable
             return self._postgenerate(res)
         return dostuff
@@ -261,11 +168,10 @@ class BaseCBCGenerator(BaseGenerator):
         # compare a set of all args of the generator to the input parameters
         # of the functions that do conversions and adds to list of pregenerate
         # functions if it is needed
-        params_used = set([])
-        for func in generator_functions:
-            if set(func.input_params).issubset(all_args):
-                self._add_pregenerate(func)
-                params_used.update(func.input_params)
+        params_used, cs = transforms.get_common_cbc_transforms(
+                                       list(self.possible_args), variable_args)
+        for c in cs:
+            self._add_pregenerate(c.transform)
         # check that there are no unused parameters
         unused_args = all_args.difference(params_used) \
                               .difference(self.possible_args)

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -134,7 +134,7 @@ class BaseGenerator(object):
         """
         def dostuff(self):
             for func in self._pregenerate_functions:
-                self.current_params = func.transform(self.current_params)
+                self.current_params = func(self.current_params)
             res = generate_func(self) # pylint:disable=not-callable
             return self._postgenerate(res)
         return dostuff

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -30,9 +30,9 @@ import unittest
 import numpy
 from pycbc import distributions
 from pycbc import inference
-from pycbc import waveform
 from pycbc import psd as pypsd
 from utils import parse_args_cpu_only, simple_exit
+from pycbc.waveform import generator
 
 # tests only need to happen on the CPU
 parse_args_cpu_only("Inference")
@@ -52,8 +52,8 @@ class TestInference(unittest.TestCase):
         # setup waveform generator and signal parameters
         m1, m2, s1z, s2z, tsig = 38.6, 29.3, 0., 0., 3.1
         ra, dec, pol, dist = 1.37, -1.26, 2.76, 3*500.
-        generator = waveform.FDomainDetFrameGenerator(
-                        waveform.FDomainCBCGenerator, 0., variable_args=["tc"],
+        generator = generator.FDomainDetFrameGenerator(
+                        generator.FDomainCBCGenerator, 0., variable_args=["tc"],
                         detectors=["H1", "L1"], delta_f=1./seglen,
                         f_lower=fmin, approximant="TaylorF2",
                         mass1=m1, mass2=m2, spin1z=s1z, spin2z=s2z, ra=ra,

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -51,25 +51,26 @@ class TestInference(unittest.TestCase):
 
         # setup waveform generator and signal parameters
         m1, m2, s1z, s2z, tsig = 38.6, 29.3, 0., 0., 3.1
-        ra, dec, pol, dist = 1.37, -1.26, 2.76, 3*500.
+        ra, dec, pol, dist = 1.37, -1.26, 2.76, 3 * 500.
         gen = generator.FDomainDetFrameGenerator(
-                        generator.FDomainCBCGenerator, 0., variable_args=["tc"],
-                        detectors=["H1", "L1"], delta_f=1./seglen,
-                        f_lower=fmin, approximant="TaylorF2",
-                        mass1=m1, mass2=m2, spin1z=s1z, spin2z=s2z, ra=ra,
-                        dec=dec, polarization=pol, distance=dist)
+                       generator.FDomainCBCGenerator, 0., variable_args=["tc"],
+                       detectors=["H1", "L1"], delta_f=1./seglen,
+                       f_lower=fmin, approximant="TaylorF2",
+                       mass1=m1, mass2=m2, spin1z=s1z, spin2z=s2z, ra=ra,
+                       dec=dec, polarization=pol, distance=dist)
         signal = gen.generate(tsig)
 
         # get PSDs
-        psd = pypsd.aLIGOZeroDetHighPower(N, 1./seglen, 20.)
+        psd = pypsd.aLIGOZeroDetHighPower(N, 1. / seglen, 20.)
         psds = {"H1": psd, "L1": psd}
 
         # get a prior evaluator
-        uniform_prior = distributions.Uniform(tc=(tsig-0.2,tsig+0.2))
+        uniform_prior = distributions.Uniform(tc=(tsig - 0.2,tsig + 0.2))
         prior_eval = inference.prior.PriorEvaluator(["tc"], uniform_prior)
 
         # setup likelihood evaluator
-        likelihood_eval = inference.GaussianLikelihood(generator, signal, fmin,
+        likelihood_eval = inference.GaussianLikelihood(
+                                gen, signal, fmin,
                                 psds=psds, prior=prior_eval, return_meta=False)
 
 suite = unittest.TestSuite()

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -52,13 +52,13 @@ class TestInference(unittest.TestCase):
         # setup waveform generator and signal parameters
         m1, m2, s1z, s2z, tsig = 38.6, 29.3, 0., 0., 3.1
         ra, dec, pol, dist = 1.37, -1.26, 2.76, 3*500.
-        generator = generator.FDomainDetFrameGenerator(
+        gen = generator.FDomainDetFrameGenerator(
                         generator.FDomainCBCGenerator, 0., variable_args=["tc"],
                         detectors=["H1", "L1"], delta_f=1./seglen,
                         f_lower=fmin, approximant="TaylorF2",
                         mass1=m1, mass2=m2, spin1z=s1z, spin2z=s2z, ra=ra,
                         dec=dec, polarization=pol, distance=dist)
-        signal = generator.generate(tsig)
+        signal = gen.generate(tsig)
 
         # get PSDs
         psd = pypsd.aLIGOZeroDetHighPower(N, 1./seglen, 20.)


### PR DESCRIPTION
Separates out the ``ChangeOfVariables`` commits from #1679.

This PR:
  * Changes ``PrecessionMassSpinToCartesianSpin.transform`` so that the primary and secondary masses are always mapped to the correct functions.
  * Removes functions at top of ``generator.py``.
  * Generators now use ``transforms.py`` to get transformations.
  * Update a docstring in ``bounded.py``.
  * Updates ``phi_a`` to pick the primary and secondary mass.

I realize now that since the logit transformation is initialized with bounds, etc. we will need some way to pass those to the generator. But this works for ``mchirp``-``q``, effective spins, etc.