### PR TITLE
Calculate template duration for decompressed waveforms if the corressponding field in FilterBank is populated by zeroes by ensure_standard_filter_columns

### DIFF
--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -653,7 +653,7 @@ class FilterBank(TemplateBank):
             tmpltdur = self.table[index].template_duration
         except AttributeError:
             tmpltdur = None
-        if tmpltdur is None:
+        if tmpltdur is None or tmpltdur==0.0 :
             tmpltdur = get_waveform_filter_length_in_time(approximant, **p)
         hdecomp.chirp_length = tmpltdur
         hdecomp.length_in_time = hdecomp.chirp_length


### PR DESCRIPTION
If a bank which does not store `template_duration` is given to `FilterBank`, it populates the `template_duration` field of table with 0.0s https://github.com/ligo-cbc/pycbc/blob/master/pycbc/waveform/bank.py#L612 . So, when decompressing the template in `get_decompressed_waveform`, the template duration is prevented from being generated from `get_waveform_filter_length_in_time` because 0.0 is a non-null value. This PR adds the fix so that the template duration is calculated if that field does not exist, exist but not populated *or* exists but is populated with 0.0s. 

@cdcapano could you please take a look?