### PR TITLE
Setup gating files at the workflow level

### DIFF
--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -154,7 +154,7 @@ final_veto_file, final_veto_name, ind_cats = \
                                             execute_now=False)
 
 # setup gating files if provided
-gate_files = wf.setup_gating_workflow(workflow, "gating")
+gate_files = wf.setup_gating_workflow(workflow, output_dir="gating")
 
 # add the gate files to the jobs that use them
 for job in ['calculate_psd', 'inspiral', 'single_template', 

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -158,7 +158,8 @@ gate_files = wf.setup_gating_workflow(workflow, analyzable_segs,
                                            datafind_files, "gating")
 
 # add the gate files to the jobs that use them
-for job in ['calculate_psd', 'inspiral', 'single_template']:
+for job in ['calculate_psd', 'inspiral', 'single_template', 
+            'plot_singles_timefreq']:
   for gate_file in gate_files:
       ifo_gate = gate_file.cache_entry.url
       try:

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -153,6 +153,23 @@ final_veto_file, final_veto_name, ind_cats = \
                                             rdir['analysis_time/segment_data'],
                                             execute_now=False)
 
+# setup gating files if provided
+gate_files = wf.setup_gating_workflow(workflow, analyzable_segs,
+                                           datafind_files, "gating")
+
+# add the gate files to the jobs that use them
+for job in ['calculate_psd', 'inspiral', 'single_template']:
+  for gate_file in gate_files:
+      ifo_gate = gate_file.cache_entry.url
+      try:
+          workflow.cp.set('{}-{}'.format(job, gate_file.ifo.lower()), 
+                          'gating-file', ifo_gate)
+      except ConfigParser.SectionError:
+          workflow.cp.add_section('{}-{}'.format(job, 
+                                  gate_file.ifo.lower()))
+          workflow.cp.set('{}-{}'.format(job, gate_file.ifo.lower()), 
+                          'gating-file', ifo_gate)
+
 # Precalculated PSDs
 precalc_psd_files = wf.setup_psd_workflow(workflow, analyzable_segs,
                                             datafind_files, "psdfiles")

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -154,8 +154,7 @@ final_veto_file, final_veto_name, ind_cats = \
                                             execute_now=False)
 
 # setup gating files if provided
-gate_files = wf.setup_gating_workflow(workflow, analyzable_segs,
-                                           datafind_files, "gating")
+gate_files = wf.setup_gating_workflow(workflow, "gating")
 
 # add the gate files to the jobs that use them
 for job in ['calculate_psd', 'inspiral', 'single_template', 

--- a/pycbc/workflow/__init__.py
+++ b/pycbc/workflow/__init__.py
@@ -38,6 +38,7 @@ try:
     from pycbc.workflow.datafind import *
     from pycbc.workflow.segment import *
     from pycbc.workflow.tmpltbank import *
+    from pycbc.workflow.gatefiles import *
     from pycbc.workflow.psdfiles import *
     from pycbc.workflow.splittable import *
     from pycbc.workflow.coincidence import *

--- a/pycbc/workflow/gatefiles.py
+++ b/pycbc/workflow/gatefiles.py
@@ -24,7 +24,7 @@
 
 """
 This module is responsible for setting up the gating files used by CBC
-workflows. 
+workflows.
 """
 
 from __future__ import division
@@ -45,7 +45,7 @@ def setup_gating_workflow(workflow, output_dir=None, tags=None):
     workflow: pycbc.workflow.core.Workflow
         An instanced class that manages the constructed workflow.
     output_dir : path string
-        The directory where data products will be placed. 
+        The directory where data products will be placed.
     tags : list of strings
         If given these tags are used to uniquely name and identify output files
         that would be produced in multiple calls to this function.
@@ -60,8 +60,8 @@ def setup_gating_workflow(workflow, output_dir=None, tags=None):
     logging.info("Entering gating module.")
     make_analysis_dir(output_dir)
     cp = workflow.cp
-    
-    # Parse for options in ini file.  
+
+    # Parse for options in ini file.
     try:
         gateMethod = cp.get_opt_tags("workflow-gating", "gating-method",
                                      tags)
@@ -72,7 +72,7 @@ def setup_gating_workflow(workflow, output_dir=None, tags=None):
 
     if gateMethod == "PREGENERATED_FILE":
         logging.info("Setting gating from pre-generated file(s).")
-        gate_files = setup_gate_pregenerated(workflow, 
+        gate_files = setup_gate_pregenerated(workflow,
                                              output_dir=output_dir, tags=tags)
     else:
         errMsg = "Gating method not recognized. Only "
@@ -86,7 +86,7 @@ def setup_gating_workflow(workflow, output_dir=None, tags=None):
 def setup_gate_pregenerated(workflow, output_dir=None, tags=None):
     '''
     Setup CBC workflow to use pregenerated gating files.
-    The file given in cp.get('workflow','gating-file-(ifo)') will 
+    The file given in cp.get('workflow','gating-file-(ifo)') will
     be used as the --gating-file for all jobs for that ifo.
 
     Parameters

--- a/pycbc/workflow/gatefiles.py
+++ b/pycbc/workflow/gatefiles.py
@@ -118,7 +118,7 @@ def setup_gate_pregenerated(workflow, output_dir=None, tags=None):
                             'gating-file-%s' % ifo.lower(),
                             tags)
             pre_gen_file = resolve_url(pre_gen_file,
-                                       os.path.join(os.getcwd(),output_dir)))
+                                       os.path.join(os.getcwd(),output_dir))
             file_url = urlparse.urljoin('file:',
                                          urllib.pathname2url(pre_gen_file))
             curr_file = File(ifo, user_tag, global_seg, file_url,

--- a/pycbc/workflow/gatefiles.py
+++ b/pycbc/workflow/gatefiles.py
@@ -91,8 +91,8 @@ def setup_gating_workflow(workflow, science_segs, datafind_outs,
 def setup_gate_pregenerated(workflow, tags=None):
     '''
     Setup CBC workflow to use pregenerated gating files.
-    The file given in cp.get('workflow','pregenerated-gating-file-(ifo)') will 
-    be used as the --gating-file for all matched-filtering jobs for that ifo.
+    The file given in cp.get('workflow','gating-file-(ifo)') will 
+    be used as the --gating-file for all jobs for that ifo.
 
     Parameters
     ----------
@@ -118,7 +118,7 @@ def setup_gate_pregenerated(workflow, tags=None):
     for ifo in workflow.ifos:
         try:
             pre_gen_file = cp.get_opt_tags('workflow-gating',
-                            'gating-pregenerated-file-%s' % ifo.lower(),
+                            'gating-file-%s' % ifo.lower(),
                             tags)
             pre_gen_file = resolve_url(pre_gen_file)
             file_url = urlparse.urljoin('file:',
@@ -128,10 +128,10 @@ def setup_gate_pregenerated(workflow, tags=None):
             curr_file.PFN(file_url, site='local')
             gate_files.append(curr_file)
 
+            logging.info("Using gating file {} for {}".format(file_url, ifo))
+
         except ConfigParser.Error:
-            # It's unlikely, but not impossible, that only some ifos
-            # will be gated
-            logging.warn("No gating file specified for IFO %s." % (ifo,))
+            logging.info("No gating file specified for %s." % (ifo,))
             pass
         
     return gate_files

--- a/pycbc/workflow/gatefiles.py
+++ b/pycbc/workflow/gatefiles.py
@@ -71,7 +71,8 @@ def setup_gating_workflow(workflow, output_dir=None, tags=None):
 
     if gateMethod == "PREGENERATED_FILE":
         logging.info("Setting gating from pre-generated file(s).")
-        gate_files = setup_gate_pregenerated(workflow, tags=tags)
+        gate_files = setup_gate_pregenerated(workflow, 
+                                             output_dir=output_dir, tags=tags)
     else:
         errMsg = "Gating method not recognized. Only "
         errMsg += "PREGENERATED_FILE is currently supported."

--- a/pycbc/workflow/gatefiles.py
+++ b/pycbc/workflow/gatefiles.py
@@ -1,0 +1,138 @@
+# Copyright (C) 2015 Larne Pekowsky
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+
+"""
+This module is responsible for setting up the gating files used by CBC
+workflows. 
+"""
+
+from __future__ import division
+
+import os
+import ConfigParser
+import urlparse, urllib
+import logging
+from pycbc.workflow.core import File, FileList, make_analysis_dir, resolve_url
+
+def setup_gating_workflow(workflow, science_segs, datafind_outs,
+                             output_dir=None, tags=None):
+    '''
+    Setup gating section of CBC workflow. At present this only supports pregenerated
+    gating files, in the future these could be created within the workflow.
+
+    Parameters
+    ----------
+    workflow: pycbc.workflow.core.Workflow
+        An instanced class that manages the constructed workflow.
+    science_segs : Keyed dictionary of glue.segmentlist objects
+        scienceSegs[ifo] holds the science segments to be analysed for each
+        ifo. 
+    datafind_outs : pycbc.workflow.core.FileList
+        The file list containing the datafind files.
+    output_dir : path string
+        The directory where data products will be placed. 
+    tags : list of strings
+        If given these tags are used to uniquely name and identify output files
+        that would be produced in multiple calls to this function.
+
+    Returns
+    --------
+    gate_files : pycbc.workflow.core.FileList
+        The FileList holding the gate files, 0 or 1 per ifo
+    '''
+    if tags is None:
+        tags = []
+    logging.info("Entering gating module.")
+    make_analysis_dir(output_dir)
+    cp = workflow.cp
+    
+    # Parse for options in ini file.  
+    try:
+        gateMethod = cp.get_opt_tags("workflow-gating", "gating-method",
+                                     tags)
+    except:
+        # Gating is optional, just return an empty list if not
+        # provided.
+        return FileList([])
+
+    if gateMethod == "PREGENERATED_FILE":
+        logging.info("Setting gating from pre-generated file(s).")
+        gate_files = setup_gate_pregenerated(workflow, tags=tags)
+    else:
+        errMsg = "Gating method not recognized. Only "
+        errMsg += "PREGENERATED_FILE is currently supported."
+        raise ValueError(errMsg)
+    
+    logging.info("Leaving gating module.")
+    return gate_files
+
+
+def setup_gate_pregenerated(workflow, tags=None):
+    '''
+    Setup CBC workflow to use pregenerated gating files.
+    The file given in cp.get('workflow','pregenerated-gating-file-(ifo)') will 
+    be used as the --gating-file for all matched-filtering jobs for that ifo.
+
+    Parameters
+    ----------
+    workflow: pycbc.workflow.core.Workflow
+        An instanced class that manages the constructed workflow.
+    tags : list of strings
+        If given these tags are used to uniquely name and identify output files
+        that would be produced in multiple calls to this function.
+
+    Returns
+    --------
+    gate_files : pycbc.workflow.core.FileList
+        The FileList holding the gating files
+    '''
+    if tags is None:
+        tags = []
+    gate_files = FileList([])
+
+    cp = workflow.cp
+    global_seg = workflow.analysis_time
+    user_tag = "PREGEN_GATE"
+
+    for ifo in workflow.ifos:
+        try:
+            pre_gen_file = cp.get_opt_tags('workflow-gating',
+                            'gating-pregenerated-file-%s' % ifo.lower(),
+                            tags)
+            pre_gen_file = resolve_url(pre_gen_file)
+            file_url = urlparse.urljoin('file:',
+                                         urllib.pathname2url(pre_gen_file))
+            curr_file = File(ifo, user_tag, global_seg, file_url,
+                                                                 tags=tags)
+            curr_file.PFN(file_url, site='local')
+            gate_files.append(curr_file)
+
+        except ConfigParser.Error:
+            # It's unlikely, but not impossible, that only some ifos
+            # will be gated
+            logging.warn("No gating file specified for IFO %s." % (ifo,))
+            pass
+        
+    return gate_files
+

--- a/pycbc/workflow/gatefiles.py
+++ b/pycbc/workflow/gatefiles.py
@@ -29,14 +29,12 @@ workflows.
 
 from __future__ import division
 
-import os
 import ConfigParser
 import urlparse, urllib
 import logging
 from pycbc.workflow.core import File, FileList, make_analysis_dir, resolve_url
 
-def setup_gating_workflow(workflow, science_segs, datafind_outs,
-                             output_dir=None, tags=None):
+def setup_gating_workflow(workflow, output_dir=None, tags=None):
     '''
     Setup gating section of CBC workflow. At present this only supports pregenerated
     gating files, in the future these could be created within the workflow.
@@ -45,11 +43,6 @@ def setup_gating_workflow(workflow, science_segs, datafind_outs,
     ----------
     workflow: pycbc.workflow.core.Workflow
         An instanced class that manages the constructed workflow.
-    science_segs : Keyed dictionary of glue.segmentlist objects
-        scienceSegs[ifo] holds the science segments to be analysed for each
-        ifo. 
-    datafind_outs : pycbc.workflow.core.FileList
-        The file list containing the datafind files.
     output_dir : path string
         The directory where data products will be placed. 
     tags : list of strings
@@ -71,7 +64,7 @@ def setup_gating_workflow(workflow, science_segs, datafind_outs,
     try:
         gateMethod = cp.get_opt_tags("workflow-gating", "gating-method",
                                      tags)
-    except:
+    except ConfigParser.Error:
         # Gating is optional, just return an empty list if not
         # provided.
         return FileList([])
@@ -128,11 +121,10 @@ def setup_gate_pregenerated(workflow, tags=None):
             curr_file.PFN(file_url, site='local')
             gate_files.append(curr_file)
 
-            logging.info("Using gating file {} for {}".format(file_url, ifo))
+            logging.info("Using gating file %s for %s", file_url, ifo)
 
         except ConfigParser.Error:
-            logging.info("No gating file specified for %s." % (ifo,))
-            pass
+            logging.info("No gating file specified for %s", ifo)
         
     return gate_files
 

--- a/pycbc/workflow/gatefiles.py
+++ b/pycbc/workflow/gatefiles.py
@@ -81,7 +81,7 @@ def setup_gating_workflow(workflow, output_dir=None, tags=None):
     return gate_files
 
 
-def setup_gate_pregenerated(workflow, tags=None):
+def setup_gate_pregenerated(workflow, output_dir=None, tags=None):
     '''
     Setup CBC workflow to use pregenerated gating files.
     The file given in cp.get('workflow','gating-file-(ifo)') will 
@@ -91,6 +91,8 @@ def setup_gate_pregenerated(workflow, tags=None):
     ----------
     workflow: pycbc.workflow.core.Workflow
         An instanced class that manages the constructed workflow.
+    output_dir : path string
+       The directory where data products will be placed. 
     tags : list of strings
         If given these tags are used to uniquely name and identify output files
         that would be produced in multiple calls to this function.
@@ -113,7 +115,7 @@ def setup_gate_pregenerated(workflow, tags=None):
             pre_gen_file = cp.get_opt_tags('workflow-gating',
                             'gating-file-%s' % ifo.lower(),
                             tags)
-            pre_gen_file = resolve_url(pre_gen_file)
+            pre_gen_file = resolve_url(pre_gen_file,output_dir)
             file_url = urlparse.urljoin('file:',
                                          urllib.pathname2url(pre_gen_file))
             curr_file = File(ifo, user_tag, global_seg, file_url,

--- a/pycbc/workflow/gatefiles.py
+++ b/pycbc/workflow/gatefiles.py
@@ -29,6 +29,7 @@ workflows.
 
 from __future__ import division
 
+import os
 import ConfigParser
 import urlparse, urllib
 import logging
@@ -116,7 +117,8 @@ def setup_gate_pregenerated(workflow, output_dir=None, tags=None):
             pre_gen_file = cp.get_opt_tags('workflow-gating',
                             'gating-file-%s' % ifo.lower(),
                             tags)
-            pre_gen_file = resolve_url(pre_gen_file,output_dir)
+            pre_gen_file = resolve_url(pre_gen_file,
+                                       os.path.join(os.getcwd(),output_dir)))
             file_url = urlparse.urljoin('file:',
                                          urllib.pathname2url(pre_gen_file))
             curr_file = File(ifo, user_tag, global_seg, file_url,


### PR DESCRIPTION
This restores the ability to set gating files for a detector at the workflow level and adds the gating files to all the codes that need them, rather than managing this on a per-job basis.

To enable this run ``pycbc_make_coinc_search_workflow`` with, e.g.
```
--config-overrides \
  "workflow-gating:gating-method:PREGENERATED_FILE" \
  "workflow-gating:gating-file-h1:https://git.ligo.org/detchar/veto-definitions/raw/4e17592aa5e8b2f832cefca4bb8d42d2a20b54ea/cbc/O2/H1-GATES-1185937218-1375500.txt" \
  "workflow-gating:gating-file-l1:https://git.ligo.org/detchar/veto-definitions/raw/4e17592aa5e8b2f832cefca4bb8d42d2a20b54ea/cbc/O2/L1-GATES-1185937218-1375500.txt" \
```

This adds will download the gating files, store them in the ``output`` directory and add the gate files to the DAX:
```xml
        <file name="H1-GATES-1185937218-1375500.txt">
                <pfn url="/home/dbrown/projects/osg/pre-1.7.9-test/analysis-21/o2-c00-analysis-21-pre-1.7.9-vdf-5c09540-auto-dch-gates/output/gating/H1-GATES-1185937218-1375500.txt" site="local"/>
        </file>
        <file name="L1-GATES-1185937218-1375500.txt">
                <pfn url="/home/dbrown/projects/osg/pre-1.7.9-test/analysis-21/o2-c00-analysis-21-pre-1.7.9-vdf-5c09540-auto-dch-gates/output/gating/L1-GATES-1185937218-1375500.txt" site="local"/>
        </file>
```

Then gating is enabled in the inspiral, calculate psd, and single template jobs:
```xml
        <job id="ID0000025" name="inspiral-FULL_DATA-H1_ID21">
                <argument>--sgchisq-snr-threshold 6.0 --sgchisq-locations &quot;mtotal&gt;40:20-30,20-45,20-60,20-75,20-90,20-105,20-120&quot; --pad-data 8 --strain-high-pass 15 --sample-rate 2048 --segment-length 512 --segment-start-pad 144 --segment-end-pad 16 --allow-zero-padding  --taper-data 1 --psd-estimation median --psd-segment-length 16 --psd-segment-stride 8 --psd-inverse-length 16 --psd-num-segments 63 --autogating-threshold 100 --autogating-cluster 0.5 --autogating-width 0.25 --autogating-taper 0.25 --autogating-pad 16 --enable-bank-start-frequency  --low-frequency-cutoff 20 --approximant &apos;SPAtmplt:mtotal&lt;4&apos; &apos;SEOBNRv4_ROM:else&apos; --order -1 --snr-threshold 5.5 --cluster-method window --cluster-window 1 --cluster-function symmetric --chisq-bins &quot;0.72*get_freq(&apos;fSEOBNRv4Peak&apos;,params.mass1,params.mass2,params.spin1z,params.spin2z)**0.7&quot; --newsnr-threshold 5 --filter-inj-only  --injection-window 4.5 --processing-scheme mkl --fixed-weave-cache  --channel-name H1:GDS-CALIB_STRAIN --gating-file <file name="H1-GATES-1185937218-1375500.txt"/> --gps-start-time 1186659122 --gps-end-time 1186659842 --trig-start-time 1186659122 --trig-end-time 1186659762 --output <file name="118665/H1-INSPIRAL_FULL_DATA_JOB0-1186659122-640.hdf"/> --bank-file <file name="H1L1-BANK2HDF_SPLITBANK_BANK4_FULL_DATA-1186659114-1936.hdf"/> --frame-files <file name="118665/H-H1_HOFT_C00-1186656256-4096.gwf"/></argument>
                <profile namespace="dagman" key="category">inspiral</profile>
                <profile namespace="condor" key="request_cpus">1</profile>
                <profile namespace="hints" key="execution.site">osg</profile>
                <uses name="H1-GATES-1185937218-1375500.txt" link="input" register="false" transfer="true"/>
                <uses name="H1L1-BANK2HDF_SPLITBANK_BANK4_FULL_DATA-1186659114-1936.hdf" link="input" register="false" transfer="true"/>
                <uses name="118665/H-H1_HOFT_C00-1186656256-4096.gwf" link="input" register="false" transfer="true"/>
                <uses name="118665/H1-INSPIRAL_FULL_DATA_JOB0-1186659122-640.hdf" link="output" register="true" transfer="true"/>
        </job>
```

```xml
        <job id="ID0000277" name="calculate_psd-PART0-L1_ID65">
                <argument>--cores 4 --low-frequency-cutoff 20 --pad-data 8 --strain-high-pass 15 --sample-rate 2048 --segment-length 512 --segment-start-pad 144 --segment-end-pad 16 --psd-estimation median --psd-segment-length 16 --psd-segment-stride 8 --psd-num-segments 63 --taper-data 1 --autogating-threshold 100 --autogating-cluster 0.5 --autogating-width 0.25 --autogating-taper 0.25 --autogating-pad 16 --channel-name L1:GDS-CALIB_STRAIN --gating-file <file name="L1-GATES-1185937218-1375500.txt"/> --analysis-segment-file <file name="L1-DATA_ANALYSED_0-1186659114-1936.xml"/> --segment-name DATA_ANALYSED --frame-files <file name="118665/L-L1_HOFT_C00-1186656256-4096.gwf"/> <file name="118666/L-L1_HOFT_C00-1186660352-4096.gwf"/> --output-file <file name="L1-CALCULATE_PSD_PART0-1186659114-1936.hdf"/></argument>
                <profile namespace="dagman" key="category">calculate_psd</profile>
                <profile namespace="hints" key="execution.site">local</profile>
                <profile namespace="condor" key="getenv">True</profile>
                <uses name="L1-GATES-1185937218-1375500.txt" link="input" register="false" transfer="true"/>
                <uses name="L1-DATA_ANALYSED_0-1186659114-1936.xml" link="input" register="false" transfer="true"/>
                <uses name="118666/L-L1_HOFT_C00-1186660352-4096.gwf" link="input" register="false" transfer="true"/>
                <uses name="118665/L-L1_HOFT_C00-1186656256-4096.gwf" link="input" register="false" transfer="true"/>
                <uses name="L1-CALCULATE_PSD_PART0-1186659114-1936.hdf" link="output" register="true" transfer="true"/>
        </job>
```

The configurations are also added to the ini files for the minifollowup sub-daxes:
```ini
[single_template-h1]
frame-type = H1_HOFT_C00
channel-name = H1:GDS-CALIB_STRAIN
gating-file = file://localhost/home/dbrown/projects/osg/pre-1.7.9-test/analysis-21/o2-c00-analysis-21-pre-1.7.9-vdf-5c09540-auto-dch-gates/output/gating/H1-GATES-1185937218-1375500.txt

[plot_singles_timefreq-h1]
frame-type = H1_HOFT_C00
channel-name = H1:GDS-CALIB_STRAIN
gating-file = file://localhost/home/dbrown/projects/osg/pre-1.7.9-test/analysis-21/o2-c00-analysis-21-pre-1.7.9-vdf-5c09540-auto-dch-gates/output/gating/H1-GATES-1185937218-1375500.txt

[single_template-l1]
frame-type = L1_HOFT_C00
channel-name = L1:GDS-CALIB_STRAIN
gating-file = file://localhost/home/dbrown/projects/osg/pre-1.7.9-test/analysis-21/o2-c00-analysis-21-pre-1.7.9-vdf-5c09540-auto-dch-gates/output/gating/L1-GATES-1185937218-1375500.txt

[plot_singles_timefreq-l1]
frame-type = L1_HOFT_C00
channel-name = L1:GDS-CALIB_STRAIN
gating-file = file://localhost/home/dbrown/projects/osg/pre-1.7.9-test/analysis-21/o2-c00-analysis-21-pre-1.7.9-vdf-5c09540-auto-dch-gates/output/gating/L1-GATES-1185937218-1375500.txt
```