### PR TITLE
Pull PyCBC docker images with a specific tag and switch to git.ligo.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
   - secure: oey1B+mhqfwhGgbnKFohJe56pPbvvdYA8Li6xdX2eCes9El3Sw0vNoyU9DTml9wnT2B+JKxw14l1ELHO8ugljJdXM+M5XCeDAloX661oP9c4mc0AB8KKmkDs7n5o681fp70YLesX2/ZZ8X1NRg8zayFQHwF+oQilgLXvfzEHBPqWnq6Kq/sxomkXPYR0paisTLuPzjMDv127DdZH60cYF3mEKnJvflgJWqfvUV11D06v8CKRRFZXFIhhnQ2kdF2hHA2orhcjM64HMJPOaEftEs07TWWYvdaUxUasAeUkEZhqBq/Z2DbKk3oiGuRNXOmFk+etu+YliabePsFAMFjnDdeONWNiPDarxQhrG8EZi5cv+pxbtsbPFlkPiDgIuFTZLj8SmO/5iPu9tBTPriY59xz6Eud5t6wuaiOHEat0uYmG8vHlpxeE1d7EFBeo9kvnyWOPRiPPD5g7frQ7aPQw/x+J+D1TzclrHgRfQ3K2yALnIeAeo1f7yJIMppZxHEhkLLg300Or2HtjPVbOhj6wUvhnL6+SP054NHzdXb8UjRv1lIduPJxopUxjaRc9XHgmFRa5RP+q42pMrUp5O2sHVvjMKtka57T4HukzoAQuIeqYopZjh7qUTLtjOvAh0tScUiHJh9GDQv9i8KffXAA89785Pgi22K80/Nn+dNc8xP0=
 matrix:
   include:
-  - env: PYCBC_CONTAINER=pycbc_virtualenv DOCKER_IMG=pycbc/ldg-el7
+  - env: PYCBC_CONTAINER=pycbc_virtualenv DOCKER_IMG=pycbc/ldg-el7:v1.0
     sudo: required
     services:
     - docker
@@ -48,7 +48,7 @@ matrix:
     sudo: required
     services:
     - docker
-  - env: PYCBC_CONTAINER=pycbc_docker DOCKER_IMG=pycbc/pycbc-el7
+  - env: PYCBC_CONTAINER=pycbc_docker DOCKER_IMG=pycbc/pycbc-el7:v1.0
     sudo: required
     services:
     - docker

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -56,10 +56,10 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
 
   # get library to build optimized pycbc_inspiral bundle
   wget_opts="-c --passive-ftp --no-check-certificate --tries=5 --timeout=30 --no-verbose"
-  primary_url="https://code.pycbc.phy.syr.edu/ligo-cbc/pycbc-software/download/03f2048c770492f66f80528493fd6cecded63769"
+  primary_url="https://git.ligo.org/ligo-cbc/pycbc-software/raw/"
   secondary_url="https://www.atlas.aei.uni-hannover.de/~dbrown"
   pushd /pycbc
-  for p in "x86_64/composer_xe_2015.0.090/composer_xe_2015.0.090.tar.gz" "bank-files/testbank_TF2v4ROM.hdf" ; do
+  for p in "cea5bd67440f6c3195c555a388def3cc6d695a5c/x86_64/composer_xe_2015.0.090/composer_xe_2015.0.090.tar.gz" "cea5bd67440f6c3195c555a388def3cc6d695a5c/bank-files/testbank_TF2v4ROM.hdf" ; do
     set +e
     test -r `basename $p` || wget $wget_opts ${primary_url}/${p}
     set -e

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1237,6 +1237,14 @@ cd test
 if $run_analysis; then
 echo -e "\\n\\n>> [`date`] running analysis" >&3
 
+if $silent_build ; then
+    # redirect stdout and stderr back to the screen
+    exec 1>&-
+    exec 2>&-
+    exec 1>&3
+    exec 2>&4
+fi
+
 echo -e "\\n\\n>> [`date`] downloading LOSC frame data" >&3
 p="H-H1_LOSC_4_V1-1126257414-4096.gwf"
 md5="a7d5cbd6ef395e8a79ef29228076d38d"
@@ -1343,14 +1351,6 @@ if ! test -z "$extra_approx" || ! test -z "$extra_bank" ; then
 fi
 
 n_runs=${#bank_array[@]}
-
-if $silent_build ; then
-    # redirect stdout and stderr back to the screen
-    exec 1>&-
-    exec 2>&-
-    exec 1>&3
-    exec 2>&4
-fi
 
 for (( i=0; i<${n_runs}; i++ ))
 do

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1236,6 +1236,8 @@ cd test
 
 if $run_analysis; then
 echo -e "\\n\\n>> [`date`] running analysis" >&3
+
+echo -e "\\n\\n>> [`date`] downloading LOSC frame data" >&3
 p="H-H1_LOSC_4_V1-1126257414-4096.gwf"
 md5="a7d5cbd6ef395e8a79ef29228076d38d"
 if check_md5 "$p" "$md5"; then
@@ -1251,6 +1253,7 @@ frames="$PWD/$p"
 # free some space by removing a possible old ROM tarball
 rm -f lal-data-r7.tar.gz
 
+echo -e "\\n\\n>> [`date`] downloading ROM data" >&3
 failed=false
 while read f md5; do
     if check_md5 "$f" "$md5"; then
@@ -1296,6 +1299,7 @@ if $failed; then
 fi
 
 #fb5ec108c69f9e424813de104731370c  H1L1-PREGEN_TMPLTBANK_SPLITBANK_BANK16-1126051217-3331800-short2k.xml.gz
+echo -e "\\n\\n>> [`date`] downloading template bank" >&3
 p="H1L1-SBANK_FOR_GW150914ER10.xml.gz"
 md5="c24f5513d3066b4f637daffb6aa20fec"
 if check_md5 "$p" "$md5"; then

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -63,8 +63,8 @@ pip install git+https://github.com/ligo-cbc/sphinxcontrib-programoutput.git#egg=
 
 # get library needed to build documentation
 wget_opts="-c --passive-ftp --no-check-certificate --tries=5 --timeout=30"
-primary_url="https://code.pycbc.phy.syr.edu/ligo-cbc/pycbc-software/download/b3680bfb627a7350f29d31c7d91c4e09ff8a9fdc/x86_64/composer_xe_2015.0.090"
-secondary_url="https://www.atlas.aei.uni-hannover.de/~dbrown/x86_64/composer_xe_2015.0.090"
+primary_url="https://git.ligo.org/ligo-cbc/pycbc-software/raw/cea5bd67440f6c3195c555a388def3cc6d695a5c/x86_64/composer_xe_2015.0.090"
+secondary_url="https://www.atlas.aei.uni-hannover.de/~dbrown/cea5bd67440f6c3195c555a388def3cc6d695a5c/x86_64/composer_xe_2015.0.090"
 p="libmkl_rt.so"
 pushd ${BUILD}/pycbc-sources
 set +e

--- a/tools/test_coinc_search_workflow.sh
+++ b/tools/test_coinc_search_workflow.sh
@@ -15,7 +15,7 @@ echo -e "\\n>> [`date`] Entering virtual environment pycbc-${TRAVIS_TAG}"
 source /cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/x86_64_rhel_7/virtualenv/pycbc-${TRAVIS_TAG}/bin/activate
 
 echo -e "\\n>> [`date`] Cloning pycbc-config git repository"
-test -r pycbc-config || git clone --depth 1 git@code.pycbc.phy.syr.edu:ligo-cbc/pycbc-config.git
+test -r pycbc-config || git clone --depth 1 git@github.com:ligo-cbc/pycbc-config.git
 CONFIG_PATH="file://`pwd`/pycbc-config"
 
 test -r veto-definitions || git clone --depth 1 git@code.pycbc.phy.syr.edu:detchar/veto-definitions.git


### PR DESCRIPTION
This pull request adds a specific version tag to the docker pull for the PyCBC base images. It is needed so that I can finish https://github.com/ligo-cbc/pycbc/pull/1756 without breaking the current Travis build. I also switched the pull for the MKL files from code.pycbc.phy.syr.edu to git.ligo.org.