### PR TITLE
Catch error if source and destination configuration file are the same

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -152,7 +152,10 @@ def resolve_url(url, directory=None, permissions=None):
     if u.scheme == '' or u.scheme == 'file':
         # for regular files, make a direct copy
         if os.path.isfile(u.path):
-            shutil.copy(u.path,filename)
+            if filecmp.cmp(u.path,filename):
+                filename = u.path
+            else:
+                shutil.copy(u.path,filename)
         else:
             errmsg  = "Cannot open file %s from URL %s" % (u.path, url)
             raise ValueError(errmsg)

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -153,10 +153,10 @@ def resolve_url(url, directory=None, permissions=None):
     if u.scheme == '' or u.scheme == 'file':
         # for regular files, make a direct copy
         if os.path.isfile(u.path):
-            if filecmp.cmp(u.path,filename):
+            if filecmp.cmp(u.path, filename):
                 filename = u.path
             else:
-                shutil.copy(u.path,filename)
+                shutil.copy(u.path, filename)
         else:
             errmsg  = "Cannot open file %s from URL %s" % (u.path, url)
             raise ValueError(errmsg)

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -30,6 +30,7 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/initialization_inifile.
 import os
 import re
 import shutil
+import filecmp
 import time
 import logging
 import urlparse


### PR DESCRIPTION
If the source and destination config files are the same, don't attempt to make a copy. This fixes https://github.com/ligo-cbc/pycbc/issues/1781