### PR TITLE
Allow emcee to start from samples file

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -265,9 +265,12 @@ with ctx:
     # if getting samples from file then put sampler and random number generator
     # back in its former state
     if opts.samples_file:
-        with InferenceFile(opts.samples_file, "r") as fp:
-            sampler.set_state_from_file(fp)
-            numpy.random.set_state(fp.read_random_state())
+        try:
+            with InferenceFile(opts.samples_file, "r") as fp:
+                sampler.set_state_from_file(fp)
+                numpy.random.set_state(fp.read_random_state())
+        except NotImplementedError:
+            logging.warning("Sampler does not support setting a random state")
 
     # run sampler's burn in if it is in the list of burn in functions
     n_sampler_burn_in = 0

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -265,12 +265,13 @@ with ctx:
     # if getting samples from file then put sampler and random number generator
     # back in its former state
     if opts.samples_file:
-        try:
-            with InferenceFile(opts.samples_file, "r") as fp:
+        with InferenceFile(opts.samples_file, "r") as fp:
+            try:
                 sampler.set_state_from_file(fp)
                 numpy.random.set_state(fp.read_random_state())
-        except NotImplementedError:
-            logging.warning("Sampler does not support setting a random state")
+            except NotImplementedError:
+                logging.warning("Sampler does not support setting a random "
+                                "state. Just setting initial positions.")
 
     # run sampler's burn in if it is in the list of burn in functions
     n_sampler_burn_in = 0

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -382,8 +382,9 @@ class EmceePTSampler(BaseMCMCSampler):
         p0 = numpy.ones((ntemps, nwalkers, ndim))
         # if samples are given then use those as initial poistions
         if samples is not None:
-            raise NotImplementedError("Cannot set initial positions from "
-                                      "InferenceFile with emcee sampler.")
+            # transform to sampling parameter space
+            samples = self.likelihood_evaluator.apply_sampling_transforms(
+                samples)
         # draw random samples if samples are not provided
         else:
             samples = self.likelihood_evaluator.prior_rvs(


### PR DESCRIPTION
This patch allows emcee and emcee_pt to start from a given samples file. No setting state support has been added yet, so this will not give the same result as if no break were carried out. A warning is printed to screen informing the user of this.