### PR TITLE
Fix function name error in det tc

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -572,7 +572,7 @@ def _det_tc(detector_name, ra, dec, tc, ref_frame='geocentric'):
         return tc
     detector = Detector(detector_name)
     if ref_frame == 'geocentric':
-        return tc + detector.time_delay_from_center(ra, dec, tc)
+        return tc + detector.time_delay_from_earth_center(ra, dec, tc)
     else:
         other = Detector(ref_frame)
         return tc + detector.time_delay_from_detector(other, ra, dec, tc)


### PR DESCRIPTION
The `det_tc` function in `conversions.py` tries to call `time_delay_from_center`; it should be `time_delay_from_earth_center`.