### PR TITLE
E@H build: install six unconditionally

### DIFF
--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1001,11 +1001,11 @@ if test "x$pycbc_fetch_ref" != "x" ; then
     git checkout FETCH_HEAD
 fi
 
-echo -e "[`date`] install pkgconfig beforehand"
+echo -e "[`date`] install pkgconfig and six beforehand"
 pip install `grep -w ^pkgconfig requirements.txt||echo pkgconfig==1.1.0`
+pip install `grep -w ^six requirements.txt||echo 'six>=1.9.0'`
 if $pyinstaller21_hacks; then
-    echo -e "[`date`] install six and matplotlib beforehand"
-    pip install `grep -w ^six requirements.txt||echo 'six>=1.9.0'`
+    echo -e "[`date`] install matplotlib beforehand"
     pip install `grep ^matplotlib== requirements.txt||echo matplotlib==1.4.3`
     p="`grep -w ^setuptools requirements.txt||true`"
     if test ".$p" != "."; then


### PR DESCRIPTION
- a certificate issue prevents six from being installed via
  dependency on Debian4 in a 'clean' E@H build