### PR TITLE
add description for the pypi page

### DIFF
--- a/descr.txt
+++ b/descr.txt
@@ -1,10 +1,7 @@
-PyCBC is a software package used to explore astrophysical sources of  gravitational waves. It contains algorithms to analyze gravitational-wave data from the LIGO / Virgo detectors, detect coalescing compact binaries, and measure the astrophysical parameters of detected sources. PyCBC was used in the first direct detection of gravitational waves by LIGO and is used in flagship analysis of LIGO and Virgo data.
+`PyCBC <https://ligo-cbc.github.io>`_ is a software package used to explore astrophysical sources of gravitational waves. It contains algorithms to analyze gravitational-wave data from the LIGO and Virgo detectors, detect coalescing compact binaries, and measure the astrophysical parameters of detected sources. PyCBC was used in the `first direct detection of gravitational waves <https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.116.061102>`_ and is used in the flagship analysis of LIGO and Virgo data.
 
-PyCBC is developed collaboratively and lead by a team of LIGO scientists with the aim to build accessible tools for gravitational wave data analysis. One of the easiest ways to get a full software environment is by using one of our docker images.
+PyCBC is developed collaboratively and lead by a team of LIGO scientists with the aim to build accessible tools for gravitational-wave data analysis. One of the easiest ways to get a full software environment is by `downloading one of our docker images. <https://ligo-cbc.github.io/pycbc/latest/html/docker.html>`_
 
- `Instructions for getting a Docker image with PyCBC <https://ligo-cbc.github.io/pycbc/latest/html/docker.html>`_.
+Some interactive examples using portions of the PyCBC library are also hosted as jupyter notebooks on Microsoft Azure. `Feel free to give them a try. <https://notebooks.azure.com/nitz/libraries/pycbc>`_  You can also explore the `full documentation pages <https://ligo-cbc.github.io/pycbc/latest/html/index.html>`_ or the `source code on GitHub. <https://github.com/ligo-cbc/pycbc>`_ 
 
-Some interactive examples using portions of the pycbc library are also hosted in jupyter notebooks on azure. `Feel free to give them a try. <https://notebooks.azure.com/nitz/libraries/pycbc>`_ 
-
-Documentation pages are also available `here <https://ligo-cbc.github.io/pycbc/latest/html/index.html>`_.
-
+If you use PyCBC in scientific publications, please see our `citation guidelines. https://ligo-cbc.github.io/pycbc/latest/html/credit.html>`_ 

--- a/descr.txt
+++ b/descr.txt
@@ -1,0 +1,10 @@
+PyCBC is a software package used to explore astrophysical sources of  gravitational waves. It contains algorithms to analyze gravitational-wave data from the LIGO / Virgo detectors, detect coalescing compact binaries, and measure the astrophysical parameters of detected sources. PyCBC was used in the first direct detection of gravitational waves by LIGO and is used in flagship analysis of LIGO and Virgo data.
+
+PyCBC is developed collaboratively and lead by a team of LIGO scientists with the aim to build accessible tools for gravitational wave data analysis. One of the easiest ways to get a full software environment is by using one of our docker images.
+
+ `Instructions for getting a Docker image with PyCBC <https://ligo-cbc.github.io/pycbc/latest/html/docker.html>`_.
+
+Some interactive examples using portions of the pycbc library are also hosted in jupyter notebooks on azure. `Feel free to give them a try. <https://notebooks.azure.com/nitz/libraries/pycbc>`_ 
+
+Documentation pages are also available `here <https://ligo-cbc.github.io/pycbc/latest/html/index.html>`_.
+

--- a/setup.py
+++ b/setup.py
@@ -342,6 +342,7 @@ setup (
     name = 'PyCBC',
     version = VERSION,
     description = 'Analyze gravitational-wave data, find signals, and study their parameters.',
+    long_description = open('descr.txt').read(),
     author = 'Ligo Virgo Collaboration - PyCBC team',
     author_email = 'alex.nitz@ligo.org',
     url = 'https://ligo-cbc.github.io',


### PR DESCRIPTION
This text shows up in the pypi project description page when we make the next release. Currently we have a blank section. 