### PR TITLE
Allow configuration and veto files to be on ECP authenticated servers

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -175,7 +175,7 @@ def resolve_url(url, directory=None, permissions=None):
 
         # if we are downloading from git.ligo.org, check that we
         # did not get redirected to the sign-in page
-        if u.netloc == 'git.ligo.org':
+        if u.netloc == 'git.ligo.org' or u.netloc == 'code.pycbc.phy.syr.edu':
             soup = BeautifulSoup(r.content, 'html.parser')
             desc = soup.findAll(attrs={"property":"og:url"})
             if len(desc) and \

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -155,8 +155,17 @@ def resolve_url(url, directory=None, permissions=None):
         if os.path.isfile(ecp_file):
             cj = cookielib.MozillaCookieJar()
             cj.load(ecp_file, ignore_discard=True, ignore_expires=True)
-            for c in cj: 
-                if c.domain == u.netloc: cookie_dict[c.name] = c.value
+        else:
+            cj = []
+
+        for c in cj: 
+            if c.domain == u.netloc:
+                # load cookies for this server
+                cookie_dict[c.name] = c.value
+            elif u.netloc == "code.pycbc.phy.syr.edu" and \
+              c.domain == "git.ligo.org":
+                # handle the redirect for code.pycbc to git.ligo.org
+                cookie_dict[c.name] = c.value
 
         r = s.get(url, cookies=cookie_dict, allow_redirects=True)
         if r.status_code != 200:

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -155,9 +155,8 @@ def resolve_url(url, directory=None, permissions=None):
         if os.path.isfile(ecp_file):
             cj = cookielib.MozillaCookieJar()
             cj.load(ecp_file, ignore_discard=True, ignore_expires=True)
-            for c in cj:
-                if c.domain == u.netloc:
-                    cookie_dict[c.name] = c.value
+            for c in cj: 
+                if c.domain == u.netloc: cookie_dict[c.name] = c.value
 
         r = s.get(url, cookies=cookie_dict, allow_redirects=True)
         if r.status_code != 200:

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -35,7 +35,6 @@ import logging
 import urlparse
 import cookielib
 import requests
-import time
 import distutils.spawn
 import ConfigParser
 import itertools
@@ -140,10 +139,10 @@ def resolve_url(url, directory=None, permissions=None):
     if u.scheme == '' or u.scheme == 'file':
         # for regular files, make a direct copy
         if os.path.isfile(u.path):
-           shutil.copy(u.path,filename)
+            shutil.copy(u.path,filename)
         else:
-           errMsg  = "Cannot open file %s from URL %s" % (u.path, url)
-           raise ValueError(errMsg)
+            errmsg  = "Cannot open file %s from URL %s" % (u.path, url)
+            raise ValueError(errmsg)
 
     elif u.scheme == 'http' or u.scheme == 'https':
         s = requests.Session()
@@ -162,9 +161,9 @@ def resolve_url(url, directory=None, permissions=None):
 
         r = s.get(url, cookies=cookie_dict, allow_redirects=True)
         if r.status_code != 200:
-            errMsg = "Unable to download %s\nError code = %d" % (url,
+            errmsg = "Unable to download %s\nError code = %d" % (url,
                 r.status_code)
-            raise ValueError(errMsg)
+            raise ValueError(errmsg)
 
         # if we are downloading from git.ligo.org, check that we
         # did not get redirected to the sign-in page
@@ -173,8 +172,8 @@ def resolve_url(url, directory=None, permissions=None):
             desc = soup.findAll(attrs={"property":"og:url"})
             if len(desc) and \
               desc[0]['content'] == 'https://git.ligo.org/users/sign_in':
-                errMsg = "The attempt to download the file at\n\n%s\n" % url
-                errMsg += """
+                errmsg = "The attempt to download the file at\n\n%s\n" % url
+                errmsg += """
 was redirected to the git.ligo.org sign-in page. This means that you likely
 forgot to initialize your ECP cookie or that your LIGO.ORG credentials are
 otherwise invalid. Create a valid ECP cookie for git.ligo.org by running
@@ -183,7 +182,7 @@ ecp-cookie-init LIGO.ORG https://git.ligo.org/users/auth/shibboleth/callback alb
 
 before attempting to download files from git.ligo.org.
 """
-                raise ValueError(errMsg)
+                raise ValueError(errmsg)
 
         output_fp = open(filename, 'w')
         output_fp.write(r.content)
@@ -192,13 +191,13 @@ before attempting to download files from git.ligo.org.
     else:
         # TODO: We could support other schemes such as gsiftp by
         # calling out to globus-url-copy
-        errMsg  = "Unknown URL scheme: %s\n" % (u.scheme)
-        errMsg += "Currently supported are: file, http, and https." 
-        raise ValueError(errMsg)
+        errmsg  = "Unknown URL scheme: %s\n" % (u.scheme)
+        errmsg += "Currently supported are: file, http, and https." 
+        raise ValueError(errmsg)
 
     if not os.path.isfile(filename):
-        errMsg = "Error trying to create file %s from %s" % (filename,url)
-        raise ValueError(errMsg)
+        errmsg = "Error trying to create file %s from %s" % (filename,url)
+        raise ValueError(errmsg)
 
     if permissions:
         os.chmod(filename, permissions)
@@ -349,9 +348,9 @@ class WorkflowConfigParser(pycbc_glue.pipeline.DeepCopyableConfigParser):
         # Do overrides from command line
         for override in overrideTuples:
             if len(override) not in [2,3]:
-                errMsg = "Overrides must be tuples of length 2 or 3."
-                errMsg = "Got %s." % (str(override) )
-                raise ValueError(errMsg)
+                errmsg = "Overrides must be tuples of length 2 or 3."
+                errmsg = "Got %s." % (str(override) )
+                raise ValueError(errmsg)
             section = override[0]
             option = override[1]
             value = ''
@@ -526,9 +525,9 @@ class WorkflowConfigParser(pycbc_glue.pipeline.DeepCopyableConfigParser):
             if testList[0] == 'which':
                 newString = distutils.spawn.find_executable(testList[1])
                 if not newString:
-                    errMsg = "Cannot find exe %s in your path " %(testList[1])
-                    errMsg += "and you specified ${which:%s}." %(testList[1])
-                    raise ValueError(errMsg)
+                    errmsg = "Cannot find exe %s in your path " %(testList[1])
+                    errmsg += "and you specified ${which:%s}." %(testList[1])
+                    raise ValueError(errmsg)
 
         return newString
 

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -121,7 +121,20 @@ def _really_load(self, f, filename, ignore_discard, ignore_expires):
                         (filename, line))
 
 # Now monkey patch the code
-cookielib.MozillaCookieJar._really_load = _really_load
+cookielib.MozillaCookieJar._really_load = _really_load # noqa
+
+ecp_cookie_error = """The attempt to download the file at
+
+{}
+
+was redirected to the git.ligo.org sign-in page. This means that you likely
+forgot to initialize your ECP cookie or that your LIGO.ORG credentials are
+otherwise invalid. Create a valid ECP cookie for git.ligo.org by running
+
+ecp-cookie-init LIGO.ORG https://git.ligo.org/users/auth/shibboleth/callback albert.einstein
+
+before attempting to download files from git.ligo.org.
+"""
 
 def resolve_url(url, directory=None, permissions=None):
     """
@@ -180,17 +193,7 @@ def resolve_url(url, directory=None, permissions=None):
             desc = soup.findAll(attrs={"property":"og:url"})
             if len(desc) and \
               desc[0]['content'] == 'https://git.ligo.org/users/sign_in':
-                errmsg = "The attempt to download the file at\n\n%s\n" % url
-                errmsg += """
-was redirected to the git.ligo.org sign-in page. This means that you likely
-forgot to initialize your ECP cookie or that your LIGO.ORG credentials are
-otherwise invalid. Create a valid ECP cookie for git.ligo.org by running
-
-ecp-cookie-init LIGO.ORG https://git.ligo.org/users/auth/shibboleth/callback albert.einstein
-
-before attempting to download files from git.ligo.org.
-"""
-                raise ValueError(errmsg)
+                raise ValueError(ecp_cookie_error.format(url))
 
         output_fp = open(filename, 'w')
         output_fp.write(r.content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ pyRXP>=2.1.0
 pycbc-glue-obsolete==1.1.0
 weave>=0.16.0
 requests>=1.2.1
+beautifulsoup4>=4.6.0
 
 # Needed for Parameter Estimation Tasks
 kombine==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ mpld3>=0.3
 pyRXP>=2.1.0
 pycbc-glue-obsolete==1.1.0
 weave>=0.16.0
+requests>=1.2.1
 
 # Needed for Parameter Estimation Tasks
 kombine==0.8.1

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'kombine==0.8.1',
                       'emcee>=2.2.0',
                       'corner>=2.0.1',
+                      'requests>=1.2.1'
                       ]
 
 #FIXME Remove me when we bump to h5py > 2.5

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,8 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'kombine==0.8.1',
                       'emcee>=2.2.0',
                       'corner>=2.0.1',
-                      'requests>=1.2.1'
+                      'requests>=1.2.1',
+                      'beautifulsoup4>=4.6.0'
                       ]
 
 #FIXME Remove me when we bump to h5py > 2.5


### PR DESCRIPTION
This patch allows PyCBC to download files from ECP cookie authenticated servers as well as regular http and https. It has been tested as follows:

First, check for a sane failure mode:
```
(pycbc-dev)[dbrown@sugwg-condor pycbc]$ rm -f /tmp/ecpcookie.u620 
(pycbc-dev)[dbrown@sugwg-condor pycbc]$ python -c 'import pycbc.workflow; pycbc.workflow.resolve_url("https://git.ligo.org/duncan-brown/veto-definitions/raw/5fde1cd3f84e5983b81995f901b69b210b15d051/cbc/O2/H1L1-HOFT_C01_O2_CBC.xml")'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "pycbc/workflow/configuration.py", line 186, in resolve_url
    raise ValueError(errMsg)
ValueError: The attempt to download the file at

https://git.ligo.org/duncan-brown/veto-definitions/raw/5fde1cd3f84e5983b81995f901b69b210b15d051/cbc/O2/H1L1-HOFT_C01_O2_CBC.xml

was redirected to the git.ligo.org sign-in page. This means that you likely
forgot to initialize your ECP cookie or that your LIGO.ORG credentials are
otherwise invalid. Create a valid ECP cookie for git.ligo.org by running

ecp-cookie-init LIGO.ORG https://git.ligo.org/users/auth/shibboleth/callback albert.einstein

before attempting to download files from git.ligo.org.
```

Follow the instructions in the error message to get an ECP cookie:
```
(pycbc-dev)[dbrown@sugwg-condor pycbc]$ ecp-cookie-init LIGO.ORG https://git.ligo.org/users/auth/shibboleth/callback duncan.brown
Enter host password for user 'duncan.brown':
<html><body>You are being <a href="https://git.ligo.org/">redirected</a>.</body></html>(pycbc-dev)[dbrown@sugwg-condor pycbc]$ 
```
That fluff about being redirected is an issue with ``ecp-cookie-init`` so should be ignored.

Try again:
```
(pycbc-dev)[dbrown@sugwg-condor pycbc]$ python -c 'import pycbc.workflow; pycbc.workflow.resolve_url("https://git.ligo.org/duncan-brown/veto-definitions/raw/5fde1cd3f84e5983b81995f901b69b210b15d051/cbc/O2/H1L1-HOFT_C01_O2_CBC.xml")'
(pycbc-dev)[dbrown@sugwg-condor pycbc]$ echo $?
0
(pycbc-dev)[dbrown@sugwg-condor pycbc]$ head H1L1-HOFT_C01_O2_CBC.xml 
<?xml version='1.0' encoding='utf-8'?>
<!DOCTYPE LIGO_LW SYSTEM "http://ldas-sw.ligo.caltech.edu/doc/ligolwAPI/html/ligolw_dtd.txt">
<LIGO_LW>
	<Table Name="process:table">
		<Column Type="lstring" Name="process:comment"/>
		<Column Type="lstring" Name="process:node"/>
		<Column Type="lstring" Name="process:domain"/>
		<Column Type="int_4s" Name="process:unix_procid"/>
		<Column Type="int_4s" Name="process:start_time"/>
		<Column Type="ilwd:char" Name="process:process_id"/>
```
and we have a valid XML veto definer file.

Check a non-ECP URL from GitHub:
```
(pycbc-dev)[dbrown@sugwg-condor pycbc]$ python -c 'import pycbc.workflow; pycbc.workflow.resolve_url("https://raw.githubusercontent.com/ligo-cbc/pycbc-config/master/O2/pipeline/analysis.ini")'
(pycbc-dev)[dbrown@sugwg-condor pycbc]$ head analysis.ini 
; PyCBC configuration for BNS-NSBH-BBH search on O1-ER9-ER10-02 data
;
; Documentation for running the workflow generator is here:
;
;    http://ligo-cbc.github.io/pycbc/releases/v1.2.0/html/workflow/pycbc_make_coinc_search_workflow.html



[workflow]
; http://ligo-cbc.github.io/pycbc/releases/v1.2.0/html/workflow/initialization.html
```

Check the old redirects still work:
```
(pycbc-dev)[dbrown@sugwg-condor pycbc]$ python -c 'import pycbc.workflow; pycbc.workflow.resolve_url("https://code.pycbc.phy.syr.edu/ligo-cbc/pycbc-config/download/7a437f481796ffa57a0cf73caa53a1ee641895ab/O2/bank/H1L1-HYPERBANK_SEOBNRv4v2_VARFLOW_THORNE-1163174417-604800.xml.gz")'
(pycbc-dev)[dbrown@sugwg-condor pycbc]$ gunzip H1L1-HYPERBANK_SEOBNRv4v2_VARFLOW_THORNE-1163174417-604800.xml.gz 
(pycbc-dev)[dbrown@sugwg-condor pycbc]$ file H1L1-HYPERBANK_SEOBNRv4v2_VARFLOW_THORNE-1163174417-604800.xml 
H1L1-HYPERBANK_SEOBNRv4v2_VARFLOW_THORNE-1163174417-604800.xml: XML 1.0 document text
```