### PR TITLE
witness-frame-type option breaks from_multi_ifo

### DIFF
--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -306,7 +306,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         logging.info("Highpass Filtering")
         strain = highpass(strain, frequency=opt.strain_high_pass)
 
-        if opt.witness_frame_type:
+        if hasattr(opt, 'witness_frame_type') and opt.witness_frame_type:
             stilde = strain.to_frequencyseries()
             import h5py
             tf_file = h5py.File(opt.witness_tf_file)


### PR DESCRIPTION
The witness-frame-type options were added to the strain option group, but not the multi ifo strain option group. That broke `pycbc_inference`, or any other program that uses the multi ifo option group. This fixes that by checking if the attribute exists in `from_cli` before trying to access it.