### PR TITLE
Allow filtering of frames by url

### DIFF
--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -111,7 +111,8 @@ def locations_to_cache(locations):
     return cum_cache
 
 def read_frame(location, channels, start_time=None, 
-               end_time=None, duration=None, check_integrity=True):
+               end_time=None, duration=None, check_integrity=True,
+               sieve=None):
     """Read time series from frame data.
 
     Using the `location`, which can either be a frame file ".gwf" or a 
@@ -137,6 +138,9 @@ def read_frame(location, channels, start_time=None,
         incompatible with `end`.
     check_integrity : {True, bool}, optional
         Test the frame files for internal integrity.
+    sieve : string, optional
+        Selects only frames where the frame URL matches the regular
+        expression sieve
 
     Returns
     -------
@@ -154,6 +158,10 @@ def read_frame(location, channels, start_time=None,
         locations = [location]
 
     cum_cache = locations_to_cache(locations)    
+    if sieve:
+        logging.info("Using frames that match regexp: {}".format(sieve))
+        lal.CacheSieve(cum_cache, 0, 0, None, None, sieve)
+
     stream = lalframe.FrStreamCacheOpen(cum_cache)
     stream.mode = lalframe.FR_STREAM_VERBOSE_MODE
    
@@ -290,7 +298,8 @@ def frame_paths(frame_type, start_time, end_time, server=None):
     paths = [entry.path for entry in cache]
     return paths    
     
-def query_and_read_frame(frame_type, channels, start_time, end_time):
+def query_and_read_frame(frame_type, channels, start_time, end_time,
+                         sieve=None):
     """Read time series from frame data.
 
     Query for the locatin of physical frames matching the frame type. Return
@@ -308,6 +317,9 @@ def query_and_read_frame(frame_type, channels, start_time, end_time):
         beginning of the available frame(s). 
     end_time : LIGOTimeGPS or int
         The gps end time of the time series. Defaults to the end of the frame.
+    sieve : string, optional
+        Selects only frames where the frame URL matches the regular
+        expression sieve
 
     Returns
     -------
@@ -331,7 +343,8 @@ def query_and_read_frame(frame_type, channels, start_time, end_time):
     logging.info('found files: %s' % (' '.join(paths)))
     return read_frame(paths, channels, 
                       start_time=start_time, 
-                      end_time=end_time)
+                      end_time=end_time,
+                      sieve=sieve)
     
 __all__ = ['read_frame', 'frame_paths', 
            'datafind_connection', 

--- a/pycbc/frame/frame.py
+++ b/pycbc/frame/frame.py
@@ -159,7 +159,7 @@ def read_frame(location, channels, start_time=None,
 
     cum_cache = locations_to_cache(locations)    
     if sieve:
-        logging.info("Using frames that match regexp: {}".format(sieve))
+        logging.info("Using frames that match regexp: %s", sieve)
         lal.CacheSieve(cum_cache, 0, 0, None, None, sieve)
 
     stream = lalframe.FrStreamCacheOpen(cum_cache)


### PR DESCRIPTION
This adds a ``--frame-sieve`` command line argument which exposes the [``lal.CacheSieve``](http://software.ligo.org/docs/lalsuite/lal/group___l_a_l_cache__h.html#gaf03f09f0250f09e8fd718c7a4563c120) function to filter frame files. The string given to ``--frame-sieve`` is used to filter the frame files found (either on the command line or located by datafind).

For example, to use only frames from the local filsyste, ``/frames`` and not CVMFS:
```shell
(pycbc-dev)[dbrown@sugwg-condor ~]$ pycbc_plot_singles_timefreq --f-low 20 --rank newsnr --num-loudest 20 --approximant 'SPAtmplt:mtotal<4' 'SEOBNRv4_ROM:else' --strain-high-pass 15 --sample-rate 2048 --pad-data 8 --frame-type L1_HOFT_C00 --channel-name L1:GDS-CALIB_STRAIN --trig-file L1-HDF_TRIGGER_MERGE_NSBHIMRPHENOMD_INJ-1185937218-687600.hdf --bank-file H1L1-BANK2HDF-1185937218-687600.hdf --gps-start-time 1186359509 --gps-end-time 1186359529 --center-time 1186359519 --detector L1 --output-file L1-PLOT_SINGLES_TIMEFREQ_0-1185937218-687600.png  --frame-sieve 'file://localhost/frames'
2017-08-24 23:08:14,296 Reading Frames
2017-08-24 23:08:14,297 querying datafind server
2017-08-24 23:08:14,354 found files: /frames/O2/hoft/L1/L-L1_HOFT_C00-11863/L-L1_HOFT_C00-1186357248-4096.gwf /frames/O2/hoft/L1/L-L1_HOFT_C00-11863/L-L1_HOFT_C00-1186357248-4096.gwf /cvmfs/oasis.opensciencegrid.org/ligo/frames/O2/hoft/L1/L-L1_HOFT_C00-11863/L-L1_HOFT_C00-1186357248-4096.gwf /cvmfs/oasis.opensciencegrid.org/ligo/frames/O2/hoft/L1/L-L1_HOFT_C00-11863/L-L1_HOFT_C00-1186357248-4096.gwf
2017-08-24 23:08:14,363 Using frames that match regexp: file://localhost/frames
2017-08-24 23:08:16,982 Highpass Filtering
2017-08-24 23:08:17,021 Converting to float32
2017-08-24 23:08:17,024 Resampling data
2017-08-24 23:08:17,220 Highpass Filtering
2017-08-24 23:08:17,224 Remove Padding
2017-08-24 23:08:17,273 Plotting strain spectrogram
2017-08-24 23:08:17,665 Loading trigs
2017-08-24 23:08:18,055 Loading bank
2017-08-24 23:08:18,361 Plotting 20 trigs
2017-08-24 23:08:23,865 Loading and plotting gates
2017-08-24 23:08:25,268 Done
```

If the sieve is too restrictive and eliminates all frames, then the error
```
XLAL Error - XLALFrStreamFileOpen (LALFrStream.c:128): No files in stream file cache
``` 
is raised.