### PR TITLE
Always run bank2hdf for HDF banks

### DIFF
--- a/pycbc/workflow/tmpltbank.py
+++ b/pycbc/workflow/tmpltbank.py
@@ -143,9 +143,7 @@ def setup_tmpltbank_workflow(workflow, science_segs, datafind_outs,
     if return_format is None :
         tmplt_banks_return = tmplt_banks
     elif return_format in ('hdf', 'h5', 'hdf5'):
-        if ext in ('hdf', 'h5', 'hdf5'):
-            tmplt_banks_return = tmplt_banks
-        elif ext in ('xml.gz' , 'xml'):
+        if ext in ('hdf', 'h5', 'hdf5') or ext in ('xml.gz' , 'xml'):
             tmplt_banks_return = pycbc.workflow.convert_bank_to_hdf(workflow,
                                                         tmplt_banks, "bank")
     else :


### PR DESCRIPTION
Currently there are subtle format differences between PyCBC and sbank HDF template banks (specifically the template_hash column), which cause failures if banks are fed directly to pycbc_inspiral. This can be solved by running bank2hdf to convert a sbank HDF bank to a PyCBC compatible HDF bank. Removing the necessity of this step can be a post-O2 goal.