### PR TITLE
Specify desired number of indep. samples in pycbc inference

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -358,12 +358,13 @@ with ctx:
             start = end
 
     # compute evidence, if supported
-    try:
-        lnz, dlnz = sampler.calculate_logevidence(fp)
-        logging.info("Saving evidence")
-        sampler.write_logevidence(fp, lnz, dlnz)
-    except NotImplementedError:
-        pass
+    with InferenceFile(opts.output_file, 'a') as fp:
+        try:
+            lnz, dlnz = sampler.calculate_logevidence(fp)
+            logging.info("Saving evidence")
+            sampler.write_logevidence(fp, lnz, dlnz)
+        except NotImplementedError:
+            pass
 
 
 # exit

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -94,10 +94,12 @@ parser.add_argument("--save-psd", action="store_true", default=False,
                     help="Save the psd of each ifo to the output file.")
 parser.add_argument("--checkpoint-interval", type=int, default=None,
                     help="Number of iterations to take before saving new "
-                         "samples to file.")
+                         "samples to file, calculating ACL, and updating "
+                         "burn-in estimate.")
 parser.add_argument("--checkpoint-fast", action="store_true",
-                    help="Do not calculate derived data (eg. ACL or evidence) "
-                         "after each checkpoint. Calculate them at the end.")
+                    help="Do not calculate ACL after each checkpoint, only at "
+                         "the end. Not applicable if n-independent-samples "
+                         "have been specified.")
 
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
@@ -127,6 +129,22 @@ pycbc.weave.verify_weave_options(opts, parser)
 if os.path.exists(opts.output_file) and not opts.force:
     raise OSError("output-file already exists; use --force if you wish to "
                   "overwrite it.")
+
+# check for how many iterations to run
+max_iterations = opts.niterations
+if opts.niterations is not None and opts.n_independent_samples is not None:
+    raise ValueError("Must specify either niterations or n-independent-"
+                     "samples, not both")
+elif opts.niterations is not None:
+    get_nsamples = opts.niterations
+elif opts.n_independent_samples is not None:
+    if opts.checkpoint_interval is None:
+        raise ValueError("n-independent-samples requires a checkpoint-"
+                         "interval; see help")
+    get_nsamples = opts.n_independent_samples
+else:
+    raise ValueError("Must specify niterations or n-independent-samples; "
+                     "see --help")
 
 # setup log
 pycbc.init_logging(opts.verbose)
@@ -244,26 +262,6 @@ with ctx:
         p0 = None
     sampler.set_p0(samples=p0, prior=init_prior)
 
-    # setup checkpointing
-    if opts.checkpoint_interval:
-
-        # determine intervals to run sampler until we save the new samples 
-        intervals = [i for i in range(0, opts.niterations,
-                                      opts.checkpoint_interval)]
-
-        # determine if there is a small bit at the end
-        remainder = opts.niterations % opts.checkpoint_interval
-        if remainder:
-            intervals += [intervals[-1] + remainder]
-        else:
-            intervals += [opts.niterations]
-
-    # if not checkpointing then set intervals to run sampler in one call
-    else:
-        intervals = [0, opts.niterations]
-
-    intervals = numpy.array(intervals)
-
     # if getting samples from file then put sampler and random number generator
     # back in its former state
     if opts.samples_file:
@@ -272,6 +270,7 @@ with ctx:
             numpy.random.set_state(fp.read_random_state())
 
     # run sampler's burn in if it is in the list of burn in functions
+    n_sampler_burn_in = 0
     if "use_sampler" in burn_in_eval.burn_in_functions:
         # remove the sampler's burn in so we don't run more than once
         burn_in_eval.burn_in_functions.pop("use_sampler")
@@ -280,32 +279,42 @@ with ctx:
             burnidx = burn_in.use_sampler(sampler, fp)
             sampler.write_burn_in_iterations(fp, burnidx)
             # write the burn in results
-            nburn_in = burnidx.max()
+            n_sampler_burn_in = burnidx.max()
+            if max_iterations is not None:
+                max_iterations += n_sampler_burn_in
             logging.info("Writing burn in samples to file")
-            sampler.write_results(fp,
-                                  max_iterations=opts.niterations + nburn_in)
+            sampler.write_results(fp, max_iterations=max_iterations)
             try:
                 sampler.write_state(fp)
             except NotImplementedError:
                 logging.warn("Writing state is not implemented for %s",
                              sampler.name)
-            # increase the intervals to account for the burn in
-            intervals += n_sampler_burn_in
-    else:
-        n_sampler_burn_in = 0
+            # increase the number of iterations
 
+    # run sampler until we have the desired number of samples
+    nsamples = 0
+    interval = opts.checkpoint_interval
+    if interval is None:
+        interval = get_nsamples
+    # start keeps track of the number of iterations we have advances (which
+    # may not be the same as the number of samples, if we are using
+    # n-independent-samples)
+    start = n_sampler_burn_in
 
-    # loop over number of checkpoints
-    for i, start in enumerate(intervals[:-1]):
+    while nsamples < get_nsamples:
 
-        end = intervals[i + 1]
+        end = start + interval
+
+        # adjust the interval if we would go past the number of iterations
+        if opts.n_independent_samples is None and end > get_nsamples:
+            interval = get_nsamples - start
+            end = start + interval
 
         # run sampler and set initial values to None so that sampler
         # picks up from where it left off next call
-        logging.info("Running sampler for %i to %i out of %i iterations",
-                     start - n_sampler_burn_in, end - n_sampler_burn_in,
-                     opts.niterations)
-        sampler.run(end - start)
+        logging.info("Running sampler for {} to {} iterations".format(start,
+                                                                      end))
+        sampler.run(interval)
 
         # write new samples
         with InferenceFile(opts.output_file, "a") as fp:
@@ -313,8 +322,7 @@ with ctx:
             logging.info("Writing results to file")
             sampler.write_results(fp, start_iteration=start,
                                   end_iteration=end,
-                                  max_iterations=opts.niterations +
-                                                 n_sampler_burn_in)
+                                  max_iterations=max_iterations)
             logging.info("Writing state to file")
             fp.write_random_state()
 
@@ -329,23 +337,34 @@ with ctx:
                 logging.warn("Writing state is not implemented for %s",
                              sampler.name)
 
-            if not opts.checkpoint_fast or end == opts.niterations:
-
-                # compute the acls and write
+            # compute the acls and write
+            if opts.n_independent_samples is not None or end >= get_nsamples \
+                    or not opts.checkpoint_fast:
                 logging.info("Computing acls")
                 sampler.write_acls(fp, sampler.compute_acls(fp))
 
-                # compute evidence, if supported
-                try:
-                    lnz, dlnz = sampler.calculate_logevidence(fp)
-                    logging.info("Saving evidence")
-                    sampler.write_logevidence(fp, lnz, dlnz)
-                except NotImplementedError:
-                    pass
+            # update nsamples for next loop
+            if opts.n_independent_samples is not None:
+                with InferenceFile(opts.output_file, 'r') as fp:
+                    nsamples = fp.n_independent_samples
+                logging.info("Have {} independent samples".format(nsamples))
+            else:
+                nsamples += interval
 
             # clear the in-memory chain to save memory
             logging.info("Clearing chain")
             sampler.clear_chain()
+
+            start = end
+
+    # compute evidence, if supported
+    try:
+        lnz, dlnz = sampler.calculate_logevidence(fp)
+        logging.info("Saving evidence")
+        sampler.write_logevidence(fp, lnz, dlnz)
+    except NotImplementedError:
+        pass
+
 
 # exit
 logging.info("Done")

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -235,11 +235,19 @@ def add_sampler_option_group(parser):
     sampler_group.add_argument("--sampler", required=True,
         choices=pycbc.inference.sampler.samplers.keys(),
         help="Sampler class to use for finding posterior.")
-    sampler_group.add_argument("--niterations", type=int, required=True,
+    sampler_group.add_argument("--niterations", type=int,
         help="Number of iterations to perform. If 'use_sampler' is given to "
              "burn-in-function, this will be counted after the sampler's burn "
              "function has run. Otherwise, this is the total number of "
              "iterations, including any burn in.")
+    sampler_group.add_argument("--n-independent-samples", type=int,
+        help="Run the sampler until the specified number of "
+             "independent samples is obtained, at minimum. Requires "
+             "checkpoint-interval. At each checkpoint the burn-in iteration "
+             "and ACL is updated. The number of independent samples is the "
+             "number of samples across all walkers starting at the "
+             "burn-in-iteration and skipping every `ACL`th iteration. "
+             "Either this or niteration should be specified (but not both).")
     # sampler-specific options
     sampler_group.add_argument("--nwalkers", type=int, default=None,
         help="Number of walkers to use in sampler. Required for MCMC "

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -398,13 +398,11 @@ class BaseMCMCSampler(_BaseSampler):
             arrays on disk. This is needed if you are adding new samples to
             a chain that was previously written to file, and you want to
             preserve the history (e.g., after a checkpoint). Default is 0.
-        max_iterations : {None, int}
-            If samples have not previously been written to the file, a new
-            dataset will be created. By default, the size of this dataset will
-            be whatever the length of the sampler's chain is at this point. If
-            you intend to run more iterations, set this value to that size so
-            that the array in the file will be large enough to accomodate
-            future data.
+        max_iterations : int, optional
+            Set the maximum size that the arrays in the hdf file may be resized
+            to. Only applies if the samples have not previously been written
+            to file. The default (None) is to use the maximum size allowed by
+            h5py.
         """
         # due to clearing memory, there can be a difference between indices in
         # memory and on disk
@@ -420,8 +418,6 @@ class BaseMCMCSampler(_BaseSampler):
         if max_iterations is not None and max_iterations < niterations:
             raise IndexError("The provided max size is less than the "
                              "number of iterations")
-        elif max_iterations is None:
-            max_iterations = niterations
 
         group = samples_group + '/{name}/walker{wi}'
 
@@ -463,13 +459,11 @@ class BaseMCMCSampler(_BaseSampler):
             Write results starting from the given iteration.
         end_iteration : {None, int}
             Write results up to the given iteration.
-        max_iterations : {None, int}
-            If samples have not previously been written to the file, a new
-            dataset will be created. By default, the size of this dataset will
-            be whatever the length of the sampler's chain is at this point. If
-            you intend to run more iterations, set this value to that size so
-            that the array in the file will be large enough to accomodate
-            future data.
+        max_iterations : int, optional
+            Set the maximum size that the arrays in the hdf file may be resized
+            to. Only applies if the samples have not previously been written
+            to file. The default (None) is to use the maximum size allowed by
+            h5py.
         samples_group : str
             Name of samples group to write.
         """
@@ -506,13 +500,11 @@ class BaseMCMCSampler(_BaseSampler):
             Write results starting from the given iteration.
         end_iteration : {None, int}
             Write results up to the given iteration.
-        max_iterations : {None, int}
-            If the stats have not previously been written to the file, a new
-            dataset will be created. By default, the size of this dataset will
-            be whatever the length of the sampler's chain is at this point. If
-            you intend to run more iterations, set this value to that size so
-            that the array in the file will be large enough to accomodate
-            future data.
+        max_iterations : int, optional
+            Set the maximum size that the arrays in the hdf file may be resized
+            to. Only applies if the samples have not previously been written
+            to file. The default (None) is to use the maximum size allowed by
+            h5py.
 
         Returns
         -------
@@ -546,13 +538,11 @@ class BaseMCMCSampler(_BaseSampler):
         -----------
         fp : InferenceFile
             A file handler to an open inference file.
-        max_iterations : {None, int}
-            If acceptance fraction have not previously been written to the
-            file, a new dataset will be created. By default, the size of this
-            dataset will be whatever the length of the sampler's chain is at
-            this point. If you intend to run more iterations, set this value
-            to that size so that arrays in the file will be large enough to
-            accomodate future data.
+        max_iterations : int, optional
+            Set the maximum size that the arrays in the hdf file may be resized
+            to. Only applies if the acceptance fraction has not previously been
+            written to the file. The default (None) is to use the maximum size
+            allowed by h5py.
         """
         dataset_name = "acceptance_fraction"
         acf = self.acceptance_fraction
@@ -563,8 +553,6 @@ class BaseMCMCSampler(_BaseSampler):
         if max_iterations is not None and max_iterations < acf.size:
             raise IndexError("The provided max size is less than the "
                              "number of iterations")
-        elif max_iterations is None:
-            max_iterations = acf.size
 
         try:
             if end_iteration > fp[dataset_name].size:
@@ -594,13 +582,11 @@ class BaseMCMCSampler(_BaseSampler):
             Write results starting from the given iteration.
         end_iteration : {None, int}
             Write results up to the given iteration.
-        max_iterations : {None, int}
-            If results have not previously been written to the
-            file, new datasets will be created. By default, the size of these
-            datasets will be whatever the length of the sampler's chain is at
-            this point. If you intend to run more iterations in the future,
-            set this value to that size so that the array in the file will be
-            large enough to accomodate future data.
+        max_iterations : int, optional
+            Set the maximum size that the arrays in the hdf file may be resized
+            to. Only applies if the acceptance fraction has not previously been
+            written to the file. The default (None) is to use the maximum size
+            allowed by h5py.
         """
         self.write_metadata(fp)
         self.write_chain(fp, start_iteration=start_iteration,
@@ -738,6 +724,24 @@ class BaseMCMCSampler(_BaseSampler):
                                 thin_interval=thin_interval, thin_end=thin_end,
                                 iteration=iteration, walkers=walkers,
                                 flatten=flatten)
+
+    @classmethod
+    def n_independent_samples(cls, fp):
+        """Returns the number of independent samples stored in a file.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            An open file handler to read.
+
+        Returns
+        -------
+        int
+            The number of independent samples.
+        """
+        # we'll just read a single parameter from the file
+        samples = cls.read_samples(fp, fp.variable_args[0])
+        return samples.size
 
     @staticmethod
     def read_acceptance_fraction(fp, thin_start=None, thin_interval=None,

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -204,13 +204,11 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
             Write results starting from the given iteration.
         end_iteration : {None, int}
             Write results up to the given iteration.
-        max_iterations : {None, int}
-            If results have not previously been written to the
-            file, new datasets will be created. By default, the size of these
-            datasets will be whatever the length of the sampler's chain is at
-            this point. If you intend to run more iterations in the future,
-            set this value to that size so that the array in the file will be
-            large enough to accomodate future data.
+        max_iterations : int, optional
+            Set the maximum size that the arrays in the hdf file may be resized
+            to. Only applies if the samples have not previously been written
+            to file. The default (None) is to use the maximum size allowed by
+            h5py.
         """
         self.write_metadata(fp)
         self.write_chain(fp, start_iteration=start_iteration,
@@ -528,13 +526,11 @@ class EmceePTSampler(BaseMCMCSampler):
             arrays on disk. This is needed if you are adding new samples to
             a chain that was previously written to file, and you want to
             preserve the history (e.g., after a checkpoint). Default is 0.
-        max_iterations : {None, int}
-            If samples have not previously been written to the file, a new
-            dataset will be created. By default, the size of this dataset will
-            be whatever the length of the sampler's chain is at this point. If
-            you intend to run more iterations, set this value to that size so
-            that the array in the file will be large enough to accomodate
-            future data.
+        max_iterations : int, optional
+            Set the maximum size that the arrays in the hdf file may be resized
+            to. Only applies if the samples have not previously been written
+            to file. The default (None) is to use the maximum size allowed by
+            h5py.
         """
         ntemps, nwalkers, niterations = samples.shape
         # due to clearing memory, there can be a difference between indices in
@@ -550,8 +546,6 @@ class EmceePTSampler(BaseMCMCSampler):
         if max_iterations is not None and max_iterations < niterations:
             raise IndexError("The provided max size is less than the "
                              "number of iterations")
-        elif max_iterations is None:
-            max_iterations = niterations
 
         group = samples_group + '/{name}/temp{tk}/walker{wi}'
 
@@ -592,13 +586,11 @@ class EmceePTSampler(BaseMCMCSampler):
             Write results starting from the given iteration.
         end_iteration : {None, int}
             Write results up to the given iteration.
-        max_iterations : {None, int}
-            If results have not previously been written to the
-            file, new datasets will be created. By default, the size of these
-            datasets will be whatever the length of the sampler's chain is at
-            this point. If you intend to run more iterations in the future,
-            set this value to that size so that the array in the file will be
-            large enough to accomodate future data.
+        max_iterations : int, optional
+            Set the maximum size that the arrays in the hdf file may be resized
+            to. Only applies if the samples have not previously been written
+            to file. The default (None) is to use the maximum size allowed by
+            h5py.
         """
         self.write_metadata(fp)
         self.write_chain(fp, start_iteration=start_iteration,

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -86,6 +86,12 @@ class _PosteriorOnlyParser(object):
             grp = '{}/{}'.format(samples_group, field)
             fp[grp] = samples[field]
 
+    @classmethod
+    def n_independent_samples(cls, fp):
+        """Returns the number of independent samples stored in the file.
+        """
+        return cls.read_samples(fp, fp.variable_args[0]).size
+
 
 class InferenceFile(h5py.File):
     """ A subclass of the h5py.File object that has extra functions for
@@ -186,6 +192,12 @@ class InferenceFile(h5py.File):
             Number of iterations performed.
         """
         return self.attrs["niterations"]
+
+    @property
+    def n_independent_samples(self):
+        """Returns the number of independent samples stored in the file.
+        """
+        return self.samples_parser.n_independent_samples(self)
 
     @property
     def burn_in_iterations(self):


### PR DESCRIPTION
This patch adds a `--n-indepedent-samples` option to `pycbc_inference` that can be used instead of `--niterations`. If the new option is given, `pycbc_inference` will run until it estimates that it has obtained at least the requested number of independent samples. The number of independent samples is recalculated at each checkpoint. At the checkpoint the burn-in-iterations are updated and the ACLs re-calculated. The number of independent samples is then obtained by retrieving every ACL-th sample starting from the burn in iteration until the end from every walker. This should make doing large-scale PP tests easier.

At the moment this is probably overly conservative, since we're using the max ACL across all walkers. The issue reported in #1815  will probably make this more efficient.

Also, if you set the number of independent samples to be the same as the number of walkers, the code will exit after the first checkpoint. This is because all of the burn-in methods in `burn_in.py` just return the last iteration if the walker hasn't burned in yet. That can be fixed in a future PR; for now, making the number of independent samples > the number of walkers (even if by 1) should be sufficient to force the code to run until all the walkers have burned in.

I've done a quick test with all 3 samplers. I'm currently running the GW150914 example in the docs with `n-independent-samples` set to 10000 and `burn-in-function` set to `max_posterior posterior_step`. Will update this PR when it's finished.