### PR TITLE
pycbc_live: survive vanishing frame files

### DIFF
--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -611,12 +611,10 @@ class DataBuffer(object):
             if lal.GPSTimeNow() > timeout + self.raw_buffer.end_time:
                 # The frame is not there and it should be by now, so we give up
                 # and treat it as zeros
-                logging.info('{0} frame missing, giving up'.format(self.detector))
                 DataBuffer.null_advance(self, blocksize)
                 return None
             else:
                 # I am too early to give up on this frame, so we should try again
-                logging.info('{0} frame missing, waiting a bit more'.format(self.detector))
                 time.sleep(1)
                 return self.attempt_advance(blocksize, timeout=timeout)
 
@@ -749,10 +747,9 @@ class StatusBuffer(DataBuffer):
             Returns True if all of the status information if valid,
             False if any is not.
         """
-        if self.increment_update_cache:
-            self.update_cache_by_increment(blocksize)
-
         try:
+            if self.increment_update_cache:
+                self.update_cache_by_increment(blocksize)
             ts = DataBuffer.advance(self, blocksize)
             return self.check_valid(ts)
         except RuntimeError:

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -1465,7 +1465,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
 
         # We have given up so there is no time series
         if ts is None:
-            logging.info("Giving on up %s frame...", self.detector)
+            logging.info("%s frame is late, giving up", self.detector)
             self.null_advance_strain(blocksize)
             if self.state:
                 self.state.null_advance(blocksize)


### PR DESCRIPTION
Over the last few days, this error killed the analysis a couple times:
```
Traceback (most recent call last):
  File "/home/pycbc.live/projects/pycbc_live_production/local/bin/pycbc_live", line 4, in <module>
    __import__('pkg_resources').run_script('PyCBC==1.7.4', 'pycbc_live')
  File "/home/pycbc.live/.local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 719, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/home/pycbc.live/.local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1504, in run_script
    exec(code, namespace, namespace)
  File "/home/pycbc.live/projects/pycbc_live_production/local/lib/python2.7/site-packages/PyCBC-1.7.4-py2.7.egg/EGG-INFO/scripts/pycbc_live", line 415, in <module>
    status = data_reader[ifo].advance(valid_pad, timeout=args.frame_read_timeout)
  File "/home/pycbc.live/projects/pycbc_live_production/local/lib/python2.7/site-packages/PyCBC-1.7.4-py2.7.egg/pycbc/strain.py", line 1477, in advance
    if self.state and self.state.advance(blocksize) is False:
  File "/home/pycbc.live/projects/pycbc_live_production/local/lib/python2.7/site-packages/PyCBC-1.7.4-py2.7.egg/pycbc/frame/frame.py", line 755, in advance
    self.update_cache_by_increment(blocksize)
  File "/home/pycbc.live/projects/pycbc_live_production/local/lib/python2.7/site-packages/PyCBC-1.7.4-py2.7.egg/pycbc/frame/frame.py", line 578, in update_cache_by_increment
    raise RuntimeError
RuntimeError
```
This seems to be due to the analysis "falling behind" so much that at some point the frames being read have already been removed from /dev/shm. The actual strain is read successfully, but when the state buffer is advanced to the same point, the frame file is not there anymore.

The reason of the analysis falling behind is not entirely clear to me. In at least one case I think it happened because the nodes I was using for a test became full with Condor jobs. In another case, the transfer of V1 frames stopped for a while, but I am not sure that would lead to a runaway lag. There could have been some simultaneous filesystem issues.

Irrespective of why the "falling behind" happens, however, I think we should catch this exception and be robust to it. This patch basically sets the state to offline when the state buffer cannot find the frame file. I also dropped a redundant log message and clarified another one.

I am testing this on CIT but it needs to wait for another such case of the analysis falling behind. In the mean time, what do you think Alex? Is this a sensible approach?