### PR TITLE
Store individual detectors' log LR

### DIFF
--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -327,7 +327,9 @@ class BaseMCMCSampler(_BaseSampler):
         stats were returned to the sampler by the likelihood evaluator, returns
         None.
         """
-        stats = numpy.array(self._sampler.blobs)
+        getordered = lambda x: [x[field]
+            for field in self.likelihood_evaluator.metadata_fields]
+        stats = numpy.array(map(getordered, self._sampler.blobs))
         if stats.size == 0:
             return None
         # we'll force arrays to float; this way, if there are `None`s in the

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -327,17 +327,21 @@ class BaseMCMCSampler(_BaseSampler):
         stats were returned to the sampler by the likelihood evaluator, returns
         None.
         """
-        getordered = lambda x: [x[field]
-            for field in self.likelihood_evaluator.metadata_fields]
-        stats = numpy.array(map(getordered, self._sampler.blobs))
+        stats = numpy.array(self._sampler.blobs)
         if stats.size == 0:
             return None
-        # we'll force arrays to float; this way, if there are `None`s in the
-        # blobs, they will be changed to `nan`s
-        arrays = {field: stats[..., fi].astype(float)
+        # since the blobs are dictionarys, the dtype is object. Convert each
+        # dictionary into an array of values, in order of the metadata fields.
+        # we'll also force arrays to float; this way, if there are `None`s in
+        # the blobs, they will be changed to `nan`s
+        getordered = lambda x: [x[field]
+            for field in self.likelihood_evaluator.metadata_fields]
+        stats = numpy.array([map(getordered, stats[...,ii])
+                             for ii in range(stats.shape[-1])]).astype(float)
+        arrays = {field: stats[..., fi]
                   for fi, field in
                   enumerate(self.likelihood_evaluator.metadata_fields)}
-        return FieldArray.from_kwargs(**arrays).transpose()
+        return FieldArray.from_kwargs(**arrays)
 
     # write and read functions
     def write_metadata(self, fp):


### PR DESCRIPTION
This adds the log likelihood ratio in each detector to the metadata returned by the likelihood evaluator. These are saved to the stats group in the results file as `{detector}_loglr`. The SNR in each detector may then be plotted after the run. Since the number of metadata fields can change depending on the number of detectors in each run, I've made the metadata a dictionary instead of a tuple. The resulting list of dictionaries returned by `sampler.blobs` is converted to arrays by `write_likelihood_stats`.

I haven't tested with `emcee_pt` yet; marking this as a work in progress until I do.