### PR TITLE
Add error message to ringdown module

### DIFF
--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -499,8 +499,9 @@ def get_td_lm(template=None, taper=None, **kwargs):
     final_spin = input_params.pop('final_spin')
     l, m = input_params.pop('l'), input_params.pop('m')
     nmodes = input_params.pop('nmodes')
-    if nmodes == 0:
-        raise ValueError('Number of overtones (nmodes) must be greater than zero.')
+    if int(nmodes) == 0:
+        raise ValueError('Number of overtones (nmodes) must be greater '
+                         'than zero.')
     # The following may not be in input_params
     delta_t = input_params.pop('delta_t', None)
     t_final = input_params.pop('t_final', None)
@@ -586,8 +587,9 @@ def get_fd_lm(template=None, **kwargs):
     final_spin = input_params.pop('final_spin')
     l, m = input_params.pop('l'), input_params.pop('m')
     nmodes = input_params.pop('nmodes')
-    if nmodes == 0:
-        raise ValueError('Number of overtones (nmodes) must be greater than zero.')
+    if int(nmodes) == 0:
+        raise ValueError('Number of overtones (nmodes) must be greater '
+                         'than zero.')
     # The following may not be in input_params
     delta_f = input_params.pop('delta_f', None)
     f_lower = input_params.pop('f_lower', None)
@@ -670,7 +672,11 @@ def get_td_lm_allmodes(template=None, taper=None, **kwargs):
     final_mass = input_params['final_mass']
     final_spin = input_params['final_spin']
     lmns = input_params['lmns']
-    # The following may not be in input_params
+    for lmn in lmns:
+        if int(lmn[2]) == 0:
+            raise ValueError('Number of overtones (nmodes) must be greater '
+                             'than zero.')
+    # following may not be in input_params
     delta_t = input_params.pop('delta_t', None)
     t_final = input_params.pop('t_final', None)
 
@@ -754,6 +760,10 @@ def get_fd_lm_allmodes(template=None, **kwargs):
     final_mass = input_params['final_mass']
     final_spin = input_params['final_spin']
     lmns = input_params['lmns']
+    for lmn in lmns:
+        if int(lmn[2]) == 0:
+            raise ValueError('Number of overtones (nmodes) must be greater '
+                             'than zero.')
     # The following may not be in input_params
     delta_f = input_params.pop('delta_f', None)
     f_lower = input_params.pop('f_lower', None)

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -499,6 +499,8 @@ def get_td_lm(template=None, taper=None, **kwargs):
     final_spin = input_params.pop('final_spin')
     l, m = input_params.pop('l'), input_params.pop('m')
     nmodes = input_params.pop('nmodes')
+    if nmodes == 0:
+        raise ValueError('Number of overtones (nmodes) must be greater than zero.')
     # The following may not be in input_params
     delta_t = input_params.pop('delta_t', None)
     t_final = input_params.pop('t_final', None)
@@ -584,6 +586,8 @@ def get_fd_lm(template=None, **kwargs):
     final_spin = input_params.pop('final_spin')
     l, m = input_params.pop('l'), input_params.pop('m')
     nmodes = input_params.pop('nmodes')
+    if nmodes == 0:
+        raise ValueError('Number of overtones (nmodes) must be greater than zero.')
     # The following may not be in input_params
     delta_f = input_params.pop('delta_f', None)
     f_lower = input_params.pop('f_lower', None)


### PR DESCRIPTION
After a while not directly calling the functions to generate ringdown waveforms, I had forgotten that if one wants the mode '220' has to specify '221' (because the last number is the number of overtones, and not which "n"). From the error message I was getting, it was not immediately obvious where the problem was, so I thought it would be nice for new people using the code (and forgetful people like me) to add an error message that specifically will tell to change the zero (the documentation on the multi-mode function does provide information to figure out how it works).