### PR TITLE
Add program to extract posterior samples from inference files

### DIFF
--- a/bin/inference/pycbc_inference_extract_samples
+++ b/bin/inference/pycbc_inference_extract_samples
@@ -1,0 +1,124 @@
+#! /user/bin/env python
+
+# Copyright (C) 2017 Collin Capano
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""Extracts some or all samples from an InferenceFile, writing results to a new
+InferenceFile.
+"""
+
+import os
+import argparse
+import logging
+import numpy
+import pycbc
+from pycbc.inference import option_utils
+from pycbc.io.inference_hdf import InferenceFile
+
+parser = argparse.ArgumentParser(description=__doc__)
+
+parser.add_argument("--input-file", type=str, required=True,
+    help="Path to input HDF file.")
+parser.add_argument("--output-file", type=str, required=True,
+                    help="Output file to create.")
+parser.add_argument("--force", action="store_true", default=False,
+                    help="If the output-file already exists, overwrite it. "
+                         "Otherwise, an IOError is raised.")
+parser.add_argument("--posterior-only", action="store_true", default=False,
+                    help="Write copied parameter samples and likelihood stats "
+                         "as flattened arrays. For example, if the sampler "
+                         "wrote a parameter's samples to "
+                         "{samples_group}/{param}/walker{x}/, then the "
+                         "copied file will have all selected samples from "
+                         "all walkers in {samples_group/{param}/. Default is "
+                         "for the copied file to have the same structure "
+                         "as the input file.")
+# options for down selecting parameters
+parser.add_argument("--parameters", type=str, nargs="+",
+    metavar="PARAM[:NAME]",
+    help="Name of parameters to copy. If none provided will copy all of "
+         "the variable_args in the input file. If provided, the "
+         "parameters can be any of the variable args in "
+         "the input file, derived parameters from them, or any function "
+         "of them. Syntax for functions is python; any math functions in "
+         "the numpy libary may be used. Can optionally also specify a "
+         "name for each parameter, in which case the parameter will be "
+         "saved with the given name in the output file.")
+parser.add_argument("--thin-start", type=int, default=None,
+    help="Sample number to start collecting samples to plot. If none "
+         "provided, will start at the end of the burn-in.")
+parser.add_argument("--thin-interval", type=int,
+    default=None,
+    help="Interval to use for thinning samples. If none provided, will "
+         "use the auto-correlation length found in the file.")
+parser.add_argument("--thin-end", type=int, default=None,
+    help="Sample number to stop collecting samples to plot. If none "
+         "provided, will stop at the last sample from the sampler.")
+parser.add_argument("--iteration", type=int, default=None,
+    help="Only retrieve the given iteration. To load the last n-th sampe "
+         "use -n, e.g., -1 will load the last iteration. This overrides "
+         "the thin-start/interval/end options.")
+# add additional, sampler-specific options
+parser.add_argument("--temperature", nargs='+',
+                    help="For parallel-tempered samplers, which temperature "
+                         "chain(s) to extract. Options are 'all', or one or "
+                         "more indices indicating the temperature chain "
+                         "(0 = coldest). Default is to only extract from "
+                         "the coldest chain. ")
+parser.add_argument("--verbose", action="store_true", default=False,
+                    help="Be verbose")
+
+opts = parser.parse_args()
+
+pycbc.init_logging(opts.verbose)
+
+# check that the output doesn't already exist
+if os.path.exists(opts.output_file) and not opts.force:
+    raise IOError("output file already exists; use --force if you wish to "
+                  "overwrite.")
+
+# add any sampler specific options
+sampler_kwargs = {}
+if opts.temperature is not None:
+    temps = opts.temperature
+    if temps == ['all']:
+        temps = temps[0]
+    else:
+        temps = map(int, temps)
+    sampler_kwargs['temps'] = temps
+
+# open the input and parse parameters
+source = InferenceFile(opts.input_file)
+parameters, pnames = option_utils.parse_parameters_opt(opts.parameters)
+
+# copy to output
+target = source.copy(opts.output_file, parameters=parameters,
+                     parameter_names=pnames,
+                     posterior_only=opts.posterior_only,
+                     thin_start=opts.thin_start, thin_end=opts.thin_end,
+                     thin_interval=opts.thin_interval,
+                     iteration=opts.iteration,
+                     **sampler_kwargs) 
+
+target.close()

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -381,9 +381,13 @@ class BaseMCMCSampler(_BaseSampler):
         end_iteration : {None, int}
             Write results up to the given iteration.
         index_offset : int, optional
-            Offset the indices used to access the arrays on disk and the
-            samples. Specifically, index_offset = file array indices - samples'
-            indices. Default is 0.
+            Write the samples to the arrays on disk starting at
+            `start_iteration` + `index_offset`. For example, if
+            `start_iteration=0`, `end_iteration=1000` and `index_offset=500`,
+            then `samples[0:1000]` will be written to indices `500:1500` in the
+            arrays on disk. This is needed if you are adding new samples to
+            a chain that was previously written to file, and you want to
+            preserve the history (e.g., after a checkpoint). Default is 0.
         max_iterations : {None, int}
             If samples have not previously been written to the file, a new
             dataset will be created. By default, the size of this dataset will

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -352,9 +352,10 @@ class BaseMCMCSampler(_BaseSampler):
         fp.attrs["nwalkers"] = self.nwalkers
         fp.attrs['burn_in_iterations'] = self.burn_in_iterations
 
-    def _write_samples_group(self, fp, samples_group, parameters, samples,
-                             start_iteration=0, end_iteration=None,
-                             max_iterations=None):
+    @staticmethod
+    def write_samples_group(fp, samples_group, parameters, samples,
+                            start_iteration=0, end_iteration=None,
+                            index_offset=0, max_iterations=None):
         """Writes samples to the given file.
 
         Results are written to:
@@ -379,6 +380,10 @@ class BaseMCMCSampler(_BaseSampler):
             Write results starting from the given iteration.
         end_iteration : {None, int}
             Write results up to the given iteration.
+        index_offset : int, optional
+            Offset the indices used to access the arrays on disk and the
+            samples. Specifically, index_offset = file array indices - samples'
+            indices. Default is 0.
         max_iterations : {None, int}
             If samples have not previously been written to the file, a new
             dataset will be created. By default, the size of this dataset will
@@ -390,13 +395,13 @@ class BaseMCMCSampler(_BaseSampler):
         # due to clearing memory, there can be a difference between indices in
         # memory and on disk
         nwalkers, niterations = samples.shape
-        niterations += self._lastclear
+        niterations += index_offset
         fa = start_iteration # file start index
         if end_iteration is None:
             end_iteration = niterations
         fb = end_iteration # file end index
-        ma = fa - self._lastclear # memory start index
-        mb = fb - self._lastclear # memory end index
+        ma = fa - index_offset # memory start index
+        mb = fb - index_offset # memory end index
 
         if max_iterations is not None and max_iterations < niterations:
             raise IndexError("The provided max size is less than the "
@@ -459,10 +464,11 @@ class BaseMCMCSampler(_BaseSampler):
         parameters = self.variable_args
         samples_group = fp.samples_group
         # write data
-        self._write_samples_group(
+        self.write_samples_group(
                          fp, samples_group, parameters, samples,
                          start_iteration=start_iteration,
                          end_iteration=end_iteration,
+                         index_offset=self._lastclear,
                          max_iterations=max_iterations)
 
     def write_likelihood_stats(self, fp, start_iteration=0, end_iteration=None,
@@ -509,10 +515,11 @@ class BaseMCMCSampler(_BaseSampler):
         parameters = samples.fieldnames
         samples_group = fp.stats_group
         # write data
-        self._write_samples_group(
+        self.write_samples_group(
                          fp, samples_group, parameters, samples,
                          start_iteration=start_iteration,
                          end_iteration=end_iteration,
+                         index_offset=self._lastclear,
                          max_iterations=max_iterations)
         return samples
 

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -589,9 +589,13 @@ class EmceePTSampler(BaseMCMCSampler):
         end_iteration : {None, int}
             Write results up to the given iteration.
         index_offset : int, optional
-            Offset the indices used to access the arrays on disk and the
-            samples. Specifically, index_offset = file array indices - samples'
-            indices. Default is 0.
+            Write the samples to the arrays on disk starting at
+            `start_iteration` + `index_offset`. For example, if
+            `start_iteration=0`, `end_iteration=1000` and `index_offset=500`,
+            then `samples[0:1000]` will be written to indices `500:1500` in the
+            arrays on disk. This is needed if you are adding new samples to
+            a chain that was previously written to file, and you want to
+            preserve the history (e.g., after a checkpoint). Default is 0.
         max_iterations : {None, int}
             If samples have not previously been written to the file, a new
             dataset will be created. By default, the size of this dataset will

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -559,10 +559,10 @@ class EmceePTSampler(BaseMCMCSampler):
             arrays.append(fp[group.format(tk=tk)][wmask])
         return numpy.vstack(arrays)
 
-    def _write_samples_group(self, fp, samples_group, parameters, samples,
+    @staticmethod
+    def write_samples_group(fp, samples_group, parameters, samples,
                              start_iteration=0, end_iteration=None,
-                             max_iterations=None,
-                             apply_boundary_conditions=False):
+                             index_offset=0, max_iterations=None):
         """Writes samples to the given file.
 
         Results are written to:
@@ -588,6 +588,10 @@ class EmceePTSampler(BaseMCMCSampler):
             Write results starting from the given iteration.
         end_iteration : {None, int}
             Write results up to the given iteration.
+        index_offset : int, optional
+            Offset the indices used to access the arrays on disk and the
+            samples. Specifically, index_offset = file array indices - samples'
+            indices. Default is 0.
         max_iterations : {None, int}
             If samples have not previously been written to the file, a new
             dataset will be created. By default, the size of this dataset will
@@ -599,13 +603,13 @@ class EmceePTSampler(BaseMCMCSampler):
         ntemps, nwalkers, niterations = samples.shape
         # due to clearing memory, there can be a difference between indices in
         # memory and on disk
-        niterations += self._lastclear
+        niterations += index_offset
         fa = start_iteration # file start index
         if end_iteration is None:
             end_iteration = niterations
         fb = end_iteration # file end index
-        ma = fa - self._lastclear # memory start index
-        mb = fb - self._lastclear # memory end index
+        ma = fa - index_offset # memory start index
+        mb = fb - index_offset # memory end index
 
         if max_iterations is not None and max_iterations < niterations:
             raise IndexError("The provided max size is less than the "

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -718,7 +718,7 @@ class EmceePTSampler(BaseMCMCSampler):
 
         # get the slice to use
         if iteration is not None:
-            get_index = iteration
+            get_index = [iteration]
         else:
             if thin_end is None:
                 # use the number of current iterations

--- a/setup.py
+++ b/setup.py
@@ -447,6 +447,7 @@ setup (
                'bin/pycbc_condition_strain',
                'bin/workflows/pycbc_make_inference_workflow',
                'bin/inference/pycbc_inference',
+               'bin/inference/pycbc_inference_extract_samples',
                'bin/inference/pycbc_inference_plot_acceptance_rate',
                'bin/inference/pycbc_inference_plot_acf',
                'bin/inference/pycbc_inference_plot_acl',


### PR DESCRIPTION
This adds an executable, `pycbc_inference_extract_samples`, that will copy an inference result file to another inference file, but only writing out the desired samples. What samples to extract are given by the standard `--thin-start/end/interval / --iteration` arguments. If these are not provided, the acl and burn_in_iterations in the file will be used. By default, the program will write the samples to the new file with the same group structure as the original. In this case, the file could still be used as the starting point for another run even though it contains fewer samples.

If `--posterior-only` is given, the samples will be written as flat arrays, and a `posterior_only` attribute to be set in the output file. This causes information to be lost about walkers/temps/etc., but yields smaller files that are simple to read, with identical group structure, regardless of the sampler that was used.

File sizes from ~5000 walkers with 16000 iterations can be reduced from O(10GB) to O(100MB), and down to a O(MB) if `posterior-only` is on. I figure this is useful for PP tests, where we don't want to keep large numbers of very large files laying around, when we only care about a few iterations stored in them.

A subset of parameters and/or functions of parameters may be chosen to be written out using the standard `--parameters` option. The parameters can be renamed in the copied file. The output files are readable by plot_posterior, even if posterior_only is on.

Most of the leg work is done by a copy method that I've added to InferenceFile. I also added a class in `inference_hdf.py` to handle reading/writing samples in posterior_only files. If the number of samples being written out is not exactly the same, the acl and burn_in_iterations, and niterations in the output file is reset.

Example usage:
```
pycbc_inference_extract_samples --input-file emcee_pt_quicktest.hdf --output-file emcee_pt_extract_poster_lastiter.hdf --iteration -1 --verbose --posterior-only
```

I tested with kombine, emcee, and emcee_pt.