### PR TITLE
Update likelihood docs

### DIFF
--- a/docs/conf_std.py
+++ b/docs/conf_std.py
@@ -30,7 +30,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
           'sphinx.ext.intersphinx', 'sphinx.ext.coverage', 
               'sphinx.ext.viewcode', 
             'sphinxcontrib.programoutput',
-         'sphinx.ext.napoleon',           'matplotlib.sphinxext.mathmpl',
+         'sphinx.ext.napoleon',           'sphinx.ext.mathjax',
           'matplotlib.sphinxext.only_directives',
           'matplotlib.sphinxext.plot_directive', 'sphinx.ext.autosummary']
 

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -58,19 +58,19 @@ class BaseLikelihoodEvaluator(object):
     follows: Given some model parameters :math:`\Theta` and some data
     :math:`d` with noise model :math:`n`, we define:
 
-     * the *likelihood function*: :math:`p(d|\Theta)`
+     * the **likelihood function**: :math:`p(d|\Theta)`
 
-     * the *noise likelihood*: :math:`p(d|n)`
+     * the **noise likelihood**: :math:`p(d|n)`
 
-     * the *likelihood ratio*: :math:`\mathcal{L}(\Theta) = \frac{p(d|\Theta)}{p(d|n)}`
+     * the **likelihood ratio**: :math:`\mathcal{L}(\Theta) = \frac{p(d|\Theta)}{p(d|n)}`
 
-     * the *prior*: :math:`p(\Theta)`
+     * the **prior**: :math:`p(\Theta)`
 
-     * the *posterior*: :math:`p(\Theta|d) \propto p(d|\Theta)p(\Theta)`
+     * the **posterior**: :math:`p(\Theta|d) \propto p(d|\Theta)p(\Theta)`
 
-     * the *prior-weighted likelihood ratio*: :math:`\hat{\mathcal{L}}(\Theta) = \frac{p(d|\Theta)p(\Theta)}{p(d|n)}`
+     * the **prior-weighted likelihood ratio**: :math:`\hat{\mathcal{L}}(\Theta) = \frac{p(d|\Theta)p(\Theta)}{p(d|n)}`
    
-     * the *SNR*: :math:`\rho(\Theta) = \sqrt{2\log\mathcal{L}(\Theta)}`; for
+     * the **SNR**: :math:`\rho(\Theta) = \sqrt{2\log\mathcal{L}(\Theta)}`; for
        two detectors, this is approximately the same quantity as the coincident
        SNR used in the CBC search.
    
@@ -94,7 +94,7 @@ class BaseLikelihoodEvaluator(object):
     This class provides boiler-plate methods and attributes for evaluating the
     log likelihood ratio, log prior, and log likelihood. This class
     makes no assumption about the detectors' noise model :math:`n`. As such,
-    the methods for computing these values raise ``NotImplementedError``s. These
+    the methods for computing these values raise ``NotImplementedErrors``. These
     functions need to be monkey patched, or other classes that inherit from
     this class need to define their own functions.
 
@@ -290,7 +290,7 @@ class BaseLikelihoodEvaluator(object):
         Let :math:`\mathbf{x}` be the set of variable parameters,
         :math:`\mathbf{y} = f(\mathbf{x})` the set of sampling parameters, and
         :math:`p_x(\mathbf{x})` a probability density function defined over
-        :math:`mathbf{x}`. The corresponding pdf in :math:`\mathbf{y}` is then:
+        :math:`\mathbf{x}`. The corresponding pdf in :math:`\mathbf{y}` is then:
 
         .. math::
 
@@ -498,13 +498,13 @@ class GaussianLikelihood(BaseLikelihoodEvaluator):
     r"""Computes log likelihoods assuming the detectors' noise is Gaussian.
 
     With Gaussian noise the log likelihood functions for signal
-    :math:`\log p(d|\Theta)` and for noise :math:`log p(d|n)` are given by:
+    :math:`\log p(d|\Theta)` and for noise :math:`\log p(d|n)` are given by:
 
     .. math::
 
-        \log p(d|\Theta) = -\frac{1}{2} \sum_i \left<h_i(\Theta) - d_i | h_i(\Theta) - d_i\right>
+            \log p(d|\Theta) = -\frac{1}{2} \sum_i \left<h_i(\Theta) - d_i | h_i(\Theta) - d_i\right>
 
-        \log p(d|n) = -\frac{1}{2} \sum_i \left<d_i | d_i\right>
+            \log p(d|n) = -\frac{1}{2} \sum_i \left<d_i | d_i\right>
 
     where the sum is over the number of detectors, :math:`d_i` is the data in
     each detector, and :math:`h_i(\Theta)` is the model signal in each

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -502,9 +502,9 @@ class GaussianLikelihood(BaseLikelihoodEvaluator):
 
     .. math::
 
-            \log p(d|\Theta) = -\frac{1}{2} \sum_i \left<h_i(\Theta) - d_i | h_i(\Theta) - d_i\right>
+        \log p(d|\Theta) = -\frac{1}{2} \sum_i \left<h_i(\Theta) - d_i | h_i(\Theta) - d_i\right>
 
-            \log p(d|n) = -\frac{1}{2} \sum_i \left<d_i | d_i\right>
+        \log p(d|n) = -\frac{1}{2} \sum_i \left<d_i | d_i\right>
 
     where the sum is over the number of detectors, :math:`d_i` is the data in
     each detector, and :math:`h_i(\Theta)` is the model signal in each

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -88,6 +88,7 @@ class BaseLikelihoodEvaluator(object):
     simply sum over the detectors. For example, the log likelihood ratio is:
 
     .. math::
+
         \log \mathcal{L}(\Theta) = \sum_i \left[\log p(\Theta|d_i) - \log p(n|d_i)\right]
    
     This class provides boiler-plate methods and attributes for evaluating the
@@ -501,9 +502,9 @@ class GaussianLikelihood(BaseLikelihoodEvaluator):
 
     .. math::
 
-        \log p(d|\Theta) &= -\frac{1}{2} \sum_i \left<h_i(\Theta) - d_i | h_i(\Theta) - d_i\right> \\
+        \log p(d|\Theta) = -\frac{1}{2} \sum_i \left<h_i(\Theta) - d_i | h_i(\Theta) - d_i\right>
 
-        \log p(d|n) &= -\frac{1}{2} \sum_i \left<d_i | d_i\right>
+        \log p(d|n) = -\frac{1}{2} \sum_i \left<d_i | d_i\right>
 
     where the sum is over the number of detectors, :math:`d_i` is the data in
     each detector, and :math:`h_i(\Theta)` is the model signal in each

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -50,7 +50,7 @@ class _NoPrior(object):
     def __call__(self, **params):
         return 0.
 
-class _BaseLikelihoodEvaluator(object):
+class BaseLikelihoodEvaluator(object):
     r"""Base container class for generating waveforms, storing the data, and
     computing posteriors.
 
@@ -68,7 +68,7 @@ class _BaseLikelihoodEvaluator(object):
 
      * the *posterior*: :math:`p(\Theta|d) \propto p(d|\Theta)p(\Theta)`
 
-     * the *prior-weighted likelihood ratio*: :math:`\hat{\mathcal{L}}(\Theta) = \frac{p(d|\Theta)p(\Theta)}{p(d|n)}
+     * the *prior-weighted likelihood ratio*: :math:`\hat{\mathcal{L}}(\Theta) = \frac{p(d|\Theta)p(\Theta)}{p(d|n)}`
    
      * the *SNR*: :math:`\rho(\Theta) = \sqrt{2\log\mathcal{L}(\Theta)}`; for
        two detectors, this is approximately the same quantity as the coincident
@@ -93,18 +93,18 @@ class _BaseLikelihoodEvaluator(object):
     This class provides boiler-plate methods and attributes for evaluating the
     log likelihood ratio, log prior, and log likelihood. This class
     makes no assumption about the detectors' noise model :math:`n`. As such,
-    the methods for computing these values raise `NotImplementedError`s. These
+    the methods for computing these values raise ``NotImplementedError``s. These
     functions need to be monkey patched, or other classes that inherit from
     this class need to define their own functions.
 
     Instances of this class can be called like a function. The default is for
-    this class to call its `logposterior` function, but this can be changed
-    with the `set_callfunc` method.
+    this class to call its ``logposterior`` function, but this can be changed
+    with the ``set_callfunc`` method.
 
     Parameters
     ----------
     waveform_generator : generator class
-        A generator class that creates waveforms. This must have a `generate`
+        A generator class that creates waveforms. This must have a ``generate``
         function which takes parameter values as keyword arguments, a
         detectors attribute which is a dictionary of detectors keyed by their
         names, and an epoch which specifies the start time of the generated
@@ -116,17 +116,17 @@ class _BaseLikelihoodEvaluator(object):
         data set must be the same as the waveform generator's epoch.
     prior : callable
         A callable class or function that computes the log of the prior. If
-        None provided, will use `_noprior`, which returns 0 for all parameter
+        None provided, will use ``_noprior``, which returns 0 for all parameter
         values.
     sampling_parameters : list, optional
         Replace one or more of the variable args with the given parameters
         for sampling.
     replace_parameters : list, optional
         The variable args to replace with sampling parameters. Must be the
-        same length as `sampling_parameters`.
+        same length as ``sampling_parameters``.
     sampling_transforms : list, optional
         List of transforms to use to go between the variable args and the
-        sampling parameters. Required if `sampling_parameters` is not None.
+        sampling parameters. Required if ``sampling_parameters`` is not None.
 
     Attributes
     ----------
@@ -137,9 +137,9 @@ class _BaseLikelihoodEvaluator(object):
     lognl : {None, float}
         The log of the noise likelihood summed over the number of detectors.
     return_meta : {True, bool}
-        If True, `prior`, `logposterior`, and `logplr` will return the value
-        of the prior, the loglikelihood ratio, and the log jacobian, along with
-        the posterior/plr.
+        If True, ``prior``, ``logposterior``, and ``logplr`` will return the
+        value of the prior, the loglikelihood ratio, and the log jacobian,
+        along with the posterior/plr.
 
     Methods
     -------
@@ -246,7 +246,7 @@ class _BaseLikelihoodEvaluator(object):
     def apply_sampling_transforms(self, samples, inverse=False):
         """Applies the sampling transforms to the given samples.
 
-        If `sampling_transforms` is None, just returns the samples.
+        If ``sampling_transforms`` is None, just returns the samples.
 
         Parameters
         ----------
@@ -283,7 +283,8 @@ class _BaseLikelihoodEvaluator(object):
 
     def logjacobian(self, **params):
         r"""Returns the log of the jacobian needed to transform pdfs in the
-        `variable_args` parameter space to the `sampling_args` parameter space.
+        ``variable_args`` parameter space to the ``sampling_args`` parameter
+        space.
 
         Let :math:`\mathbf{x}` be the set of variable parameters,
         :math:`\mathbf{y} = f(\mathbf{x})` the set of sampling parameters, and
@@ -334,7 +335,7 @@ class _BaseLikelihoodEvaluator(object):
     def prior_rvs(self, size=1, prior=None):
         """Returns random variates drawn from the prior.
 
-        If the `sampling_args` are different from the `variable_args`, the
+        If the ``sampling_args`` are different from the ``variable_args``, the
         variates are transformed to the `sampling_args` parameter space before
         being returned.
 
@@ -467,13 +468,13 @@ class _BaseLikelihoodEvaluator(object):
             variable args.
         callfunc : str, optional
             The name of the function to call. If None, will use
-            `self._callfunc`. Default is None.
+            ``self._callfunc``. Default is None.
 
         Returns
         -------
         float or tuple :
-            If `return_meta` is False, the output of the call function. If
-            `return_meta` is True, a tuple of the output of the call function
+            If ``return_meta`` is False, the output of the call function. If
+            ``return_meta`` is True, a tuple of the output of the call function
             and the meta data.
         """
         params = dict(zip(self._sampling_args, params))
@@ -492,7 +493,7 @@ class _BaseLikelihoodEvaluator(object):
 
 
 
-class GaussianLikelihood(_BaseLikelihoodEvaluator):
+class GaussianLikelihood(BaseLikelihoodEvaluator):
     r"""Computes log likelihoods assuming the detectors' noise is Gaussian.
 
     With Gaussian noise the log likelihood functions for signal
@@ -500,9 +501,9 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
 
     .. math::
 
-        \log p(d|\Theta) = -\frac{1}{2} \sum_i \left<h_i(\Theta) - d_i | h_i(\Theta - d_i\right>
+        \log p(d|\Theta) &= -\frac{1}{2} \sum_i \left<h_i(\Theta) - d_i | h_i(\Theta) - d_i\right> \\
 
-        \log p(d|n) = -\frac{1}{2} \sum_i \left<d_i | d_i\right>
+        \log p(d|n) &= -\frac{1}{2} \sum_i \left<d_i | d_i\right>
 
     where the sum is over the number of detectors, :math:`d_i` is the data in
     each detector, and :math:`h_i(\Theta)` is the model signal in each
@@ -522,9 +523,9 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
 
         \log \hat{\mathcal{L}} = \log p(\Theta) + \sum_i \left[ \left<h_i(\Theta)|d_i\right> - \frac{1}{2} \left<h_i(\Theta)|h_i(\Theta)\right> \right]
 
-    For this reason, by default this class returns `logplr` when called as a
-    function instead of `logposterior`. This can be changed via the
-    `set_callfunc` method.
+    For this reason, by default this class returns ``logplr`` when called as a
+    function instead of ``logposterior``. This can be changed via the
+    ``set_callfunc`` method.
 
     Upon initialization, the data is whitened using the given PSDs. If no PSDs
     are given the data and waveforms returned by the waveform generator are
@@ -538,15 +539,15 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
     
     By default, the data is assumed to be equally sampled in frequency, but
     unequally sampled data can be supported by passing the appropriate
-    normalization using the `norm` keyword argument.
+    normalization using the ``norm`` keyword argument.
 
     For more details on initialization parameters and definition of terms, see
-    `_BaseLikelihoodEvaluator`.
+    ``BaseLikelihoodEvaluator``.
 
     Parameters
     ----------
     waveform_generator : generator class
-        A generator class that creates waveforms. This must have a `generate`
+        A generator class that creates waveforms. This must have a ``generate``
         function which takes parameter values as keyword arguments, a
         detectors attribute which is a dictionary of detectors keyed by their
         names, and an epoch which specifies the start time of the generated
@@ -569,12 +570,12 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
         and a given waveform will be used.
     norm : {None, float or array}
         An extra normalization weight to apply to the inner products. Can be
-        either a float or an array. If `None`, `4*data.values()[0].delta_f`
+        either a float or an array. If ``None``, ``4*data.values()[0].delta_f``
         will be used.
     prior : callable
         A callable class or function that computes the prior.
     return_meta : {True, bool}
-        If True, `logposterior` and `logplr` will return the value of the
+        If True, ``logposterior`` and ``logplr`` will return the value of the
         prior and the loglikelihood ratio, along with the posterior/plr.
 
     Examples
@@ -612,7 +613,7 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
     Using the same likelihood evaluator, evaluate the log prior-weighted
     likelihood ratio at several points in time, check that the max is at tsig,
     and plot (note that we use the class as a function here, which defaults
-    to calling `logplr`):
+    to calling ``logplr``):
 
     >>> from matplotlib import pyplot
     >>> times = numpy.arange(seglen*sample_rate)/float(sample_rate)
@@ -762,7 +763,7 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
             The value of the log-posterior evaluated at the given point in
             parameter space.
         metadata : tuple
-            If `return_meta`, the prior and likelihood ratio as a tuple.
+            If ``return_meta``, the prior and likelihood ratio as a tuple.
             Otherwise, just returns the log-posterior.
         """
         # since the logplr has fewer terms, we'll call that, then just add
@@ -777,5 +778,5 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
 
 likelihood_evaluators = {GaussianLikelihood.name: GaussianLikelihood}
 
-__all__ = ['_BaseLikelihoodEvaluator', 'GaussianLikelihood',
+__all__ = ['BaseLikelihoodEvaluator', 'GaussianLikelihood',
            'likelihood_evaluators']

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -582,12 +582,15 @@ class GaussianLikelihood(BaseLikelihoodEvaluator):
     --------
     Create a signal, and set up the likelihood evaluator on that signal:
 
+    >>> from pycbc import psd as pypsd
+    >>> from pycbc.waveform.generator import FDomainDetFrameGenerator
+    >>> from pycbc import inference
     >>> seglen = 4
     >>> sample_rate = 2048
     >>> N = seglen*sample_rate/2+1
     >>> fmin = 30.
     >>> m1, m2, s1z, s2z, tsig, ra, dec, pol, dist = 38.6, 29.3, 0., 0., 3.1, 1.37, -1.26, 2.76, 3*500.
-    >>> generator = waveform.FDomainDetFrameGenerator(waveform.FDomainCBCGenerator, 0., variable_args=['tc'], detectors=['H1', 'L1'], delta_f=1./seglen, f_lower=fmin, approximant='SEOBNRv2_ROM_DoubleSpin', mass1=m1, mass2=m2, spin1z=s1z, spin2z=s2z, ra=ra, dec=dec, polarization=pol, distance=dist)
+    >>> generator = FDomainDetFrameGenerator(waveform.FDomainCBCGenerator, 0., variable_args=['tc'], detectors=['H1', 'L1'], delta_f=1./seglen, f_lower=fmin, approximant='SEOBNRv2_ROM_DoubleSpin', mass1=m1, mass2=m2, spin1z=s1z, spin2z=s2z, ra=ra, dec=dec, polarization=pol, distance=dist)
     >>> signal = generator.generate(tc=tsig)
     >>> psd = pypsd.aLIGOZeroDetHighPower(N, 1./seglen, 20.)
     >>> psds = {'H1': psd, 'L1': psd}
@@ -625,11 +628,11 @@ class GaussianLikelihood(BaseLikelihoodEvaluator):
         [<matplotlib.lines.Line2D at 0x1274b5c50>]
     >>> fig.show()
 
-    Create a prior and use it (see prior module for more details):
+    Create a prior and use it (see distributions module for more details):
 
-    >>> from pycbc.inference import prior
-    >>> uniform_prior = prior.Uniform(tc=(tsig-0.2,tsig+0.2))
-    >>> prior_eval = prior.PriorEvaluator(['tc'], uniform_prior)
+    >>> from pycbc import distributions
+    >>> uniform_prior = distributions.Uniform(tc=(tsig-0.2,tsig+0.2))
+    >>> prior_eval = inference.PriorEvaluator(['tc'], uniform_prior)
     >>> likelihood_eval = inference.GaussianLikelihood(generator, signal, 20., psds=psds, prior=prior_eval, return_meta=False)
     >>> likelihood_eval.logplr([tsig]), likelihood_eval.logposterior([tsig])
         (ArrayWithAligned(278.84574353071264), ArrayWithAligned(0.9162907318741418))

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -583,14 +583,14 @@ class GaussianLikelihood(BaseLikelihoodEvaluator):
     Create a signal, and set up the likelihood evaluator on that signal:
 
     >>> from pycbc import psd as pypsd
-    >>> from pycbc.waveform.generator import FDomainDetFrameGenerator
+    >>> from pycbc.waveform.generator import FDomainDetFrameGenerator, FDomainCBCGenerator
     >>> from pycbc import inference
     >>> seglen = 4
     >>> sample_rate = 2048
     >>> N = seglen*sample_rate/2+1
     >>> fmin = 30.
     >>> m1, m2, s1z, s2z, tsig, ra, dec, pol, dist = 38.6, 29.3, 0., 0., 3.1, 1.37, -1.26, 2.76, 3*500.
-    >>> generator = FDomainDetFrameGenerator(waveform.FDomainCBCGenerator, 0., variable_args=['tc'], detectors=['H1', 'L1'], delta_f=1./seglen, f_lower=fmin, approximant='SEOBNRv2_ROM_DoubleSpin', mass1=m1, mass2=m2, spin1z=s1z, spin2z=s2z, ra=ra, dec=dec, polarization=pol, distance=dist)
+    >>> generator = FDomainDetFrameGenerator(FDomainCBCGenerator, 0., variable_args=['tc'], detectors=['H1', 'L1'], delta_f=1./seglen, f_lower=fmin, approximant='SEOBNRv2_ROM_DoubleSpin', mass1=m1, mass2=m2, spin1z=s1z, spin2z=s2z, ra=ra, dec=dec, polarization=pol, distance=dist)
     >>> signal = generator.generate(tc=tsig)
     >>> psd = pypsd.aLIGOZeroDetHighPower(N, 1./seglen, 20.)
     >>> psds = {'H1': psd, 'L1': psd}


### PR DESCRIPTION
This renames `_BaseLikelihoodEvaluator` to `BaseLikelihoodEvaluator` so that it will show up in the pycbc documentation page. That class defines a number of terms in its docs string which are useful to have in the docs pages. This patch also fixes some typos in the doc strings for both `BaseLikelihoodEvaluator` and `GaussianLikelihood`. Sample page is [here.](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/scratch/testdocs/latest/html/pycbc.inference.html#pycbc.inference.likelihood.BaseLikelihoodEvaluator)

One thing that I haven't been able to fix, and can't figure out why, is the doc string for [GaussianLikelihood](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/scratch/testdocs/latest/html/pycbc.inference.html#pycbc.inference.likelihood.GaussianLikelihood). The first equation (after "are given by:") should be two lines: there should be a line break between `d_i>` and `\log p(d|n)`. Looking at the instructions [here](http://www.sphinx-doc.org/en/stable/ext/math.html), I think I'm doing the correct thing -- I put a blank line between the lines (see Line 505-507 of likelihood.py) -- but it still won't render correctly. I've tried several different things to get it to work. Is there a bug in the version of sphinx we are using?

Also, in general, math rendering doesn't look that great. What are we using for a rendering engine? Looking at the [sphinx docs](http://www.sphinx-doc.org/en/stable/ext/math.html) it looks like you can use different extensions. Maybe one of the other extensions would give nicer looking results?