### PR TITLE
Average ACF/L over walkers

### DIFF
--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -75,6 +75,7 @@ logging.info("Plotting autocorrelation functions")
 fig = plt.figure()
 ax = fig.add_subplot(111)
 for pi,param in enumerate(parameters):
+    logging.info("Parameter {}".format(param))
     if opts.per_walker:
         for wi in range(acfs.shape[0]):
             ax.plot(acfs[param][wi,:], alpha=0.25)

--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -18,12 +18,12 @@
 
 import argparse
 import h5py
+import pycbc
 import logging
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy
 import sys
-import pycbc
 from pycbc import results
 from pycbc.inference import option_utils
 
@@ -51,12 +51,28 @@ parser.add_argument("--per-walker", action="store_true", default=False,
          "increase the run time.")
 parser.add_argument("--walkers", type=int, nargs="+", default=None,
     help="Only include the given walkers when computing the ACF.")
+parser.add_argument("--temps", nargs="+", default=None,
+    help="For multi-tempered samplers, plot the given temperatures. May "
+         "provide either a sequence of integers specifying the temperatures "
+         "to plot, or 'all' for all temperatures. Default is to only plot "
+         "the coldest (= 0) temperature chain.")
+parser.add_argument("--no-legend", action="store_true", default=False,
+    help="Do not add a legend to the plot.")
 
 # parse the command line
 opts = parser.parse_args()
 
 # setup log
 pycbc.init_logging(opts.verbose)
+
+# add the temperature args if it is specified
+additional_args = {}
+if opts.temps is not None:
+    if 'all' in opts.temps:
+        temps = 'all'
+    else:
+        temps = map(int, opts.temps)
+    additional_args['temps'] = temps 
 
 # load the results
 fp, parameters, labels, _ = option_utils.results_from_cli(opts,
@@ -68,35 +84,64 @@ acfs = fp.sampler_class.compute_acfs(fp, start_index=opts.thin_start,
                                      end_index=opts.thin_end,
                                      per_walker=opts.per_walker,
                                      walkers=opts.walkers,
-                                     parameters=parameters)
+                                     parameters=parameters,
+                                     **additional_args)
+
+# check if we have multiple temperatures
+if opts.per_walker:
+    multi_tempered = acfs.ndim == 3
+else:
+    multi_tempered = acfs.ndim == 2
+try:
+    temps = additional_args['temps']
+    if temps == 'all':
+        temps = range(acfs.shape[0])
+except KeyError:
+    temps = [0]
+fig_height = max(6, 3*len(temps))
 
 # plot autocorrelation
 logging.info("Plotting autocorrelation functions")
-fig = plt.figure()
-ax = fig.add_subplot(111)
-for pi,param in enumerate(parameters):
-    logging.info("Parameter {}".format(param))
-    if opts.per_walker:
-        for wi in range(acfs.shape[0]):
-            ax.plot(acfs[param][wi,:], alpha=0.25)
-    else:
-        ax.plot(acfs[param], label=labels[pi])
-ax.legend()
-plt.xlabel("iteration")
-plt.ylabel(r'autocorrelation function')
+fig = plt.figure(figsize=(8,fig_height))
+for kk,tk in enumerate(temps):
+    if multi_tempered:
+        logging.info("Temperature {}".format(tk))
+    axnum = len(temps) - kk
+    ax = fig.add_subplot(len(temps), 1, axnum)
+    for pi,param in enumerate(parameters):
+        logging.info("Parameter {}".format(param))
+        if multi_tempered:
+            acf = acfs[param][kk,...]
+        else:
+            acf = acfs[param]
+        if opts.per_walker:
+            lbl = '{}, walker {}'
+            for wi in range(acf.shape[0]):
+                wnum = opts.walkers[wi] if opts.walkers is not None else wi
+                ax.plot(acf[wi,:], label=lbl.format(labels[pi], wnum))
+        else:
+            ax.plot(acf, label=labels[pi])
+    if multi_tempered:
+        t = 1./fp.attrs['betas'][tk]
+        ax.set_title(r'$T = {}$ (chain {})'.format(t, tk))
+    if axnum == len(temps):
+        ax.set_xlabel("iteration")
+    ax.set_ylabel("autocorrelation function")
+    if opts.ymin:
+        ax.set_ylim(ymin=opts.ymin)
+    if opts.ymax:
+        ax.set_ylim(ymax=opts.ymax)
+# add legend to the top axis
+if not opts.no_legend:
+    ax.legend()
 
-# format plot
-if opts.ymin:
-    plt.ylim(ymin=opts.ymin)
-if opts.ymax:
-    plt.ylim(ymax=opts.ymax)
+plt.tight_layout()
 
 # save figure with meta-data
 caption_kwargs = {
     "parameters" : ", ".join(labels),
 }
-caption = """Autocorrelation function (ACF) from all the walker chains for the
-parameters. Each line is an ACF for a chain of walker samples."""
+caption = """Autocorrelation function (ACF)."""
 title = "Autocorrelation Function for {parameters}".format(**caption_kwargs)
 results.save_fig_with_metadata(fig, opts.output_file,
                                cmd=" ".join(sys.argv),

--- a/bin/inference/pycbc_inference_plot_acf
+++ b/bin/inference/pycbc_inference_plot_acf
@@ -23,8 +23,8 @@ import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy
 import sys
+import pycbc
 from pycbc import results
-from pycbc.filter import autocorrelation
 from pycbc.inference import option_utils
 
 # command line usage
@@ -44,49 +44,45 @@ parser.add_argument("--ymax", type=float,
     help="Maximum value to plot on y-axis.")
 # add results group
 option_utils.add_inference_results_option_group(parser)
+parser.add_argument("--per-walker", action="store_true", default=False,
+    help="Plot the ACF for each walker separately. Default is to average "
+         "parameter values over the walkers, then compute the ACF for the "
+         "averaged chain. Warning: turning this option on can significantly "
+         "increase the run time.")
+parser.add_argument("--walkers", type=int, nargs="+", default=None,
+    help="Only include the given walkers when computing the ACF.")
 
 # parse the command line
 opts = parser.parse_args()
 
 # setup log
-if opts.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
+pycbc.init_logging(opts.verbose)
 
 # load the results
 fp, parameters, labels, _ = option_utils.results_from_cli(opts,
     load_samples=False)
 
-# calculate autocorrelation function for each walker
+# calculate autocorrelation function
 logging.info("Calculating autocorrelation functions")
-all_acfs = []
-for param_name in parameters:
-
-    # loop over walkers and save an autocorrelation function
-    # for each walker
-    param_acfs = []
-    for i in range(fp.nwalkers):
-
-        # get all the past samples for this walker
-        y = fp.read_samples(param_name, walkers=i, thin_start=opts.thin_start,
-                           thin_interval=opts.thin_interval)
-
-        # autocorrelate and add to list
-        param_acfs.append( autocorrelation.calculate_acf(y[param_name]) )
-
-    # add list with parameters ACF to list of all ACFs
-    all_acfs.append(param_acfs)
+acfs = fp.sampler_class.compute_acfs(fp, start_index=opts.thin_start,
+                                     end_index=opts.thin_end,
+                                     per_walker=opts.per_walker,
+                                     walkers=opts.walkers,
+                                     parameters=parameters)
 
 # plot autocorrelation
 logging.info("Plotting autocorrelation functions")
 fig = plt.figure()
-for param_acfs in all_acfs:
-    for acf in param_acfs:
-        plt.plot(range(len(acf)), acf, alpha=0.25)
-plt.xlabel("Iteration")
-plt.ylabel(r'Autocorrelation Function for %s'%', '.join(labels))
+ax = fig.add_subplot(111)
+for pi,param in enumerate(parameters):
+    if opts.per_walker:
+        for wi in range(acfs.shape[0]):
+            ax.plot(acfs[param][wi,:], alpha=0.25)
+    else:
+        ax.plot(acfs[param], label=labels[pi])
+ax.legend()
+plt.xlabel("iteration")
+plt.ylabel(r'autocorrelation function')
 
 # format plot
 if opts.ymin:

--- a/bin/inference/pycbc_inference_plot_acl
+++ b/bin/inference/pycbc_inference_plot_acl
@@ -18,6 +18,7 @@
 
 import argparse
 import h5py
+import pycbc
 import logging
 import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
@@ -47,11 +48,7 @@ option_utils.add_inference_results_option_group(parser)
 opts = parser.parse_args()
 
 # setup log
-if opts.verbose:
-    log_level = logging.DEBUG
-else:
-    log_level = logging.WARN
-logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
+pycbc.init_logging(opts.verbose)
 
 # load the results
 fp, parameters, labels, _ = option_utils.results_from_cli(opts,

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -795,7 +795,8 @@ class BaseMCMCSampler(_BaseSampler):
         given file.
 
         Parameter values are averaged over all walkers at each iteration.
-        The ACL is then calculated over the averaged chain.
+        The ACL is then calculated over the averaged chain. If the returned ACL
+        is `inf`,  will default to the number of current iterations.
 
         Parameters
         -----------

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -827,7 +827,9 @@ class BaseMCMCSampler(_BaseSampler):
             ``nwalkers x niterations``.
         """
         acfs = {}
-        for param in fp.variable_args:
+        if parameters is None:
+            parameters = fp.variable_args
+        for param in parameters:
             if per_walker:
                 # just call myself with a single walker
                 if walkers is None:
@@ -844,9 +846,9 @@ class BaseMCMCSampler(_BaseSampler):
                                            thin_interval=1, thin_end=end_index,
                                            walkers=walkers,
                                            flatten=False)[param]
-                samples = samples.mean(axis=-1)
-                acfs[param] = autocorrelation.calculate_acf(samples)
-        return FieldArray.from_kwargs(**acls)
+                samples = samples.mean(axis=0)
+                acfs[param] = autocorrelation.calculate_acf(samples).numpy()
+        return FieldArray.from_kwargs(**acfs)
 
     @classmethod
     def compute_acls(cls, fp, start_index=None, end_index=None):
@@ -880,7 +882,7 @@ class BaseMCMCSampler(_BaseSampler):
                                            thin_start=start_index,
                                            thin_interval=1, thin_end=end_index,
                                            flatten=False)[param]
-            samples = samples.mean(axis=-1)
+            samples = samples.mean(axis=0)
             acls[param] = autocorrelation.calculate_acl(samples)
         return acls
 

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -885,7 +885,10 @@ class BaseMCMCSampler(_BaseSampler):
                                            thin_interval=1, thin_end=end_index,
                                            flatten=False)[param]
             samples = samples.mean(axis=0)
-            acls[param] = autocorrelation.calculate_acl(samples)
+            acl = autocorrelation.calculate_acl(samples)
+            if numpy.isinf(acl):
+                acl = samples.size
+            acls[param] = acl
         return acls
 
     @staticmethod

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -829,6 +829,8 @@ class BaseMCMCSampler(_BaseSampler):
         acfs = {}
         if parameters is None:
             parameters = fp.variable_args
+        if isinstance(parameters, str) or isinstance(parameters, unicode):
+            parameters = [parameters]
         for param in parameters:
             if per_walker:
                 # just call myself with a single walker

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -816,18 +816,15 @@ class BaseMCMCSampler(_BaseSampler):
         acls = {}
         if end_index is None:
             end_index = fp.niterations
-        widx = numpy.arange(fp.nwalkers)
+        acls = {}
         for param in fp.variable_args:
-            these_acls = []
-            for wi in widx:
-                samples = cls.read_samples(fp, param,
+            samples = cls.read_samples(fp, param,
                                            thin_start=start_index,
                                            thin_interval=1, thin_end=end_index,
-                                           walkers=wi)[param]
-                acl = autocorrelation.calculate_acl(samples)
-                these_acls.append(min(acl, samples.size))
-            acls[param] = numpy.array(these_acls, dtype=int)
-        return FieldArray.from_kwargs(**acls)
+                                           flatten=False)[param]
+            samples = samples.mean(axis=-1)
+            acls[param] = autocorrelation.calculate_acl(samples)
+        return acls
 
     @staticmethod
     def write_acls(fp, acls):

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -779,7 +779,7 @@ class EmceePTSampler(BaseMCMCSampler):
                 samples = cls.read_samples(fp, param, thin_start=start_index,
                                            thin_interval=1, thin_end=end_index,
                                            temps=tk, flatten=False)[param]
-                samples = samples.mean(axis=-1)
+                samples = samples.mean(axis=0)
                 these_acls[tk] = autocorrelation.calculate_acl(samples)
             acls[param] = these_acls
         return FieldArray.from_kwargs(**acls)

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -832,7 +832,7 @@ class EmceePTSampler(BaseMCMCSampler):
             if per_walker:
                 nw, ni = subacfs[0].shape
                 acfs[param] = numpy.zeros((len(temps), nw, ni), dtype=float)
-                for tk in temps:
+                for tk in range(len(temps)):
                     acfs[param][tk,...] = subacfs[tk]
             else:
                 acfs[param] = numpy.vstack(subacfs)

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -877,8 +877,13 @@ class EmceePTSampler(BaseMCMCSampler):
                 samples = cls.read_samples(fp, param, thin_start=start_index,
                                            thin_interval=1, thin_end=end_index,
                                            temps=tk, flatten=False)[param]
-                samples = samples.mean(axis=0)
-                these_acls[tk] = autocorrelation.calculate_acl(samples)
+                # contract the walker dimension using the mean, and flatten
+                # the (length 1) temp dimension
+                samples = samples.mean(axis=1)[0,:]
+                acl = autocorrelation.calculate_acl(samples)
+                if numpy.isinf(acl):
+                    acl = samples.size
+                these_acls[tk] = acl
             acls[param] = these_acls
         return FieldArray.from_kwargs(**acls)
 


### PR DESCRIPTION
This addresses #1815. @cmbiwer @farr it was fairly quick for me to do this, and I wanted it for my PP runs. I haven't added ACF support for emcee_pt yet, hence the work in progress tag.

Example output of `plot_acf` [here](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/pycbc_inference/cbc/gw150914/kombine/example_test-nindep_samples-max_post/plot_acf_test.png).

@farr For emcee_pt: right now I'm computing the ACL separately for each temperature, than taking the max over all temperatures. Is that the correct thing to do?