### PR TITLE
Gate template along with data

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -40,6 +40,7 @@ from pycbc.waveform import generator
 from pycbc.inference import option_utils
 from pycbc.inference import prior
 from pycbc.inference import burn_in
+from pycbc import gate
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
@@ -225,13 +226,16 @@ with ctx:
     generator_function = generator.select_waveform_generator(
                                                     static_args["approximant"])
 
+    # get gates for templates
+    gates = gate.gates_from_cli(opts)
+
     # construct class that will generate waveforms
     generated_waveform = generator.FDomainDetFrameGenerator(
                        generator_function, epoch=stilde_dict.values()[0].epoch,
                        variable_args=variable_args, detectors=opts.instruments,
                        delta_f=stilde_dict.values()[0].delta_f,
                        delta_t=strain_dict.values()[0].delta_t,
-                       recalib=recalib,
+                       recalib=recalib, gates=gates,
                        **static_args)
 
     # construct class that will return the natural logarithm of likelihood

--- a/pycbc/gate.py
+++ b/pycbc/gate.py
@@ -77,7 +77,6 @@ def apply_gates_to_td(strain_dict, gates):
     # copy data to new dictionary
     outdict = dict(strain_dict.items())
     for ifo in gates:
-        logging.info("Gating {} strain".format(ifo))
         outdict[ifo] = strain.gate_data(outdict[ifo], gates[ifo])
     return outdict
 

--- a/pycbc/gate.py
+++ b/pycbc/gate.py
@@ -16,7 +16,6 @@
 """ Functions for applying gates to data.
 """
 
-import logging
 from pycbc import strain
 
 def _gates_from_cli(opts, gate_opt):

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -31,7 +31,8 @@ from pycbc import filter
 from pycbc import transforms
 from pycbc.types import TimeSeries
 from pycbc.waveform import parameters
-from pycbc.waveform.utils import apply_fd_time_shift, taper_timeseries
+from pycbc.waveform.utils import apply_fd_time_shift, taper_timeseries, \
+                                 ceilpow2
 from pycbc.detector import Detector
 import lal as _lal
 from pycbc import gate
@@ -530,6 +531,8 @@ class FDomainDetFrameGenerator(object):
                                          copy=False)
             h['RF'] = hp
         if self.gates is not None:
+            # resize all to nearest power of 2
+            [d.resize(ceilpow2(len(d)-1)+1) for d in h.values()]
             h = gate.apply_gates_to_fd(h, self.gates)
         return h
 

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -34,6 +34,7 @@ from pycbc.waveform import parameters
 from pycbc.waveform.utils import apply_fd_time_shift, taper_timeseries
 from pycbc.detector import Detector
 import lal as _lal
+from pycbc import gate
 
 #
 #   Generator for CBC waveforms
@@ -427,7 +428,7 @@ class FDomainDetFrameGenerator(object):
     location_args = set(['tc', 'ra', 'dec', 'polarization'])
 
     def __init__(self, rFrameGeneratorClass, epoch, detectors=None,
-            variable_args=(), recalib=None, **frozen_params):
+                 variable_args=(), recalib=None, gates=None, **frozen_params):
         # initialize frozen & current parameters:
         self.current_params = frozen_params.copy()
         self._static_args = frozen_params.copy()
@@ -461,6 +462,7 @@ class FDomainDetFrameGenerator(object):
         else:
             self.detectors = {'RF': None}
         self.detector_names = sorted(self.detectors.keys())
+        self.gates = gates
 
     def set_epoch(self, epoch):
         """Sets the epoch; epoch should be a float or a LIGOTimeGPS."""
@@ -527,6 +529,8 @@ class FDomainDetFrameGenerator(object):
                 hp = apply_fd_time_shift(hp, self.current_params['tc']+tshift,
                                          copy=False)
             h['RF'] = hp
+        if self.gates is not None:
+            h = gate.apply_gates_to_fd(h, self.gates)
         return h
 
 

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -532,7 +532,8 @@ class FDomainDetFrameGenerator(object):
             h['RF'] = hp
         if self.gates is not None:
             # resize all to nearest power of 2
-            [d.resize(ceilpow2(len(d)-1)+1) for d in h.values()]
+            for d in h.values():
+                d.resize(ceilpow2(len(d)-1) + 1)
             h = gate.apply_gates_to_fd(h, self.gates)
         return h
 


### PR DESCRIPTION
This adds gating to both the template and data in `pycbc_inference`. I've tested by generating a template with/without a gate using FDomainDetFrameGenerator, then adding to some data with the same gate applied. [This plot](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/scratch/template_with_gated_data.png) shows a Q scan of the template not gated; [this plot](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/scratch/gated_template_with_gated_data.png) shows the template gated. I'm running a test run now.