### PR TITLE
Fix bug in call to concatenate

### DIFF
--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -479,18 +479,18 @@ class PrecessionMassSpinToCartesianSpin(BaseTransform):
             mass1, mass2 = map(numpy.array, [maps["mass1"], maps["mass2"]])
             mask_mass1_gte_mass2 = mass1 >= mass2
             mask_mass1_lt_mass2 = mass1 < mass2
-            out[parameters.spin1x] = numpy.concatenate(
+            out[parameters.spin1x] = numpy.concatenate((
                                         spinx_p[mask_mass1_gte_mass2],
-                                        spinx_s[mask_mass1_lt_mass2])
-            out[parameters.spin1y] = numpy.concatenate(
+                                        spinx_s[mask_mass1_lt_mass2]))
+            out[parameters.spin1y] = numpy.concatenate((
                                         spiny_p[mask_mass1_gte_mass2],
-                                        spiny_s[mask_mass1_lt_mass2])
-            out[parameters.spin2x] = numpy.concatenate(
+                                        spiny_s[mask_mass1_lt_mass2]))
+            out[parameters.spin2x] = numpy.concatenate((
                                         spinx_p[mask_mass1_lt_mass2],
-                                        spinx_s[mask_mass1_gte_mass2])
-            out[parameters.spin2y] = numpy.concatenate(
+                                        spinx_s[mask_mass1_gte_mass2]))
+            out[parameters.spin2y] = numpy.concatenate((
                                         spinx_p[mask_mass1_lt_mass2],
-                                        spinx_s[mask_mass1_gte_mass2])
+                                        spinx_s[mask_mass1_gte_mass2]))
         elif maps["mass1"] > maps["mass2"]:
             out[parameters.spin1x] = spinx_p
             out[parameters.spin1y] = spiny_p


### PR DESCRIPTION
The `PrecessionMassSpinToCartesianSpin` transform uses `numpy.concatenate`, giving the list of arrays to concatenate as a list of arguments. However, concatenate apparently expects only the first argument to be a list or tuple of arrays. I'm not sure how this worked before; it may be a change that was introduced in newer versions of numpy. Anyway, this patch fixes that.