### PR TITLE
Solve issues with td ringdown tapering

### DIFF
--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -281,8 +281,7 @@ def apply_taper(delta_t, taper, f_0, tau, amp, phi, l, m, inclination):
     """
 
     # Times of tapering do not include t=0
-    taper_times = -numpy.arange(delta_t, taper*tau, delta_t)
-    taper_times.sort()
+    taper_times = -numpy.arange(1, int(taper*tau/delta_t))[::-1] * delta_t
     Y_plus, Y_cross = spher_harms(l, m, inclination)
     taper_hp = amp * Y_plus * numpy.exp(10*taper_times/tau) * \
                      numpy.cos(two_pi*f_0*taper_times + phi)


### PR DESCRIPTION
When introducing the spherical harmonics into the ringdown, I forgot to add them to the taper too, so that the td ringdown with tapering ended up looking like
https://www.atlas.aei.uni-hannover.de/~miriam.cabero/LSC/tests/ringdown_approximants/wfMassSpin_taper.png
That also brought to my attention that the epoch for the multi-mode tapered ringdown was wrong, although this must have been introduced later because I remember doing some sanity checks when I first added the tapering option, such as https://www.atlas.aei.uni-hannover.de/~miriam.cabero/LSC/tests/ringdown_taper/multi_mode.png
Anyway, in this PR I tried to fix both issues, so that a tapered ringdown now looks like https://www.atlas.aei.uni-hannover.de/~miriam.cabero/LSC/tests/ringdown_taper/spherharms_MassSpin.png
My only problem is that the start of the ringdown is not exactly at t=0, as can be seen in this zoom
https://www.atlas.aei.uni-hannover.de/~miriam.cabero/LSC/tests/ringdown_taper/spherharms_MassSpin_zoom.png
After much testing I believe this is due to the behaviour of `numpy.arange` when used with a non-integer step (in our case delta_t on line 284), the documentation recommends to use `numpy.linspace` instead but then I cannot control that the step will be exactly delta_t.
So I am open to suggestions on how to fix this, or otherwise leave it as is since the loss is minimal (it looks like ~0.05ms in the zoomed plot, maybe not even worth mentioning it?)
