### PR TITLE
Add ability to read hdf files in inject module

### DIFF
--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -88,7 +88,7 @@ class _HDFInjectionSet(object):
     def __init__(self, sim_file, **kwds):
         # open the file
         fp = h5py.File(sim_file, 'r')
-        self.filehandler = fp 
+        self.filehandler = fp
         # get parameters
         parameters = fp.keys()
         # get all injection parameter values

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -248,7 +248,8 @@ class _HDFInjectionSet(object):
             hp_tapered = wfutils.taper_timeseries(hp, inj.taper)
             hc_tapered = wfutils.taper_timeseries(hc, inj.taper)
         except AttributeError:
-            pass
+            hp_tapered = hp
+            hc_tapered = hc
 
         # compute the detector response and add it to the strain
         signal = detector.project_wave(hp_tapered, hc_tapered,


### PR DESCRIPTION
This allows the inject module to use hdf files created by `pycbc_create_injection`. Since we need to continue to support xml at the moment, I've added this ability by copying the current `InjectionSet` to two different classes, `_HDFInjectionSet` and an `_XMLInjectionSet`, and modified the former to read hdf files. Now, `InjectionSet` initializes one of those based on the file extension. I figure that when we get to the point that we can drop xml support, we can just delete `_XMLInjectionSet` and rename `_HDFInjectionSet` to `InjectionSet`.

I've tested this on a single injection using `pycbc_condition_strain`. Here is a plot of the injection in zero noise when generated from the xml file:
https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/scratch/hdfinj_tests/xml_strain.png
the hdf file:
https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/scratch/hdfinj_tests/hdf_strain.png
and the difference between them:
https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/scratch/hdfinj_tests/diff_compare.png

You can see no visual difference, but the difference plot does show a difference of around ~1e-6 that of the peak amplitude. I think this is due to numerical differences in how the parameters are stored in the xml and hdf files.

I haven't run a test pipeline with this yet to make sure it still works; will try that tomorrow.