### PR TITLE
Silence numpy warnings in inference

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -134,6 +134,10 @@ pycbc.init_logging(opts.verbose)
 numpy.random.seed(opts.seed)
 logging.info("Using seed %i", opts.seed)
 
+# we'll silence numpy warnings since they are benign and make for confusing
+# logging output
+numpy.seterr(divide='ignore', invalid='ignore')
+
 # get scheme
 ctx = scheme.from_cli(opts)
 fft.from_cli(opts)

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -479,7 +479,10 @@ class _BaseLikelihoodEvaluator(object):
         params = dict(zip(self._sampling_args, params))
         # apply inverse transforms to go from sampling parameters to
         # variable args
+        # temporarily silence numpy warnings
+        numpysettings = numpy.seterr(divide='ignore', invalid='ignore')
         params = self.apply_sampling_transforms(params, inverse=True)
+        numpy.seterr(**numpysettings)
         # apply any boundary conditions to the parameters before
         # generating/evaluating
         if callfunc is not None:

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -479,10 +479,7 @@ class _BaseLikelihoodEvaluator(object):
         params = dict(zip(self._sampling_args, params))
         # apply inverse transforms to go from sampling parameters to
         # variable args
-        # temporarily silence numpy warnings
-        numpysettings = numpy.seterr(divide='ignore', invalid='ignore')
         params = self.apply_sampling_transforms(params, inverse=True)
-        numpy.seterr(**numpysettings)
         # apply any boundary conditions to the parameters before
         # generating/evaluating
         if callfunc is not None:


### PR DESCRIPTION
When running pycbc inference, the sampler may propose a jump that is in to an unphysical part of parameter space. This is ok, since the prior will just return -inf for such jumps before trying to generate a waveform, and so the sampler will move on (and if it doesn't, the waveform generator will raise an error anyway). However, with the default settings, numpy will print a warning to stdout when transforming these unphysical values to parameters needed by the prior/waveform generator. For example, when sampling in mchirp and q, the sampler may make several proposals with -q at the beginning. When transforming this to m1, m2 this causes numpy to print:
```
/home/cdcapano/.virtualenvs/pycbc_master/lib/python2.7/site-packages/PyCBC-693686-py2.7.egg/pycbc/transforms.py:254: RuntimeWarning: invalid value encountered in double_scalars
  return mchirp * ((1.+q)/q**3.)**(2./5)
```
This happens every time a -q jump proposal happens, which can be confusing for users, and makes it difficult to read the logging messages for more relevant things (like when a checkpoint occurs).

This patch fixes this by silencing invalid and divide by zero warnings from numpy when `pycbc_inference` is setting up.