### PR TITLE
The minifollow up generator need to be told that --gating-file takes a file

### DIFF
--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -289,9 +289,18 @@ def setup_injection_minifollowups(workflow, injection_file, inj_xml_file,
     workflow._adag.addDependency(dep)
     logging.info('Leaving injection minifollowups module')
 
+
 class SingleTemplateExecutable(PlotExecutable):
     """Class to be used for to create workflow.Executable instances for the
     pycbc_single_template executable. Basically inherits directly from
+    PlotExecutable but adds the file_input_options.
+    """
+    file_input_options = ['--gating-file']
+
+
+class SingleTimeFreqExecutable(PlotExecutable):
+    """Class to be used for to create workflow.Executable instances for the
+    pycbc_plot_singles_timefreq executable. Basically inherits directly from
     PlotExecutable but adds the file_input_options.
     """
     file_input_options = ['--gating-file']
@@ -586,7 +595,7 @@ def make_singles_timefreq(workflow, single, bank_file, trig_time, out_dir,
     makedir(out_dir)
     name = 'plot_singles_timefreq'
 
-    curr_exe = PlotExecutable(workflow.cp, name, ifos=[single.ifo],
+    curr_exe = SingleTimeFreqExecutable(workflow.cp, name, ifos=[single.ifo],
                           out_dir=out_dir, tags=tags)
     node = curr_exe.create_node()
     node.add_input_opt('--trig-file', single)

--- a/setup.py
+++ b/setup.py
@@ -271,8 +271,8 @@ def get_version_info():
 
     # If this is a release or another kind of source distribution of PyCBC
     except:
-        version = '1.8.0dev'
-        release = 'False'
+        version = '1.7.10'
+        release = 'True'
 
         date = hash = branch = tag = author = committer = status = builder = build_date = ''
 


### PR DESCRIPTION
This is done correctly for ``pycbc_single_template`` but not for ``pycbc_plot_singles_timefreq `` which causes the ``pycbc_plot_singles_timefreq`` jobs to fail with:
```
IOError: [Errno 2] No such file or directory: &apos;file://localhost/home/dbrown/projects/aligo/o2/analysis-21/o2-c00-analysis-21-v1.7.9-vdf-5c09540-auto-dch-gates/output/gating/L1-GATES-1185937218-1375500.txt&apos;
```
Temporary patch for a running DAX is
```
perl -pi.bak -e  's+--gating-file file://localhost+--gating-file +g' /usr1/dbrown/pycbc-tmp.fsMfVJH09l/work/o2-c00-analysis-21-v1.7.9-vdf-5c09540-auto-dch-gates-main_ID0000001/*MINIFOLLOWUP*/*.sh
```
but this fixes it properly.

This also sets the release tag to 1.7.10 to make a new release with this fix.