### PR TITLE
Temporary fix for Travis build

### DIFF
--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -157,7 +157,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_virtualenv" ] ; then
 
   echo -e "\\n>> [`date`] Installing PyCBC and dependencies"
   cd /pycbc
-  pip install Mako
+  pip install Mako olefile
   python setup.py install
 
   echo -e "\\n>> [`date`] Installing PyCBC PyLAL"

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -157,6 +157,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_virtualenv" ] ; then
 
   echo -e "\\n>> [`date`] Installing PyCBC and dependencies"
   cd /pycbc
+  pip install Mako
   python setup.py install
 
   echo -e "\\n>> [`date`] Installing PyCBC PyLAL"


### PR DESCRIPTION
It looks like Travis has changed their code and the ``build_and_test`` target disappeared between the build https://travis-ci.org/ligo-cbc/pycbc/builds/237446645 and the build https://travis-ci.org/ligo-cbc/pycbc/builds/237633407

There is now also an error in the virtualenv container as Mako fails to install as part of the PyCBC install.  This is a workaround for the Mako problem by just installing Mako with pip prior to doing the ``python setup.py install`` on PyCBC.

I need to figure out what has gone wrong in Travis, but that will need to  wait until I get back to Syracuse next week.