### PR TITLE
Let hierarchical removal plotting codes generate empty plots

### DIFF
--- a/bin/hdfcoinc/pycbc_page_foreground
+++ b/bin/hdfcoinc/pycbc_page_foreground
@@ -47,8 +47,18 @@ except KeyError:
     h_iterations = None
 
 if h_num_rm > h_iterations:
-    raise ValueError('User requested FANs after %s hierarchical removals. '
-                     'This many removals were not done.' % h_num_rm)
+    col_one = numpy.array([h_num_rm])
+    col_two = numpy.array([h_iterations])
+    columns = [col_one, col_two]
+    names = ["hierarchical removals requested", "hierarchical removals performed"]
+    format_strings = ['#', '#']
+    html_table = pycbc.results.table(columns, names,
+                                   format_strings=format_strings, page_size=10)
+
+    kwds = { 'title' : 'No more hierarchical removals were performed.',
+        'cmd' :' '.join(sys.argv), }
+    save_fig_with_metadata(str(html_table), args.output_file, **kwds)
+    sys.exit(0)
 
 if args.verbose:
     log_level = logging.INFO

--- a/bin/hdfcoinc/pycbc_page_foreground
+++ b/bin/hdfcoinc/pycbc_page_foreground
@@ -50,7 +50,7 @@ if h_num_rm > h_iterations:
     col_one = numpy.array([h_num_rm])
     col_two = numpy.array([h_iterations])
     columns = [col_one, col_two]
-    names = ["hierarchical removals requested", "hierarchical removals performed"]
+    names = ["Hierarchical Removals Requested", "Hierarchical Removals Performed"]
     format_strings = ['#', '#']
     html_table = pycbc.results.table(columns, names,
                                    format_strings=format_strings, page_size=10)

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -108,9 +108,12 @@ if h_inc_back_num > h_iterations:
     ax.set_xlim(0, 1)
     ax.set_ylim(0, 1)
 
-    ax.text(0.5, 0.5, 'No more hierarchical removals performed',
-        horizontalalignment='center',
-        verticalalignment='center')
+    output_message = "No more hierarchical removals performed.\n" \
+                     "Attempted to show " + str(h_inc_back_num) + " removals,\n" \
+                     "but only " + str(h_iterations) + " removals done."
+
+    ax.text(0.5, 0.5, output_message, horizontalalignment='center',
+            verticalalignment='center')
 
     pycbc.results.save_fig_with_metadata(fig, args.output_file,
       title="%s bin, Cumulative Rate vs Rank" % f.attrs['name'] if 'name' in f.attrs else "FAR vs Rank",

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -100,8 +100,25 @@ if h_inc_back_num is None:
     h_inc_back_num = 0
 
 if h_inc_back_num > h_iterations:
-    raise ValueError('User requested inclusive background after '
-                     'hierarchical removals that does not exist!')
+    # Produce a null plot saying no hierarchical removals can be plotted
+    import sys
+    fig = pylab.figure()
+    ax = fig.add_subplot(111)
+
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+
+    ax.text(0.5, 0.5, 'No more hierarchical removals performed',
+        horizontalalignment='center',
+        verticalalignment='center')
+
+    pycbc.results.save_fig_with_metadata(fig, args.output_file,
+      title="%s bin, Cumulative Rate vs Rank" % f.attrs['name'] if 'name' in f.attrs else "FAR vs Rank",
+      caption='No hierarchical removals done here',
+      cmd=' '.join(sys.argv))
+
+    # Exit the code successfully and bypass the rest of the plotting code.
+    sys.exit(0)
 
 args.cumulative = not args.not_cumulative
 

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -68,14 +68,13 @@ if h_inc_back_num > h_iterations:
     ax.set_xlim(0, 1)    
     ax.set_ylim(0, 1)
 
-    ax.text(0.25, 0.5, 'No more hierarchical removals performed',
+    ax.text(0.5, 0.5, 'No more hierarchical removals performed',
         horizontalalignment='center',
         verticalalignment='center')
 
     pycbc.results.save_fig_with_metadata(fig, args.output_file,
         title="%s bin, Count vs Rank" % f.attrs['name'] if 'name' in f.attrs else "Count vs Rank",
-        caption="Histogram of the FAR vs the ranking statistic in the search. Null plot, no "
-                "hierarchical removals performed.",
+        caption="No hierarchical removals performed.",
         cmd=' '.join(sys.argv))    
 
     # Exit the code successfully and bypass the rest of the plotting code.

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -62,7 +62,7 @@ if h_inc_back_num is None:
 if h_inc_back_num > h_iterations:
     # Produce a null plot saying no hierarchical removals can be plotted
     import sys
-    fig = plt.figure()
+    fig = pylab.figure()
     ax = fig.add_subplot(111)
 
     ax.set_xlim(0, 1)    

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -68,9 +68,12 @@ if h_inc_back_num > h_iterations:
     ax.set_xlim(0, 1)    
     ax.set_ylim(0, 1)
 
-    ax.text(0.5, 0.5, 'No more hierarchical removals performed',
-        horizontalalignment='center',
-        verticalalignment='center')
+    output_message = "No more hierarchical removals performed.\n" \
+                     "Attempted to show " + str(h_inc_back_num) + " removals,\n" \
+                     "but only " + str(h_iterations) + " removals done."
+
+    ax.text(0.5, 0.5, output_message, horizontalalignment='center',
+            verticalalignment='center')
 
     pycbc.results.save_fig_with_metadata(fig, args.output_file,
         title="%s bin, Count vs Rank" % f.attrs['name'] if 'name' in f.attrs else "Count vs Rank",

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -60,8 +60,26 @@ if h_inc_back_num is None:
     h_inc_back_num = h_iterations
 
 if h_inc_back_num > h_iterations:
-    raise ValueError('User requested inclusive background after '
-                     'hierarchical removals that does not exist!')
+    # Produce a null plot saying no hierarchical removals can be plotted
+    import sys
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+
+    ax.set_xlim(0, 1)    
+    ax.set_ylim(0, 1)
+
+    ax.text(0.25, 0.5, 'No more hierarchical removals performed',
+        horizontalalignment='center',
+        verticalalignment='center')
+
+    pycbc.results.save_fig_with_metadata(fig, args.output_file,
+        title="%s bin, Count vs Rank" % f.attrs['name'] if 'name' in f.attrs else "Count vs Rank",
+        caption="Histogram of the FAR vs the ranking statistic in the search. Null plot, no "
+                "hierarchical removals performed.",
+        cmd=' '.join(sys.argv))    
+
+    # Exit the code successfully and bypass the rest of the plotting code.
+    sys.exit(0)
 
 if args.verbose:
     log_level = logging.INFO


### PR DESCRIPTION
This changes the behaviors of the plotting codes so that instead of failing when given too many hierarchical removals, they instead produce empty plots or an empty table.

Relevant plots for these cases:

SNR-RATE-HIST makes if you ask it to plot 3 hierarchical removals: 
https://www.atlas.aei.uni-hannover.de/~steven.reyes/LSC/O2/test_h_removal_plots_remake/snrrate-h-removal-3.png

SNR-IFAR CUMULATIVE HIST makes:
https://www.atlas.aei.uni-hannover.de/~steven.reyes/LSC/O2/test_h_removal_plots_remake/snrifar-h-removal-3.png

SNR-IFAR SIGNIFICANCE PLOT makes:
https://www.atlas.aei.uni-hannover.de/~steven.reyes/LSC/O2/test_h_removal_plots_remake/snrifar-not-cum-h-removal-3.png

Foreground Table makes:
https://www.atlas.aei.uni-hannover.de/~steven.reyes/LSC/O2/test_h_removal_plots_remake/H1L1-PAGE_FOREGROUND_HTML-1126051216-11203201-h3.html

Ready to review.

Additional plots available at https://www.atlas.aei.uni-hannover.de/~steven.reyes/LSC/O2/test_h_removal_plots_remake/