### PR TITLE
Reorder imports in prior exe plotting

### DIFF
--- a/bin/inference/pycbc_inference_plot_prior
+++ b/bin/inference/pycbc_inference_plot_prior
@@ -16,12 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import matplotlib as mpl; mpl.use("Agg")
+import matplotlib.pyplot as plt
 import argparse
 import corner
 import itertools
 import logging
-import matplotlib as mpl; mpl.use("Agg")
-import matplotlib.pyplot as plt
 import numpy
 import sys
 from pycbc import distributions


### PR DESCRIPTION
Addresses the Issue #1802 - sorry, I seemed to have forgotten about this.

As far as @cdcapano comment in #1802, there would need to be some reworking of that plotting function. The points need to be weighted. But yeah, we should move from corner now. I do like the aesthetics of the plots you've put together.

If you want ``import corner`` gone ASAP, instead of plotting the PDF we can draw from the prior and set the default very high.