### PR TITLE
pycbc_live: survive GraceDB errors

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -115,11 +115,10 @@ class LiveEventManager(object):
                 fname = 'single-%s-%s.xml' % (ifo, int(single.time))
                 fname = os.path.join(self.path, fname)
                 if args.enable_single_detector_upload:
-                    single.upload(fname, {ifo:psds[ifo]},
-                              low_frequency_cutoff,
-                              testing=self.gracedb_testing) 
+                    single.upload(fname, psds, low_frequency_cutoff,
+                                  testing=self.gracedb_testing)
                 else:
-                    single.save(fname)                   
+                    single.save(fname)
 
     def dump(self, results, name, store_psd=False, time_index=None,
                   store_loudest_index=False,


### PR DESCRIPTION
During ER11, gracedb-test went down a few times, taking PyCBC Live down with it. This catches GraceDB exceptions and ensures that the relevant files remain available to be uploaded manually later.

This also fixes an error which prevented PSDs of followup detectors to make their way into GraceDB for single-detector events.