### PR TITLE
Reenable important tests

### DIFF
--- a/test/bankvetotest.py
+++ b/test/bankvetotest.py
@@ -10,10 +10,10 @@ sr = 4096.0
 dt = 1.0/sr
 bl = 256
 df = 1.0/bl
-N = sr * bl
+N = int(sr * bl)
 n = N/2 + 1
 
-psd = pycbc.psd.from_txt("ZERO_DET_high_P.txt", n, df, 14)
+psd = pycbc.psd.from_string("aLIGOZeroDetHighPower", n, df, 14)
 strain = noise_from_psd(N, dt, psd, seed=0)
 
 htildep, htildec = get_fd_waveform(approximant="TaylorF2", mass1=10, mass2=10, f_lower=15, delta_f=df)
@@ -52,7 +52,7 @@ for bank_template in bank_veto_bank:
              low_frequency_cutoff=15))
 
 bank_veto = bank_chisq_from_filters(snr,norm,bank_snrs,bank_norms,bank_veto_curr_overlaps)
-numpy.savetxt('BV_TEST1.txt',bank_veto)
+#numpy.savetxt('BV_TEST1.txt',bank_veto)
 
 # TEST 2
 bank_tilde1,_ = get_fd_waveform(approximant="TaylorF2", mass1=9.9, mass2=9.9, f_lower=15, delta_f=df)
@@ -89,5 +89,5 @@ for bank_template in bank_veto_bank:
     sigmasq2 = sigmasq(bank_template, psd, 15, None)
 
 bank_veto = bank_chisq_from_filters(snr,norm,bank_snrs,bank_norms,bank_veto_curr_overlaps)
-numpy.savetxt('BV_TEST2.txt',bank_veto)
+#numpy.savetxt('BV_TEST2.txt',bank_veto)
 

--- a/tools/travis_build_and_test.sh
+++ b/tools/travis_build_and_test.sh
@@ -23,7 +23,7 @@ RESULT=0
 #     Some tests fail for reasons not necessarily related to PyCBC
 #     Setup.py seems to returns 0 even when tests fail
 # So we rather run specific tests manually
-for prog in `find test -name '*.py' -print | egrep -v '(autochisq|bankveto|fft|schemes|long|lalsim|test_waveform)'`
+for prog in `find test -name '*.py' -print | egrep -v '(long|lalsim|test_waveform)'`
 do 
     echo -e ">> [`date`] running unit test for $prog"
     python $prog &> $LOG_FILE


### PR DESCRIPTION
@duncan-brown seems to have disabled some of the sanity tests in Travis. This probably comes from some previous time when these tests were failing. I patched the failing tests in January, so these should be re-enabled now. This would have caught the issue @johnveitch reports in #1803. Until #1803 is pushed and this is rebased it will fail, this is expected.

I also added a few lines to make the bankveto script work again. This isn't a formal test script (maybe it should be made one), but we can at least exercise it here.

Lalsimulation testing is still disabled. This currently uses the ROM waveforms which are not available in Travis. Fixing that should be done, but maybe in a separate pull request.