### PR TITLE
Reduce mem usage in noise.reproducible

### DIFF
--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -114,7 +114,7 @@ def colored_noise(psd, start_time, end_time, seed=0, low_frequency_cutoff=1.0):
             psd.data[i] = psd[oldlen - 2]
         if psd[i] == 0:
             psd.data[i] = max_val
-    wn_dur = (end_time - start_time) + 2*FILTER_LENGTH
+    wn_dur = int(end_time - start_time) + 2*FILTER_LENGTH
     if psd.delta_f >= 1. / (2.*FILTER_LENGTH):
         # If the PSD is short enough, this method is less memory intensive than
         # resizing and then calling inverse_spectrum_truncation

--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -151,7 +151,9 @@ def colored_noise(psd, start_time, end_time, seed=0, low_frequency_cutoff=1.0):
     # Here we color. Do not want to duplicate memory here though so use '*='
     white_noise *= psd
     del psd
-    return white_noise.to_timeseries()
+    colored = white_noise.to_timeseries()
+    del white_noise
+    return colored.time_slice(start_time, end_time)
 
 def noise_from_string(psd_name, start_time, end_time, seed=0, low_frequency_cutoff=1.0):
     """ Create noise from an analytic PSD

--- a/pycbc/noise/reproduceable.py
+++ b/pycbc/noise/reproduceable.py
@@ -136,7 +136,6 @@ def colored_noise(psd, start_time, end_time, seed=0, low_frequency_cutoff=1.0):
         # As time series is still mirrored the complex frequency components are
         # 0. But convert to real by using abs as in inverse_spectrum_truncate
         psd = psd.to_frequencyseries()
-        psd = abs(psd)**0.5
     else:
         wn_dur = (end_time - start_time) + 2*FILTER_LENGTH
         psd = pycbc.psd.interpolate(psd, 1.0 / wn_dur)
@@ -144,13 +143,14 @@ def colored_noise(psd, start_time, end_time, seed=0, low_frequency_cutoff=1.0):
                                 FILTER_LENGTH * SAMPLE_RATE,
                                 low_frequency_cutoff=low_frequency_cutoff,
                                 trunc_method='hann')
-        psd = psd**0.5
+    asd = (psd.real())**0.5
+    del psd
     white_noise = normal(start_time - FILTER_LENGTH, end_time + FILTER_LENGTH,
                           seed=seed)
     white_noise = white_noise.to_frequencyseries()
     # Here we color. Do not want to duplicate memory here though so use '*='
-    white_noise *= psd
-    del psd
+    white_noise *= asd
+    del asd
     colored = white_noise.to_timeseries()
     del white_noise
     return colored.time_slice(start_time, end_time)

--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -230,13 +230,16 @@ def inverse_spectrum_truncation(psd, max_filter_len, low_frequency_cutoff=None, 
     
     trunc_start = max_filter_len / 2
     trunc_end = N - max_filter_len / 2
+    if trunc_end < trunc_start:
+        raise ValueError('Invalid value in inverse_spectrum_truncation')
 
     if trunc_method == 'hann':
         trunc_window = Array(numpy.hanning(max_filter_len), dtype=q.dtype)
         q[0:trunc_start] *= trunc_window[max_filter_len/2:max_filter_len]
         q[trunc_end:N] *= trunc_window[0:max_filter_len/2]
 
-    q[trunc_start:trunc_end] = 0
+    if trunc_start < trunc_end:
+        q[trunc_start:trunc_end] = 0
     psd_trunc = FrequencySeries(numpy.zeros(len(psd)), delta_f=psd.delta_f, \
                                 dtype=complex_same_precision_as(psd))
     fft(q, psd_trunc)

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -17,7 +17,7 @@
 This modules contains functions reading, generating, and segmenting strain data
 """
 import copy
-import logging, numpy, lal
+import logging, numpy
 import pycbc.noise
 import pycbc.types
 from pycbc.types import TimeSeries, zeros


### PR DESCRIPTION
This reduces the high memory usage in inverse_spectrum_truncate, keeping `pycbc_inspiral` within 2GB (at least during this stage). There's no real change in functionality, I just do some reordering and avoid calling `inverse_spectrum_truncation` on the full PSD when needed as that code stores a few representations of the full PSD, which is quite big in this case.

... This also fixes a minor issue that the PSD representation previously changed (slightly) based on the amount of data being requested, so you wouldn't always get exactly the same data back. Here the time-domain representation of the PSD does not vary based on the amount of data being requested, so this should be a little more consistent.

I also added some comments because it took a while to get my head around all the PSD inversions that are needed here.

In testing (old code):

```
	Maximum resident set size (kbytes): 2638672
```

new code:

```
	Maximum resident set size (kbytes): 1475112
```
