### PR TITLE
Set for 1.7.6 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -271,7 +271,7 @@ def get_version_info():
 
     # If this is a release or another kind of source distribution of PyCBC
     except:
-        version = '1.7.5'
+        version = '1.7.6'
         release = 'True'
         date = hash = branch = tag = author = committer = status = builder = build_date = ''
 


### PR DESCRIPTION
Create a 1.7.6 release so that we get the statmap file from CVMFS not git.ligo.org