### PR TITLE
Start of pycbc qtransform inspiral integration

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -30,6 +30,9 @@ import pycbc.weave
 import pycbc.inject
 import time
 
+sys.path.insert(0, '/home/hunter.gabbard/ml_fulbright/pycbc_qtransform/pycbc_copy/pycbc/filter')
+import qtransform
+
 last_progress_update = -1.0
 
 def update_progress(p,u,n):
@@ -223,6 +226,7 @@ with ctx:
         'bank_chisq'     : float32,
         'bank_chisq_dof' : int,
         'cont_chisq'     : float32,
+        'qtransform'     : dict,
                 }
     out_types.update(SingleDetSGChisq.returns)
     out_vals = {key: None for key in out_types}
@@ -307,13 +311,16 @@ with ctx:
 
     tsetup = time.time() - tstart
 
+    logging.info("Performing q-transform on analysis segments")
+    out_vals['qtransform'] = qtransform.pycbc_insp_main(segments)
+
     # Note: in the class-based approach used now, 'template' is not explicitly used
     # within the loop.  Rather, the iteration simply fills the memory specifed in
     # the 'template_mem' argument to MatchedFilterControl with the next template
     # from the bank.
     for t_num in xrange(len(bank)):
         tmplt_generated = False
-
+       
         for s_num, stilde in enumerate(segments):
             # Filter check checks the 'inj_filter_rejector' options to
             # determine whether

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -22,16 +22,13 @@ import pycbc
 import pycbc.version
 from pycbc import vetoes, psd, waveform, events, strain, scheme, fft, DYN_RANGE_FAC
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
-from pycbc.filter import MatchedFilterControl, make_frequency_series
+from pycbc.filter import MatchedFilterControl, make_frequency_series, qtransform
 from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, complex64
 import pycbc.fft.fftw, pycbc.version
 import pycbc.opt
 import pycbc.weave
 import pycbc.inject
 import time
-
-sys.path.insert(0, '/home/hunter.gabbard/ml_fulbright/pycbc_qtransform/pycbc_copy/pycbc/filter')
-import qtransform
 
 last_progress_update = -1.0
 

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -20,7 +20,7 @@ import sys
 import logging, argparse, numpy, itertools
 import pycbc
 import pycbc.version
-from pycbc import vetoes, psd, waveform, events, strain, scheme, fft, DYN_RANGE_FAC
+from pycbc import vetoes, psd, waveform, strain, scheme, fft, DYN_RANGE_FAC, events
 from pycbc.vetoes.sgchisq import SingleDetSGChisq
 from pycbc.filter import MatchedFilterControl, make_frequency_series, qtransform
 from pycbc.types import TimeSeries, FrequencySeries, zeros, float32, complex64
@@ -226,7 +226,6 @@ with ctx:
         'bank_chisq'     : float32,
         'bank_chisq_dof' : int,
         'cont_chisq'     : float32,
-        'qtransform'     : dict,
                 }
     out_types.update(SingleDetSGChisq.returns)
     out_vals = {key: None for key in out_types}
@@ -242,10 +241,17 @@ with ctx:
         logging.info("Finished")
         sys.exit(0)
 
+    if opt.q_transform == True:
+        logging.info("Performing q-transform on analysis segments")
+        q_trans = qtransform.inspiral_qtransform_generator(segments)
+
+    elif opt.q_transform == False:
+        q_trans = {}
+
     # FIXME: Maybe we should use the PSD corresponding to each trigger
     event_mgr = events.EventManager(
             opt, names, [out_types[n] for n in names], psd=segments[0].psd,
-            gating_info=gwstrain.gating_info)
+            gating_info=gwstrain.gating_info, q_trans=q_trans)
 
     template_mem = zeros(tlen, dtype = complex64)
     cluster_window = int(opt.cluster_window * gwstrain.sample_rate)
@@ -310,10 +316,6 @@ with ctx:
         logging.info("Template bank size after thinning: %s", len(bank))
 
     tsetup = time.time() - tstart
-
-    if opt.q_transform == True:
-        logging.info("Performing q-transform on analysis segments")
-        out_vals['qtransform'] = qtransform.inspiral_qtransform_generator(segments)
 
     # Note: in the class-based approach used now, 'template' is not explicitly used
     # within the loop.  Rather, the iteration simply fills the memory specifed in

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -309,7 +309,7 @@ with ctx:
     tsetup = time.time() - tstart
 
     logging.info("Performing q-transform on analysis segments")
-    out_vals['qtransform'] = qtransform.pycbc_insp_main(segments)
+    out_vals['qtransform'] = qtransform.inspiral_qtransform_generator(segments)
 
     # Note: in the class-based approach used now, 'template' is not explicitly used
     # within the loop.  Rather, the iteration simply fills the memory specifed in

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -72,6 +72,9 @@ parser.add_argument("--max-template-length", type=float,
                   help="The maximum length of a template is seconds. The "
                        "starting frequency of the template is modified to "
                        "ensure the proper length")
+parser.add_argument("--q-transform", type=bool, default=False,
+                  help="compute the q-transform for each segment of a "
+                       "given analysis run. (default = False)"
 # add approximant arg
 pycbc.waveform.bank.add_approximant_arg(parser)
 parser.add_argument("--order", type=int,
@@ -308,8 +311,9 @@ with ctx:
 
     tsetup = time.time() - tstart
 
-    logging.info("Performing q-transform on analysis segments")
-    out_vals['qtransform'] = qtransform.inspiral_qtransform_generator(segments)
+    if opt.q_transform == True:
+        logging.info("Performing q-transform on analysis segments")
+        out_vals['qtransform'] = qtransform.inspiral_qtransform_generator(segments)
 
     # Note: in the class-based approach used now, 'template' is not explicitly used
     # within the loop.  Rather, the iteration simply fills the memory specifed in

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -74,7 +74,7 @@ parser.add_argument("--max-template-length", type=float,
                        "ensure the proper length")
 parser.add_argument("--q-transform", type=bool, default=False,
                   help="compute the q-transform for each segment of a "
-                       "given analysis run. (default = False)"
+                       "given analysis run. (default = False)")
 # add approximant arg
 pycbc.waveform.bank.add_approximant_arg(parser)
 parser.add_argument("--order", type=int,

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -72,7 +72,7 @@ parser.add_argument("--max-template-length", type=float,
                   help="The maximum length of a template is seconds. The "
                        "starting frequency of the template is modified to "
                        "ensure the proper length")
-parser.add_argument("--q-transform", type=bool, default=False,
+parser.add_argument("--enable-q-transform", action='store_true',
                   help="compute the q-transform for each segment of a "
                        "given analysis run. (default = False)")
 # add approximant arg
@@ -241,11 +241,11 @@ with ctx:
         logging.info("Finished")
         sys.exit(0)
 
-    if opt.q_transform == True:
+    if opt.q_transform:
         logging.info("Performing q-transform on analysis segments")
         q_trans = qtransform.inspiral_qtransform_generator(segments)
 
-    elif opt.q_transform == False:
+    else:
         q_trans = {}
 
     # FIXME: Maybe we should use the PSD corresponding to each trigger

--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -241,7 +241,7 @@ with ctx:
         logging.info("Finished")
         sys.exit(0)
 
-    if opt.q_transform:
+    if opt.enable_q_transform:
         logging.info("Performing q-transform on analysis segments")
         q_trans = qtransform.inspiral_qtransform_generator(segments)
 

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -742,18 +742,6 @@ class EventManagerMultiDet(EventManager):
                 f['search/setup_time_fraction'] = \
                     numpy.array([float(self.setup_time) / float(self.run_time)])
 
-            if 'q_trans' in self.global_params:
-                qtrans = self.global_params['q_trans']
-                for key in qtrans:
-                    if key == 'qtiles':
-                        for seg in qtrans[key]:
-                            for q in qtrans[key][seg]:
-                                f['qtransform/%s/%s/%s' % (key,seg,q)]=qtrans[key][seg][q]
-                    elif key == 'qplanes':
-                        for seg in qtrans[key]:
-                            f['qtransform/%s/%s' % (key,seg)]=qtrans[key][seg]
-
-
             if 'gating_info' in self.global_params:
                 gating_info = self.global_params['gating_info']
                 for gate_type in ['file', 'auto']:

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -517,7 +517,7 @@ class EventManager(object):
                             f['qtransform/%s/%s/%s' % (key,seg,q)]=qtrans[key][seg][q]
                 elif key == 'qplanes':
                     for seg in qtrans[key]:
-                        f['qtransform/%s/%s' % (key,seg)]=qtrans[key][seg] 
+                        f['qtransform/%s/%s' % (key,seg)]=qtrans[key][seg]
 
         if 'gating_info' in self.global_params:
             gating_info = self.global_params['gating_info']

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -508,6 +508,17 @@ class EventManager(object):
             f['search/setup_time_fraction'] = \
                 numpy.array([float(self.setup_time) / float(self.run_time)])
 
+        if 'q_trans' in self.global_params:
+            qtrans = self.global_params['q_trans']
+            for key in qtrans:
+                if key == 'qtiles':
+                    for seg in qtrans[key]:
+                        for q in qtrans[key][seg]:
+                            f['qtransform/%s/%s/%s' % (key,seg,q)]=qtrans[key][seg][q]
+                elif key == 'qplanes':
+                    for seg in qtrans[key]:
+                        f['qtransform/%s/%s' % (key,seg)]=qtrans[key][seg] 
+
         if 'gating_info' in self.global_params:
             gating_info = self.global_params['gating_info']
             for gate_type in ['file', 'auto']:
@@ -730,6 +741,18 @@ class EventManagerMultiDet(EventManager):
                     numpy.array([filters_per_core / float(self.run_time)])
                 f['search/setup_time_fraction'] = \
                     numpy.array([float(self.setup_time) / float(self.run_time)])
+
+            if 'q_trans' in self.global_params:
+                qtrans = self.global_params['q_trans']
+                for key in qtrans:
+                    if key == 'qtiles':
+                        for seg in qtrans[key]:
+                            for q in qtrans[key][seg]:
+                                f['qtransform/%s/%s/%s' % (key,seg,q)]=qtrans[key][seg][q]
+                    elif key == 'qplanes':
+                        for seg in qtrans[key]:
+                            f['qtransform/%s/%s' % (key,seg)]=qtrans[key][seg]
+
 
             if 'gating_info' in self.global_params:
                 gating_info = self.global_params['gating_info']

--- a/pycbc/filter/qtransform.py
+++ b/pycbc/filter/qtransform.py
@@ -176,8 +176,8 @@ def plotter(interp, out_dir, now, frange, tres, fres):
 
 def qplane(qplane_tile_dict, fseries, frange, normalized=True, tres=1., fres=1., seg=None):
     """Performs q-transform on each tile for each q-plane and selects
-       tile with the maximum normalized energy. Q-transform is then
-       interpolated to a desired frequency and time resolution.
+       tile with the maximum normalized energy. Q-transform can then
+       be interpolated to a desired frequency and time resolution.
 
     Parameters
     ----------

--- a/pycbc/filter/qtransform.py
+++ b/pycbc/filter/qtransform.py
@@ -204,10 +204,10 @@ def qplane(qplane_tile_dict, fseries, frange, normalized=True, tres=1., fres=1.,
     """
     # store q-transforms of each tile in a dict
     qplane_qtrans_dict = {}
-    dur = fseries.to_timeseries().duration
+    dur = fseries.duration
 
     # check for sampling rate
-    sampling = (len(fseries) - 1) * 2 * fseries.delta_f
+    sampling = fseries.sample_rate
 
     max_energy = []
     for i, key in enumerate(qplane_tile_dict):
@@ -295,11 +295,11 @@ def qtiling(fseries, qrange, frange, mismatch=0.2):
     deltam = deltam_f(mismatch)
     qrange = (float(qrange[0]), float(qrange[1]))
     frange = [float(frange[0]), float(frange[1])]
-    dur = fseries.to_timeseries().duration
+    dur = fseries.duration
     qplane_tile_dict = {}
 
     # check for sampling rate
-    sampling = (len(fseries) - 1) * 2 * fseries.delta_f
+    sampling = fseries.sample_rate
 
     qs = list(_iter_qs(qrange, deltam))
     if frange[0] == 0:  # set non-zero lower frequency
@@ -415,10 +415,10 @@ def qtransform(fseries, Q, f0):
 
     # initialize parameters
     qprime = Q / 11**(1/2.) # ... self.qprime
-    dur = fseries.to_timeseries().duration
+    dur = fseries.duration
 
     # check for sampling rate
-    sampling = (len(fseries) - 1) * 2 * fseries.delta_f
+    sampling = fseries.sample_rate
 
     # window fft
     window_size = 2 * int(f0 / qprime * dur) + 1
@@ -434,7 +434,7 @@ def qtransform(fseries, Q, f0):
 
     # choice of output sampling rate
     output_sampling = sampling # Can lower this to highest bandwidth
-    output_samples = dur * output_sampling
+    output_samples = int(dur * output_sampling)
 
     # pad data, move negative frequencies to the end, and IFFT
     padded = np.pad(windowed, padding(window_size, output_samples), mode='constant')
@@ -442,7 +442,7 @@ def qtransform(fseries, Q, f0):
 
     # return a 'TimeSeries'
     wenergy = FrequencySeries(wenergy, delta_f=1./dur)
-    tdenergy = TimeSeries(zeros(int(output_samples), dtype=np.complex128),
+    tdenergy = TimeSeries(zeros(output_samples, dtype=np.complex128),
                             delta_t=1./sampling)
     ifft(wenergy, tdenergy)
     cenergy = TimeSeries(tdenergy,

--- a/pycbc/filter/qtransform.py
+++ b/pycbc/filter/qtransform.py
@@ -45,6 +45,7 @@ import os
 import h5py
 from pycbc.filter import highpass_fir, matched_filter
 from pycbc.psd import welch, interpolate
+from pycbc.io import hdf
 
 def pycbc_insp_main(segments, filename='q_info.hdf'):
     """Main function for pycbc_inspiral implementation of qtransform.py
@@ -127,68 +128,6 @@ def pycbc_insp_tiling(seg, frange=(0,np.inf), qrange=(4,64), mismatch=0.2):
     Qbase, frange = qtiling(data, qrange, frange, mismatch)
 
     return Qbase, frange, data
-
-def save_dict_to_hdf5(dic, filename):
-    """
-    Parameters
-    ----------
-    dic:
-        python dictionary to be converted to hdf5 format
-    filename:
-        desired name of hdf5 file
-    """
-    with h5py.File(filename, 'w') as h5file:
-        recursively_save_dict_contents_to_group(h5file, '/', dic)
-
-def recursively_save_dict_contents_to_group(h5file, path, dic):
-    """
-    Parameters
-    ----------
-    h5file:
-        h5py file to be written to
-    path:
-        path within h5py file to saved dictionary
-    dic:
-        python dictionary to be converted to hdf5 format
-    """
-    for key, item in dic.items():
-        if isinstance(item, (np.ndarray, np.int64, np.float64, str, bytes, tuple, list)):
-            h5file[path + str(key)] = item
-        elif isinstance(item, dict):
-            recursively_save_dict_contents_to_group(h5file, path + key + '/', item)
-        else:
-            raise ValueError('Cannot save %s type'%type(item))
-
-def load_dict_from_hdf5(filename):
-    """
-    Parameters
-    ----------
-    filename:
-        name of h5py file to be loaded
-
-    Returns
-    -------
-    recursively_load_dict_contents_from_group():
-        python dictionary object
-    """
-    with h5py.File(filename, 'r') as h5file:
-        return recursively_load_dict_contents_from_group(h5file, '/')
-
-def recursively_load_dict_contents_from_group(h5file, path):
-    """
-    Parameters
-    ----------
-    h5file:
-        h5py file to be loaded from
-    path:
-        path within h5py file to items
-    """
-    ans = {}
-    for key, item in h5file[path].items():
-        if isinstance(item, h5py._hl.dataset.Dataset):
-            ans[key] = item.value
-
-    
 
 def plotter(interp, out_dir, now, frange, tres, fres):
     """Plotting mechanism for pycbc spectrograms

--- a/pycbc/filter/qtransform.py
+++ b/pycbc/filter/qtransform.py
@@ -42,8 +42,6 @@ from pycbc.fft import ifft
 from pycbc.types import zeros
 from numpy import fft as npfft
 import os
-from pycbc.filter import highpass_fir
-from pycbc.psd import welch
 
 def inspiral_qtransform_generator(segments):
     """Main function for pycbc_inspiral implementation of qtransform.py

--- a/pycbc/filter/qtransform.py
+++ b/pycbc/filter/qtransform.py
@@ -47,7 +47,7 @@ from pycbc.filter import highpass_fir, matched_filter
 from pycbc.psd import welch, interpolate
 from pycbc.io import hdf
 
-def pycbc_insp_main(segments, filename='q_info.hdf'):
+def inspiral_qtransform_generator(segments, filename='q_info.hdf'):
     """Main function for pycbc_inspiral implementation of qtransform.py
     Parameters
     ----------
@@ -61,7 +61,7 @@ def pycbc_insp_main(segments, filename='q_info.hdf'):
     comb_q_dict = {}
     for s_num, stilde in enumerate(segments):
         # getting q-tiles for segments
-        Qbase, q_frange, q_data = pycbc_insp_tiling(stilde)
+        Qbase, q_frange, q_data = inspiral_tiling(stilde)
 
         # getting q-plane for segment
         Qplane, interp, qs_time, qe_time = qplane(Qbase, q_data, q_frange, fres=None, seg=stilde)
@@ -82,14 +82,10 @@ def pycbc_insp_main(segments, filename='q_info.hdf'):
             comb_q_dict['qtiles']['seg_%s-%s' % (str(qs_time),str(qe_time))] = Qbase
             comb_q_dict['qplanes']['seg_%s-%s' % (str(qs_time),str(qe_time))] = Qplane
 
-    # save qtransform info to hdf5 file
-    #path = '/'
-    #recursively_save_dict_contents_to_group(out_vals, path, comb_q_dict)
-
     return comb_q_dict
 
-def pycbc_insp_tiling(seg, frange=(0,np.inf), qrange=(4,64), mismatch=0.2):
-    """Iterable constructor of QTile tuples
+def inspiral_tiling(seg, frange=(0,np.inf), qrange=(4,64), mismatch=0.2):
+    """Pycbc inspiral iterable constructor of QTile tuples
     Parameters
     ----------
     seg:

--- a/pycbc/filter/qtransform.py
+++ b/pycbc/filter/qtransform.py
@@ -71,7 +71,6 @@ def inspiral_qtransform_generator(segments):
         # write q info to an hdf file
         q_base_tmp = {}
         q_plane_tmp = {}
-        print 'start time: %s, end time: %s' % (qs_time, qe_time)
         if 'qtiles' not in comb_q_dict:
             q_base_tmp['seg_%s-%s' % (str(qs_time),str(qe_time))] = q_base
             comb_q_dict['qtiles'] = q_base_tmp

--- a/pycbc/filter/qtransform.py
+++ b/pycbc/filter/qtransform.py
@@ -237,7 +237,6 @@ def qplane(qplane_tile_dict, fseries, frange, normalized=True, tres=1., fres=1.,
         if not seg:
             return result, qtile_max
         elif seg:
-            #result[0].start_time
             s_time = seg.epoch + (seg.analyze.start*(1. / sampling))
             e_time = seg.epoch + (seg.analyze.stop*(1. / sampling))
             result = np.array(result)

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -866,31 +866,3 @@ def recursively_save_dict_contents_to_group(h5file, path, dic):
         else:
             raise ValueError('Cannot save %s type'%type(item))
 
-def load_dict_from_hdf5(filename):
-    """
-    Parameters
-    ----------
-    filename:
-        name of h5py file to be loaded
-
-    Returns
-    -------
-    recursively_load_dict_contents_from_group():
-        python dictionary object
-    """
-    with h5py.File(filename, 'r') as h5file:
-        return recursively_load_dict_contents_from_group(h5file, '/')
-
-def recursively_load_dict_contents_from_group(h5file, path):
-    """
-    Parameters
-    ----------
-    h5file:
-        h5py file to be loaded from
-    path:
-        path within h5py file to items
-    """
-    ans = {}
-    for key, item in h5file[path].items():
-        if isinstance(item, h5py._hl.dataset.Dataset):
-            ans[key] = item.value

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -835,3 +835,62 @@ def get_chisq_from_file_choice(hdfile, chisq_choice):
         raise ValueError(err_msg)
     return chisq
 
+def save_dict_to_hdf5(dic, filename):
+    """
+    Parameters
+    ----------
+    dic:
+        python dictionary to be converted to hdf5 format
+    filename:
+        desired name of hdf5 file
+    """
+    with h5py.File(filename, 'w') as h5file:
+        recursively_save_dict_contents_to_group(h5file, '/', dic)
+
+def recursively_save_dict_contents_to_group(h5file, path, dic):
+    """
+    Parameters
+    ----------
+    h5file:
+        h5py file to be written to
+    path:
+        path within h5py file to saved dictionary
+    dic:
+        python dictionary to be converted to hdf5 format
+    """
+    for key, item in dic.items():
+        if isinstance(item, (np.ndarray, np.int64, np.float64, str, bytes, tuple, list)):
+            h5file[path + str(key)] = item
+        elif isinstance(item, dict):
+            recursively_save_dict_contents_to_group(h5file, path + key + '/', item)
+        else:
+            raise ValueError('Cannot save %s type'%type(item))
+
+def load_dict_from_hdf5(filename):
+    """
+    Parameters
+    ----------
+    filename:
+        name of h5py file to be loaded
+
+    Returns
+    -------
+    recursively_load_dict_contents_from_group():
+        python dictionary object
+    """
+    with h5py.File(filename, 'r') as h5file:
+        return recursively_load_dict_contents_from_group(h5file, '/')
+
+def recursively_load_dict_contents_from_group(h5file, path):
+    """
+    Parameters
+    ----------
+    h5file:
+        h5py file to be loaded from
+    path:
+        path within h5py file to items
+    """
+    ans = {}
+    for key, item in h5file[path].items():
+        if isinstance(item, h5py._hl.dataset.Dataset):
+            ans[key] = item.value


### PR DESCRIPTION
pycbc_inspiral changes:
1.) added import of qtransform.py script from pycbc.filter
2.) generate qtransform for each segment in a pycbc_inspiral run
- Still need to save output to ref.hdf file
-Make output compatible with pycbc_coinc_mergetrigs module

qtransform.py changes:
1.) qplane function now returns uninterpolated qtransforms by default
2.) functions for use of qtransform.py in pycbc_inspiral have been added
3.) new functions to recursively save/convert multilevel python dictionary to h5py file and vice versa. 