### PR TITLE
Fix bug that in pycbc_page_foreground if no hierarchical removals were done

### DIFF
--- a/bin/hdfcoinc/pycbc_page_foreground
+++ b/bin/hdfcoinc/pycbc_page_foreground
@@ -71,7 +71,10 @@ if args.output_file.endswith('.xml') or args.output_file.endswith('.xml.gz'):
         err_msg += "trigger lists with --single-detector-triggers."
         raise ValueError(err_msg)
 
-if h_num_rm >= 0:
+# Insure that the user uses a coinc trigger file that is hierarchical
+# removal compatible. Also default to regular behavior if hierarchical
+# removals were not performed.
+if h_num_rm >= 0 and h_iterations is not None and h_iterations!=0:
     # read in the triggers from the group corresponding to the removal stage
     fortrigs = hdf.ForegroundTriggers(args.trigger_file, args.bank_file,
                                       sngl_files=args.single_detector_triggers,
@@ -99,7 +102,7 @@ if args.output_file.endswith('.html'):
     time1 = fortrigs.get_coincfile_array('time1')
     time2 = fortrigs.get_coincfile_array('time2')
 
-    if h_num_rm >= 0:
+    if h_num_rm >= 0 and h_iterations is not None and h_iterations!=0:
         # This information is not stored at all levels of the coinc trigger file
         # so grab from the top level and populate the variables for output later
  


### PR DESCRIPTION
Fix bug that if no hierarchical removals were done that the results page doesn't crash trying to access something that's not written to file. That is to say, if no hierarchical removals were done, the original code tries to access `f['foreground_h0']` which is not written if hierarchical removals are not done. This also insures that old statmap files are still compatible with `pycbc_page_foreground`.

This also permits backwards functionality with old coinc files to default to original behavior.