### PR TITLE
Clean up removal messages

### DIFF
--- a/bin/hdfcoinc/pycbc_page_foreground
+++ b/bin/hdfcoinc/pycbc_page_foreground
@@ -55,7 +55,8 @@ if h_num_rm > h_iterations:
     html_table = pycbc.results.table(columns, names,
                                    format_strings=format_strings, page_size=10)
 
-    kwds = { 'title' : 'No more hierarchical removals were performed.',
+    kwds = { 'title' :
+        'No more events louder than all background at this removal level.',
         'cmd' :' '.join(sys.argv), }
     save_fig_with_metadata(str(html_table), args.output_file, **kwds)
     sys.exit(0)

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -108,7 +108,8 @@ if h_inc_back_num > h_iterations:
     ax.set_xlim(0, 1)
     ax.set_ylim(0, 1)
 
-    output_message = "No more hierarchical removals performed.\n" \
+    output_message = "No more foreground events louder than all background\n" \
+                     "at this removal level.\n" \
                      "Attempted to show " + str(h_inc_back_num) + " removals,\n" \
                      "but only " + str(h_iterations) + " removals done."
 
@@ -117,7 +118,7 @@ if h_inc_back_num > h_iterations:
 
     pycbc.results.save_fig_with_metadata(fig, opts.output_file,
      title='Cumulative Number vs. IFAR',
-     caption='No hierarchical removals done here',
+     caption=output_message,
      cmd=' '.join(sys.argv))
 
     # Exit the code successfully and bypass the rest of the plotting code.

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -110,8 +110,8 @@ if h_inc_back_num > h_iterations:
 
     output_message = "No more foreground events louder than all background\n" \
                      "at this removal level.\n" \
-                     "Attempted to show " + str(h_inc_back_num) + " removals,\n" \
-                     "but only " + str(h_iterations) + " removals done."
+                     "Attempted to show " + str(h_inc_back_num) + " removal(s),\n" \
+                     "but only " + str(h_iterations) + " removal(s) done."
 
     ax.text(0.5, 0.5, output_message, horizontalalignment='center',
             verticalalignment='center')

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -108,7 +108,8 @@ if h_inc_back_num > h_iterations:
     ax.set_xlim(0, 1)
     ax.set_ylim(0, 1)
 
-    output_message = "No more hierarchical removals performed.\n" \
+    output_message = "No more foreground events louder than all background\n" \
+                     "at this removal level.\n" \
                      "Attempted to show " + str(h_inc_back_num) + " removals,\n" \
                      "but only " + str(h_iterations) + " removals done."
 
@@ -117,7 +118,7 @@ if h_inc_back_num > h_iterations:
 
     pycbc.results.save_fig_with_metadata(fig, args.output_file,
       title="%s bin, Cumulative Rate vs Rank" % f.attrs['name'] if 'name' in f.attrs else "FAR vs Rank",
-      caption='No hierarchical removals done here',
+      caption=output_message,
       cmd=' '.join(sys.argv))
 
     # Exit the code successfully and bypass the rest of the plotting code.

--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -110,8 +110,8 @@ if h_inc_back_num > h_iterations:
 
     output_message = "No more foreground events louder than all background\n" \
                      "at this removal level.\n" \
-                     "Attempted to show " + str(h_inc_back_num) + " removals,\n" \
-                     "but only " + str(h_iterations) + " removals done."
+                     "Attempted to show " + str(h_inc_back_num) + " removal(s),\n" \
+                     "but only " + str(h_iterations) + " removal(s) done."
 
     ax.text(0.5, 0.5, output_message, horizontalalignment='center',
             verticalalignment='center')

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -68,7 +68,8 @@ if h_inc_back_num > h_iterations:
     ax.set_xlim(0, 1)    
     ax.set_ylim(0, 1)
 
-    output_message = "No more hierarchical removals performed.\n" \
+    output_message = "No more foreground events louder than all background\n" \
+                     "at this removal level.\n" \
                      "Attempted to show " + str(h_inc_back_num) + " removals,\n" \
                      "but only " + str(h_iterations) + " removals done."
 
@@ -77,7 +78,7 @@ if h_inc_back_num > h_iterations:
 
     pycbc.results.save_fig_with_metadata(fig, args.output_file,
         title="%s bin, Count vs Rank" % f.attrs['name'] if 'name' in f.attrs else "Count vs Rank",
-        caption="No hierarchical removals performed.",
+        caption=output_message,
         cmd=' '.join(sys.argv))    
 
     # Exit the code successfully and bypass the rest of the plotting code.

--- a/bin/hdfcoinc/pycbc_page_snrratehist
+++ b/bin/hdfcoinc/pycbc_page_snrratehist
@@ -70,8 +70,8 @@ if h_inc_back_num > h_iterations:
 
     output_message = "No more foreground events louder than all background\n" \
                      "at this removal level.\n" \
-                     "Attempted to show " + str(h_inc_back_num) + " removals,\n" \
-                     "but only " + str(h_iterations) + " removals done."
+                     "Attempted to show " + str(h_inc_back_num) + " removal(s),\n" \
+                     "but only " + str(h_iterations) + " removal(s) done."
 
     ax.text(0.5, 0.5, output_message, horizontalalignment='center',
             verticalalignment='center')

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -307,12 +307,13 @@ for hierarchical_level in range(int(max_hierarchical_removal) + 1):
     results_hier_page = []
 
     if hierarchical_level == 0:
-        hierarchical_level_page = 'open_box_result/no_events_removed'
+        hierarchical_level_page = \
+        'open_box_result/no_events_removed_from_background'
     elif hierarchical_level == 1:
         hierarchical_level_page = 'open_box_result/loudest_event_removed'
     else:
         hierarchical_level_page = \
-            'open_box_result/loudest_{}_events_removed'.format(
+            'open_box_result/loudest_{}_events_removed_from_background'.format(
                  hierarchical_level)
 
     for bin_file in bin_files:

--- a/bin/workflows/pycbc_make_coinc_search_workflow
+++ b/bin/workflows/pycbc_make_coinc_search_workflow
@@ -310,7 +310,8 @@ for hierarchical_level in range(int(max_hierarchical_removal) + 1):
         hierarchical_level_page = \
         'open_box_result/no_events_removed_from_background'
     elif hierarchical_level == 1:
-        hierarchical_level_page = 'open_box_result/loudest_event_removed'
+        hierarchical_level_page = \
+        'open_box_result/loudest_event_removed_from_background'
     else:
         hierarchical_level_page = \
             'open_box_result/loudest_{}_events_removed_from_background'.format(


### PR DESCRIPTION
Minor patches to improve the clarity of the message printed when there are no more events louder than the background and the section titles.