### PR TITLE
Fix inconsistency in pycbc.strain.from_cli, add option to condition_strain

### DIFF
--- a/bin/pycbc_condition_strain
+++ b/bin/pycbc_condition_strain
@@ -18,13 +18,15 @@
 
 """
 Read strain data, apply the standard preparation done in offline CBC searches
-(highpass, downsampling, gating, injections etc) and write the result back to
-a file. Optionally also write the gating data to a text file.
+(highpass, downsampling, gating, injections etc) and write the result back to a
+file. Optionally also write the gating data to a text file. This program can
+also be used to generate frames of simulated strain data.  Note that, by
+default, the output strain is scaled by a large factor (pycbc.DYN_RANGE_FAC) in
+order to make it representable in single precision without underflowing.
 """
 
 import logging
 import argparse
-import numpy as np
 import pycbc.strain
 import pycbc.version
 import pycbc.frame
@@ -44,8 +46,12 @@ parser.add_argument('--output-gates-file',
                     help='Save gating info to specified file, in the same '
                          'format as accepted by the --gating-file option')
 parser.add_argument('--single-precision', action='store_true',
-                    help='Multiply the conditioned strain by %f and save it '
-                         'in single precision' % pycbc.DYN_RANGE_FAC)
+                    help='Output the strain in single precision.')
+parser.add_argument('--no-dyn-range-factor', action='store_true',
+                    help='Do not apply the %f scaling factor to the output '
+                         'strain. Use this to generate frames of simulated '
+                         'data. Incompatible with --single-precision as that '
+                         'would produce underflows.' % pycbc.DYN_RANGE_FAC)
 parser.add_argument('--low-frequency-cutoff', type=float,
                     help='Provide a low-frequency-cutoff for fake strain. '
                          'This is only needed if fake-strain or '
@@ -55,11 +61,12 @@ args = parser.parse_args()
 
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
-if args.single_precision:
-    precision = 'single'
-else:
-    precision = 'double'
-out_strain = pycbc.strain.from_cli(args, pycbc.DYN_RANGE_FAC, precision=precision)
+if args.single_precision and args.no_dyn_range_factor:
+    parser.error('Refusing to save strain in single precision without the '
+                 'dynamic range factor, as it would lead to underflows')
+precision = 'single' if args.single_precision else 'double'
+dyn_range_factor = 1 if args.no_dyn_range_factor else pycbc.DYN_RANGE_FAC
+out_strain = pycbc.strain.from_cli(args, dyn_range_factor, precision=precision)
 
 logging.info('Writing output strain')
 output_channel_name = args.output_channel_name or args.channel_name

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -194,9 +194,11 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         required attributes  (gps-start-time, gps-end-time, strain-high-pass, 
         pad-data, sample-rate, (frame-cache or frame-files), channel-name, 
         fake-strain, fake-strain-seed, fake-strain-from-file, gating_file).
-    dyn_range_fac: {float, 1}, optional
+    dyn_range_fac : {float, 1}, optional
         A large constant to reduce the dynamic range of the strain.
-    inj_filter_rejector: InjFilterRejector instance; optional, default=None
+    precision : string
+        Precision of the returned strain ('single' or 'double').
+    inj_filter_rejector : InjFilterRejector instance; optional, default=None
         If given send the InjFilterRejector instance to the inject module so
         that it can store a reduced representation of injections if
         necessary.
@@ -269,7 +271,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             logging.info("Converting to float64")
             strain = (strain * dyn_range_fac).astype(pycbc.types.float64)
         else:
-            raise ValueError("unrecognized precision {}".format(precision))
+            raise ValueError("Unrecognized precision {}".format(precision))
 
         if opt.gating_file is not None:
             logging.info("Gating glitches")
@@ -362,6 +364,11 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         if precision == 'single':
             logging.info("Converting to float32")
             strain = (dyn_range_fac * strain).astype(pycbc.types.float32)
+        elif precision == 'double':
+            logging.info("Converting to float64")
+            strain = (dyn_range_fac * strain).astype(pycbc.types.float64)
+        else:
+            raise ValueError("Unrecognized precision {}".format(precision))
 
     if opt.taper_data:
         logging.info("Tapering data")


### PR DESCRIPTION
There is currently an inconsistency in `pycbc.strain.from_cli`: the `dyn_range_factor` argument is ignored when generating fake strain in double precision, but it is honored in all the other cases (i.e. reading real frames, or outputting strain in single precision). This patch fixes that inconsistency so that `dyn_range_factor` is considered both when reading frames and generating fake strain, and irrespective of the output precision.

This patch also gives `pycbc_condition_strain` an explicit option to generate frames which are not scaled by the dynamic range factor. Previously this behavior was implicitly achieved by virtue of the inconsistency in `pycbc.strain.from_cli`. Thanks Derek Davis and @stevereyes01 for finding this.

A couple docstrings have also been updated to (hopefully) clarify these things.