### PR TITLE
Allow FieldArray access to snr_from_loglr

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -579,6 +579,39 @@ def _det_tc(detector_name, ra, dec, tc, ref_frame='geocentric'):
 
 det_tc = numpy.vectorize(_det_tc)
 
+#
+# =============================================================================
+#
+#                         Likelihood statistic parameter functions
+#
+# =============================================================================
+#
+def snr_from_loglr(loglr):
+    """Returns SNR computed from the given log likelihood ratio(s). This is
+    defined as `sqrt(2*loglr)`.If the log likelihood ratio is < 0, returns 0.
+
+    Parameters
+    ----------
+    loglr : array or float
+        The log likelihood ratio(s) to evaluate.
+
+    Returns
+    -------
+    array or float
+        The SNRs computed from the log likelihood ratios.
+    """
+    singleval = isinstance(loglr, float)
+    if singleval:
+        loglr = numpy.array([loglr])
+    # temporarily quiet sqrt(-1) warnings
+    numpysettings = numpy.seterr(invalid='ignore')
+    snrs = numpy.sqrt(2*loglr)
+    numpy.seterr(**numpysettings)
+    snrs[numpy.isnan(snrs)] = 0.
+    if singleval:
+        snrs = snrs[0]
+    return snrs
+
 
 __all__ = ['primary_mass', 'secondary_mass', 'mtotal_from_mass1_mass2',
            'q_from_mass1_mass2', 'invq_from_mass1_mass2',
@@ -605,5 +638,5 @@ __all__ = ['primary_mass', 'secondary_mass', 'mtotal_from_mass1_mass2',
            'spin1x_from_xi1_phi_a_phi_s', 'spin1y_from_xi1_phi_a_phi_s',
            'spin2x_from_mass1_mass2_xi2_phi_a_phi_s',
            'spin2y_from_mass1_mass2_xi2_phi_a_phi_s',
-           'chirp_distance', 'det_tc'
+           'chirp_distance', 'det_tc', 'snr_from_loglr',
           ]

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -26,6 +26,7 @@ This modules provides classes and functions for evaluating the log likelihood
 for parameter estimation.
 """
 
+from pycbc import conversions
 from pycbc import filter
 import pycbc.transforms
 from pycbc.waveform import NoWaveformError
@@ -48,32 +49,6 @@ class _NoPrior(object):
 
     def __call__(self, **params):
         return 0.
-
-def snr_from_loglr(loglr):
-    """Returns SNR computed from the given log likelihood ratio(s). This is
-    defined as `sqrt(2*loglr)`.If the log likelihood ratio is < 0, returns 0.
-
-    Parameters
-    ----------
-    loglr : array or float
-        The log likelihood ratio(s) to evaluate.
-
-    Returns
-    -------
-    array or float
-        The SNRs computed from the log likelihood ratios.
-    """
-    singleval = isinstance(loglr, float)
-    if singleval:
-        loglr = numpy.array([loglr])
-    # temporarily quiet sqrt(-1) warnings
-    numpysettings = numpy.seterr(invalid='ignore')
-    snrs = numpy.sqrt(2*loglr)
-    numpy.seterr(**numpysettings)
-    snrs[numpy.isnan(snrs)] = 0.
-    if singleval:
-        snrs = snrs[0]
-    return snrs
 
 class _BaseLikelihoodEvaluator(object):
     r"""Base container class for generating waveforms, storing the data, and
@@ -464,7 +439,7 @@ class _BaseLikelihoodEvaluator(object):
         """Returns the "SNR" of the given params. This will return
         imaginary values if the log likelihood ratio is < 0.
         """
-        return snr_from_loglr(self.loglr(**params))
+        return conversions.snr_from_loglr(self.loglr(**params))
 
     _callfunc = logposterior
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -19,6 +19,7 @@
 
 import logging
 import numpy
+from pycbc import conversions
 from pycbc import transforms
 from pycbc.io import InferenceFile
 from pycbc.workflow import WorkflowConfigParser
@@ -538,7 +539,7 @@ def get_zvalues(fp, arg, likelihood_stats):
         zvals = likelihood_stats.loglr
         zlbl = r'$\log\mathcal{L}(\vec{\vartheta})$'
     elif arg == 'snr':
-        zvals = likelihood.snr_from_loglr(likelihood_stats.loglr)
+        zvals = conversions.snr_from_loglr(likelihood_stats.loglr)
         zlbl = r'$\rho(\vec{\vartheta})$'
     elif arg == 'logplr':
         zvals = likelihood_stats.loglr + likelihood_stats.prior


### PR DESCRIPTION
As title says.

Inference executables can then plot Network SNR with ``--parameters-group likelihood_stats --parameters "snr_from_loglr(loglr):Network SNR"``.