### PR TITLE
More flexible use of frame files in the workflow

### DIFF
--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -521,7 +521,7 @@ DB_TRY=0
 
 # force a condor reschedule to get the workflow running
 set +e
-condor_reschdule &> /dev/null
+condor_reschedule &> /dev/null
 set -e
 
 /bin/echo "Querying Pegasus database for workflow stored in ${SUBMIT_DIR}/work"

--- a/bin/pycbc_submit_dax
+++ b/bin/pycbc_submit_dax
@@ -518,6 +518,12 @@ fi
 WORKFLOW_ID_STRING=""
 WORKFLOW_DB_CMD="sqlite3 -csv ${HOME}/.pegasus/workflow.db \"select submit_hostname,wf_id,wf_uuid from master_workflow where submit_dir = '${SUBMIT_DIR}/work';\""
 DB_TRY=0
+
+# force a condor reschedule to get the workflow running
+set +e
+condor_reschdule &> /dev/null
+set -e
+
 /bin/echo "Querying Pegasus database for workflow stored in ${SUBMIT_DIR}/work"
 /bin/echo -n "This may take up to 120 seconds. Please wait..."
 rm -f pegasus_db.log

--- a/pycbc/workflow/pegasus_files/pegasus-properties.conf
+++ b/pycbc/workflow/pegasus_files/pegasus-properties.conf
@@ -42,4 +42,4 @@ pegasus.metrics.app=ligo-pycbc
 # turn off the creation of the registration jobs even 
 # though the files maybe marked to be registered in the 
 # replica catalog
-pegasus.register=False
+pegasus.register=True

--- a/pycbc/workflow/pegasus_files/pegasus-properties.conf
+++ b/pycbc/workflow/pegasus_files/pegasus-properties.conf
@@ -7,11 +7,12 @@ pegasus.dir.storage.mapper.replica.file=output.map
 # Add Replica selection options so that it will try URLs first, then 
 # XrootD for OSG, then gridftp, then anything else
 pegasus.selector.replica=Regex
-pegasus.selector.replica.regex.rank.1=file:///cvmfs/.*
-pegasus.selector.replica.regex.rank.2=file://.*
+pegasus.selector.replica.regex.rank.1=file://(?!.*(cvmfs)).*
+pegasus.selector.replica.regex.rank.2=file:///cvmfs/.*
 pegasus.selector.replica.regex.rank.3=root://.*
-pegasus.selector.replica.regex.rank.4=gridftp://.*
-pegasus.selector.replica.regex.rank.5=.\*
+pegasus.selector.replica.regex.rank.4=gsiftp://red-gridftp.unl.edu.*
+pegasus.selector.replica.regex.rank.5=gridftp://.*
+pegasus.selector.replica.regex.rank.6=.\*
 
 # Do not transfer files coming from outside the worklow, simply
 # create symbolic links

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ corner>=2.0.1
 
 # For LDG service access
 dqsegdb
-http://download.pegasus.isi.edu/pegasus/4.7.3/pegasus-python-source-4.7.3.tar.gz
+http://download.pegasus.isi.edu/pegasus/4.7.4/pegasus-python-source-4.7.4.tar.gz
 
 # For building documentation
 Sphinx>=1.5.0


### PR DESCRIPTION
This pull request allows the workflow generator to make use of multiple different PFNs for the same frame file. It also fixes a bug where ``convert_cachelist_to_filelist`` assumed that the frames were sequentially ordered in time, but nothing guarantees this.

I also added a ``condor_reschdule`` to ``pycbc_submit_dax`` to get a speedier response when submitting workflows.

I have tested both in the independently with the code:


```python
import os
import pycbc.workflow.datafind
from pycbc_glue import segments, lal
```


```python
# scramble the time ordering of the urls

urls = ['file://localhost/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174200320-4096.gwf',
'file://localhost/cvmfs/oasis.opensciencegrid.org/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174200320-4096.gwf',
'file://localhost/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174208512-4096.gwf',
'file://localhost/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174204416-4096.gwf',
'file://localhost/cvmfs/oasis.opensciencegrid.org/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174204416-4096.gwf',
'file://localhost/cvmfs/oasis.opensciencegrid.org/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174208512-4096.gwf']
```


```python
c = lal.Cache.from_urls(urls,coltype=lal.LIGOTimeGPS)
c.ifo = 'H1'
```


```python
files = pycbc.workflow.datafind.convert_cachelist_to_filelist([c])
```


```python
for f in files:
    print f.toXML()
```

```xml
    <file name="117420/H-H1_HOFT_C01-1174200320-4096.gwf">
    	<pfn url="gsiftp://ldas-grid.ligo.caltech.edu/hdfs/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174200320-4096.gwf" site="osg"/>
    	<pfn url="file:///cvmfs/oasis.opensciencegrid.org/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174200320-4096.gwf" site="osg"/>
    	<pfn url="root://xrootd-local.unl.edu/user/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174200320-4096.gwf" site="osg"/>
    	<pfn url="file:///frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174200320-4096.gwf" site="local"/>
    	<pfn url="gsiftp://red-gridftp.unl.edu/user/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174200320-4096.gwf" site="osg"/>
    	<pfn url="file:///cvmfs/oasis.opensciencegrid.org/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174200320-4096.gwf" site="local"/>
    </file>
    <file name="117420/H-H1_HOFT_C01-1174204416-4096.gwf">
    	<pfn url="file:///frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174204416-4096.gwf" site="local"/>
    	<pfn url="gsiftp://red-gridftp.unl.edu/user/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174204416-4096.gwf" site="osg"/>
    	<pfn url="root://xrootd-local.unl.edu/user/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174204416-4096.gwf" site="osg"/>
    	<pfn url="file:///cvmfs/oasis.opensciencegrid.org/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174204416-4096.gwf" site="osg"/>
    	<pfn url="gsiftp://ldas-grid.ligo.caltech.edu/hdfs/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174204416-4096.gwf" site="osg"/>
    	<pfn url="file:///cvmfs/oasis.opensciencegrid.org/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174204416-4096.gwf" site="local"/>
    </file>
    <file name="117420/H-H1_HOFT_C01-1174208512-4096.gwf">
    	<pfn url="file:///cvmfs/oasis.opensciencegrid.org/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174208512-4096.gwf" site="local"/>
    	<pfn url="gsiftp://red-gridftp.unl.edu/user/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174208512-4096.gwf" site="osg"/>
    	<pfn url="root://xrootd-local.unl.edu/user/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174208512-4096.gwf" site="osg"/>
    	<pfn url="gsiftp://ldas-grid.ligo.caltech.edu/hdfs/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174208512-4096.gwf" site="osg"/>
    	<pfn url="file:///cvmfs/oasis.opensciencegrid.org/ligo/frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174208512-4096.gwf" site="osg"/>
    	<pfn url="file:///frames/O2/hoft_C01/H1/H-H1_HOFT_C01-11742/H-H1_HOFT_C01-1174208512-4096.gwf" site="local"/>
    </file>
```

And in the workflow:
```
 { "type": "transfer",
   "id": 2,
   "src_urls": [
     { "site_label": "local", "url": "file:///frames/O2/hoft/H1/H-H1_HOFT_C00-11866/H-H1_HOFT_C00-1186660352-4096.gwf", "priority": 500, "checkpoint": "false" },
     { "site_label": "local", "url": "file:///cvmfs/oasis.opensciencegrid.org/ligo/frames/O2/hoft/H1/H-H1_HOFT_C00-11866/H-H1_HOFT_C00-1186660352-4096.gwf", "priority": 400, "checkpoint": "false" },
     { "site_label": "local", "url": "root://xrootd-local.unl.edu/user/ligo/frames/O2/hoft/H1/H-H1_HOFT_C00-11866/H-H1_HOFT_C00-1186660352-4096.gwf", "priority": 300, "checkpoint": "false" },
     { "site_label": "local", "url": "gsiftp://red-gridftp.unl.edu/user/ligo/frames/O2/hoft/H1/H-H1_HOFT_C00-11866/H-H1_HOFT_C00-1186660352-4096.gwf", "priority": 200, "checkpoint": "false" },
     { "site_label": "local", "url": "gsiftp://ldas-grid.ligo.caltech.edu/hdfs/ligo/frames/O2/hoft/H1/H-H1_HOFT_C00-11866/H-H1_HOFT_C00-1186660352-4096.gwf", "priority": 0, "checkpoint": "false" }
   ],
   "dest_urls": [
     { "site_label": "local", "url": "file://$PWD/118666/H-H1_HOFT_C00-1186660352-4096.gwf" }
   ] }
```