### PR TITLE
Fixed edge cases in resolve_url

### DIFF
--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -31,7 +31,6 @@ import os
 import re
 import stat
 import shutil
-import filecmp
 import time
 import logging
 import urlparse

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -29,6 +29,7 @@ https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/ahope/initialization_inifile.
 
 import os
 import re
+import stat
 import shutil
 import filecmp
 import time
@@ -153,8 +154,12 @@ def resolve_url(url, directory=None, permissions=None):
     if u.scheme == '' or u.scheme == 'file':
         # for regular files, make a direct copy
         if os.path.isfile(u.path):
-            if os.path.isfile(filename) and filecmp.cmp(u.path, filename):
-                filename = u.path
+            if os.path.isfile(filename):
+                # check to see if src and dest are the same file
+                src_inode = os.stat(u.path)[stat.ST_INO]
+                dst_inode = os.stat(filename)[stat.ST_INO]
+                if src_inode != dst_inode:
+                    shutil.copy(u.path, filename)
             else:
                 shutil.copy(u.path, filename)
         else:
@@ -215,7 +220,14 @@ def resolve_url(url, directory=None, permissions=None):
         raise ValueError(errmsg)
 
     if permissions:
-        os.chmod(filename, permissions)
+        if os.access(filename, os.W_OK):
+            os.chmod(filename, permissions)
+        else:
+            # check that the file has at least the permissions requested
+            s = os.stat(filename)[stat.ST_MODE]
+            if (s & permissions) != permissions:
+                errmsg = "Could not change permissions on %s (read-only)" % url
+                raise ValueError(errmsg)
 
     return filename
 


### PR DESCRIPTION
This pull request fixes two issues in ``resolve_url()``

First, this patch makes ``resolve_url()`` idempotent. Before, you could get different URLs returned if Python thought that the file was the same:
```
In [6]: pycbc.workflow.resolve_url("file:///home/dbrown/x509_test/x509_test.2461667.log")
Out[6]: '/home/dbrown/x509_test.2461667.log'

In [7]: pycbc.workflow.resolve_url("file:///home/dbrown/x509_test/x509_test.2461667.log")
Out[7]: '/home/dbrown/x509_test/x509_test.2461667.log'
```
This is now fixed:
```
In [7]: pycbc.workflow.resolve_url("/home/dbrown/x509_test/x509_test.2461667.log")
Out[7]: '/home/dbrown/x509_test.2461667.log'

In [8]: pycbc.workflow.resolve_url("/home/dbrown/x509_test/x509_test.2461667.log")
Out[8]: '/home/dbrown/x509_test.2461667.log'

In [9]: pycbc.workflow.resolve_url("/home/dbrown/x509_test/x509_test.2461667.log",directory="/home/dbrown/x509_test")
Out[9]: '/home/dbrown/x509_test/x509_test.2461667.log'

In [10]: pycbc.workflow.resolve_url("/home/dbrown/x509_test/x509_test.2461667.log",directory="/home/dbrown/x509_test")
Out[10]: '/home/dbrown/x509_test/x509_test.2461667.log'
```

Second, @ahnitz ran into a problem trying to use the v1.7.4 installation from CVMFS:
```
File "/cvmfs/oasis.opensciencegrid.org/ligo/deploy/sw/pycbc/x86_64_deb_8/virtualenv/pycbc-v1.7.4/lib/python2.7/site-packages/PyCBC-1.7.4-py2.7.egg/pycbc/workflow/configuration.py", line 218, in resolve_url
    os.chmod(filename, permissions)
OSError: [Errno 30] Read-only file system: '/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/x86_64_deb_8/virtualenv/pycbc-v1.7.4/bin/ligolw_segment_query_dqsegdb'
```
The problem is due to ``resolve_url()`` trying to change the permissions on a file that it does not have write access to. This patch also fixes that behavior.