### PR TITLE
Fix  typo in emcee PT ACL computation.

### DIFF
--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -925,7 +925,7 @@ class EmceePTSampler(BaseMCMCSampler):
             # save the maximum
             param_acls[param] = aclp.max()
         # use the parent class to write the acls overs the temps
-        return super(EmceePTSampler, self).write_acls(fp, acls)
+        return super(EmceePTSampler, EmceePTSampler).write_acls(fp, param_acls)
 
     @staticmethod
     def read_acls(fp):


### PR DESCRIPTION
The recent changes to the ACL code introduced two typos in the Emcee PT sampler's treatment of the ACL.  This branch fixes them.  Without the fix, attempting to run a simulation with the PT sampler gives errors like 

```
Traceback (most recent call last):
  File "/Users/farr/anaconda3/envs/py2/bin/pycbc_inference", line 4, in <module>
    __import__('pkg_resources').run_script('PyCBC==8876', 'pycbc_inference')
  File "/Users/farr/anaconda3/envs/py2/lib/python2.7/site-packages/setuptools-27.2.0-py2.7.egg/pkg_resources/__init__.py", line 744, in run_script
  File "/Users/farr/anaconda3/envs/py2/lib/python2.7/site-packages/setuptools-27.2.0-py2.7.egg/pkg_resources/__init__.py", line 1499, in run_script
  File "/Users/farr/anaconda3/envs/py2/lib/python2.7/site-packages/PyCBC-8876-py2.7.egg/EGG-INFO/scripts/pycbc_inference", line 344, in <module>
    sampler.write_acls(fp, sampler.compute_acls(fp))
  File "/Users/farr/anaconda3/envs/py2/lib/python2.7/site-packages/PyCBC-8876-py2.7.egg/pycbc/inference/sampler_emcee.py", line 928, in write_acls
    return super(EmceePTSampler, self).write_acls(fp, acls)
NameError: global name 'self' is not defined
```

related to the use of `self` in the call to `super` from a `@staticmethod`.  Fixing that typo leads to errors like

```
Traceback (most recent call last):
  File "/Users/farr/anaconda3/envs/py2/bin/pycbc_inference", line 4, in <module>
    __import__('pkg_resources').run_script('PyCBC==8876', 'pycbc_inference')
  File "/Users/farr/anaconda3/envs/py2/lib/python2.7/site-packages/setuptools-27.2.0-py2.7.egg/pkg_resources/__init__.py", line 744, in run_script
  File "/Users/farr/anaconda3/envs/py2/lib/python2.7/site-packages/setuptools-27.2.0-py2.7.egg/pkg_resources/__init__.py", line 1499, in run_script
  File "/Users/farr/anaconda3/envs/py2/lib/python2.7/site-packages/PyCBC-8876-py2.7.egg/EGG-INFO/scripts/pycbc_inference", line 344, in <module>
    sampler.write_acls(fp, sampler.compute_acls(fp))
  File "/Users/farr/anaconda3/envs/py2/lib/python2.7/site-packages/PyCBC-8876-py2.7.egg/pycbc/inference/sampler_emcee.py", line 928, in write_acls
    return super(EmceePTSampler, EmceePTSampler).write_acls(fp, acls)
  File "/Users/farr/anaconda3/envs/py2/lib/python2.7/site-packages/PyCBC-8876-py2.7.egg/pycbc/inference/sampler_base.py", line 917, in write_acls
    fp[pgroup.format(param=param)].attrs['acl'] = acls[param]
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper (/Users/ilan/minonda/conda-bld/h5py_1490025880382/work/h5py/_objects.c:2846)
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper (/Users/ilan/minonda/conda-bld/h5py_1490025880382/work/h5py/_objects.c:2804)
  File "/Users/farr/anaconda3/envs/py2/lib/python2.7/site-packages/h5py/_hl/group.py", line 169, in __getitem__
    oid = h5o.open(self.id, self._e(name), lapl=self._lapl)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper (/Users/ilan/minonda/conda-bld/h5py_1490025880382/work/h5py/_objects.c:2846)
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper (/Users/ilan/minonda/conda-bld/h5py_1490025880382/work/h5py/_objects.c:2804)
  File "h5py/h5o.pyx", line 190, in h5py.h5o.open (/Users/ilan/minonda/conda-bld/h5py_1490025880382/work/h5py/h5o.c:3740)
KeyError: "Unable to open object (Object '(8, 8, 8, 8, 8, 8, 1, 8, 8, 8, 1, 1, 8, 8, 8)' doesn't exist)"
```

because the code expects a dictionary mapping parameters to ACLs, not an array.  Fixing that typo permits a simulation to run.