### PR TITLE
Ensure strain is double precision

### DIFF
--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -266,7 +266,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             strain = (strain * dyn_range_fac).astype(pycbc.types.float32)
         elif precision == "double":
             logging.info("Converting to float64")
-            strain = strain.astype(pycbc.types.float64)
+            strain = (strain * dyn_range_fac).astype(pycbc.types.float64)
         else:
             raise ValueError("unrecognized precision {}".format(precision))
 

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -264,6 +264,11 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         if precision == 'single':
             logging.info("Converting to float32")
             strain = (strain * dyn_range_fac).astype(pycbc.types.float32)
+        elif precision == "double":
+            logging.info("Converting to float64")
+            strain = strain.astype(pycbc.types.float64)
+        else:
+            raise ValueError("unrecognized precision {}".format(precision))
 
         if opt.gating_file is not None:
             logging.info("Gating glitches")


### PR DESCRIPTION
This forces the strain retrieved by `from_cli` to be double precision if the precision argument is set to double. Also checks that the precision argument is either 'single' or 'double', raising an error otherwise.