### PR TITLE
pycbc_live: check state & DQ of followup detectors

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -365,7 +365,8 @@ with ctx:
                             force_update_cache=args.force_update_cache,
                             increment_update_cache=args.increment_update_cache[ifo],
                             analyze_flags=args.analyze_flags,
-                            data_quality_flags=args.data_quality_flags)
+                            data_quality_flags=args.data_quality_flags,
+                            dq_padding=args.data_quality_padding)
     if args.enable_background_estimation and evnt.rank == 0:
         estimator = LiveCoincTimeslideBackgroundEstimator.from_cli(args,
                             len(bank), args.analysis_chunk, ifos)
@@ -429,8 +430,9 @@ with ctx:
                     start = data_reader[ifo].start_time
                     end = data_reader[ifo].end_time
                     times = results[ifo]['end_time']
-                    idx = data_reader[ifo].dq.indices_of_flag(start, valid_pad, times,
-                                                              padding=args.data_quality_padding)
+                    idx = data_reader[ifo].dq.indices_of_flag(
+                            start, valid_pad, times,
+                            padding=data_reader[ifo].dq.padding)
                     logging.info('Keeping %s triggers out of %s triggers in %s', len(idx), len(times), ifo)
                     for key in results[ifo]:
                         if len(results[ifo][key]) > 0:

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -432,7 +432,7 @@ with ctx:
                     times = results[ifo]['end_time']
                     idx = data_reader[ifo].dq.indices_of_flag(
                             start, valid_pad, times,
-                            padding=data_reader[ifo].dq.padding)
+                            padding=data_reader[ifo].dq_padding)
                     logging.info('Keeping %s triggers out of %s triggers in %s', len(idx), len(times), ifo)
                     for key in results[ifo]:
                         if len(results[ifo][key]) > 0:

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1552,7 +1552,7 @@ def compute_followup_snr_series(data_reader, htilde, trig_time,
         dq_duration = state_duration + 2 * data_reader.dq.padding
         if data_reader.dq is not None \
                 and not data_reader.dq.is_extent_valid(
-                        dq_start_time, dq_duration)):
+                        dq_start_time, dq_duration):
             return None, None
 
     stilde = data_reader.overwhitened_data(htilde.delta_f)

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1498,7 +1498,7 @@ class LiveBatchMatchedFilter(object):
         return result, veto_info
 
 def compute_followup_snr_series(data_reader, htilde, trig_time,
-                                duration=0.095):
+                                duration=0.095, check_state=True):
     """Given a StrainBuffer, a template frequency series and a trigger time,
     compute a portion of the SNR time series centered on the trigger for its
     rapid sky localization and followup.
@@ -1523,14 +1523,38 @@ def compute_followup_snr_series(data_reader, htilde, trig_time,
         Duration of the computed SNR series in seconds. If omitted, it defaults
         to twice the Earth light travel time plus 10 ms of timing uncertainty.
 
+    check_state : boolean
+        If True, and the detector was offline or flagged for bad data quality
+        at any point during the inspiral, then return (None, None) instead.
+
     Returns
     -------
     snr : TimeSeries
-        The portion of SNR around the trigger.
+        The portion of SNR around the trigger. None if the detector is offline
+        or has bad data quality, and check_state is True.
 
     psd : FrequencySeries
-        The noise PSD corresponding to the trigger time.
+        The noise PSD corresponding to the trigger time. None if the detector
+        is offline or has bad data quality, and check_state is True.
     """
+    if check_state:
+        # was the detector observing for the full amount of involved data?
+        state_start_time = trig_time - duration / 2 - htilde.duration
+        state_end_time = trig_time + duration / 2
+        state_duration = state_end_time - state_start_time
+        if data_reader.state is not None \
+                and not data_reader.state.is_extent_valid(
+                        state_start_time, state_duration):
+            return None, None
+
+        # was the data quality ok for the full amount of involved data?
+        dq_start_time = state_start_time - data_reader.dq.padding
+        dq_duration = state_duration + 2 * data_reader.dq.padding
+        if data_reader.dq is not None \
+                and not data_reader.dq.is_extent_valid(
+                        dq_start_time, dq_duration)):
+            return None, None
+
     stilde = data_reader.overwhitened_data(htilde.delta_f)
 
     norm = 4.0 * htilde.delta_f * htilde.sigmasq(stilde.psd) ** (-0.5)

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1548,8 +1548,8 @@ def compute_followup_snr_series(data_reader, htilde, trig_time,
             return None, None
 
         # was the data quality ok for the full amount of involved data?
-        dq_start_time = state_start_time - data_reader.dq.padding
-        dq_duration = state_duration + 2 * data_reader.dq.padding
+        dq_start_time = state_start_time - data_reader.dq_padding
+        dq_duration = state_duration + 2 * data_reader.dq_padding
         if data_reader.dq is not None \
                 and not data_reader.dq.is_extent_valid(
                         dq_start_time, dq_duration):

--- a/pycbc/filter/matchedfilter.py
+++ b/pycbc/filter/matchedfilter.py
@@ -1539,7 +1539,7 @@ def compute_followup_snr_series(data_reader, htilde, trig_time,
     """
     if check_state:
         # was the detector observing for the full amount of involved data?
-        state_start_time = trig_time - duration / 2 - htilde.duration
+        state_start_time = trig_time - duration / 2 - htilde.length_in_time
         state_end_time = trig_time + duration / 2
         state_duration = state_end_time - state_start_time
         if data_reader.state is not None \

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -631,7 +631,8 @@ class StatusBuffer(DataBuffer):
                        max_buffer=2048,
                        valid_mask=3,
                        force_update_cache=False,
-                       increment_update_cache=None):
+                       increment_update_cache=None,
+                       padding=0):
         """ Create a rolling buffer of status data from a frame
 
         Parameters
@@ -654,6 +655,8 @@ class StatusBuffer(DataBuffer):
                             increment_update_cache=increment_update_cache,
                             dtype=numpy.int32)
         self.valid_mask = valid_mask
+        # NOTE padding is only saved, not actually enforced in the methods
+        self.padding = padding
 
     def check_valid(self, values, flag=None):
         """Check if the data contains any non-valid status information

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -631,8 +631,7 @@ class StatusBuffer(DataBuffer):
                        max_buffer=2048,
                        valid_mask=3,
                        force_update_cache=False,
-                       increment_update_cache=None,
-                       padding=0):
+                       increment_update_cache=None):
         """ Create a rolling buffer of status data from a frame
 
         Parameters
@@ -655,8 +654,6 @@ class StatusBuffer(DataBuffer):
                             increment_update_cache=increment_update_cache,
                             dtype=numpy.int32)
         self.valid_mask = valid_mask
-        # NOTE padding is only saved, not actually enforced in the methods
-        self.padding = padding
 
     def check_valid(self, values, flag=None):
         """Check if the data contains any non-valid status information

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -79,7 +79,7 @@ class SingleCoincForGraceDB(object):
             in the hdf file for this time.
         """
         self.ifos = ifos
-        self.followup_ifos = kwargs.get('followup_ifos') or []
+        followup_ifos = kwargs.get('followup_ifos') or []
         self.template_id = coinc_results['foreground/%s/template_id' % self.ifos[0]]
 
         # remember if this should be marked as HWINJ
@@ -129,7 +129,7 @@ class SingleCoincForGraceDB(object):
             self.snr_series = {}
             self.snr_series_psd = {}
             htilde = kwargs['bank'][self.template_id]
-            for ifo in self.ifos + self.followup_ifos:
+            for ifo in ifos + followup_ifos:
                 if ifo in ifos:
                     trig_time = coinc_results['foreground/%s/end_time' % ifo]
                 else:
@@ -139,7 +139,7 @@ class SingleCoincForGraceDB(object):
                 # produce valid SNR series.
                 snr_series, snr_series_psd = compute_followup_snr_series(
                         kwargs['data_readers'][ifo], htilde, trig_time,
-                        check_state=(ifo in self.followup_ifos))
+                        check_state=(ifo in followup_ifos))
                 if snr_series is not None:
                     self.snr_series[ifo] = snr_series
                     self.snr_series_psd[ifo] = snr_series_psd
@@ -149,7 +149,7 @@ class SingleCoincForGraceDB(object):
         coinc_event_map_table = lsctables.New(lsctables.CoincMapTable)
 
         sngl_populated = None
-        for sngl_id, ifo in enumerate(ifos + self.followup_ifos):
+        for sngl_id, ifo in enumerate(ifos + followup_ifos):
             if self.upload_snr_series and ifo not in self.snr_series:
                 # SNR series could not be computed, so skip this
                 continue
@@ -193,7 +193,7 @@ class SingleCoincForGraceDB(object):
         bayestar_check_fields = ('mass1 mass2 mtotal mchirp eta spin1x '
                                  'spin1y spin1z spin2x spin2y spin2z').split()
         for sngl in sngl_inspiral_table:
-            if sngl.ifo in self.followup_ifos:
+            if sngl.ifo in followup_ifos:
                 for bcf in bayestar_check_fields:
                     setattr(sngl, bcf, getattr(sngl_populated, bcf))
                 sngl.set_end(lal.LIGOTimeGPS(subthreshold_sngl_time))

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -79,10 +79,7 @@ class SingleCoincForGraceDB(object):
             in the hdf file for this time.
         """
         self.ifos = ifos
-        if 'followup_ifos' in kwargs and kwargs['followup_ifos'] is not None:
-            self.followup_ifos = kwargs['followup_ifos']
-        else:
-            self.followup_ifos = []
+        self.followup_ifos = kwargs.get('followup_ifos') or []
         self.template_id = coinc_results['foreground/%s/template_id' % self.ifos[0]]
 
         # remember if this should be marked as HWINJ
@@ -123,16 +120,42 @@ class SingleCoincForGraceDB(object):
         coinc_event_table.append(coinc_event_row)
         outdoc.childNodes[0].appendChild(coinc_event_table)
 
+        # compute SNR time series
+        subthreshold_sngl_time = numpy.mean(
+                [coinc_results['foreground/%s/end_time' % ifo]
+                 for ifo in ifos])
+        self.upload_snr_series = kwargs.get('upload_snr_series')
+        if self.upload_snr_series:
+            self.snr_series = {}
+            self.snr_series_psd = {}
+            htilde = kwargs['bank'][self.template_id]
+            for ifo in self.ifos + self.followup_ifos:
+                if ifo in ifos:
+                    trig_time = coinc_results['foreground/%s/end_time' % ifo]
+                else:
+                    trig_time = subthreshold_sngl_time
+                # NOTE we only check the state/DQ of followup IFOs here.
+                # IFOs producing the coincidence are assumed to also
+                # produce valid SNR series.
+                snr_series, snr_series_psd = compute_followup_snr_series(
+                        kwargs['data_readers'][ifo], htilde, trig_time,
+                        check_state=(ifo in self.followup_ifos))
+                if snr_series is not None:
+                    self.snr_series[ifo] = snr_series
+                    self.snr_series_psd[ifo] = snr_series_psd
+
         # Set up sngls
         sngl_inspiral_table = lsctables.New(lsctables.SnglInspiralTable)
         coinc_event_map_table = lsctables.New(lsctables.CoincMapTable)
 
-        sngl_event_id_map = {}
         sngl_populated = None
         for sngl_id, ifo in enumerate(ifos + self.followup_ifos):
+            if self.upload_snr_series and ifo not in self.snr_series:
+                # SNR series could not be computed, so skip this
+                continue
+
             sngl = return_empty_sngl(nones=True)
             sngl.event_id = lsctables.SnglInspiralID(sngl_id)
-            sngl_event_id_map[ifo] = sngl.event_id
             sngl.process_id = proc_id
             sngl.ifo = ifo
             names = [n.split('/')[-1] for n in coinc_results
@@ -163,12 +186,12 @@ class SingleCoincForGraceDB(object):
             coinc_map_row.event_id = sngl.event_id
             coinc_event_map_table.append(coinc_map_row)
 
+            if self.upload_snr_series and ifo in self.snr_series:
+                snr_series_to_xml(self.snr_series[ifo], outdoc, sngl.event_id)
+
         # for subthreshold detectors, respect BAYESTAR's assumptions and checks
         bayestar_check_fields = ('mass1 mass2 mtotal mchirp eta spin1x '
                                  'spin1y spin1z spin2x spin2y spin2z').split()
-        subthreshold_sngl_time = numpy.mean(
-                [coinc_results['foreground/%s/end_time' % ifo]
-                 for ifo in ifos])
         for sngl in sngl_inspiral_table:
             if sngl.ifo in self.followup_ifos:
                 for bcf in bayestar_check_fields:
@@ -197,24 +220,6 @@ class SingleCoincForGraceDB(object):
         outdoc.childNodes[0].appendChild(coinc_inspiral_table)
         self.outdoc = outdoc
         self.time = sngl_populated.get_end()
-
-        # compute SNR time series
-        self.upload_snr_series = kwargs['upload_snr_series']
-        if self.upload_snr_series:
-            htilde = kwargs['bank'][self.template_id]
-            self.snr_series = {}
-            self.snr_series_psd = {}
-            for ifo in self.ifos + self.followup_ifos:
-                if ifo in ifos:
-                    trig_time = coinc_results['foreground/%s/end_time' % ifo]
-                else:
-                    trig_time = subthreshold_sngl_time
-                self.snr_series[ifo], self.snr_series_psd[ifo] = \
-                        compute_followup_snr_series(
-                                kwargs['data_readers'][ifo], htilde,
-                                trig_time)
-                snr_series_to_xml(self.snr_series[ifo], outdoc,
-                                  sngl_event_id_map[ifo])
 
     def save(self, filename):
         """Write this trigger to gracedb compatible xml format
@@ -286,7 +291,7 @@ class SingleCoincForGraceDB(object):
 
         if self.upload_snr_series:
             snr_series_fname = fname + '.hdf'
-            for ifo in self.ifos + self.followup_ifos:
+            for ifo in self.snr_series:
                 self.snr_series[ifo].save(snr_series_fname,
                                           group='%s/snr' % ifo)
                 self.snr_series_psd[ifo].save(snr_series_fname,

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -1202,6 +1202,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         self.data_quality_flags = data_quality_flags
         self.state = None
         self.dq = None
+        self.dq_padding = dq_padding
 
         # State channel
         if state_channel is not None:
@@ -1228,7 +1229,6 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                 valid_mask=valid_mask,
                 force_update_cache=force_update_cache,
                 increment_update_cache=increment_update_cache)
-            self.dq_padding = dq_padding
 
         self.highpass_frequency = highpass_frequency
         self.highpass_reduction = highpass_reduction

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -1120,7 +1120,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                  increment_update_cache=None,
                  analyze_flags=None,
                  data_quality_flags=None,
-                 ):
+                 dq_padding=0):
         """ Class to produce overwhitened strain incrementally
         
         Parameters
@@ -1182,6 +1182,8 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             *any* use.
         data_quality_flags: list of strs
             The flags used to determine if to keep triggers.
+        dq_padding: {float, 0}, optional
+            Extra seconds to consider invalid before/after times with bad DQ.
         increment_update_cache: {str, None}, Optional
             Pattern to look for frame files in a GPS dependent directory. This
             is an alternate to the forced updated of the frame cache, and
@@ -1225,7 +1227,8 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                 max_buffer=max_buffer,
                 valid_mask=valid_mask,
                 force_update_cache=force_update_cache,
-                increment_update_cache=increment_update_cache)
+                increment_update_cache=increment_update_cache,
+                padding=dq_padding)
 
         self.highpass_frequency = highpass_frequency
         self.highpass_reduction = highpass_reduction

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -1227,8 +1227,8 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                 max_buffer=max_buffer,
                 valid_mask=valid_mask,
                 force_update_cache=force_update_cache,
-                increment_update_cache=increment_update_cache,
-                padding=dq_padding)
+                increment_update_cache=increment_update_cache)
+            self.dq_padding = dq_padding
 
         self.highpass_frequency = highpass_frequency
         self.highpass_reduction = highpass_reduction


### PR DESCRIPTION
Adds a check for the state and DQ of followup detectors when calculating the SNR timeseries for PyCBC Live. Needs testing, but I am opening for consideration. In particular I want to make two notes:

* A followup detector is ignored if it was offline or had DQ issues at any point during the duration of the template, with some padding and taking into account the duration of the SNR timeseries. Maybe this is too strict though. I.e. if DQ issues affect just a few samples at the beginning or end of the SNR series, there may still be value in sending the timeseries to BAYESTAR. Sounds like some risk/benefit tradeoff needs to be discussed. For the moment it might be ok to be overly conservative, and maybe revisit the decision once Virgo proves to be super valuable for sky localization.
* Detectors which made the coincidence (i.e. not followup detectors) are assumed to have valid data for the whole SNR timeseries and are *not* checked. In principle they can be checked as well, but I am not sure what to do if the check fails! In that case we claim to have a coincidence, but we refuse to report the SNR timeseries around it, which sounds strange.

Thoughts?