### PR TITLE
Modified pycbc.fotonfilter module to work with new version of foton

### DIFF
--- a/examples/cal/foton_filter_esd_saturation/pycbc_foton_filter
+++ b/examples/cal/foton_filter_esd_saturation/pycbc_foton_filter
@@ -1,5 +1,4 @@
-#! /usr/bin/python
-
+#!/usr/bin/env python
 # Copyright (C) 2015  Christopher M. Biwer
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -16,10 +15,13 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from foton import FilterFile, Filter
 import argparse
 import logging
 import numpy
 import sys
+import foton
+
 from pycbc.filter.fotonfilter import filter_data, get_swstat_bits, read_gain_from_frames
 from pycbc.frame import frame_paths
 from pycbc.inject import InjectionSet, legacy_approximant_name
@@ -77,12 +79,6 @@ parser.add_argument("--sample-rate", type=int, required=True,
 
 # parse command line
 opts = parser.parse_args()
-
-# import dependencies that are not standard to pycbc
-import ROOT
-ROOT.gSystem.Load('/usr/lib64/libdmtsigp.so')
-ROOT.gSystem.Load('/usr/lib64/libgdsplot.so')
-from foton import FilterFile, Filter
 
 # setup log
 logging_level = logging.DEBUG

--- a/examples/cal/foton_filter_esd_saturation/pycbc_foton_filter
+++ b/examples/cal/foton_filter_esd_saturation/pycbc_foton_filter
@@ -15,12 +15,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from foton import FilterFile, Filter
 import argparse
 import logging
 import numpy
 import sys
-import foton
+from foton import FilterFile, Filter
 
 from pycbc.filter.fotonfilter import filter_data, get_swstat_bits, read_gain_from_frames
 from pycbc.frame import frame_paths

--- a/pycbc/filter/fotonfilter.py
+++ b/pycbc/filter/fotonfilter.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright (C) 2015  Christopher M. Biwer
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -20,9 +21,6 @@ import sys
 from pycbc import frame
 
 # import dependencies that are not standard to pycbc
-import ROOT
-ROOT.gSystem.Load('/usr/lib64/libdmtsigp.so')
-ROOT.gSystem.Load('/usr/lib64/libgdsplot.so')
 from foton import FilterFile, Filter, iir2z
 
 def get_swstat_bits(frame_filenames, swstat_channel_name, start_time, end_time):


### PR DESCRIPTION
I needed to make these modifications when testing DetChar hardware injections to check for PCAL saturations. It seems ROOT dependencies have been pulled into the foton package.