### PR TITLE
add helper to get a slice of a time series using actual times

### DIFF
--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -148,7 +148,7 @@ class TimeSeries(Array):
     sample_rate = property(get_sample_rate,
                            doc="The sample rate of the time series.")
 
-    def select_time(self, start, end):
+    def time_slice(self, start, end):
         """Return the slice of the time series that contains the time range
         in GPS seconds.
         """

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -147,6 +147,21 @@ class TimeSeries(Array):
         return int(1.0/self.delta_t)
     sample_rate = property(get_sample_rate,
                            doc="The sample rate of the time series.")
+
+    def select_time(self, start, end):
+        """Return the slice of the time series that contains the time range
+        in GPS seconds.
+        """
+        if start < self.start_time:
+            raise ValueError('Time series does not contain a time as early as %s' % start)
+
+        if end > self.end_time:
+            raise ValueError('Time series does not contain a time as late as %s' % end)
+
+        start_idx = int((start - self.start_time) * self.sample_rate)
+        end_idx = int((end - self.start_time) * self.sample_rate)
+        return self[start_idx:end_idx]
+
     @property
     def delta_f(self):
         """Return the delta_f this ts would have in the frequency domain


### PR DESCRIPTION
Make it more convenient to slice a time series using gps times. 

i.e.

p = data.select_time(1192343232.50, 1192343232.90)