### PR TITLE
Use git.ligo.org for E@H test data on Travis

### DIFF
--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -59,7 +59,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   primary_url="https://git.ligo.org/ligo-cbc/pycbc-software/raw/"
   secondary_url="https://www.atlas.aei.uni-hannover.de/~dbrown"
   pushd /pycbc
-  for p in "cea5bd67440f6c3195c555a388def3cc6d695a5c/x86_64/composer_xe_2015.0.090/composer_xe_2015.0.090.tar.gz" "cea5bd67440f6c3195c555a388def3cc6d695a5c/bank-files/testbank_TF2v4ROM.hdf" ; do
+  for p in "cea5bd67440f6c3195c555a388def3cc6d695a5c/x86_64/composer_xe_2015.0.090/composer_xe_2015.0.090.tar.gz" "2d7e4a4f2f1503db5b93d70907fa24ad54bffbcb/travis/testbank_TF2v4ROM.hdf" ; do
     set +e
     test -r `basename $p` || wget $wget_opts ${primary_url}/${p}
     set -e

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -70,7 +70,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   # run the einstein at home build and test script
   echo -e "\\n>> [`date`] Running pycbc_build_eah.sh"
   pushd ${BUILD}
-  /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/blob/710a51f4770cbba77f61dfb798472bebe6c43d38/travis --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
+  /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/raw/710a51f4770cbba77f61dfb798472bebe6c43d38/travis --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
 
   if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then
     echo -e "\\n>> [`date`] Deploying pycbc_inspiral bundle"

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -70,7 +70,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   # run the einstein at home build and test script
   echo -e "\\n>> [`date`] Running pycbc_build_eah.sh"
   pushd ${BUILD}
-  /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --silent-build --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
+  /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/blob/710a51f4770cbba77f61dfb798472bebe6c43d38/travis --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
 
   if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then
     echo -e "\\n>> [`date`] Deploying pycbc_inspiral bundle"

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -54,6 +54,7 @@ extra_bank=""
 extra_approx=""
 processing_scheme=""
 lal_data_path="."
+albert="http://albert.phys.uwm.edu/download"
 
 # defaults, possibly overwritten by OS-specific settings
 build_ssl=false
@@ -275,6 +276,8 @@ usage="
 
     --no-cleanup                    keep build directories after successful build for later inspection
 
+    --download-url=<url>            download test frame, template bank, and roms from <url>
+
     --with-extra-libs=<url>         add extra files from a tar file at <url> to the bundles
 
     --with-extra-bank=<file>        run pycbc_inspiral again with an extra template bank
@@ -341,6 +344,7 @@ for i in $*; do
                     echo $now > "$SOURCE/last_sunday_build"
                 fi
             fi ;;
+        --download-url=*) albert="`echo $i|sed 's/^--download-url=//'`";;
         --with-extra-libs=*) extra_libs="`echo $i|sed 's/^--with-extra-libs=//'`";;
         --with-extra-bank=*) extra_bank="$extra_bank `echo $i|sed 's/^--with-extra-bank=//'`";;
         --with-extra-approximant=*) extra_approx="${extra_approx}`echo $i|sed 's/^--with-extra-approximant=//'` ";;
@@ -389,7 +393,6 @@ echo "WORKSPACE='$WORKSPACE'" # for Jenkins jobs
 pypi="https://pypi.python.org/packages"
 gitlab="https://gitlab.aei.uni-hannover.de/einsteinathome"
 atlas="https://www.atlas.aei.uni-hannover.de/~bema"
-albert="http://albert.phys.uwm.edu/download"
 duncan="https://www.atlas.aei.uni-hannover.de/~dbrown"
 aei="http://www.aei.mpg.de/~bema"
 

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1240,14 +1240,6 @@ cd test
 if $run_analysis; then
 echo -e "\\n\\n>> [`date`] running analysis" >&3
 
-if $silent_build ; then
-    # redirect stdout and stderr back to the screen
-    exec 1>&-
-    exec 2>&-
-    exec 1>&3
-    exec 2>&4
-fi
-
 echo -e "\\n\\n>> [`date`] downloading LOSC frame data" >&3
 p="H-H1_LOSC_4_V1-1126257414-4096.gwf"
 md5="a7d5cbd6ef395e8a79ef29228076d38d"
@@ -1354,6 +1346,14 @@ if ! test -z "$extra_approx" || ! test -z "$extra_bank" ; then
 fi
 
 n_runs=${#bank_array[@]}
+
+if $silent_build ; then
+    # redirect stdout and stderr back to the screen
+    exec 1>&-
+    exec 2>&-
+    exec 1>&3
+    exec 2>&4
+fi
 
 for (( i=0; i<${n_runs}; i++ ))
 do

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1240,6 +1240,14 @@ cd test
 if $run_analysis; then
 echo -e "\\n\\n>> [`date`] running analysis" >&3
 
+if $silent_build ; then
+    # redirect stdout and stderr back to the screen
+    exec 1>&-
+    exec 2>&-
+    exec 1>&3
+    exec 2>&4
+fi
+
 echo -e "\\n\\n>> [`date`] downloading LOSC frame data" >&3
 p="H-H1_LOSC_4_V1-1126257414-4096.gwf"
 md5="a7d5cbd6ef395e8a79ef29228076d38d"
@@ -1346,14 +1354,6 @@ if ! test -z "$extra_approx" || ! test -z "$extra_bank" ; then
 fi
 
 n_runs=${#bank_array[@]}
-
-if $silent_build ; then
-    # redirect stdout and stderr back to the screen
-    exec 1>&-
-    exec 2>&-
-    exec 1>&3
-    exec 2>&4
-fi
 
 for (( i=0; i<${n_runs}; i++ ))
 do

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -26,7 +26,7 @@ export XDG_CACHE_HOME=${BUILD}/.cache
 
 # run the einstein at home build and test script
 pushd ${BUILD}
-${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh ${LALSUITE_CODE} ${PYCBC_CODE} --clean-pycbc --silent-build
+${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh ${LALSUITE_CODE} ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/blob/710a51f4770cbba77f61dfb798472bebe6c43d38/travis
 popd
 
 # setup the pycbc environment to run the additional travis tests

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -26,7 +26,7 @@ export XDG_CACHE_HOME=${BUILD}/.cache
 
 # run the einstein at home build and test script
 pushd ${BUILD}
-${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh ${LALSUITE_CODE} ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/blob/710a51f4770cbba77f61dfb798472bebe6c43d38/travis
+${LOCAL}/tools/einsteinathome/pycbc_build_eah.sh ${LALSUITE_CODE} ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/raw/710a51f4770cbba77f61dfb798472bebe6c43d38/travis
 popd
 
 # setup the pycbc environment to run the additional travis tests


### PR DESCRIPTION
This adds an option to ``pycbc_build_eah.sh`` to use an alternative URL to ``albert.phys.uwm.edu`` for downloading the frame, bank, and ROM data needed by the E@H test. It then uses this option to switch the Travis build to pull the data from ``git.ligo.org``.

This is needed, as I am seeing very slow download times from albert:
```
[pycbc@sugwg-test1 travis]$ wget http://albert.phys.uwm.edu/download/lal-data-r11.tar.gz
--2017-06-26 14:06:13--  http://albert.phys.uwm.edu/download/lal-data-r11.tar.gz
Resolving albert.phys.uwm.edu (albert.phys.uwm.edu)... 129.89.61.67
Connecting to albert.phys.uwm.edu (albert.phys.uwm.edu)|129.89.61.67|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 604681670 (577M) [application/x-gzip]
Saving to: ‘lal-data-r11.tar.gz’

100%[============================================================================================================>] 604,681,670  547KB/s   in 18m 30s

2017-06-26 14:24:44 (532 KB/s) - ‘lal-data-r11.tar.gz’ saved [604681670/604681670]
```
which cause Travis to time out, e.g. https://travis-ci.org/ligo-cbc/pycbc/jobs/247185016