### PR TITLE
add mode_array support for get_td_waveform

### DIFF
--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -390,11 +390,12 @@ side_bands = Parameter("side_bands",
                 dtype=int, default=0,
                 description="Flag for generating sidebands")
 mode_array = Parameter("mode_array",
-                dtype=int, default=-1,
+                dtype=int, default=None,
                 description="Choose which (l,m) modes to include when "
                             "generating a waveform. "
                             "Only if approximant supports this feature."
-                            "By default generate all available modes. "
+                            "By default pass None and let lalsimulation "
+                            "use it's default behaviour."
                             "Example: mode_array = [ [2,2], [2,-2] ]")
 #
 # =============================================================================

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -390,10 +390,12 @@ side_bands = Parameter("side_bands",
                 dtype=int, default=0,
                 description="Flag for generating sidebands")
 mode_array = Parameter("mode_array",
-                dtype=None, default="",
+                dtype=int, default=-1,
                 description="Choose which (l,m) modes to include when "
                             "generating a waveform. "
-                            "Only if approximant supports this feature.")
+                            "Only if approximant supports this feature."
+                            "By default generate all available modes. "
+                            "Example: mode_array = [ [2,2], [2,-2] ]")
 #
 # =============================================================================
 #

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -389,7 +389,11 @@ modes_choice = Parameter("modes_choice",
 side_bands = Parameter("side_bands",
                 dtype=int, default=0,
                 description="Flag for generating sidebands")
-
+mode_array = Parameter("mode_array",
+                dtype=None, default="",
+                description="Choose which (l,m) modes to include when "
+                            "generating a waveform. "
+                            "Only if approximant supports this feature.")
 #
 # =============================================================================
 #
@@ -411,7 +415,7 @@ location_params = ParameterList([tc, ra, dec, polarization])
 orientation_params = ParameterList([distance, coa_phase, inclination, long_asc_nodes, mean_per_ano])
 
 # the extrinsic parameters of a waveform
-extrinsic_params = orientation_params + location_params 
+extrinsic_params = orientation_params + location_params
 
 # intrinsic parameters of a CBC waveform
 cbc_intrinsic_params = ParameterList([
@@ -428,7 +432,7 @@ common_generation_params = ParameterList([
 
 # Flags having discrete values, optional to generate either
 # a TD, FD, or frequency sequence waveform
-flags_generation_params = ParameterList([frame_axis, modes_choice, side_bands])
+flags_generation_params = ParameterList([frame_axis, modes_choice, side_bands, mode_array])
 
 # the following are parameters needed to generate an FD or TD waveform that
 # is equally sampled

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -390,7 +390,7 @@ side_bands = Parameter("side_bands",
                 dtype=int, default=0,
                 description="Flag for generating sidebands")
 mode_array = Parameter("mode_array",
-                dtype=int, default=None,
+                dtype=int, default=0,
                 description="Choose which (l,m) modes to include when "
                             "generating a waveform. "
                             "Only if approximant supports this feature."

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -110,6 +110,8 @@ def _check_lal_pars(p):
         lalsimulation.SimInspiralWaveformParamsInsertFrameAxis(lal_pars, p['frame_axis'])
     if p['side_bands']:
         lalsimulation.SimInspiralWaveformParamsInsertSideband(lal_pars, p['side_bands'])
+    if p['mode_array']:
+        lalsimulation.SimInspiralWaveformParamsInsertModeArray(lal_pars, p['mode_array'])
     return lal_pars
 
 def _lalsim_td_waveform(**p):

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -113,15 +113,12 @@ def _check_lal_pars(p):
     if p['mode_array']:
         try:
             ma = lalsimulation.SimInspiralCreateModeArray()
-            if p['mode_array']==-1:
-                lalsimulation.SimInspiralModeArrayActivateAllModes(ma)
-            else:
-                for l,m in p['mode_array']:
-                    lalsimulation.SimInspiralModeArrayActivateMode(ma, l, m)
+            for l,m in p['mode_array']:
+                lalsimulation.SimInspiralModeArrayActivateMode(ma, l, m)
             lalsimulation.SimInspiralWaveformParamsInsertModeArray(lal_pars, ma)
         except AttributeError:
-            print("AttributeError: SimInspiralCreateModeArray not found. "
-                  "lalsimulation version probably too old.")
+            pass
+
     return lal_pars
 
 def _lalsim_td_waveform(**p):

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -120,7 +120,8 @@ def _check_lal_pars(p):
                     lalsimulation.SimInspiralModeArrayActivateMode(ma, l, m)
             lalsimulation.SimInspiralWaveformParamsInsertModeArray(lal_pars, ma)
         except AttributeError:
-            raise
+            print("AttributeError: SimInspiralCreateModeArray not found. "
+                  "lalsimulation version probably too old.")
     return lal_pars
 
 def _lalsim_td_waveform(**p):

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -111,13 +111,16 @@ def _check_lal_pars(p):
     if p['side_bands']:
         lalsimulation.SimInspiralWaveformParamsInsertSideband(lal_pars, p['side_bands'])
     if p['mode_array']:
-        ma = lalsimulation.SimInspiralCreateModeArray()
-        if p['mode_array']==-1:
-            lalsimulation.SimInspiralModeArrayActivateAllModes(ma)
-        else:
-            for l,m in p['mode_array']:
-                lalsimulation.SimInspiralModeArrayActivateMode(ma, l, m)
-        lalsimulation.SimInspiralWaveformParamsInsertModeArray(lal_pars, ma)
+        try:
+            ma = lalsimulation.SimInspiralCreateModeArray()
+            if p['mode_array']==-1:
+                lalsimulation.SimInspiralModeArrayActivateAllModes(ma)
+            else:
+                for l,m in p['mode_array']:
+                    lalsimulation.SimInspiralModeArrayActivateMode(ma, l, m)
+            lalsimulation.SimInspiralWaveformParamsInsertModeArray(lal_pars, ma)
+        except AttributeError:
+            raise
     return lal_pars
 
 def _lalsim_td_waveform(**p):

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -111,7 +111,13 @@ def _check_lal_pars(p):
     if p['side_bands']:
         lalsimulation.SimInspiralWaveformParamsInsertSideband(lal_pars, p['side_bands'])
     if p['mode_array']:
-        lalsimulation.SimInspiralWaveformParamsInsertModeArray(lal_pars, p['mode_array'])
+        ma = lalsimulation.SimInspiralCreateModeArray()
+        if p['mode_array']==-1:
+            lalsimulation.SimInspiralModeArrayActivateAllModes(ma)
+        else:
+            for l,m in p['mode_array']:
+                lalsimulation.SimInspiralModeArrayActivateMode(ma, l, m)
+        lalsimulation.SimInspiralWaveformParamsInsertModeArray(lal_pars, ma)
     return lal_pars
 
 def _lalsim_td_waveform(**p):


### PR DESCRIPTION
mode_array was introduced in lalsimulation in this
redmine issue https://bugs.ligo.org/redmine/issues/5592
see example python script: https://bugs.ligo.org/redmine/attachments/5911/mode-array-example.py

It is a method that allows the user to specify the exact
(l,m) modes to use when generating a waveform.

Currently on the NR waveforms are supported.

This patch adds the mode_array parameter to get_td_waveform

Note: the default behaviour is completely unchanged.


```

# This script will run on atlas
# Make sure you have a recent build of LALSuite
# from June 30th 2017
# It needs the commit: 45f0eec2e2f9083a4f0ec977ebbe6fe54ccac591

import matplotlib
matplotlib.use('Agg')
import matplotlib.pyplot as plt
import lal
import lalsimulation as lalsim
from pycbc import pnutils
import h5py
import numpy as np
from pycbc.waveform import get_td_waveform

# filepath = '/Users/sebastian/work/data/SXS_BBH_0063_Res4.h5'
filepath = '/home/sebastian.khan/ligo-nr-data/lvcnr-lfs/SXS/SXS_BBH_0063_Res4.h5'

f = h5py.File(filepath, 'r')

mtotal = 150

mass1 = f.attrs['mass1']*mtotal
mass2 = f.attrs['mass2']*mtotal

f.close()

# The NR spins need to be transformed into the lal frame:
spins = lalsim.SimInspiralNRWaveformGetSpinsFromHDF5File(-1.,1.,filepath)

spin1x = spins[0]
spin1y = spins[1]
spin1z = spins[2]
spin2x = spins[3]
spin2y = spins[4]
spin2z = spins[5]

# Choose extrinsic parameters:

f_lower = 20.
inclination = np.pi/2.
distance = 600.
coa_phase = np.pi/3.

# Generating the waveform via PyCBC:

# default behaviour: Nothing has changed - when calling an NR
# waveform all modes are generated by default

hp, hc = get_td_waveform(approximant='NR_hdf5',
                                 numrel_data=filepath,
                                 mass1=mass1,
                                 mass2=mass2,
                                 spin1x=spin1x,
                                 spin1y=spin1y,
                                 spin1z=spin1z,
                                 spin2x=spin2x,
                                 spin2y=spin2y,
                                 spin2z=spin2z,
                                 delta_t=1.0/4096.,
                                 f_lower=f_lower,
                                 inclination=inclination,
                                 coa_phase=coa_phase,
                                 distance=distance,
                                 long_asc_nodes=np.pi/2.)

# Next we demonstrate how to use ModeArray to only generating the
# NR waveform with just the 22, and 2-2 modes.

# See https://bugs.ligo.org/redmine/attachments/5911/mode-array-example.py
# for more examples of functionality

# setup the ModeArray

ma = [ [2,2], [2,-2] ]

hp1, hc1 = get_td_waveform(approximant='NR_hdf5',
                                 numrel_data=filepath,
                                 mass1=mass1,
                                 mass2=mass2,
                                 spin1x=spin1x,
                                 spin1y=spin1y,
                                 spin1z=spin1z,
                                 spin2x=spin2x,
                                 spin2y=spin2y,
                                 spin2z=spin2z,
                                 delta_t=1.0/4096.,
                                 f_lower=f_lower,
                                 inclination=inclination,
                                 coa_phase=coa_phase,
                                 distance=distance,
                                 long_asc_nodes=np.pi/2.,
                                 mode_array=ma)
# assert(hp1==hp)

plt.figure()
plt.plot(hp,label='all modes')
plt.plot(hp1,label='just (l,m)=((2,2),(2,-2))')
plt.legend(loc='best')
plt.savefig('./nr-plot.png')
```

