### PR TITLE
HDF split bank doesn't actually randomize template order

### DIFF
--- a/bin/pycbc_hdf5_splitbank
+++ b/bin/pycbc_hdf5_splitbank
@@ -104,6 +104,7 @@ if args.random_sort:
     idx = numpy.arange(templates.size)
     numpy.random.shuffle(idx)
     templates = templates[idx]
+    tmplt_bank.table = templates
 
 # Split the templates in the bank taken as input into the smaller banks
 


### PR DESCRIPTION
Line 106 of HDF split bank randomizes the order of the templates. However, the randomized bank is never actually written out to file. The randomization step at line 106 causes a copy of the template table to be made, which is then named "templates". But because `tmplt_bank.table` is never reset to this randomized copy, the original ordered table is the one that is written out by `write_to_hdf`. This patch fixes that by resetting the bank's table attribute to point to the new copy after the randomization. Thanks to @josh-willis for catching this.