### PR TITLE
bugfix in normalization, inside compute_max_snr_over_sky_loc_stat

### DIFF
--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -723,7 +723,7 @@ def compute_max_snr_over_sky_loc_stat(hplus, hcross, hphccorr,
         sqroot[indices] = 0
     sqroot = numpy.sqrt(sqroot)
     det_stat_sq = 0.5 * (hplus_magsq + hcross_magsq - \
-                         2 * rho_pluscross*hphccorr + sqroot)
+                         2 * rho_pluscross*hphccorr + sqroot) / denom
 
     det_stat = numpy.sqrt(det_stat_sq)
 


### PR DESCRIPTION
This fixes a bug in the normalization of an intermediate quantity that is computed while calculating the *sky-maxed* SNR/statistic. Ian says "It looks like this was introduced in some recent reorganization and was *not* present in the version used for the paper: https://github.com/spxiwh/pycbc/blob/VERSION_USED_FOR_PAPER_RUNS/pycbc/filter/matchedfilter.py#L438"