### PR TITLE
Cast to integer

### DIFF
--- a/bin/bank/pycbc_geom_nonspinbank
+++ b/bin/bank/pycbc_geom_nonspinbank
@@ -355,7 +355,7 @@ for iter, (v1, v2) in enumerate(zip(v1s, v2s)):
         continue
     iters = points[:,0]
     bestXis = points[dist.argmin(),1:]
-    bestMasses = physMasses[points[dist.argmin(),0]]
+    bestMasses = physMasses[int(points[dist.argmin(),0] + 0.5)]
     
     # Reject point if it is too far from physical space
     masses = tmpltbank.get_physical_covaried_masses([v1,v2],\


### PR DESCRIPTION
Numpy now requires integer indexes. We had been abusing float-but-actually-integer (ie. 7.0) values here. A better fix would be to not use floats at all here, but this allows the code to run with current numpy.