### PR TITLE
Enable splitbank code to write template duration in sub banks

### DIFF
--- a/bin/pycbc_hdf5_splitbank
+++ b/bin/pycbc_hdf5_splitbank
@@ -43,24 +43,24 @@ parser.add_argument('--templates-per-bank', type = int,
                     "calculate the other in the code. Do not supply "
                     "both.")
 parser.add_argument("--number-of-banks", type=int,
-                    help="This specifies the number of output sub-banks."
-                    "Either specify this or --templates-per-bank, as one"
-                    "of them is used to calculate the other in the code."
-                    "Do not supply both.")
+                    help="This specifies the number of output sub-banks. "
+                    "Either specify this or --templates-per-bank, as one "
+                    "of them is used to calculate the other in the code. "
+                    "Do not supply both. ")
 parser.add_argument("--output-filenames", nargs='*', default=None,
                     action="store",
-                    help="Directly specify the names of the output files."
+                    help="Directly specify the names of the output files. "
                     "The number of files specified here will dictate "
                     "how to split the bank. It will be split equally "
                     "between all specified files.")
 parser.add_argument("--output-prefix", default=None,
-                    help="Prefix to add to the output template bank names,"
-                    "for example 'sub-bank'. The output file names would"
+                    help="Prefix to add to the output template bank names, "
+                    "for example 'sub-bank'. The output file names would "
                     "become args.output_prefix.hdf")
 parser.add_argument("--random-sort", action="store_true", default=False,
                     help='Sort templates randomly before splitting')
 parser.add_argument("--random-seed", type=int,
-                    help="Random seed to use when sorting randomly the"
+                    help="Random seed to use when sorting randomly the "
                     "indices of array of templates")
 parser.add_argument("--force", action="store_true", default=False,
                     help="Overwrite the given hdf file if it exists. "
@@ -153,8 +153,7 @@ for ii in range(num_files):
     # be a slice of the input template bank having a start index and
     # end index as calculated above
     output = tmplt_bank.write_to_hdf(outname, start_idx, end_idx,
-                                     force=args.force,
-                                     skip_fields='template_duration')
+                                     force=args.force)
     output.close()
 
 logging.info("finished")


### PR DESCRIPTION
This PR removes the `skip_fields=template_duration` from the splitbank code so that when the sub banks are used in a workflow, `template_duration` does not have to be generated again. This would help in saving time when generating waveforms. The compressed waveform banks now store the `template_duration`. But due to the `skip_fields` condition in the spiltbank code, they were not getting written in the sub banks, and so were being regenerated when running the pipeline.