### PR TITLE
New multi-mode ringdown approximant

### DIFF
--- a/bin/pycbc_ringinj
+++ b/bin/pycbc_ringinj
@@ -37,14 +37,14 @@ def mode_info_from_input(all_modes, option, input):
     for mode in all_modes:
         if mode not in info_modes:
             raise ValueError('Number of modes in option lmns does not match '
-                             'number of modes in option %s'.format(option))
+                             'number of modes in option {}'.format(option))
     for info in input:
         try:
             x['%s' %info.split(':')[0]]=info.split(':')[1]
             y['%s' %info.split(':')[0]]=info.split(':')[2]
         except:
-            raise ValueError('Information missing in %s '
-                             'for mode %s'.format(option,mode))
+            raise ValueError('Information missing in {} '
+                             'for mode {}'.format(option,mode))
     return x, y
 
 parser = argparse.ArgumentParser()
@@ -135,18 +135,6 @@ else:
     if opts.t_final is not None:
         injection.create_dataset('t_final', data=opts.t_final)
 
-## Single mode approximant
-#if opts.approximant=='FdQNM' or opts.approximant=='TdQNM':
-#    # Check that the necessary arguments are given
-#    for parameter in ringdown.qnm_required_args:
-#        if getattr(opts, parameter) is None:
-#            raise ValueError('%s is required' %parameter)
-#    # Create datasets for each argument
-#    injection.create_dataset('f_0', data=opts.f_0)
-#    injection.create_dataset('tau', data=opts.tau)
-#    injection.create_dataset('amp', data=opts.amp)
-#    injection.create_dataset('phi', data=opts.phi)
-
 # Amplitudes and phases for each mode have to be given
 all_modes = []
 for lmn in opts.lmns:
@@ -164,8 +152,8 @@ if '220' not in all_modes:
     except:
         raise ValueError('Please provide information of 220 mode')
 
-if opts.approximant=='FdQNMfrom_final_mass_spin' \
-or opts.approximant=='TdQNMfrom_final_mass_spin':
+if opts.approximant=='FdQNMfromFinalMassSpin' \
+or opts.approximant=='TdQNMfromFinalMassSpin':
     # Check that the necessary arguments are given
     for parameter in ringdown.mass_spin_required_args:
         if getattr(opts, parameter) is None:
@@ -173,8 +161,8 @@ or opts.approximant=='TdQNMfrom_final_mass_spin':
     injection.create_dataset('final_mass', data=opts.final_mass)
     injection.create_dataset('final_spin', data=opts.final_spin)
 
-if opts.approximant=='FdQNMfrom_freqtau' \
-or opts.approximant=='TdQNMfrom_freqtau':
+if opts.approximant=='FdQNMfromFreqTau' \
+or opts.approximant=='TdQNMfromFreqTau':
     # Frequencies and damping times for each mode have to be given
     freqs, taus = mode_info_from_input(all_modes, 'freqs-taus', opts.freqs_taus)
     # Create datasets for each argument

--- a/bin/pycbc_ringinj
+++ b/bin/pycbc_ringinj
@@ -31,6 +31,22 @@ import argparse
 import h5py
 from pycbc.waveform import ringdown
 
+def mode_info_from_input(all_modes, option, input):
+    info_modes = [info.split(':')[0] for info in input]
+    x, y = {}, {}
+    for mode in all_modes:
+        if mode not in info_modes:
+            raise ValueError('Number of modes in option lmns does not match '
+                             'number of modes in option %s'.format(option))
+    for info in input:
+        try:
+            x['%s' %info.split(':')[0]]=info.split(':')[1]
+            y['%s' %info.split(':')[0]]=info.split(':')[2]
+        except:
+            raise ValueError('Information missing in %s '
+                             'for mode %s'.format(option,mode))
+    return x, y
+
 parser = argparse.ArgumentParser()
 parser.add_argument('--output', required=True,
                     help='Path to output hdf file.')
@@ -39,26 +55,21 @@ parser.add_argument('--approximant', required=True,
 parser.add_argument('--tc', required=True, type=float,
                     help='Geocentric coalescence time '
                          '(start time of the ringdown injection).')
-parser.add_argument('--f-0', type=float,
-                    help='Central frequency of the ringdown for '
-                         'single mode approximants.')
-parser.add_argument('--tau', type=float,
-                    help='Damping time of the ringdown for '
-                         'single mode approximants.')
-parser.add_argument('--amp', type=float,
-                    help='Amplitude for single mode approximants.')
-parser.add_argument('--phi', type=float,
-                    help='Phase for single mode approximants.')
+parser.add_argument('--lmns', nargs='+',
+                    help='Modes desired, choose only one for single-mode '
+                         'ringdown (lm modes available: 22, 21, 33, 44, 55). '
+                         'Example: 222 331 gives the modes 220, 221, and 330.')
 parser.add_argument('--final-mass', type=float,
                     help='Mass of the final black hole for '
-                         'multi-mode approximants.')
+                         'MassSpin approximants.')
 parser.add_argument('--final-spin', type=float,
-                    help='Spin of the final black hole for ' 
-                         'multi-mode approximants.')
-parser.add_argument('--lmns', nargs='+',
-                    help='Modes desired for multi-mode approximants ' 
-                         '(lm modes available: 22, 21, 33, 44, 55). '
-                         'Example: 222 331 gives the modes 220, 221, and 330.')
+                    help='Spin of the final black hole for '
+                         'MassSpin approximants.')
+parser.add_argument('--freqs-taus', nargs='+',
+                    help='Central frequency (Hz) and damping time (s) of the '
+                         'ringdown for each mode (FreqTau approximants).'
+                         'Use format mode:freq:tau.'
+                         'Example: 220:317:0.003 221:309:0.001 330:503:0.003')
 parser.add_argument('--amps-phis', nargs='+',
                     help='Amplitudes and phases for each mode. '
                          'Use format mode:amplitude:phase. '
@@ -98,7 +109,8 @@ if opts.approximant not in approxs:
     raise ValueError('Invalid ringdown approximant')
 
 # Check that the taper option is only given with time-domain approximan
-if opts.taper is not None and opts.approximant in ringdown.ringdown_fd_approximants.keys():
+if opts.taper is not None \
+and opts.approximant in ringdown.ringdown_fd_approximants.keys():
     raise ValueError('The taper option can only be given for time-domain approximants.')
 
 # Write hdf file with the parameters for the injection
@@ -106,6 +118,7 @@ injection = h5py.File('%s' %opts.output, 'w')
 # Store common arguments
 injection.create_dataset('approximant', data=opts.approximant)
 injection.create_dataset('tc', data=opts.tc)
+injection.create_dataset('lmns', data=opts.lmns)
 injection.create_dataset('ra', data=opts.ra)
 injection.create_dataset('dec', data=opts.dec)
 injection.create_dataset('polarization', data=opts.polarization)
@@ -122,52 +135,51 @@ else:
     if opts.t_final is not None:
         injection.create_dataset('t_final', data=opts.t_final)
 
-# Single mode approximant
-if opts.approximant=='FdQNM' or opts.approximant=='TdQNM':
-    # Check that the necessary arguments are given
-    for parameter in ringdown.qnm_required_args:
-        if getattr(opts, parameter) is None:
-            raise ValueError('%s is required' %parameter)
-    # Create datasets for each argument
-    injection.create_dataset('f_0', data=opts.f_0)
-    injection.create_dataset('tau', data=opts.tau)
-    injection.create_dataset('amp', data=opts.amp)
-    injection.create_dataset('phi', data=opts.phi)
+## Single mode approximant
+#if opts.approximant=='FdQNM' or opts.approximant=='TdQNM':
+#    # Check that the necessary arguments are given
+#    for parameter in ringdown.qnm_required_args:
+#        if getattr(opts, parameter) is None:
+#            raise ValueError('%s is required' %parameter)
+#    # Create datasets for each argument
+#    injection.create_dataset('f_0', data=opts.f_0)
+#    injection.create_dataset('tau', data=opts.tau)
+#    injection.create_dataset('amp', data=opts.amp)
+#    injection.create_dataset('phi', data=opts.phi)
 
-# Multi-mode approximant
-if opts.approximant=='FdQNMmultiModes' or opts.approximant=='TdQNMmultiModes':
+# Amplitudes and phases for each mode have to be given
+all_modes = []
+for lmn in opts.lmns:
+    l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
+    [all_modes.append('%d%d%d' %(l,m,n)) for n in range(nmodes)]
+amps, phis = mode_info_from_input(all_modes, 'amps-phis', opts.amps_phis)
+# Create datasets for each argument
+for mode in all_modes:
+    injection.create_dataset('amp%s' %mode, data=float(amps[mode]))
+    injection.create_dataset('phi%s' %mode, data=float(phis[mode]))
+# Amplitude of 220 mode is always required, even if 22 not included
+if '220' not in all_modes:
+    try:
+        injection.create_dataset('amp220', data=float(amps['220']))
+    except:
+        raise ValueError('Please provide information of 220 mode')
+
+if opts.approximant=='FdQNMfrom_final_mass_spin' \
+or opts.approximant=='TdQNMfrom_final_mass_spin':
     # Check that the necessary arguments are given
-    for parameter in ringdown.lm_allmodes_required_args:
+    for parameter in ringdown.mass_spin_required_args:
         if getattr(opts, parameter) is None:
             raise ValueError('%s is required' %parameter)
-    # Amplitudes and phases for each mode have to be given
-    all_modes = []
-    for lmn in opts.lmns:
-        l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
-        [all_modes.append('%d%d%d' %(l,m,n)) for n in range(nmodes)]
-    info_modes=[info.split(':')[0] for info in opts.amps_phis]
-    amps, phis = {}, {}
-    for mode in all_modes:
-        if mode not in info_modes:
-            raise ValueError('Amplitude and phase for mode %s are required' %mode)
-    for info in opts.amps_phis:
-        try:
-            amps['%s' %info.split(':')[0]]=info.split(':')[1]
-            phis['%s' %info.split(':')[0]]=info.split(':')[2]
-        except:
-            raise ValueError('Amplitude or phase for one of the modes is missing')
-    # Create datasets for each argument
     injection.create_dataset('final_mass', data=opts.final_mass)
     injection.create_dataset('final_spin', data=opts.final_spin)
-    injection.create_dataset('lmns', data=opts.lmns)
+
+if opts.approximant=='FdQNMfrom_freqtau' \
+or opts.approximant=='TdQNMfrom_freqtau':
+    # Frequencies and damping times for each mode have to be given
+    freqs, taus = mode_info_from_input(all_modes, 'freqs-taus', opts.freqs_taus)
+    # Create datasets for each argument
     for mode in all_modes:
-        injection.create_dataset('amp%s' %mode, data=float(amps[mode]))
-        injection.create_dataset('phi%s' %mode, data=float(phis[mode]))
-    # Amplitude of 220 mode is always required, even if 22 not included
-    if '220' not in all_modes:
-        try:
-            injection.create_dataset('amp220', data=float(amps['220']))
-        except:
-            raise ValueError('Please provide information of 220 mode')
+        injection.create_dataset('f_%s' %mode, data=float(freqs[mode]))
+        injection.create_dataset('tau_%s' %mode, data=float(taus[mode]))
 
 injection.close()

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -281,49 +281,56 @@ class TDomainCBCGenerator(BaseCBCGenerator):
         return hp, hc
 
 
-class FDomainRingdownGenerator(BaseGenerator):
-    """Uses ringdown.get_fd_qnm as a generator function to create frequency-
-    domain ringdown waveforms in the radiation frame; i.e., with no detector response
-    function applied. For more details, see BaseGenerator.
-
-    Examples
-    --------
-    Initialize a generator:
-
-    >>> generator = waveform.FDomainRingdownGenerator(variable_args=['tau', 'f_0', 'amp', 'phi'], delta_f=1./32, f_lower=30., f_final=500)
-
-    Create a ringdown with the variable arguments (in this case, tau, f_0):
-
-    >>> generator.generate(tau=5., f_0=100., amp=1., phi=0.)
-        (<pycbc.types.frequencyseries.FrequencySeries at 0x1110c1450>,
-         <pycbc.types.frequencyseries.FrequencySeries at 0x1110c1510>)
-
-    """
-    def __init__(self, variable_args=(), **frozen_params):
-        super(FDomainRingdownGenerator, self).__init__(ringdown.get_fd_qnm,
-            variable_args=variable_args, **frozen_params)
-
-class FDomainMultiModeRingdownGenerator(BaseGenerator):
-    """Uses ringdown.get_fd_lm_allmodes as a generator function to create 
-    frequency-domain ringdown waveforms with higher modes in the radiation 
-    frame; i.e., with no detector response function applied. 
+class FDomainMassSpinRingdownGenerator(BaseGenerator):
+    """Uses ringdown.get_fd_from_final_mass_spin as a generator function to
+    create frequency-domain ringdown waveforms with higher modes in the
+    radiation frame; i.e., with no detector response function applied. 
     For more details, see BaseGenerator.
 
     Examples
     --------
     Initialize a generator:
 
-    >>> generator = waveform.FDomainMultiModeRingdownGenerator(variable_args=['final_mass', 'final_spin', 'lmns','amp220','amp210','phi220','phi210'], delta_f=1./32, f_lower=30., f_final=500)
+    >>> generator = waveform.FDomainMassSpinRingdownGenerator(variable_args=['final_mass',
+                    'final_spin','amp220','amp210','phi220','phi210'], lmns=['221','211'],
+                    delta_f=1./32, f_lower=30., f_final=500)
 
     Create a ringdown with the variable arguments:
 
-    >>> generator.generate(final_mass=65., final_spin=0.7, lmns=['221','211'], amp220=1e-21, amp210=1./10, phi220=0., phi210=0.)
+    >>> generator.generate(final_mass=65., final_spin=0.7,
+                           amp220=1e-21, amp210=1./10, phi220=0., phi210=0.)
         (<pycbc.types.frequencyseries.FrequencySeries at 0x51614d0>,
          <pycbc.types.frequencyseries.FrequencySeries at 0x5161550>)
 
     """
     def __init__(self, variable_args=(), **frozen_params):
-        super(FDomainMultiModeRingdownGenerator, self).__init__(ringdown.get_fd_lm_allmodes,
+        super(FDomainMassSpinRingdownGenerator, self).__init__(ringdown.get_fd_from_final_mass_spin,
+            variable_args=variable_args, **frozen_params)
+
+class FDomainFreqTauRingdownGenerator(BaseGenerator):
+    """Uses ringdown.get_fd_from_freqtau as a generator function to 
+    create frequency-domain ringdown waveforms with higher modes in the
+    radiation frame; i.e., with no detector response function applied.
+    For more details, see BaseGenerator.
+
+    Examples
+    --------
+    Initialize a generator:
+
+    >>> generator = waveform.FDomainFreqTauRingdownGenerator(variable_args=['f_220',
+                    'tau_220','f_210','tau_210','amp220','amp210','phi220','phi210'],
+                    lmns=['221','211'], delta_f=1./32, f_lower=30., f_final=500)
+
+    Create a ringdown with the variable arguments:
+
+    >>> generator.generate(f_220=317., tau_220=0.003, f_210=274., tau_210=0.003,
+                           amp220=1e-21, amp210=1./10, phi220=0., phi210=0.)
+        (<pycbc.types.frequencyseries.FrequencySeries at 0x51614d0>,
+         <pycbc.types.frequencyseries.FrequencySeries at 0x5161550>)
+
+    """
+    def __init__(self, variable_args=(), **frozen_params):
+        super(FDomainMassSpinRingdownGenerator, self).__init__(ringdown.get_fd_from_freqtau,
             variable_args=variable_args, **frozen_params)
 
 class FDomainDetFrameGenerator(object):
@@ -545,10 +552,10 @@ def select_waveform_generator(approximant):
 
     # check if frequency-domain ringdown waveform
     elif approximant in ringdown.ringdown_fd_approximants:
-        if approximant == 'FdQNM':
-            return FDomainRingdownGenerator
-        elif approximant == 'FdQNMmultiModes':
-            return FDomainMultiModeRingdownGenerator
+        if approximant == 'FdQNMfromFinalMassSpin':
+            return FDomainMassSpinRingdownGenerator
+        elif approximant == 'FdQNMfromFreqTau':
+            return FDomainFreqTauRingdownGenerator
 
     # otherwise waveform approximant is not supported
     elif approximant in ringdown.ringdown_td_approximants:

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -330,7 +330,7 @@ class FDomainFreqTauRingdownGenerator(BaseGenerator):
 
     """
     def __init__(self, variable_args=(), **frozen_params):
-        super(FDomainMassSpinRingdownGenerator, self).__init__(ringdown.get_fd_from_freqtau,
+        super(FDomainFreqTauRingdownGenerator, self).__init__(ringdown.get_fd_from_freqtau,
             variable_args=variable_args, **frozen_params)
 
 class FDomainDetFrameGenerator(object):

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -32,8 +32,9 @@ from pycbc.waveform.waveform import get_obj_attrs
 
 default_qnm_args = {'t_0':0}
 qnm_required_args = ['f_0', 'tau', 'amp', 'phi']
-lm_required_args = ['final_mass','final_spin','l','m','nmodes']
+lm_required_args = ['freqs','taus','l','m','nmodes']
 lm_allmodes_required_args = ['final_mass','final_spin', 'lmns']
+freqtau_allmodes_required_args = ['lmns']
 
 max_freq = 16384.
 min_dt = 1. / (2 * max_freq)
@@ -90,6 +91,28 @@ def lm_amps_phases(**kwargs):
             raise ValueError('phi%d%d%d is required' %(l,m,n))
 
     return amps, phis
+
+def lm_freqs_taus(**kwargs):
+    """ Take input_params and return dictionaries with frequencies and damping
+    times of each overtone of a specific lm mode, checking that all of them
+    are given.
+    """
+    lmns = kwargs['lmns']
+    freqs, taus = {}, {}
+
+    for lmn in lmns:
+        l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
+        for n in range(nmodes):
+            try:
+                freqs['%d%d%d' %(l,m,n)] = kwargs['f_%d%d%d' %(l,m,n)]
+            except KeyError:
+                raise ValueError('f_%d%d%d is required' %(l,m,n))
+            try:
+                taus['%d%d%d' %(l,m,n)] = kwargs['tau_%d%d%d' %(l,m,n)]
+            except KeyError:
+                raise ValueError('tau_%d%d%d is required' %(l,m,n))
+
+    return freqs, taus
 
 # Functions to obtain f_0 and tau for the higher modes ########################
 
@@ -170,33 +193,32 @@ def qnm_freq_decay(f_0, tau, decay):
     q_sq = (alpha_sq + 4*q_0*q_0 + alpha*numpy.sqrt(alpha_sq + 16*q_0*q_0)) / 4.
     return numpy.sqrt(q_sq) / pi / tau
 
-def lm_tfinal(mass, spin, modes):
+def lm_tfinal(damping_times, modes):
     """Return the maximum t_final of the modes given, with t_final the time
     at which the amplitude falls to 1/1000 of the peak amplitude
     """
 
-    _, tau = get_lm_f0tau_allmodes(mass, spin, modes)
     t_max = {}
     for lmn in modes:
         l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
         for n in range(nmodes):
-            t_max['%d%d%d' %(l,m,n)] = qnm_time_decay(tau['%d%d%d' %(l,m,n)], 1./1000)
+            t_max['%d%d%d' %(l,m,n)] = \
+            qnm_time_decay(damping_times['%d%d%d' %(l,m,n)], 1./1000)
 
     return max(t_max.values())
 
-def lm_deltat(mass, spin, modes):
+def lm_deltat(freqs, damping_times, modes):
     """Return the minimum delta_t of all the modes given, with delta_t given by
     the inverse of the frequency at which the amplitude of the ringdown falls to
     1/1000 of the peak amplitude.
     """
 
-    f_0, tau = get_lm_f0tau_allmodes(mass, spin, modes)
     dt = {}
     for lmn in modes:
         l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
         for n in range(nmodes):
-            dt['%d%d%d' %(l,m,n)] = 1. / qnm_freq_decay(f_0['%d%d%d' %(l,m,n)],
-                                                tau['%d%d%d' %(l,m,n)], 1./1000)
+            dt['%d%d%d' %(l,m,n)] = 1. / qnm_freq_decay(freqs['%d%d%d' %(l,m,n)],
+                                       damping_times['%d%d%d' %(l,m,n)], 1./1000)
 
     delta_t = min(dt.values())
     if delta_t < min_dt:
@@ -204,18 +226,17 @@ def lm_deltat(mass, spin, modes):
 
     return delta_t
 
-def lm_ffinal(mass, spin, modes):
+def lm_ffinal(freqs, damping_times, modes):
     """Return the maximum f_final of the modes given, with f_final the frequency
     at which the amplitude falls to 1/1000 of the peak amplitude
     """
 
-    f_0, tau = get_lm_f0tau_allmodes(mass, spin, modes)
     f_max = {}
     for lmn in modes:
         l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
         for n in range(nmodes):
-            f_max['%d%d%d' %(l,m,n)] = qnm_freq_decay(f_0['%d%d%d' %(l,m,n)],
-                                                tau['%d%d%d' %(l,m,n)], 1./1000)
+            f_max['%d%d%d' %(l,m,n)] = qnm_freq_decay(freqs['%d%d%d' %(l,m,n)],
+                                      damping_times['%d%d%d' %(l,m,n)], 1./1000)
 
     f_final = max(f_max.values())
     if f_final > max_freq:
@@ -223,18 +244,18 @@ def lm_ffinal(mass, spin, modes):
     
     return f_final
 
-def lm_deltaf(mass, spin, modes):
+def lm_deltaf(damping_times, modes):
     """Return the minimum delta_f of all the modes given, with delta_f given by
     the inverse of the time at which the amplitude of the ringdown falls to
     1/1000 of the peak amplitude.
     """
 
-    _, tau = get_lm_f0tau_allmodes(mass, spin, modes)
     df = {}
     for lmn in modes:
         l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
         for n in range(nmodes):
-            df['%d%d%d' %(l,m,n)] = 1. / qnm_time_decay(tau['%d%d%d' %(l,m,n)], 1./1000)
+            df['%d%d%d' %(l,m,n)] = \
+                1. / qnm_time_decay(damping_times['%d%d%d' %(l,m,n)], 1./1000)
 
     return min(df.values())
 
@@ -268,6 +289,10 @@ def taper_shift(waveform, output):
     return output
 
 # Functions to generate ringdown waveforms ####################################
+
+######################################################
+#### Single mode approximants
+######################################################
 
 def get_td_qnm(template=None, taper=None, **kwargs):
     """Return a time domain damped sinusoid.
@@ -476,6 +501,10 @@ def get_fd_qnm(template=None, **kwargs):
 
     return hplustilde, hcrosstilde
 
+######################################################
+#### Single lm mode with overtones
+######################################################
+
 def get_td_lm(template=None, taper=None, **kwargs):
     """Return frequency domain lm mode with the given number of overtones.
 
@@ -493,10 +522,12 @@ def get_td_lm(template=None, taper=None, **kwargs):
         taper will add a rapid ringup with timescale tau/10.
         Each overtone will have a different taper depending on its tau, the
         final taper being the superposition of all the tapers.
-    final_mass : float
-        Mass of the final black hole.
-    final_spin : float
-        Spin of the final black hole.
+    freqs : dict
+        {lmn:f_lmn} Dictionary of the central frequencies for each overtone,
+        as many as number of modes. 
+    taus : dict
+        {lmn:tau_lmn} Dictionary of the damping times for each overtone,
+        as many as number of modes.
     l : int
         l mode (lm modes available: 22, 21, 33, 44, 55).
     m : int
@@ -508,11 +539,9 @@ def get_td_lm(template=None, taper=None, **kwargs):
     amplmn : float
         Fraction of the amplitude of the lmn overtone relative to the 
         fundamental mode, as many as the number of subdominant modes.
-    phi : float
-        Phase of the lmn overtone, as many as the number of nmodes.
     philmn : float
-        The initial phase of the ringdown. Should also include the information
-        from the azimuthal angle (phi + m*Phi).
+        Phase of the lmn overtone, as many as the number of modes. Should also
+        include the information from the azimuthal angle (phi + m*Phi).
     inclination : {0., float}, optional
         Inclination of the system in radians. Default is 0 (face on).
     delta_t : {None, float}, optional
@@ -536,8 +565,8 @@ def get_td_lm(template=None, taper=None, **kwargs):
 
     # Get required args
     amps, phis = lm_amps_phases(**input_params)
-    final_mass = input_params.pop('final_mass')
-    final_spin = input_params.pop('final_spin')
+    f_0 = input_params.pop('freqs')
+    tau = input_params.pop('taus')
     inc = input_params.pop('inclination', 0.)
     l, m = input_params.pop('l'), input_params.pop('m')
     nmodes = input_params.pop('nmodes')
@@ -549,25 +578,25 @@ def get_td_lm(template=None, taper=None, **kwargs):
     t_final = input_params.pop('t_final', None)
 
     if delta_t is None:
-        delta_t = lm_deltat(final_mass, final_spin, ['%d%d%d' %(l,m,nmodes)]) 
+        delta_t = lm_deltat(f_0, tau, ['%d%d%d' %(l,m,nmodes)]) 
     if t_final is None:
-        t_final = lm_tfinal(final_mass, final_spin, ['%d%d%d' %(l, m, nmodes)])
-
-    f_0, tau = get_lm_f0tau(final_mass, final_spin, l, m, nmodes)
+        t_final = lm_tfinal(tau, ['%d%d%d' %(l, m, nmodes)])
 
     kmax = int(t_final / delta_t) + 1
     # Different overtones will have different tapering window-size
     # Find maximum window size to create long enough output vector
     if taper is not None:
-        taper_window = int(taper*max(tau)/delta_t)
+        taper_window = int(taper*max(tau.values())/delta_t)
         kmax += taper_window
 
     outplus = TimeSeries(zeros(kmax, dtype=float64), delta_t=delta_t)
     outcross = TimeSeries(zeros(kmax, dtype=float64), delta_t=delta_t)
 
     for n in range(nmodes):
-        hplus, hcross = get_td_qnm(template=None, taper=taper, f_0=f_0[n],
-                            tau=tau[n], phi=phis['%d%d%d' %(l,m,n)],
+        hplus, hcross = get_td_qnm(template=None, taper=taper,
+                            f_0=f_0['%d%d%d' %(l,m,n)],
+                            tau=tau['%d%d%d' %(l,m,n)],
+                            phi=phis['%d%d%d' %(l,m,n)],
                             amp=amps['%d%d%d' %(l,m,n)],
                             inclination=inc, l=l, m=m,
                             delta_t=delta_t, t_final=t_final)
@@ -588,10 +617,12 @@ def get_fd_lm(template=None, **kwargs):
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-    final_mass : float
-        Mass of the final black hole.
-    final_spin : float
-        Spin of the final black hole.
+    freqs : dict
+        {lmn:f_lmn} Dictionary of the central frequencies for each overtone,
+        as many as number of modes.
+    taus : dict
+        {lmn:tau_lmn} Dictionary of the damping times for each overtone,
+        as many as number of modes.
     l : int
         l mode (lm modes available: 22, 21, 33, 44, 55).
     m : int
@@ -601,8 +632,8 @@ def get_fd_lm(template=None, **kwargs):
     amplmn : float
         Amplitude of the lmn overtone, as many as the number of nmodes.
     philmn : float
-        The initial phase of the ringdown. Should also include the information
-        from the azimuthal angle (phi + m*Phi).
+        Phase of the lmn overtone, as many as the number of modes. Should also
+        include the information from the azimuthal angle (phi + m*Phi).
     inclination : {0., float}, optional
         Inclination of the system in radians. Default is 0 (face on).
     delta_f : {None, float}, optional
@@ -629,8 +660,8 @@ def get_fd_lm(template=None, **kwargs):
 
     # Get required args
     amps, phis = lm_amps_phases(**input_params)
-    final_mass = input_params.pop('final_mass')
-    final_spin = input_params.pop('final_spin')
+    f_0 = input_params.pop('freqs')
+    tau = input_params.pop('taus')
     l, m = input_params.pop('l'), input_params.pop('m')
     inc = input_params.pop('inclination', 0.)
     nmodes = input_params.pop('nmodes')
@@ -643,25 +674,29 @@ def get_fd_lm(template=None, **kwargs):
     f_final = input_params.pop('f_final', None)
 
     if delta_f is None:
-        delta_f = lm_deltaf(final_mass, final_spin, ['%d%d%d' %(l,m,nmodes)])
+        delta_f = lm_deltaf(tau, ['%d%d%d' %(l,m,nmodes)])
     if f_final is None:
-        f_final = lm_ffinal(final_mass, final_spin, ['%d%d%d' %(l, m, nmodes)])
+        f_final = lm_ffinal(f_0, tau, ['%d%d%d' %(l, m, nmodes)])
     kmax = int(f_final / delta_f) + 1
 
     outplus = FrequencySeries(zeros(kmax, dtype=complex128), delta_f=delta_f)
     outcross = FrequencySeries(zeros(kmax, dtype=complex128), delta_f=delta_f)
 
-    f_0, tau = get_lm_f0tau(final_mass, final_spin, l, m, nmodes)
     for n in range(nmodes):
-        hplus, hcross = get_fd_qnm(template=None, f_0=f_0[n], tau=tau[n], 
+        hplus, hcross = get_fd_qnm(template=None, f_0=f_0['%d%d%d' %(l,m,n)],
+                            tau=tau['%d%d%d' %(l,m,n)], 
                             amp=amps['%d%d%d' %(l,m,n)],
                             phi=phis['%d%d%d' %(l,m,n)],
-                            inclination=inc, l=l, m=m, delta_f=delta_f, 
+                            inclination=inc, l=l, m=m, delta_f=delta_f,
                             f_lower=f_lower, f_final=f_final)
         outplus.data += hplus.data
         outcross.data += hcross.data
 
     return outplus, outcross
+
+######################################################
+#### Multi mode approximants in mass and spin
+######################################################
 
 def get_td_lm_allmodes(template=None, taper=None, **kwargs):
     """Return time domain ringdown with all the modes specified.
@@ -695,8 +730,8 @@ def get_td_lm_allmodes(template=None, taper=None, **kwargs):
         Fraction of the amplitude of the lmn overtone relative to the 
         fundamental mode, as many as the number of subdominant modes.
     philmn : float
-        The initial phase of the ringdown. Should also include the information
-        from the azimuthal angle (phi + m*Phi).
+        Phase of the lmn overtone, as many as the number of modes. Should also
+        include the information from the azimuthal angle (phi + m*Phi).
     inclination : {0., float}, optional
         Inclination of the system in radians. Default is 0 (face on).
     delta_t : {None, float}, optional
@@ -733,13 +768,14 @@ def get_td_lm_allmodes(template=None, taper=None, **kwargs):
     delta_t = input_params.pop('delta_t', None)
     t_final = input_params.pop('t_final', None)
 
+    f_0, tau = get_lm_f0tau_allmodes(final_mass, final_spin, lmns)
+
     if delta_t is None:
-        delta_t = lm_deltat(final_mass, final_spin, lmns)
+        delta_t = lm_deltat(f_0, tau, lmns)
     if t_final is None:
-        t_final = lm_tfinal(final_mass, final_spin, lmns)
+        t_final = lm_tfinal(tau, lmns)
 
     kmax = int(t_final / delta_t) + 1
-    _, tau = get_lm_f0tau_allmodes(final_mass, final_spin, lmns)
     # Different overtones will have different tapering window-size
     # Find maximum window size to create long enough output vector
     if taper is not None:
@@ -750,8 +786,9 @@ def get_td_lm_allmodes(template=None, taper=None, **kwargs):
     outcross = TimeSeries(zeros(kmax, dtype=float64), delta_t=delta_t)
     for lmn in lmns:
         l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
-        hplus, hcross = get_td_lm(taper=taper, l=l, m=m, nmodes=nmodes,
-                             inclination=inc, delta_t=delta_t, t_final=t_final,
+        hplus, hcross = get_td_lm(taper=taper, freqs=f_0, taus=tau,
+                             inclination=inc, l=l, m=m, nmodes=nmodes,
+                             delta_t=delta_t, t_final=t_final,
                              **input_params)
         if taper is None:
             outplus.data += hplus.data
@@ -785,8 +822,8 @@ def get_fd_lm_allmodes(template=None, **kwargs):
         Fraction of the amplitude of the lmn overtone relative to the 
         fundamental mode, as many as the number of subdominant modes.
     philmn : float
-        The initial phase of the ringdown. Should also include the information
-        from the azimuthal angle (phi + m*Phi).
+        Phase of the lmn overtone, as many as the number of modes. Should also
+        include the information from the azimuthal angle (phi + m*Phi).
     inclination : {0., float}, optional
         Inclination of the system in radians. Default is 0 (face on).
     delta_f : {None, float}, optional
@@ -827,10 +864,12 @@ def get_fd_lm_allmodes(template=None, **kwargs):
     f_lower = input_params.pop('f_lower', None)
     f_final = input_params.pop('f_final', None)
 
+    f_0, tau = get_lm_f0tau_allmodes(final_mass, final_spin, lmns)
+
     if delta_f is None:
-        delta_f = lm_deltaf(final_mass, final_spin, lmns)
+        delta_f = lm_deltaf(tau, lmns)
     if f_final is None:
-        f_final = lm_ffinal(final_mass, final_spin, lmns)
+        f_final = lm_ffinal(f_0, tau, lmns)
     if f_lower is None:
         f_lower = delta_f
     kmax = int(f_final / delta_f) + 1
@@ -839,15 +878,200 @@ def get_fd_lm_allmodes(template=None, **kwargs):
     outcrosstilde = FrequencySeries(zeros(kmax, dtype=complex128), delta_f=delta_f)
     for lmn in lmns:
         l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
-        hplustilde, hcrosstilde = get_fd_lm(l=l, m=m, nmodes=nmodes,
-                                       inclination=inc, delta_f=delta_f,
-                                       f_lower=f_lower, f_final=f_final,
-                                       **input_params)
+        hplustilde, hcrosstilde = get_fd_lm(freqs=f_0, taus=tau,
+                                        l=l, m=m, nmodes=nmodes,
+                                        delta_f=delta_f, f_lower=f_lower,
+                                        f_final=f_final, **input_params)
+        outplustilde.data += hplustilde.data
+        outcrosstilde.data += hcrosstilde.data
+
+    return outplustilde, outcrosstilde
+
+######################################################
+#### Multi mode approximants in f_0 and tau
+######################################################
+
+def get_td_freqtau_allmodes(template=None, taper=None, **kwargs):
+    """Return time domain ringdown with all the modes specified.
+    Parameters
+    ----------
+    template: object
+        An object that has attached properties. This can be used to substitute
+        for keyword arguments. A common example would be a row in an xml table.
+    taper: {None, float}, optional
+        Tapering at the beginning of the waveform with duration taper * tau.
+        This option is recommended with timescales taper=1./2 or 1. for
+        time-domain ringdown-only injections.
+        The abrupt turn on of the ringdown can cause issues on the waveform
+        when doing the fourier transform to the frequency domain. Setting
+        taper will add a rapid ringup with timescale tau/10.
+        Each mode and overtone will have a different taper depending on its tau,
+        the final taper being the superposition of all the tapers.
+    lmns : list
+        Desired lmn modes as strings (lm modes available: 22, 21, 33, 44, 55).
+        The n specifies the number of overtones desired for the corresponding
+        lm pair (maximum n=8).
+        Example: lmns = ['223','331'] are the modes 220, 221, 222, and 330
+    f_lmn: float
+        Central frequency of the lmn overtone, as many as number of modes.
+    tau_lmn: float
+        Damping time of the lmn overtone, as many as number of modes.
+    amp220 : float
+        Amplitude of the fundamental 220 mode.
+    amplmn : float
+        Fraction of the amplitude of the lmn overtone relative to the 
+        fundamental mode, as many as the number of subdominant modes.
+    philmn : float
+        Phase of the lmn overtone, as many as the number of modes. Should also
+        include the information from the azimuthal angle (phi + m*Phi).
+    inclination : {0., float}, optional
+        Inclination of the system in radians. Default is 0 (face on).
+    delta_t : {None, float}, optional
+        The time step used to generate the ringdown.
+        If None, it will be set to the inverse of the frequency at which the
+        amplitude is 1/1000 of the peak amplitude (the minimum of all modes).
+    t_final : {None, float}, optional
+        The ending time of the output frequency series.
+        If None, it will be set to the time at which the amplitude
+        is 1/1000 of the peak amplitude (the maximum of all modes).
+    Returns
+    -------
+    hplustilde: FrequencySeries
+        The plus phase of a ringdown with the lm modes specified and
+        n overtones in frequency domain.
+    hcrosstilde: FrequencySeries
+        The cross phase of a ringdown with the lm modes specified and
+        n overtones in frequency domain.
+    """
+
+    input_params = props(template, freqtau_allmodes_required_args, **kwargs)
+
+    # Get required args
+    f_0, tau = lm_freqs_taus(**input_params)
+    lmns = input_params['lmns']
+    for lmn in lmns:
+        if int(lmn[2]) == 0:
+            raise ValueError('Number of overtones (nmodes) must be greater '
+                             'than zero.')
+    # following may not be in input_params
+    inc = input_params.pop('inclination', 0.)
+    delta_t = input_params.pop('delta_t', None)
+    t_final = input_params.pop('t_final', None)
+
+    if delta_t is None:
+        delta_t = lm_deltat(f_0, tau, lmns)
+    if t_final is None:
+        t_final = lm_tfinal(tau, lmns)
+
+    kmax = int(t_final / delta_t) + 1
+    # Different overtones will have different tapering window-size
+    # Find maximum window size to create long enough output vector
+    if taper is not None:
+        taper_window = int(taper*max(tau.values())/delta_t)
+        kmax += taper_window
+
+    outplus = TimeSeries(zeros(kmax, dtype=float64), delta_t=delta_t)
+    outcross = TimeSeries(zeros(kmax, dtype=float64), delta_t=delta_t)
+    for lmn in lmns:
+        l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
+        hplus, hcross = get_td_lm(freqs=f_0, taus=tau, l=l, m=m, nmodes=nmodes,
+                             taper=taper, inclination=inc, delta_t=delta_t,
+                             t_final=t_final, **input_params)
+        if taper is None:
+            outplus.data += hplus.data
+            outcross.data += hcross.data
+        else:
+            outplus = taper_shift(hplus, outplus)
+            outcross = taper_shift(hcross, outcross)
+
+    return outplus, outcross
+
+def get_fd_freqtau_allmodes(template=None, **kwargs):
+    """Return frequency domain ringdown with all the modes specified.
+    Parameters
+    ----------
+    template: object
+        An object that has attached properties. This can be used to substitute
+        for keyword arguments. A common example would be a row in an xml table.
+    f_lmn: float
+        Central frequency of the lmn overtone, as many as number of modes.
+    tau_lmn: float
+        Damping time of the lmn overtone, as many as number of modes.
+    lmns : list
+        Desired lmn modes as strings (lm modes available: 22, 21, 33, 44, 55).
+        The n specifies the number of overtones desired for the corresponding
+        lm pair (maximum n=8).
+        Example: lmns = ['223','331'] are the modes 220, 221, 222, and 330
+    amp220 : float
+        Amplitude of the fundamental 220 mode.
+    amplmn : float
+        Fraction of the amplitude of the lmn overtone relative to the 
+        fundamental mode, as many as the number of subdominant modes.
+    philmn : float
+        Phase of the lmn overtone, as many as the number of modes. Should also
+        include the information from the azimuthal angle (phi + m*Phi).
+    inclination : {0., float}, optional
+        Inclination of the system in radians. Default is 0 (face on).
+    delta_f : {None, float}, optional
+        The frequency step used to generate the ringdown.
+        If None, it will be set to the inverse of the time at which the
+        amplitude is 1/1000 of the peak amplitude (the minimum of all modes).
+    f_lower: {None, float}, optional
+        The starting frequency of the output frequency series.
+        If None, it will be set to delta_f.
+    f_final : {None, float}, optional
+        The ending frequency of the output frequency series.
+        If None, it will be set to the frequency at which the amplitude
+        is 1/1000 of the peak amplitude (the maximum of all modes).
+    Returns
+    -------
+    hplustilde: FrequencySeries
+        The plus phase of a ringdown with the lm modes specified and
+        n overtones in frequency domain.
+    hcrosstilde: FrequencySeries
+        The cross phase of a ringdown with the lm modes specified and
+        n overtones in frequency domain.
+    """
+
+    input_params = props(template, freqtau_allmodes_required_args, **kwargs)
+
+    # Get required args
+    f_0, tau = lm_freqs_taus(**input_params)
+    lmns = input_params['lmns']
+    for lmn in lmns:
+        if int(lmn[2]) == 0:
+            raise ValueError('Number of overtones (nmodes) must be greater '
+                             'than zero.')
+    # The following may not be in input_params
+    inc = input_params.pop('inclination', 0.)
+    delta_f = input_params.pop('delta_f', None)
+    f_lower = input_params.pop('f_lower', None)
+    f_final = input_params.pop('f_final', None)
+
+    if delta_f is None:
+        delta_f = lm_deltaf(tau, lmns)
+    if f_final is None:
+        f_final = lm_ffinal(f_0, tau, lmns)
+    if f_lower is None:
+        f_lower = delta_f
+    kmax = int(f_final / delta_f) + 1
+
+    outplustilde = FrequencySeries(zeros(kmax, dtype=complex128), delta_f=delta_f)
+    outcrosstilde = FrequencySeries(zeros(kmax, dtype=complex128), delta_f=delta_f)
+    for lmn in lmns:
+        l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
+        hplustilde, hcrosstilde = get_fd_lm(freqs=f_0, taus=tau,
+                                        l=l, m=m, nmodes=nmodes,
+                                        inclination=inc,
+                                        delta_f=delta_f, f_lower=f_lower,
+                                        f_final=f_final, **input_params)
         outplustilde.data += hplustilde.data
         outcrosstilde.data += hcrosstilde.data
 
     return outplustilde, outcrosstilde
 
 # Approximant names ###########################################################
-ringdown_fd_approximants = {'FdQNM': get_fd_qnm, 'FdQNMmultiModes': get_fd_lm_allmodes}
-ringdown_td_approximants = {'TdQNM': get_td_qnm, 'TdQNMmultiModes': get_td_lm_allmodes}
+ringdown_fd_approximants = {'FdQNM': get_fd_qnm, 'FdQNMmultiModes': get_fd_lm_allmodes,
+                            'FdFreqTauMultiModes': get_fd_freqtau_allmodes}
+ringdown_td_approximants = {'TdQNM': get_td_qnm, 'TdQNMmultiModes': get_td_lm_allmodes,
+                            'TdFreqTauMultiModes': get_td_freqtau_allmodes}

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -291,7 +291,7 @@ def taper_shift(waveform, output):
 # Functions to generate ringdown waveforms ####################################
 
 ######################################################
-#### Single mode approximants
+#### Basic functions to generate damped sinusoid
 ######################################################
 
 def get_td_qnm(template=None, taper=None, **kwargs):
@@ -695,10 +695,10 @@ def get_fd_lm(template=None, **kwargs):
     return outplus, outcross
 
 ######################################################
-#### Multi mode approximants in mass and spin
+#### Approximants
 ######################################################
 
-def get_td_lm_allmodes(template=None, taper=None, **kwargs):
+def get_td_from_final_mass_spin(template=None, taper=None, **kwargs):
     """Return time domain ringdown with all the modes specified.
 
     Parameters
@@ -799,7 +799,7 @@ def get_td_lm_allmodes(template=None, taper=None, **kwargs):
 
     return outplus, outcross
 
-def get_fd_lm_allmodes(template=None, **kwargs):
+def get_fd_from_final_mass_spin(template=None, **kwargs):
     """Return frequency domain ringdown with all the modes specified.
 
     Parameters
@@ -887,11 +887,7 @@ def get_fd_lm_allmodes(template=None, **kwargs):
 
     return outplustilde, outcrosstilde
 
-######################################################
-#### Multi mode approximants in f_0 and tau
-######################################################
-
-def get_td_freqtau_allmodes(template=None, taper=None, **kwargs):
+def get_td_from_freqtau(template=None, taper=None, **kwargs):
     """Return time domain ringdown with all the modes specified.
 
     Parameters
@@ -988,7 +984,7 @@ def get_td_freqtau_allmodes(template=None, taper=None, **kwargs):
 
     return outplus, outcross
 
-def get_fd_freqtau_allmodes(template=None, **kwargs):
+def get_fd_from_freqtau(template=None, **kwargs):
     """Return frequency domain ringdown with all the modes specified.
 
     Parameters
@@ -1075,7 +1071,7 @@ def get_fd_freqtau_allmodes(template=None, **kwargs):
     return outplustilde, outcrosstilde
 
 # Approximant names ###########################################################
-ringdown_fd_approximants = {'FdQNM': get_fd_qnm, 'FdQNMmultiModes': get_fd_lm_allmodes,
-                            'FdFreqTauMultiModes': get_fd_freqtau_allmodes}
-ringdown_td_approximants = {'TdQNM': get_td_qnm, 'TdQNMmultiModes': get_td_lm_allmodes,
-                            'TdFreqTauMultiModes': get_td_freqtau_allmodes}
+ringdown_fd_approximants = {'FdQNMfromFinalMassSpin': get_fd_from_final_mass_spin,
+                            'FdQNMfromFreqTau': get_fd_from_freqtau}
+ringdown_td_approximants = {'TdQNMfromFinalMassSpin': get_td_from_final_mass_spin,
+                            'TdQNMfromFreqTau': get_td_from_freqtau}

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -893,6 +893,7 @@ def get_fd_lm_allmodes(template=None, **kwargs):
 
 def get_td_freqtau_allmodes(template=None, taper=None, **kwargs):
     """Return time domain ringdown with all the modes specified.
+
     Parameters
     ----------
     template: object
@@ -934,6 +935,7 @@ def get_td_freqtau_allmodes(template=None, taper=None, **kwargs):
         The ending time of the output frequency series.
         If None, it will be set to the time at which the amplitude
         is 1/1000 of the peak amplitude (the maximum of all modes).
+
     Returns
     -------
     hplustilde: FrequencySeries
@@ -988,20 +990,21 @@ def get_td_freqtau_allmodes(template=None, taper=None, **kwargs):
 
 def get_fd_freqtau_allmodes(template=None, **kwargs):
     """Return frequency domain ringdown with all the modes specified.
+
     Parameters
     ----------
     template: object
         An object that has attached properties. This can be used to substitute
         for keyword arguments. A common example would be a row in an xml table.
-    f_lmn: float
-        Central frequency of the lmn overtone, as many as number of modes.
-    tau_lmn: float
-        Damping time of the lmn overtone, as many as number of modes.
     lmns : list
         Desired lmn modes as strings (lm modes available: 22, 21, 33, 44, 55).
         The n specifies the number of overtones desired for the corresponding
         lm pair (maximum n=8).
         Example: lmns = ['223','331'] are the modes 220, 221, 222, and 330
+    f_lmn: float
+        Central frequency of the lmn overtone, as many as number of modes.
+    tau_lmn: float
+        Damping time of the lmn overtone, as many as number of modes.
     amp220 : float
         Amplitude of the fundamental 220 mode.
     amplmn : float
@@ -1023,6 +1026,7 @@ def get_fd_freqtau_allmodes(template=None, **kwargs):
         The ending frequency of the output frequency series.
         If None, it will be set to the frequency at which the amplitude
         is 1/1000 of the peak amplitude (the maximum of all modes).
+
     Returns
     -------
     hplustilde: FrequencySeries

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -879,7 +879,7 @@ def get_fd_from_final_mass_spin(template=None, **kwargs):
     for lmn in lmns:
         l, m, nmodes = int(lmn[0]), int(lmn[1]), int(lmn[2])
         hplustilde, hcrosstilde = get_fd_lm(freqs=f_0, taus=tau,
-                                        l=l, m=m, nmodes=nmodes,
+                                        inclination=inc, l=l, m=m, nmodes=nmodes,
                                         delta_f=delta_f, f_lower=f_lower,
                                         f_final=f_final, **input_params)
         outplustilde.data += hplustilde.data

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -33,8 +33,8 @@ from pycbc.waveform.waveform import get_obj_attrs
 default_qnm_args = {'t_0':0}
 qnm_required_args = ['f_0', 'tau', 'amp', 'phi']
 lm_required_args = ['freqs','taus','l','m','nmodes']
-lm_allmodes_required_args = ['final_mass','final_spin', 'lmns']
-freqtau_allmodes_required_args = ['lmns']
+mass_spin_required_args = ['final_mass','final_spin', 'lmns']
+freqtau_required_args = ['lmns']
 
 max_freq = 16384.
 min_dt = 1. / (2 * max_freq)
@@ -753,7 +753,7 @@ def get_td_from_final_mass_spin(template=None, taper=None, **kwargs):
         n overtones in frequency domain.
     """
 
-    input_params = props(template, lm_allmodes_required_args, **kwargs)
+    input_params = props(template, mass_spin_required_args, **kwargs)
 
     # Get required args
     final_mass = input_params['final_mass']
@@ -848,7 +848,7 @@ def get_fd_from_final_mass_spin(template=None, **kwargs):
         n overtones in frequency domain.
     """
 
-    input_params = props(template, lm_allmodes_required_args, **kwargs)
+    input_params = props(template, mass_spin_required_args, **kwargs)
 
     # Get required args
     final_mass = input_params['final_mass']
@@ -942,7 +942,7 @@ def get_td_from_freqtau(template=None, taper=None, **kwargs):
         n overtones in frequency domain.
     """
 
-    input_params = props(template, freqtau_allmodes_required_args, **kwargs)
+    input_params = props(template, freqtau_required_args, **kwargs)
 
     # Get required args
     f_0, tau = lm_freqs_taus(**input_params)
@@ -1033,7 +1033,7 @@ def get_fd_from_freqtau(template=None, **kwargs):
         n overtones in frequency domain.
     """
 
-    input_params = props(template, freqtau_allmodes_required_args, **kwargs)
+    input_params = props(template, freqtau_required_args, **kwargs)
 
     # Get required args
     f_0, tau = lm_freqs_taus(**input_params)


### PR DESCRIPTION
Up to now, the ringdown damped sinusoid approximant with higher modes would take the mass and the spin of the black hole as arguments and internally compute the frequencies and damping times of each mode using Berti's fits (general relativity).
For tests of GR, one needs to loosen the assumption that a certain mass and spin translate into certain frequencies and damping times. For that purpose, this PR adds a new ringdown damped sinusoid approximant with higher modes whose arguments are the frequency and damping time for each mode instead of the mass and the spin.