### PR TITLE
Run the workflow test using an ECP authenticated server

### DIFF
--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -221,7 +221,7 @@ EOF
     echo -e "\\n>> [`date`] Running test_coinc_search_workflow.sh"
     mkdir -p /pycbc/workflow-test
     pushd /pycbc/workflow-test
-    /pycbc/tools/test_coinc_search_workflow.sh ${VENV_PATH}
+    /pycbc/tools/test_coinc_search_workflow.sh ${VENV_PATH} ${TRAVIS_TAG}
     popd
   fi
 

--- a/tools/test_coinc_search_workflow.sh
+++ b/tools/test_coinc_search_workflow.sh
@@ -5,23 +5,32 @@ set -e
 echo -e "\\n>> [`date`] Testing pycbc_make_coinc_search_workflow"
 
 VENV_PATH=${1}
+TRAVIS_TAG=${2}
 
 if [ "x${VENV_PATH}" == "x" ] ; then
   echo -e "\\n>> [`date`] Error: VENV_PATH was not passed to script or is empty"
   exit 1
 fi
 
+if [ "x${TRAVIS_TAG}" == "x" ] ; then
+  echo -e "\\n>> [`date`] Error: TRAVIS_TAG was not passed to script or is empty"
+  exit 1
+fi
+
 echo -e "\\n>> [`date`] Entering virtual environment $VENV_PATH"
 source ${VENV_PATH}/bin/activate
 
-echo -e "\\n>> [`date`] Cloning pycbc-config git repository"
-test -r pycbc-config || git clone --depth 1 git@github.com:ligo-cbc/pycbc-config.git
-CONFIG_PATH="file://`pwd`/pycbc-config"
+CONFIG_PATH="https://raw.githubusercontent.com/ligo-cbc/pycbc-config/${TRAVIS_TAG}"
+echo -e "\\n>> [`date`] Using config files from ${CONFIG_PATH}"
 
-test -r veto-definitions || git clone --depth 1 git@code.pycbc.phy.syr.edu:detchar/veto-definitions.git
-VETO_PATH="file://`pwd`/veto-definitions"
+VETO_DEFINER="https://git.ligo.org/detchar/veto-definitions/raw/a07f542b37ccfcfbf2b732f0d75d0f1ab4166d9f/cbc/O1/H1L1-CBC_VETO_DEFINER_C02_O1_1126051217-11203200.xml"
+echo -e "\\n>> [`date`] Using veto definer file from ${VETO_DEFINER}"
+
+BANK_FILE="${CONFIG_PATH}/O1/bank/H1L1-UBERBANK_MAXM100_NS0p05_ER8HMPSD-1126033217-223200.xml.gz"
+echo -e "\\n>> [`date`] Using template bank from ${BANK_FIL}"
 
 echo -e "\\n>> [`date`] Building test workflow $WORKFLOWNAME"
+
 cp `which ligo-proxy-init` .
 patch -p0 ligo-proxy-init 1>/dev/null <<EOF
 --- /bin/ligo-proxy-init	2016-12-05 07:18:14.000000000 -0500
@@ -36,10 +45,26 @@ patch -p0 ligo-proxy-init 1>/dev/null <<EOF
  fi
 EOF
 
+cp `which ecp-cookie-init` .
+patch -p0 ecp-cookie-init 1>/dev/null << EOF
+--- /bin/ecp-cookie-init        2016-12-21 08:41:13.000000000 -0500
++++ /tmp/ecp-cookie-init        2017-07-11 09:43:30.846451317 -0400
+@@ -268,7 +268,7 @@
+     target=\$2
+     login=\$3
+ 
+-    curl_auth_method="--user \$login"
++    curl_auth_method="--user \$login:\${LIGO_TOKEN}"
+ fi
+ 
+ if [ "\${idp_tag}" = "LIGO.ORG" ] ; then
+EOF
+
 unset X509_USER_PROXY
 export LIGO_TOKEN=`cat ~/.ssh/ldg_token`
 LIGO_USER=`cat ~/.ssh/ldg_user`
 ./ligo-proxy-init -p ${LIGO_USER} 1>/dev/null
+./ecp-cookie-init LIGO.ORG https://git.ligo.org/users/auth/shibboleth/callback ${LIGO_USER} 1>/dev/null
 unset LIGO_TOKEN LIGO_USER
 
 UUID=`uuidgen`
@@ -80,8 +105,8 @@ pycbc_make_coinc_search_workflow \
   "workflow-segments:segments-final-veto-group:12H" \
   "workflow-segments:segments-veto-groups:" \
   "datafind:urltype:file" \
-  "workflow-segments:segments-veto-definer-url:${VETO_PATH}/cbc/O1/H1L1-CBC_VETO_DEFINER_C02_O1_1126051217-11203200.xml" \
-  "workflow-tmpltbank:tmpltbank-pregenerated-bank:${CONFIG_PATH}/O1/bank/H1L1-UBERBANK_MAXM100_NS0p05_ER8HMPSD-1126033217-223200.xml.gz" \
+  "workflow-segments:segments-veto-definer-url:${VETO_DEFINER}" \
+  "workflow-tmpltbank:tmpltbank-pregenerated-bank:${BANK_FILE}" \
   "inspiral:low-frequency-cutoff:30" \
   "s-mchirp:bins:0.8 1.74 8.07 14.92 21.77 100" \
   "s-mtotal:bins:2 4 27.25 51.5 75.75 100" \


### PR DESCRIPTION
This will run the Travis test that builds the workflow against an ECP cookie authenticated server to perform a unit test of the new code in https://github.com/ligo-cbc/pycbc/pull/1773

@ahnitz this won't be exercised unless it's on the master or a tag of the master because security, so please go ahead, override the checks, and merge this. If there are any errors, I'll have to debug on master.