### PR TITLE
add option to set gracedb server

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -85,7 +85,8 @@ class LiveEventManager(object):
             event = SingleCoincForGraceDB(
                     ifos, coinc_results, data_readers=data_readers,
                     bank=bank, upload_snr_series=args.upload_snr_series,
-                    followup_ifos=followup_ifos)
+                    followup_ifos=followup_ifos,
+                    gracedb_server=args.gracedb_server)
 
             end_time = int(coinc_results['foreground/%s/end_time' % ifos[0]])
             fname = os.path.join(self.path, 'coinc-%s.xml' % end_time)
@@ -104,7 +105,11 @@ class LiveEventManager(object):
         active = [k for k in results if results[k] != None]
         if len(active) == 1:
             ifo = active[0]
-            single = sngl_estimator[ifo].check(results[ifo], data_reader[ifo])
+            single = sngl_estimator[ifo].check(results[ifo], data_reader[ifo],
+                    data_readers=data_readers,
+                    bank=bank, upload_snr_series=args.upload_snr_series,
+                    followup_ifos=followup_ifos,
+                    gracedb_server=args.gracedb_server)
             if single is not None:
                 fname = 'single-%s-%s.xml' % (ifo, int(single.time))
                 fname = os.path.join(self.path, fname)
@@ -260,6 +265,9 @@ parser.add_argument('--round-start-time', type=int,
                     help="Round up the start time to the nearest multiple of X"
                          " seconds. This is useful for forcing agreement "
                          " with frame file production.")
+parser.add_argument('--gracedb-server',
+                    help="Location of gracedb server. If not provide, the "
+                         "default location is used. ")
 
 scheme.insert_processing_option_group(parser)
 LiveSingleFarThreshold.insert_args(parser)

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -30,7 +30,7 @@ class LiveSingleFarThreshold(object):
                    duration_threshold=args.single_duration_threshold,
                    )
 
-    def check(self, triggers, data_reader):
+    def check(self, triggers, data_reader, **kwds):
         """ Look for a single detector trigger that passes the thresholds in 
         the current data.
         """
@@ -51,6 +51,7 @@ class LiveSingleFarThreshold(object):
             d['stat'] = nsnr
             d['ifar'] = self.fixed_ifar
             return SingleForGraceDB(self.ifo, d, 
-                                    hardware_injection=data_reader.near_hwinj())
+                                    hardware_injection=data_reader.near_hwinj(), 
+                                    **kwds)
         else:
             return None        

--- a/pycbc/io/live.py
+++ b/pycbc/io/live.py
@@ -85,6 +85,9 @@ class SingleCoincForGraceDB(object):
         # remember if this should be marked as HWINJ
         self.is_hardware_injection = ('HWINJ' in coinc_results)
 
+        # remember if we want to use a non-standard gracedb server
+        self.gracedb_server = kwargs.get('gracedb_server')
+
         # Set up the bare structure of the xml document
         outdoc = ligolw.Document()
         outdoc.appendChild(ligolw.LIGO_LW())
@@ -259,7 +262,10 @@ class SingleCoincForGraceDB(object):
         else:
             group = 'CBC'
 
-        gracedb = GraceDb()
+        if self.gracedb_server is not None:
+            gracedb = GraceDb(self.gracedb_server)
+        else:
+            gracedb = GraceDb()
         r = gracedb.createEvent(group, "pycbc", fname, "AllSky").json()
         logging.info("Uploaded event %s.", r["graceid"])
 
@@ -302,7 +308,7 @@ class SingleCoincForGraceDB(object):
 
 class SingleForGraceDB(SingleCoincForGraceDB):
     """Create xml files and submit them to gracedb from PyCBC Live"""
-    def __init__(self, ifo, sngls_dict, hardware_injection=False):
+    def __init__(self, ifo, sngls_dict, hardware_injection=False, **kwds):
         """Initialize a ligolw xml representation of this single trigger for
         upload to gracedb
 
@@ -321,5 +327,5 @@ class SingleForGraceDB(SingleCoincForGraceDB):
             fake_coinc['foreground/%s/%s' % (ifo, key)] = sngls_dict[key]
         if hardware_injection:
             fake_coinc['HWINJ'] = True
-        SingleCoincForGraceDB.__init__(self, [ifo], fake_coinc)
+        SingleCoincForGraceDB.__init__(self, [ifo], fake_coinc, **kwds)
  


### PR DESCRIPTION
* pycbc live can now be told which gracedb server to use on the command line
* Keywoards are now passed to single detector events as well as standard coinc ones (so H1V1 time series should now be possible, have not tested this scenario, however). 


Example upload to the gracedb-test server

https://gracedb-test.ligo.org/events/view/T249742