### PR TITLE
Catch nans from transform

### DIFF
--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -327,6 +327,8 @@ class _BaseLikelihoodEvaluator(object):
         """
         logj = self.logjacobian(**params)
         logp = self._prior(**params) + logj
+        if numpy.isnan(logp):
+            logp = -numpy.inf
         return self._formatreturn(logp, prior=logp, logjacobian=logj)
 
     def prior_rvs(self, size=1, prior=None):


### PR DESCRIPTION
When using a transform to sample in different coordinates than the parameters, the sampler can wander in to unphysical regions, giving a nan. For example, if sampling in mchirp, q with a prior defined in mass1, mass2, the sampler may go to negative q. The inverse transform then returns nans for mass1 and mass2, which in turn causes the uniform prior to return a nan. This catches that by setting the prior to -inf if the returned value is nan.