### PR TITLE
Add hierarchical removal plots for pycbc_page_ifar

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_statmap
+++ b/bin/hdfcoinc/pycbc_coinc_statmap
@@ -234,6 +234,7 @@ while numpy.any(fnlouder == 0):
     if h_iterations == 0:
         f['background_h%s/stat' % h_iterations] = back_stat 
         f['background_h%s/ifar' % h_iterations] = sec_to_year(background_time / (back_cnum + 1))
+        f['background_h%s/timeslide_id' % h_iterations] = all_trigs.data['timeslide_id'][back_locs]
         f['foreground_h%s/stat' % h_iterations] = fore_stat
         f['foreground_h%s/ifar' % h_iterations] = sec_to_year(ifar)
         f['foreground_h%s/fap' % h_iterations] = fap

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -67,6 +67,20 @@ parser.add_argument('--all-decimated-background-min-ifar', type=float,
                           'zerolag down to VAL*(zerolag coinc time/total '
                           'decimated slide time). Recommended value equal '
                           'to default value 0.01yr.')
+parser.add_argument('--use-hierarchical-level', type=int, default=None,
+                    help='Indicate which inclusive background and FARs of '
+                         'foreground triggers to plot if there were any '
+                         'hierarchical removals done. Choosing None plots '
+                         'the inclusive backgrounds prior to any '
+                         'hierarchical removals with the updated FARs for '
+                         'foreground triggers after hierarchical removal(s). '
+                         'Choosing 0 means plotting inclusive background '
+                         'from prior to any hierarchical removals with FARs '
+                         'for foreground triggers prior to hierarchical '
+                         'removal. Choosing 1 means plotting the inclusive '
+                         'background after doing 1 hierarchical removal, and '
+                         'includes updated FARs from after 1 hierarchical '
+                         'removal. [default=None]')
 parser.add_argument('--open-box', action='store_true', default=False,
                     help='Show the foreground triggers on the output plot. ')
 opts = parser.parse_args()
@@ -74,9 +88,61 @@ opts = parser.parse_args()
 # read file
 fp = h5py.File(opts.trigger_file, 'r')
 
+# Parse which inclusive background to use for the plotting
+h_inc_back_num = opts.use_hierarchical_level
+
+try:
+    h_iterations = fp.attrs['hierarchical_removal_iterations']
+except KeyError:
+    h_iterations = 0
+
+if h_inc_back_num is None:
+    h_inc_back_num = h_iterations
+
+if h_inc_back_num > h_iterations:
+    # Produce a null plot saying no hierarchical removals can be plotted
+    import sys
+    fig = pylab.figure()
+    ax = fig.add_subplot(111)
+
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+
+    output_message = "No more hierarchical removals performed.\n" \
+                     "Attempted to show " + str(h_inc_back_num) + " removals,\n" \
+                     "but only " + str(h_iterations) + " removals done."
+
+    ax.text(0.5, 0.5, output_message, horizontalalignment='center',
+            verticalalignment='center')
+
+    pycbc.results.save_fig_with_metadata(fig, opts.output_file,
+     title='Cumulative Number vs. IFAR',
+     caption='No hierarchical removals done here',
+     cmd=' '.join(sys.argv))
+
+    # Exit the code successfully and bypass the rest of the plotting code.
+    sys.exit(0)
+
 # get foreground IFAR values and cumulative number for each IFAR value
 if opts.open_box:
-    fore_ifar = fp['foreground/ifar'][:]
+
+    if h_inc_back_num > 0:
+        fore_ifar = fp['foreground_h%s/ifar' % h_inc_back_num][:]
+        # Get ifar of hierarchically removed foreground triggers
+        supp_fore_ifar = fp['foreground/ifar'][:]
+#        count_hrm_diff = len(supp_fore_ifar) - len(fore_ifar)
+
+        # Use to plot hierarchically removed foreground triggers
+        # on the plot and correct the cumulative number at IFAR level
+        hrm_sorted = sorted(supp_fore_ifar)
+        idx_start = len(supp_fore_ifar) - h_inc_back_num
+
+        h_rm_ifar = hrm_sorted[idx_start:]
+        h_rm_cumnum = numpy.arange(len(h_rm_ifar), 0, -1)
+
+    else :
+        fore_ifar = fp['foreground/ifar'][:]
+
     fore_ifar.sort()
     fore_cumnum = numpy.arange(len(fore_ifar), 0, -1)
 
@@ -85,8 +151,12 @@ expected_ifar = numpy.logspace(-8, 2, num=100, endpoint=True, base=10.0)
 expected_cumnum = fp.attrs['foreground_time'] / expected_ifar / lal.YRJUL_SI 
 
 # get background timeslide IDs and IFAR values
-back_tsid = fp['background/timeslide_id'][:]
-back_ifar = fp['background/ifar'][:]
+if h_inc_back_num > 0:
+    back_tsid = fp['background_h%s/timeslide_id' % h_inc_back_num][:]
+    back_ifar = fp['background_h%s/ifar' % h_inc_back_num][:]
+else :
+    back_tsid = fp['background/timeslide_id'][:]
+    back_ifar = fp['background/ifar'][:]
 
 # get IFO segments
 h1_segments = segments.segmentlist([segments.segment(s,e) for s,e in zip(fp['segments']['H1']['start'][:],fp['segments']['H1']['end'][:])])
@@ -174,6 +244,9 @@ pylab.fill(xs, ys, facecolor='y', alpha=0.2, label='$2N^{1/2}$ Errors')
 # plot the foreground triggers
 if opts.open_box:
     pylab.loglog(fore_ifar, fore_cumnum, linestyle='None', color='blue', marker='^', label='Foreground')
+
+    if h_inc_back_num > 0:
+        pylab.loglog(h_rm_ifar, h_rm_cumnum, linestyle='None', color='#b66dff', marker='v', label='Hierarchically Removed Foreground')
 
 # format plot
 if opts.open_box and len(fore_cumnum) > 100:

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -130,7 +130,6 @@ if opts.open_box:
         fore_ifar = fp['foreground_h%s/ifar' % h_inc_back_num][:]
         # Get ifar of hierarchically removed foreground triggers
         supp_fore_ifar = fp['foreground/ifar'][:]
-#        count_hrm_diff = len(supp_fore_ifar) - len(fore_ifar)
 
         # Use to plot hierarchically removed foreground triggers
         # on the plot and correct the cumulative number at IFAR level
@@ -151,12 +150,25 @@ expected_ifar = numpy.logspace(-8, 2, num=100, endpoint=True, base=10.0)
 expected_cumnum = fp.attrs['foreground_time'] / expected_ifar / lal.YRJUL_SI 
 
 # get background timeslide IDs and IFAR values
-if h_inc_back_num > 0:
+
+# Use these backgrounds for n-th stage of hierarchical removals
+# and if the open box option
+if h_inc_back_num > 0 and opts.open_box:
     back_tsid = fp['background_h%s/timeslide_id' % h_inc_back_num][:]
     back_ifar = fp['background_h%s/ifar' % h_inc_back_num][:]
 else :
-    back_tsid = fp['background/timeslide_id'][:]
-    back_ifar = fp['background/ifar'][:]
+    # If the box is closed use the background from no hierarchical
+    # removals. Results should be agnostic of judgments about
+    # whether a hierarchical removal was done.
+    if not opts.open_box and h_iterations > 0:
+        back_tsid = fp['background_h0/timeslide_id'][:]
+        back_ifar = fp['background_h0/ifar'][:]
+
+    # Otherwise the box is closed and no hierarchical removals
+    # were done so use top level background
+    else :
+        back_tsid = fp['background/timeslide_id'][:]
+        back_ifar = fp['background/ifar'][:]
 
 # get IFO segments
 h1_segments = segments.segmentlist([segments.segment(s,e) for s,e in zip(fp['segments']['H1']['start'][:],fp['segments']['H1']['end'][:])])


### PR DESCRIPTION
The code works as follows.
```
usage: pycbc_page_ifar [--options]

Plots a cumulative histogram of IFAR forcoincident foreground triggers and a
subset ofthe coincident time slide triggers.

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  --trigger-file TRIGGER_FILE
                        Path to coincident trigger HDF file.
  --output-file OUTPUT_FILE
                        Path to output plot.
  --decimation-factor DECIMATION_FACTOR
                        Decimation factor used in background
                        estimation.Decimation factor means that every nth
                        timeslide kept all of its coincident triggers inthe
                        HDF file.
  --all-decimated-background-min-ifar VAL
                        Threshold the IFARs of decimated background events
                        before combining them and rescaling to zerolag (green
                        line). Plotting all decimated background can be memory
                        intensive and is not necessary for checking the
                        background estimate at interesting IFAR levels. Slide
                        coincs with IFARs below VAL will be cut, the green
                        line will then be valid for zerolag down to
                        VAL*(zerolag coinc time/total decimated slide time).
                        Recommended value equal to default value 0.01yr.
  --use-hierarchical-level USE_HIERARCHICAL_LEVEL
                        Indicate which inclusive background and FARs of
                        foreground triggers to plot if there were any
                        hierarchical removals done. Choosing None plots the
                        inclusive backgrounds prior to any hierarchical
                        removals with the updated FARs for foreground triggers
                        after hierarchical removal(s). Choosing 0 means
                        plotting inclusive background from prior to any
                        hierarchical removals with FARs for foreground
                        triggers prior to hierarchical removal. Choosing 1
                        means plotting the inclusive background after doing 1
                        hierarchical removal, and includes updated FARs from
                        after 1 hierarchical removal. [default=None]
  --open-box            Show the foreground triggers on the output plot.
```

When run with `--open-box` and no option given:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_examples_gw170104/ifar_cum_hist_null.png

When run with `--open-box` and `--use-hierarchical-level 0` is given:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_examples_gw170104/ifar_cum_hist_0_hrm.png

When run with an `--open box` and `--use-hierarchical-level 1` is given:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_examples_gw170104/ifar_cum_hist_1_hrm.png

When run with an `--open box` and `--use-hierarchical-level 2` is given (more than was done):
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_examples_gw170104/ifar_cum_hist_2_hrm.png

******
**NOTE**
The background for closed box should be the exact same as the background with NO hierarchical removals done. This can be the `background` field in the statmap hdf field or `background_h0` field in the statmap hdf based on how many hierarchical removals were done so be very careful!

Running without `--open-box` produces a closed box seen in `Coincident Triggers` in the Results Pages:

So a plot like this should be produced in the workflow (`--use-hierarchical-level` NOT given AND `--open-box` NOT given):
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_examples_gw170104/ifar_cum_hist_null_closed.png

If for some reason, (WHICH THE WORKFLOW NEVER DOES) somebody tries to run `--use-hierarchical-level` AND `--open-box` is NOT given, that plot is reproduced:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_examples_gw170104/ifar_cum_hist_0_hrm_closed.png

https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_examples_gw170104/ifar_cum_hist_1_hrm_closed.png

But there's a mistake here when given:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_examples_gw170104/ifar_cum_hist_2_hrm_closed.png

This will need to be patched.