### PR TITLE
workflow: fix error when datafind server port is not given

### DIFF
--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -245,11 +245,9 @@ def datafind_connection(server=None):
         cert_file, key_file = None, None
 
     # Is a port specified in the server URL
-    server, port = datafind_server.split(':',1)
-    if port == "":
-        port = None
-    else:
-        port = int(port)
+    dfs_fields = datafind_server.split(':', 1)
+    server = dfs_fields[0]
+    port = int(dfs_fields[1]) if len(dfs_fields) == 2 else None
 
     # Open connection to the datafind server
     if cert_file and key_file:


### PR DESCRIPTION
With this override:
```
workflow-datafind:datafind-backup-datafind-server:ldr.ligo.caltech.edu
```
I get this error:
```
2017-07-27 22:25:44,645:INFO : Setting up connection to datafind server.
Traceback (most recent call last):
  File "/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/x86_64_deb_8/virtualenv/pycbc-v1.7.5/bin/pycbc_make_coinc_search_workflow", line 4, in <module>
    __import__('pkg_resources').run_script('PyCBC==1.7.5', 'pycbc_make_coinc_search_workflow')
  File "/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/x86_64_deb_8/virtualenv/pycbc-v1.7.5/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 741, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/x86_64_deb_8/virtualenv/pycbc-v1.7.5/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1502, in run_script
    exec(code, namespace, namespace)
  File "/cvmfs/oasis.opensciencegrid.org/ligo/deploy/sw/pycbc/x86_64_deb_8/virtualenv/pycbc-v1.7.5/lib/python2.7/site-packages/PyCBC-1.7.5-py2.7.egg/EGG-INFO/scripts/pycbc_make_coinc_search_workflow", line 141, in <module>
    seg_file=science_seg_file)
  File "/cvmfs/oasis.opensciencegrid.org/ligo/deploy/sw/pycbc/x86_64_deb_8/virtualenv/pycbc-v1.7.5/lib/python2.7/site-packages/PyCBC-1.7.5-py2.7.egg/pycbc/workflow/datafind.py", line 173, in setup_datafind_workflow
    scienceSegs, outputDir, tags=tags)
  File "/cvmfs/oasis.opensciencegrid.org/ligo/deploy/sw/pycbc/x86_64_deb_8/virtualenv/pycbc-v1.7.5/lib/python2.7/site-packages/PyCBC-1.7.5-py2.7.egg/pycbc/workflow/datafind.py", line 554, in setup_datafind_runtime_frames_single_call_perifo
    outputDir, tags=tags)
  File "/cvmfs/oasis.opensciencegrid.org/ligo/deploy/sw/pycbc/x86_64_deb_8/virtualenv/pycbc-v1.7.5/lib/python2.7/site-packages/PyCBC-1.7.5-py2.7.egg/pycbc/workflow/datafind.py", line 478, in setup_datafind_runtime_cache_single_call_perifo
    connection = setup_datafind_server_connection(cp, tags=tags)
  File "/cvmfs/oasis.opensciencegrid.org/ligo/deploy/sw/pycbc/x86_64_deb_8/virtualenv/pycbc-v1.7.5/lib/python2.7/site-packages/PyCBC-1.7.5-py2.7.egg/pycbc/workflow/datafind.py", line 810, in setup_datafind_server_connection
    return datafind_connection(datafind_server)
  File "/cvmfs/oasis.opensciencegrid.org/ligo/deploy/sw/pycbc/x86_64_deb_8/virtualenv/pycbc-v1.7.5/lib/python2.7/site-packages/PyCBC-1.7.5-py2.7.egg/pycbc/frame/frame.py", line 248, in datafind_connection
    server, port = datafind_server.split(':',1)
ValueError: need more than 1 value to unpack
```
This patch should fix it. I only tested it in a tiny test script, not by generating a full workflow. Let me know if you want a full test.