### PR TITLE
Change the frequency cutoff names to satisfy the requirements of reading in asd from file

### DIFF
--- a/bin/hwinj/pycbc_generate_hwinj
+++ b/bin/hwinj/pycbc_generate_hwinj
@@ -180,10 +180,10 @@ parser.add_argument('--geocentric-end-time', type=float, required=True,
                     help='The geocentric GPS end time of the injection.')
 
 # data conditioning options
-parser.add_argument('--psd-low-frequency-cutoff', type=float, required=True,
+parser.add_argument('--low-frequency-cutoff', type=float, required=True,
                     help='Frequency to begin generating the PSD in Hz. This '
                          'is the start frequency of the SNR calculation.')
-parser.add_argument('--psd-high-frequency-cutoff', type=float,
+parser.add_argument('--high-frequency-cutoff', type=float,
                     help='(optional) Upper frequency to terminate the SNR '
                          'calculation. Default will be Nyquist frequency, '
                          'ie. int(sample_rate/2).')
@@ -223,8 +223,8 @@ for ifo in opts.instruments:
 sample_rate = opts.sample_rate[opts.instruments[0]]
 
 # set upper frequency cutoff if not given
-if opts.psd_high_frequency_cutoff:
-    f_high = opts.psd_high_frequency_cutoff
+if opts.high_frequency_cutoff:
+    f_high = opts.high_frequency_cutoff
 else:
     f_high = int(sample_rate / 2)
 
@@ -314,10 +314,10 @@ sngl.spin2x = opts.spin2x
 
 # generate waveform
 logging.info('Generating waveform at %.3fMpc beginning at %.3fHz for '
-             'SNR calculation', sim.distance, opts.psd_low_frequency_cutoff)
+             'SNR calculation', sim.distance, opts.low_frequency_cutoff)
 h_plus, h_cross = get_td_waveform(sim, approximant=name,
                                   phase_order=phase_order,
-                                  f_lower=opts.psd_low_frequency_cutoff,
+                                  f_lower=opts.low_frequency_cutoff,
                                   delta_t=1.0 / sample_rate)
 
 # zero pad polarizations to get integer second time series
@@ -342,7 +342,7 @@ for ifo in opts.instruments:
     stilde_dict[ifo] = strain_dict[ifo].to_frequencyseries()
     length_dict[ifo] = len(stilde_dict[ifo])
     delta_f_dict[ifo] = stilde_dict[ifo].delta_f
-    low_frequency_cutoff_dict[ifo] = opts.psd_low_frequency_cutoff
+    low_frequency_cutoff_dict[ifo] = opts.low_frequency_cutoff
 
 # get PSD
 logging.info('Generating PSDs')
@@ -393,10 +393,10 @@ for ifo in opts.instruments:
     sigma_squared = sigmasq(
                         DYN_RANGE_FAC * strain_tilde,
                         psd=psd_dict[ifo],
-                        low_frequency_cutoff=opts.psd_low_frequency_cutoff,
+                        low_frequency_cutoff=opts.low_frequency_cutoff,
                         high_frequency_cutoff=f_high)
     logging.info('Sigma integrated from %.3f to %.3fHz for %s is %.3f',
-                 opts.psd_low_frequency_cutoff, f_high, ifo,
+                 opts.low_frequency_cutoff, f_high, ifo,
                  numpy.sqrt(sigma_squared))
 
     # populate IFO end time columns
@@ -426,10 +426,10 @@ for ifo in opts.instruments:
 
 # generate waveform
 logging.info('Generating waveform at %.3fMpc beginning at %.3fHz for '
-             'SNR calculation', sim.distance, opts.psd_low_frequency_cutoff)
+             'SNR calculation', sim.distance, opts.low_frequency_cutoff)
 h_plus, h_cross = get_td_waveform(sim, approximant=name,
                                   phase_order=phase_order,
-                                  f_lower=opts.psd_low_frequency_cutoff,
+                                  f_lower=opts.low_frequency_cutoff,
                                   delta_t=1.0 / sample_rate)
 
 # zero pad polarizations to get integer second time series

--- a/docs/hwinj.rst
+++ b/docs/hwinj.rst
@@ -79,9 +79,9 @@ We specify the network SNR we want the coherent injection to have on the command
 
     --network-snr 28
 
-In calculating the network SNR the executable ``pycbc_generate_hwinj`` will generate a PSD and calculate an SNR for the waveform. The options ``--psd-low-frequency-cutoff`` and ``--psd-high-frequency-cutoff`` set the min and max frequency for the SNR calculation. The waveform used in the SNR calculation is also generated at this low-frequency cutoff, note the waveform is not written to disk with this low-frequency cutoff. Example usage of the PSD options is ::
+In calculating the network SNR the executable ``pycbc_generate_hwinj`` will generate a PSD and calculate an SNR for the waveform. The options ``--low-frequency-cutoff`` and ``--high-frequency-cutoff`` set the min and max frequency for the SNR calculation. The waveform used in the SNR calculation is also generated at this low-frequency cutoff, note the waveform is not written to disk with this low-frequency cutoff. Example usage of the PSD options is ::
 
-    --psd-low-frequency-cutoff 40.0 --psd-high-frequency-cutoff 1000.0 --psd-estimation median --psd-segment-length 16 --psd-segment-stride 8 --pad-data 8
+    --low-frequency-cutoff 40.0 --high-frequency-cutoff 1000.0 --psd-estimation median --psd-segment-length 16 --psd-segment-stride 8 --pad-data 8
 
 The additional PSD options dictate how the PSD will be calculated, ie. how many seconds per FFT and how much overlap. The ``--pad-data`` option is how much data to disgard at the edges of our time series used in PSD estimation to avoid data corruption.
 
@@ -89,7 +89,7 @@ The ``--waveform-low-frequency-cutoff`` option is the frequency that ``pycbc_gen
 
 Here is a full example command for generating an injection in only H1 ::
 
-  pycbc_generate_hwinj --psd-high-frequency-cutoff 1000.0 --geocentric-end-time ${GEOCENT_END_TIME} --gps-start-time H1:${GPS_START_TIME} --gps-end-time H1:${GPS_END_TIME} --frame-type H1:${FRAME_TYPE} --channel-name H1:${CHANNEL_NAME} --approximant SEOBNRv2 --order pseudoFourPN --mass1 25.0 --mass2 25.0 --inclination 0.0 --polarization 0.0 --ra 0.0 --dec 0.0 --taper TAPER_START --network-snr 28 --waveform-low-frequency-cutoff 10.0 --psd-low-frequency-cutoff 40.0 --sample-rate 16384 --pad-data 8 --strain-high-pass 30.0 --psd-estimation median --psd-segment-length 16 --psd-segment-stride 8 --instruments H1
+  pycbc_generate_hwinj --high-frequency-cutoff 1000.0 --geocentric-end-time ${GEOCENT_END_TIME} --gps-start-time H1:${GPS_START_TIME} --gps-end-time H1:${GPS_END_TIME} --frame-type H1:${FRAME_TYPE} --channel-name H1:${CHANNEL_NAME} --approximant SEOBNRv2 --order pseudoFourPN --mass1 25.0 --mass2 25.0 --inclination 0.0 --polarization 0.0 --ra 0.0 --dec 0.0 --taper TAPER_START --network-snr 28 --waveform-low-frequency-cutoff 10.0 --low-frequency-cutoff 40.0 --sample-rate 16384 --pad-data 8 --strain-high-pass 30.0 --psd-estimation median --psd-segment-length 16 --psd-segment-stride 8 --instruments H1
 
 This will generate a single-column ASCII files that contains the h(t) time series for each detector and a LIGOLW XML file with the waveform parameters. The output filenames are not specified on the command line, they are determined internally by ``pycbc_generate_hwinj``. In this example the ASCII file with the waveform will be named ``L1-HWINJ_CBC-${START}-${DURATION}.txt`` where ``${START}`` is the start time stamp of the time series and ``${DURATION}`` is the length in seconds of the ASCII waveform file. The LIGOLW XML file will be named ``H1L1-HWINJ_CBC-${START}-${DURATION}.xml.gz``.
 
@@ -177,7 +177,9 @@ Plot ASCII waveform files with ``pycbc_plot_hwinj``
 
 You can plot the ASCII waveform files with an X11 connection. It's strongly recommended to use the X11 connection instead of saving a static image of the entire waveform. The X11 connection allows the user to zoom in and inspect the waveform more closely. A basic inspection would include checking the amplitude, the tapering, and the ringdown  of the waveforms are reasonable. For the ``pycbc_generate_hwinj`` example above one would do ::
 
-  pycbc_plot_hwinj L1-HWINJ_CBC-${START}-${DURATION}.txt
+  pycbc_plot_hwinj --input-file L1-HWINJ_CBC-${START}-${DURATION}.txt --output-file ${OUTPUT_PATH}
+
+where ``${OUTPUT_PATH}`` is the path to the output plot.
 
 If you are using ``ssh`` or ``gsissh`` to log into a cluster, you can provide the ``-Y`` option to open an X11 connection. For example ::
 

--- a/examples/cal/foton_filter_esd_saturation/README.rst
+++ b/examples/cal/foton_filter_esd_saturation/README.rst
@@ -74,7 +74,7 @@ Generate a CBC waveform
 
 Now we generate a CBC waveform using the hardware injection executable ::
 
-  pycbc_generate_hwinj --instruments ${IFO} --waveform-low-frequency-cutoff 30 --geocentric-end-time ${GEOCENT_END_TIME} --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --frame-type ${IFO}:${FRAME_TYPE} --channel-name ${IFO}:${CHANNEL_NAME} --approximant SEOBNRv2 --order pseudoFourPN --mass1 26.6637001 --mass2 23.2229004 --inclination 1.04719755 --polarization 0.0 --ra 0.0 --dec 0.0 --taper TAPER_START --network-snr 18.424 --spin1z -0.963 --spin2z  -0.988 --psd-low-frequency-cutoff 40.0 --sample-rate ${IFO}:${SAMPLE_RATE} --pad-data 8 --strain-high-pass 30.0 --psd-estimation median --psd-segment-length 16 --psd-segment-stride 8
+  pycbc_generate_hwinj --instruments ${IFO} --waveform-low-frequency-cutoff 30 --geocentric-end-time ${GEOCENT_END_TIME} --gps-start-time ${GPS_START_TIME} --gps-end-time ${GPS_END_TIME} --frame-type ${IFO}:${FRAME_TYPE} --channel-name ${IFO}:${CHANNEL_NAME} --approximant SEOBNRv2 --order pseudoFourPN --mass1 26.6637001 --mass2 23.2229004 --inclination 1.04719755 --polarization 0.0 --ra 0.0 --dec 0.0 --taper TAPER_START --network-snr 18.424 --spin1z -0.963 --spin2z  -0.988 --low-frequency-cutoff 40.0 --sample-rate ${IFO}:${SAMPLE_RATE} --pad-data 8 --strain-high-pass 30.0 --psd-estimation median --psd-segment-length 16 --psd-segment-stride 8
   
 There are a number of command line options you can change. See the hardware injection documentation for more details.
 


### PR DESCRIPTION
If the argument `--fake-strain-from-file` is used in `pycbc_generate_hwinj`, https://github.com/ligo-cbc/pycbc/blob/master/bin/hwinj/pycbc_generate_hwinj#L332 to https://github.com/ligo-cbc/pycbc/blob/master/pycbc/strain.py#L316 requires an input argument named `--low-frequency-cutoff`. That is equivalent to the current `--psd-low-frequency-cutoff` in the code. The code fails for this case if `low-frequency-cutoff` is not provided. So this PR changes `--psd-low-frequency-cutoff` --> `--low-frequency-cutoff`. Also `--psd-high-frequency-cutoff` --> `--high-frequency-cutoff` to keep the names similar.

@cmbiwer Could you please take a look?