### PR TITLE
Removed dependence on GCC function for better standards compliance.

### DIFF
--- a/pycbc/events/simd_threshold.py
+++ b/pycbc/events/simd_threshold.py
@@ -58,10 +58,16 @@ compartmentalize SIMD code from OpenMP code.
 
 tc_common_support = omp_support + pycbc.opt.simd_intel_intrin_support + """
 #include <stdint.h> // For uint32_t, int64_t
-#include <error.h>
 #include <complex> // Must use C++ header with weave
 #include <math.h> // For M_SQRT2
 
+/* Rough approx of GCC's error function. */
+void error(int status, int errnum, const char *format) {
+  fprintf(stderr, format);
+  if (status != 0) {
+    exit(status);
+  }
+}
 """
 
 # The following maximizes over an interval that can be no longer than

--- a/pycbc/filter/simd_correlate.py
+++ b/pycbc/filter/simd_correlate.py
@@ -42,8 +42,18 @@ ccorrf_parallel: Runs multicore, but not explicitly vectorized.
 
 corr_common_support = omp_support + pycbc.opt.simd_intel_intrin_support + """
 #include <stdint.h> // For uint32_t, int64_t
-#include <error.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <complex> // Must use C++ header with weave
+
+/* Rough approx of GCC's error function. */
+void error(int status, int errnum, const char *format) {
+  fprintf(stderr, format);
+  if (status != 0) {
+    exit(status);
+  }
+}
 """
 
 corr_support = corr_common_support + """


### PR DESCRIPTION
I had trouble with some of the `weave` code for doing correlations and thresholding because I'm running on Mac OS X where both `clang` and `gcc` (even the *real* `gcc`) do not supply `error.h` (which is a non-standard GCC extension).  The behaviour is simple enough to mock up, at least for these uses where the format strings are simple.  The patch does so (I think), and would prevent all sorts of dirty hacks to get the code to compile on OS X.