### PR TITLE
allow workflows to run on internaly made Gaussian noise with a given PSD

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_singles_timefreq
+++ b/bin/hdfcoinc/pycbc_plot_singles_timefreq
@@ -72,6 +72,7 @@ opts = parser.parse_args()
 
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
+opts.low_frequency_cutoff = opts.f_low
 strain = pycbc.strain.from_cli(opts, pycbc.DYN_RANGE_FAC)
 
 if opts.center_time is None:

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -175,7 +175,7 @@ bank_plot = [(wf.make_template_plot(workflow, hdfbank[0],
 
 # setup the injection files
 inj_files, inj_tags = wf.setup_injection_workflow(workflow,
-                                                     output_dir="inj_files")
+                                                  output_dir="inj_files")
 
 ######################## Setup the FULL DATA run ##############################
 tag = output_dir = "full_data"
@@ -323,11 +323,12 @@ for ifo, files in zip(*ind_insps.categorize_by_attr('ifo')):
     insp_files_seg_dict[ifo + ":" + data_analysed_name] = \
                                                         data_analysed_segs[ifo]
 
-    # NOTE: Should we also store the coalesced segments?
-
-    psd_files += [wf.setup_psd_calculate(workflow,
-                  datafind_files.find_output_with_ifo(ifo), ifo,
-                  data_analysed_segs[ifo], data_analysed_name, 'psds')]
+    if datafind_files:
+        frame_files = datafind_files.find_output_with_ifo(ifo)
+    else:
+        frame_files = None
+    psd_files += [wf.setup_psd_calculate(workflow, frame_files, ifo,
+              data_analysed_segs[ifo], data_analysed_name, 'psds')]
 
 insp_files_seg_file = wf.SegFile.from_segment_list_dict('INSP_SEGMENTS',
                  insp_files_seg_dict, valid_segment=workflow.analysis_time,
@@ -342,7 +343,7 @@ r2 = wf.make_range_plot(workflow, psd_files, rdir['detector_sensitivity'],
 
 det_summ = [(s, r[0] if len(r) != 0 else None)]
 layout.two_column_layout(rdir['detector_sensitivity'],
-                         det_summ + list(layout.grouper(r2, 2)))
+                     det_summ + list(layout.grouper(r2, 2)))
 
 # run minifollowups on the output of the loudest events
 wf.setup_foreground_minifollowups(workflow, final_bg_file,

--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -105,7 +105,7 @@ def colored_noise(psd, start_time, end_time, seed=0, low_frequency_cutoff=1.0):
     """
     white_noise = normal(start_time - FILTER_LENGTH, end_time + FILTER_LENGTH,
                           seed=seed)
-    flen = (SAMPLE_RATE / psd.delta_f) / 2 + 1
+    flen = int(SAMPLE_RATE / psd.delta_f) / 2 + 1
     psd = psd * 1
     psd.resize(flen)
     psd = pycbc.psd.interpolate(psd, 1.0 / white_noise.duration)

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -332,10 +332,11 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                                 epoch=opt.gps_start_time)
         else:
             logging.info("Making colored noise")
-            from pycbc.noise.reproduceable import noise_from_psd
-            strain = noise_from_psd(strain_psd, opt.gps_start_time,
+            from pycbc.noise.reproduceable import colored_noise
+            strain = colored_noise(strain_psd, opt.gps_start_time,
                                           opt.gps_end_time,
-                                          seed=opt.fake_strain_seed)
+                                          seed=opt.fake_strain_seed, 
+                                          low_frequency_cutoff=opt.strain_high_pass)
             strain = resample_to_delta_t(strain, 1.0/opt.sample_rate)
 
 

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -328,13 +328,16 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         if opt.fake_strain == 'zeroNoise':
             logging.info("Making zero-noise time series")
             strain = TimeSeries(pycbc.types.zeros(tlen),
-                                delta_t=1.0/opt.sample_rate)
+                                delta_t=1.0/opt.sample_rate,
+                                epoch=opt.gps_start_time)
         else:
             logging.info("Making colored noise")
-            strain = pycbc.noise.noise_from_psd(tlen, 1.0/opt.sample_rate,
-                                                strain_psd,
-                                                seed=opt.fake_strain_seed)
-        strain._epoch = lal.LIGOTimeGPS(opt.gps_start_time)
+            from pycbc.noise.reproduceable import noise_from_psd
+            strain = noise_from_psd(strain_psd, opt.gps_start_time,
+                                          opt.gps_end_time,
+                                          seed=opt.fake_strain_seed)
+            strain = resample_to_delta_t(strain, 1.0/opt.sample_rate)
+
 
         if opt.injection_file:
             logging.info("Applying injections")

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -142,7 +142,8 @@ def setup_datafind_workflow(workflow, scienceSegs, outputDir, seg_file=None,
         datafindcaches, datafindouts = \
             setup_datafind_runtime_frames_single_call_perifo(cp, scienceSegs,
                                                           outputDir, tags=tags)
-
+    elif datafind_method == "AT_RUNTIME_FAKE_DATA":
+        pass
     elif datafind_method == "FROM_PREGENERATED_LCF_FILES":
         ifos = scienceSegs.keys()
         datafindcaches, datafindouts = \
@@ -180,8 +181,7 @@ def setup_datafind_workflow(workflow, scienceSegs, outputDir, seg_file=None,
     logging.info("setup_datafind_runtime_generated completed")
     # If we don't have frame files covering all times we can update the science
     # segments.
-    if checkSegmentGaps in ['warn','update_times','raise_error'] and \
-        datafind_method is not "AT_RUNTIME_FAKE_DATA":
+    if checkSegmentGaps in ['warn','update_times','raise_error']:
         logging.info("Checking science segments against datafind output....")
         newScienceSegs = get_science_segs_from_datafind_outs(datafindcaches)
         logging.info("New segments calculated from data find output.....")
@@ -226,8 +226,7 @@ def setup_datafind_workflow(workflow, scienceSegs, outputDir, seg_file=None,
         raise ValueError(errMsg)
 
     # Do all of the frame files that were returned actually exist?
-    if checkFramesExist in ['warn','update_times','raise_error'] and \
-        datafind_method is not "AT_RUNTIME_FAKE_DATA":
+    if checkFramesExist in ['warn','update_times','raise_error']:
         logging.info("Verifying that all frames exist on disk.")
         missingFrSegs, missingFrames = \
                           get_missing_segs_from_frame_file_cache(datafindcaches)
@@ -283,8 +282,7 @@ def setup_datafind_workflow(workflow, scienceSegs, outputDir, seg_file=None,
 
     # Check if there are cases where frames exist, but no entry in the segment
     # summary table are present.
-    if checkSegmentSummary in ['warn', 'raise_error'] and \
-        datafind_method is not "AT_RUNTIME_FAKE_DATA":
+    if checkSegmentSummary in ['warn', 'raise_error']:
         logging.info("Checking the segment summary table against frames.")
         dfScienceSegs = get_science_segs_from_datafind_outs(datafindcaches)
         missingFlag = False

--- a/pycbc/workflow/jobsetup.py
+++ b/pycbc/workflow/jobsetup.py
@@ -267,7 +267,7 @@ def sngl_ifo_job_setup(workflow, ifo, out_files, curr_exe_job, science_segs,
             else:
                 curr_parent = [None]
 
-
+            curr_dfouts = None
             if datafind_outs:
                 curr_dfouts = datafind_outs.find_all_output_in_range(ifo,
                                               job_data_seg, useSplitLists=True)
@@ -637,10 +637,6 @@ class PyCBCInspiralExecutable(Executable):
                              "%s. Please check the ini file." % self.name)
         pad_data = int(self.get_opt('pad-data'))
 
-        if not dfParents:
-            raise ValueError("%s must be supplied with data file(s)"
-                              %(self.name))
-
         # set remaining options flags
         node.add_opt('--gps-start-time',
                      int_gps_time_to_str(data_seg[0] + pad_data))
@@ -657,26 +653,9 @@ class PyCBCInspiralExecutable(Executable):
         fil = node.new_output_file_opt(valid_seg, self.ext, '--output', tags=tags,
                          store_file=self.retain_files, use_tmp_subdirs=True)
         fil.add_metadata('data_seg', data_seg)
-        node.add_input_list_opt('--frame-files', dfParents)
-        node.add_input_opt('--bank-file', parent, )
-
-        # FIXME: This hack is needed for pipedown compatibility. user-tag is
-        #        no-op and is only needed for pipedown to know whether this is
-        #        a "FULL_DATA" job or otherwise. Alex wants to burn this code
-        #        with fire.
-        if node.output_files[0].storage_path is not None:
-            outFile = os.path.basename(node.output_files[0].storage_path)
-            userTag = outFile.split('-')[1]
-            userTag = userTag.split('_')[1:]
-            if userTag[0] == 'FULL' and userTag[1] == 'DATA':
-                userTag = 'FULL_DATA'
-            elif userTag[0] == 'PLAYGROUND':
-                userTag = 'PLAYGROUND'
-            elif userTag[0].endswith("INJ"):
-                userTag = userTag[0]
-            else:
-                userTag = '_'.join(userTag)
-            node.add_opt("--user-tag", userTag)
+        node.add_input_opt('--bank-file', parent)
+        if dfParents is not None:
+            node.add_input_list_opt('--frame-files', dfParents)
 
         return node
 

--- a/pycbc/workflow/psd.py
+++ b/pycbc/workflow/psd.py
@@ -92,6 +92,7 @@ def make_psd_file(workflow, frame_files, segment_file, segment_name, out_dir,
     
     if frame_files and not exe.has_opt('frame-type'):
         node.add_input_list_opt('--frame-files', frame_files)
+
     node.new_output_file_opt(workflow.analysis_time, '.hdf', '--output-file')
     workflow += node
     return node.output_files[0]

--- a/pycbc/workflow/psd.py
+++ b/pycbc/workflow/psd.py
@@ -59,7 +59,7 @@ def setup_psd_calculate(workflow, frame_files, ifo, segments,
         num_parts = 1
         
     # get rid of duplicate segments which happen when splitting the bank
-    segments = segmentlist(frozenset(segments))       
+    segments = segmentlist(frozenset(segments))
         
     segment_lists = list(chunks(segments, num_parts)) 
     
@@ -90,7 +90,7 @@ def make_psd_file(workflow, frame_files, segment_file, segment_name, out_dir,
     node.add_input_opt('--analysis-segment-file', segment_file)
     node.add_opt('--segment-name', segment_name)
     
-    if not exe.has_opt('frame-type'):
+    if frame_files and not exe.has_opt('frame-type'):
         node.add_input_list_opt('--frame-files', frame_files)
     node.new_output_file_opt(workflow.analysis_time, '.hdf', '--output-file')
     workflow += node


### PR DESCRIPTION
I'm opening this to start the debug process on travis. I can do no testing atm due to ATLAS being down though. This should be the minimal change set required to make this work in a reasonable fashion, in conjuction with changes to the config file for this mode. I haven't changed segment handling so atm, that is bootstrapped with whatever you like. That could be simplified as well to have a no segments query mode, where all time is good option.

For all PyCBC user: When this is merged, fake strain will not return the same realization it used to.