### PR TITLE
Let pycbc_page_snrifar be consistent with other hierarchical removal plots

### DIFF
--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -342,7 +342,7 @@ if args.cumulative:
 else:
     figure_caption = "Mapping between the ranking statistic and false alarm rate."
     pylab.grid()
-    pylab.legend(loc="upper right")
+    pylab.legend(loc="lower left")
     ax2.set_yscale('log')
     ymin, ymax = ax1.get_ylim()
     

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -97,7 +97,7 @@ except KeyError:
     h_iterations = 0
 
 if h_inc_back_num is None:
-    h_inc_back_num = 0
+    h_inc_back_num = h_iterations
 
 if h_inc_back_num > h_iterations:
     # Produce a null plot saying no hierarchical removals can be plotted


### PR DESCRIPTION
Revert to pycbc_page_snrratehist format where passing null produces either the full level of hierarchical removals (whether that is 0 or full).

That means we now produce :
Cumulative Plots:
0 passed as argument
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_examples_gw170104/snr_ifar_cum_hist_0.png

no option given
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_examples_gw170104/snr_ifar_cum_hist_null.png

Significance Cumulative Plots:
0 given as argument
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_examples_gw170104/snr_ifar_not_cum_hist_0.png


no option given
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_examples_gw170104/snr_ifar_not_cum_hist_null.png
