### PR TITLE
Fix bug in transforms.py

### DIFF
--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -1086,7 +1086,7 @@ def get_common_cbc_transforms(requested_params, variable_args,
         for ch in opt:
             s += ch if ch.isalnum() or ch == "_" else " "
         new_params += s.split(" ")
-    requested_params = set(requested_params + new_params)
+    requested_params = set(list(requested_params) + list(new_params))
 
     # can pass a list of valid parameters to remove garbage from parsing above
     if valid_params:


### PR DESCRIPTION
There is a bug in the master version of transforms.py:
```Traceback (most recent call last):
  File "check_likelihood.py", line 53, in <module>
    fp, parameters, _, samples = option_utils.results_from_cli(opts)
  File "/home/miriam.cabero/virtualenvs/pycbc-master/local/lib/python2.7/site-packages/PyCBC-d93c5f-py2.7.egg/pycbc/inference/option_utils.py", line 499, in results_from_cli
    parameters, fp.variable_args)
  File "/home/miriam.cabero/virtualenvs/pycbc-master/local/lib/python2.7/site-packages/PyCBC-d93c5f-py2.7.egg/pycbc/transforms.py", line 1089, in get_common_cbc_transforms
    requested_params = set(requested_params + new_params)
TypeError: ufunc 'add' did not contain a loop with signature matching types dtype('S12') dtype('S12') dtype('S12')
```

This PR should take care of that issue