### PR TITLE
Adding astropy to required packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ decorator>=3.4.2
 scipy>=0.13.0
 unittest2
 matplotlib>=1.3.1
-numpy>=1.6.4
+numpy>=1.9.0
 pillow
 h5py>=2.5
 jinja2
@@ -15,6 +15,8 @@ pycbc-glue-obsolete==1.1.0
 weave>=0.16.0
 requests>=1.2.1
 beautifulsoup4>=4.6.0
+astropy>=2.0.1
+pytest>=2.8.0
 
 # Needed for Parameter Estimation Tasks
 kombine==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ weave>=0.16.0
 requests>=1.2.1
 beautifulsoup4>=4.6.0
 astropy>=2.0.1
-pytest>=2.8.0
 
 # Needed for Parameter Estimation Tasks
 kombine==0.8.1

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'weave>=0.16.0',
                       'unittest2',
                       'matplotlib>=1.3.1',
-                      'numpy>=1.6.4',
+                      'numpy>=1.9.0',
                       'pillow',
                       'h5py>=2.5',
                       'jinja2',
@@ -73,7 +73,8 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'emcee>=2.2.0',
                       'corner>=2.0.1',
                       'requests>=1.2.1',
-                      'beautifulsoup4>=4.6.0'
+                      'beautifulsoup4>=4.6.0',
+                      'astropy>=2.0.1'
                       ]
 
 #FIXME Remove me when we bump to h5py > 2.5


### PR DESCRIPTION
To introduce support for FITS files, I've added the latest version of astropy (v2.0.1) to the list of python packages in `requirements.txt` and `setup.py`. Since astropy requires numpy>=1.9.0, I have also updated the minimum required version of numpy from >=1.6.4 to >=1.9.0. The current virtualenv installation contains numpy v1.13.0, so this update shouldn't have any effect other than to guarantee compatibility with astropy.