### PR TITLE
Triggered coherent segment generation upgrade

### DIFF
--- a/bin/pygrb/pycbc_make_offline_grb_workflow
+++ b/bin/pygrb/pycbc_make_offline_grb_workflow
@@ -95,7 +95,7 @@ single_ifo = wflow.cp.has_option("workflow", "allow-single-ifo-search")
 if len(sciSegs.keys()) == 0:
     plot_met = make_grb_segments_plot(wflow, segmentlistdict(), triggertime,
             triggername, segDir)
-    logging.error("No science segments available.")
+    logging.warning("No science segments available.")
     sys.exit()
 elif len(sciSegs.keys()) < 2 and not single_ifo:
     plot_met = make_grb_segments_plot(wflow, segmentlistdict(sciSegs),
@@ -104,20 +104,19 @@ elif len(sciSegs.keys()) < 2 and not single_ifo:
     msg += "If you wish to enable single IFO running add the option "
     msg += "'allow-single-ifo-search' to the [workflow] section of your "
     msg += "configuration file." 
-    logging.error(msg)
+    logging.warning(msg)
     sys.exit()
-elif len(sciSegs.keys()) < 2:
-    logging.info("Generating a single IFO search.")
-    onSrc, offSrc = _workflow.get_triggered_single_ifo_segment(wflow, segDir,
-                                                               sciSegs)
 else:
-    onSrc, offSrc = _workflow.get_triggered_coherent_segment(wflow, segDir,
-            sciSegs, single_ifo)
+    if len(sciSegs.keys()) < 2:
+        logging.info("Generating a single IFO search.")
+    onSrc, offSrc = _workflow.generate_triggered_segment(wflow, segDir,
+                                                         sciSegs)
 
 sciSegs = segmentlistdict(sciSegs)
 if onSrc is None:
     plot_met = make_grb_segments_plot(wflow, sciSegs, triggertime, triggername,
             segDir, fail_criterion=offSrc)
+    logging.info("Making segment plot and exiting.")
     sys.exit()
 else:
     plot_met = make_grb_segments_plot(wflow, sciSegs, triggertime, triggername,

--- a/pycbc/results/legacy_grb.py
+++ b/pycbc/results/legacy_grb.py
@@ -678,7 +678,6 @@ def make_grb_segments_plot(wkflow, science_segs, trigger_time, trigger_name,
     # Make plot
     fig, subs = plt.subplots(len(ifos), sharey=True)
     plt.xticks(rotation=20, ha='right')
-    plt.subplots_adjust(bottom=0.15)
     for sub, ifo in zip(subs, ifos):
         for seg in science_segs[ifo]:
             sub.add_patch(Rectangle((seg[0], 0.1), abs(seg), 0.8,
@@ -713,23 +712,25 @@ def make_grb_segments_plot(wkflow, science_segs, trigger_time, trigger_name,
         sub.set_frame_on(False)
         sub.set_yticks([])
         sub.set_ylabel(ifo, rotation=45)
+        sub.set_ylim([0, 1])
         sub.set_xlim([float(extent[0]), float(extent[1])])
         sub.get_xaxis().get_major_formatter().set_useOffset(False)
         sub.get_xaxis().get_major_formatter().set_scientific(False)
         sub.get_xaxis().tick_bottom()
-        if not sub is subs[-1]:
+        if sub is subs[-1]:
+            sub.tick_params(labelsize=10, pad=1)
+        else:
             sub.get_xaxis().set_ticks([])
             sub.get_xaxis().set_ticklabels([])
-        else:
-            sub.tick_params(labelsize=10, pad=1)
 
     xmin, xmax = fig.axes[-1].get_xaxis().get_view_interval()
     ymin, ymax = fig.axes[-1].get_yaxis().get_view_interval()
-    fig.axes[-1].add_artist(Line2D((xmin, xmax), (ymin, ymax), color='black',
-                                linewidth=2))
+    fig.axes[-1].add_artist(Line2D((xmin, xmax), (ymin, ymin), color='black',
+                                   linewidth=2))
     fig.axes[-1].set_xlabel('GPS Time')
 
     fig.axes[0].set_title('Science Segments for GRB%s' % trigger_name)
+    plt.tight_layout()
     fig.subplots_adjust(hspace=0)
     
     plot_name = 'GRB%s_segments.png' % trigger_name


### PR DESCRIPTION
Hi all,

This change is designed to let PyGRB handle arbitrarily many IFOs, letting the code decide on the best combination of available IFOs for the analysis. Currently this is done only based upon coherent science segment duration.

Examples can be seen in the plots [here](https://ldas-jobs.ligo.caltech.edu/~andrew.williamson/pygrb/review/three_detector_upgrade/).

One specific example is the edge case where there is science data in all three IFOs but not enough coherently across all three, and so the best 2 detector case must be selected. See the result [here](https://ldas-jobs.ligo.caltech.edu/~andrew.williamson/pygrb/review/three_detector_upgrade/H1_OK-L1_OK_trimmed-V1_OK_trimmed-969641000.png) and PyGRB's logging output for this example [here](https://ldas-jobs.ligo.caltech.edu/~andrew.williamson/pygrb/review/three_detector_upgrade/example_output.out).

Let me know if you have any comments.

Thanks,
Andrew