### PR TITLE
Add Arbitrary distribution

### DIFF
--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -26,6 +26,7 @@ from pycbc.distributions.uniform import *
 
 # a dict of all available distributions
 distribs = {
+    Arbitrary.name : Arbitrary,
     FromFile.name : FromFile,
     Gaussian.name : Gaussian,
     UniformPowerLaw.name : UniformPowerLaw,

--- a/pycbc/distributions/__init__.py
+++ b/pycbc/distributions/__init__.py
@@ -18,7 +18,7 @@ probability density function of distributions.
 """
 
 from pycbc.distributions.angular import *
-from pycbc.distributions.from_file import *
+from pycbc.distributions.arbitrary import *
 from pycbc.distributions.gaussian import *
 from pycbc.distributions.power_law import *
 from pycbc.distributions.sky_location import *

--- a/pycbc/distributions/arbitrary.py
+++ b/pycbc/distributions/arbitrary.py
@@ -173,7 +173,7 @@ class Arbitrary(bounded.BoundedDist):
     def get_kde_from_arrays(*arrays):
         """Constructs a KDE from the given arrays.
 
-        *arrays :
+        \*arrays :
             Each argument should be a 1D numpy array to construct the kde from.
             The resulting KDE will have dimension given by the number of
             parameters.

--- a/pycbc/distributions/arbitrary.py
+++ b/pycbc/distributions/arbitrary.py
@@ -21,7 +21,7 @@ import h5py
 import numpy
 import scipy.stats
 from pycbc.distributions import bounded
-from pycbc.transforms import Logit
+import pycbc.transforms
 
 class Arbitrary(bounded.BoundedDist):
     """A distribution constructed from a set of parameter values using a kde.
@@ -58,7 +58,7 @@ class Arbitrary(bounded.BoundedDist):
             if numpy.isfinite(bnds[1] - bnds[0]):
                 tparam = 'logit'+param
                 samples = kwargs[param]
-                t = Logit(param, tparam, domain=bnds)
+                t = pycbc.transforms.Logit(param, tparam, domain=bnds)
                 self._transforms[tparam] = t
                 self._tparams[param] = tparam
                 # remove any sample points that fall out side of the bounds
@@ -70,7 +70,7 @@ class Arbitrary(bounded.BoundedDist):
             elif not (~numpy.isfinite(bnds[0]) and ~numpy.isfinite(bnds[1])):
                 raise ValueError("if specifying bounds, both bounds must "
                                  "be finite")
-        # build the kde 
+        # build the kde
         self._kde = self.get_kde_from_arrays(*[kwargs[p] for p in self.params])
 
     @property
@@ -236,7 +236,7 @@ class FromFile(Arbitrary):
             ps = params.keys()
         param_vals = self.get_arrays_from_file(filename, params=ps)
         super(FromFile, self).__init__(bounds=params, **param_vals)
-    
+
     @property
     def filename(self):
         return self._filename

--- a/pycbc/distributions/arbitrary.py
+++ b/pycbc/distributions/arbitrary.py
@@ -21,7 +21,7 @@ import h5py
 import numpy
 import scipy.stats
 from pycbc.distributions import bounded
-
+from pycbc.transforms import Logit
 
 class Arbitrary(_BoundedDist):
     """A distribution constructed from a set of parameter values using a kde.
@@ -63,37 +63,32 @@ class Arbitrary(_BoundedDist):
         if set(self.params) != set(kwargs.keys()):
             raise ValueError("Must provide samples for all parameters given "
                              "in the bounds dictionary")
+        # if bounds are provided use logit transform to move the points
+        # to +/- inifinity
+        self._transforms = {}
+        self._tparams = {}
+        for param,bnds in self.bounds.items():
+            if numpy.isfinite(bnd[1] - bnd[0]):
+                tparam = 'logit'+param
+                samples = kwargs[param]
+                t = transforms.Logit(param, tparam, domain=bnds)
+                self._transforms[tparm] = t
+                self._tparams[param] = tparam
+                # remove any sample points that fall out side of the bounds
+                outside = bnds.__contains__(samples)
+                if outside.any():
+                    samples = samples[outside]
+                # transform the sample points
+                kwargs[param] = t.transform({param: samples})[tparam]
+            elif not (~numpy.isfinite(bnd[0]) and ~numpy.isfinite(bnd[1])):
+                raise ValueError("if specifying bounds, both bounds must "
+                                 "be finite")
+        # build the kde 
         self._kde = self.get_kde_from_arrays(*[kwargs[p] for p in self.params])
-        # Compute the norm and save
-        lower_bounds = [self.bounds[p][0] for p in self.params]
-        higher_bounds = [self.bounds[p][1] for p in self.params]
-        # Avoid inf because of inconsistencies in integrate_box
-        RANGE_LIMIT = 2 ** 31
-        for ii, bnd in enumerate(lower_bounds):
-            if abs(bnd) == numpy.inf:
-                lower_bounds[ii] = numpy.sign(bnd) * RANGE_LIMIT
-        for ii, bnd in enumerate(higher_bounds):
-            if abs(bnd) == numpy.inf:
-                higher_bounds[ii] = numpy.sign(bnd) * RANGE_LIMIT
-        # Array of -inf for the lower limits in integrate_box
-        lower_limits = - RANGE_LIMIT * numpy.ones(shape=len(lower_bounds))
-        # CDF(-inf,b) - CDF(-inf, a)
-        invnorm = self._kde.integrate_box(lower_limits, higher_bounds) - \
-                    self._kde.integrate_box(lower_limits, lower_bounds)
-        self._norm = 1. / invnorm
-        self._lognorm = numpy.log(self._norm)
 
     @property
     def params(self):
         return self._params
-
-    @property
-    def norm(self):
-        return self._norm
-
-    @property
-    def lognorm(self):
-        return self._lognorm
 
     @property
     def kde(self):
@@ -109,9 +104,20 @@ class Arbitrary(_BoundedDist):
                 raise ValueError('Missing parameter {} to construct pdf.'
                                  .format(p))
         if kwargs in self:
+            # transform into the kde space
+            jacobian = 1.
+            for param, tparam in self._tparams.items():
+                t = self._transforms[tparam]
+                samples = t.transform({param: kwargs[param])
+                kwargs[param] = samples[tparam]
+                # update the jacobian for the transform; if p is the pdf
+                # in the params frame (the one we want) and p' is the pdf
+                # in the transformed frame (the one that's calculated) then:
+                # p' = J^{-1}p -> p = J * p'
+                jacobian *= t.jacobian(samples)
             # for scipy < 0.15.0, gaussian_kde.pdf = gaussian_kde.evaluate
-            this_pdf = self._norm * self._kde.evaluate([kwargs[p]
-                                                        for p in self._params])
+            this_pdf = jacobian * self._kde.evaluate([kwargs[p]
+                                                      for p in self._params])
             if len(this_pdf) == 1:
                 return float(this_pdf)
             else:
@@ -124,22 +130,10 @@ class Arbitrary(_BoundedDist):
         arguments must contain all of parameters in self's params.
         Unrecognized arguments are ignored.
         """
-        for p in self._params:
-            if p not in kwargs.keys():
-                raise ValueError('Missing parameter {} to construct pdf.'
-                                 .format(p))
-        if kwargs in self:
-            # for scipy < 0.15.0,
-            # gaussian_kde.logpdf = numpy.log(gaussian_kde.evaluate)
-            this_logpdf = self._lognorm + \
-                          numpy.log(self._kde.evaluate([kwargs[p]
-                                                     for p in self._params]))
-            if len(this_logpdf) == 1:
-                return float(this_logpdf)
-            else:
-                return this_logpdf
-        else:
+        if kwargs not in self:
             return -numpy.inf
+        else:
+            return numpy.log(self._pdf(**kwargs))
 
     def rvs(self, size=1, param=None):
         """Gives a set of random values drawn from the kde.
@@ -168,16 +162,22 @@ class Arbitrary(_BoundedDist):
         arr = numpy.zeros(size, dtype=dtype)
         start = 0
         remaining = size
+        pidx = enumerate(self.params)
         while remaining:
-            randoms = self._kde.resample(remaining)
-            keep = numpy.array([{param: randoms[ii, jj]
-                               for ii,param in enumerate(self.params)} in self
-                               for jj in xrange(remaining)])
+            draws = self._kde.resample(remaining)
+            draws = {param: draws[ii,...] for ii,param in pidx}
+            # transform back to param space
+            for param, tparam in self._tparams.items():
+                tdraws = {tparam: draws[param]}
+                draws[param] = self._transforms[tparam].inverse_transform(
+                    tdraws)[param]
+            # only keep those that are in bounds
+            keep = self.__contains__(draws)
             keepcnt = int(keep.sum())
             end = start + keepcnt
             remaining -= keepcnt
-            for order, param in enumerate(dtype):
-                arr[param[0]][start:end] = randoms[order, keep]
+            for param in dtype:
+                arr[param[0]][start:end] = draws[param[0]][keep]
             start = end
         return arr
 

--- a/pycbc/distributions/arbitrary.py
+++ b/pycbc/distributions/arbitrary.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 Miriam Cabero Mueller
+# Copyright (C) 2016 Miriam Cabero Mueller, Collin Capano
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
 # Free Software Foundation; either version 3 of the License, or (at your

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -709,10 +709,10 @@ class Logit(BaseTransform):
         x = maps[self._inputvar]
         # check that x is in bounds
         isin = self._bounds.__contains__(x)
-        if isinstance(isin, numpy.ndarray) and not isin.all():
+        if isinstance(isin, numpy.ndarray):
+            isin = isin.all()
+        if not isin:
             raise ValueError("one or more values are not in bounds")
-        elif not isin:
-            raise ValueError("{} is not in bounds".format(x))
         out = {self._outputvar : self.logit(x, self._a, self._b)}
         return self.format_output(maps, out)
 


### PR DESCRIPTION
This moves the guts of `FromFile` to its own distribution called `Arbitrary`. Arbitrary takes an array of samples, so it can be created without a file. FromFile just inherits from Arbitrary now.

This also uses the Logit transform to implement bounds. If bounds are specified, the internal kde is created in the logit coordinates. This means no re-normalization needs to be done, as was done before.

A plot of an Arbitrary created from a Uniform distribution between [-1,1): [here](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/scratch/arbitrary_check-uniform.pdf). Gaussian with same bounds: [here](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/scratch/arbitrary_check-gaussian.pdf).
