### PR TITLE
Allow multiple posteriors overlaid on each other

### DIFF
--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -26,92 +26,166 @@
 #
 
 import argparse
+import itertools
 import logging
 import numpy
 import matplotlib
 matplotlib.use('agg')
+from matplotlib import patches
 from matplotlib import pyplot
 import pycbc
 from pycbc.inference import option_utils, likelihood
 from pycbc.io.inference_hdf import InferenceFile
 from pycbc.results.scatter_histograms import create_multidim_plot
 
+# add options to command line
 parser = argparse.ArgumentParser()
-
 parser.add_argument("--output-file", type=str, required=True,
                     help="Output plot path.")
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="Be verbose")
+parser.add_argument("--input-file-labels", nargs="+", default=None,
+                    help="Labels to add to plot if using more than one"
+                         "input file.")
+
 # add options for what plots to create
 option_utils.add_plot_posterior_option_group(parser)
-# Scatter configuration
+
+# scatter configuration
 option_utils.add_scatter_option_group(parser)
-# Density configuration
+
+# density configuration
 option_utils.add_density_option_group(parser)
+
 # add standard option utils
 option_utils.add_inference_results_option_group(parser)
 
+# parse command line
 opts = parser.parse_args()
 
+# set logging
 pycbc.init_logging(opts.verbose)
 
-# Get parameters
+# get parameters
 logging.info("Loading parameters")
 fp, parameters, labels, samples = option_utils.results_from_cli(opts)
-logging.info("Using {i} samples".format(i=samples.size))
+
+# typecast to list so the input files can be iterated over
+fp = fp if isinstance(fp, list) else [fp]
+parameters = parameters if isinstance(parameters[0], list) else [parameters]
+labels = labels if isinstance(labels[0], list) else [labels]
+samples = samples if isinstance(samples, list) else [samples]
+
+# get likelihood statistic values
 if opts.z_arg is not None:
     logging.info("Getting likelihood stats")
-    likelihood_stats = fp.read_likelihood_stats(thin_start=opts.thin_start,
-            thin_end=opts.thin_end, thin_interval=opts.thin_interval,
-            iteration=opts.iteration)
-    zvals, zlbl = option_utils.get_zvalues(fp, opts.z_arg, likelihood_stats)
-    show_colorbar = True
+
+    # lists to hold z-axis values and labels for each input file
+    zvals = []
+    zlbl = []
+
+    # loop over each input file and append z-axis values and labels to lists
+    for f in fp:
+        likelihood_stats = f.read_likelihood_stats(
+            thin_start=opts.thin_start, thin_end=opts.thin_end,
+            thin_interval=opts.thin_interval, iteration=opts.iteration)
+        f_zvals, f_zlbl = option_utils.get_zvalues(f, opts.z_arg,
+                                                   likelihood_stats)
+        zvals.append(f_zvals)
+        zlbl.append(f_zlbl)
+        f.close()
+
+# else there are no z-axis values
 else:
     zvals = None
     zlbl = None
-    show_colorbar = False
-fp.close()
+    for f in fp:
+        f.close()
 
-# If no plotting options selected, set default options based on number
-# of parameters.
+# determine if colorbar should be shown
+show_colorbar = True if opts.z_arg else False
+
+# if no plotting options selected, then the default options are based
+# on the number of parameters
 plot_options = [opts.plot_marginal, opts.plot_scatter, opts.plot_density]
 if not numpy.any(plot_options):
-    if len(parameters) == 1:
+    if len(parameters[0]) == 1:
         opts.plot_marginal = True
     else:
         opts.plot_scatter = True
-        # FIXME: right now if there are two parameters it wants both plot_scatter
-        # and plot_marginal. One should have the option of give only plot_scatter
-        # and that should be the default for two or more parameters
+        # FIXME: right now if there are two parameters it wants
+        # both plot_scatter and plot_marginal. One should have the option
+        # of give only plot_scatter and that should be the default for
+        # two or more parameters
         opts.plot_marginal = True
 
+# get minimum and maximum ranges for each parameter from command line
 mins, maxs = option_utils.plot_ranges_from_cli(opts)
-# add any missing parameters
-for p in parameters:
-    if p not in mins:
-        mins[p] = samples[p].min()
-for p in parameters:
-    if p not in maxs:
-        maxs[p] = samples[p].max()
 
+# add any missing parameters
+for p in parameters[0]:
+    if p not in mins:
+        mins[p] = numpy.array([s[p].min() for s in samples]).min()
+    if p not in maxs:
+        maxs[p] = numpy.array([s[p].max() for s in samples]).max()
+
+# get expected parameter values from command line
 expected_parameters = option_utils.expected_parameters_from_cli(opts)
 
+# assign some colors
+colors = itertools.cycle(["black"] + ["C{}".format(i) for i in range(10)])
+
+# plot each input file
 logging.info("Plotting")
-fig, axis_dict = create_multidim_plot(
-                parameters, samples, labels=labels,
-                plot_marginal=opts.plot_marginal,
-                plot_scatter=opts.plot_scatter,
+hist_colors = []
+for i, (p, l, s) in enumerate(zip(parameters, labels, samples)):
+
+    # on first iteration create figure otherwise update old figure
+    if i == 0:
+        fig = None
+        axis_dict = None
+
+    # loop over some contour colors
+    contour_color = colors.next() if not opts.contour_color \
+                                                else opts.contour_color
+
+    # make histograms filled if only one input file to plot
+    fill_color = "gray" if len(opts.input_file) == 1 else None
+
+    # make histogram black lines if only one
+    hist_color = "black" if len(opts.input_file) == 1 else contour_color
+    hist_colors.append(hist_color)
+
+    # pick a new color for each input file
+    linecolor = "navy" if len(opts.input_file) == 1 else contour_color
+
+    # plot
+    fig, axis_dict = create_multidim_plot(
+                    p, s, labels=l, fig=fig, axis_dict=axis_dict,
+                    plot_marginal=opts.plot_marginal,
+                    plot_scatter=opts.plot_scatter,
                     zvals=zvals, show_colorbar=show_colorbar,
                     cbar_label=zlbl, vmin=opts.vmin, vmax=opts.vmax,
                     scatter_cmap=opts.scatter_cmap,
-                plot_density=opts.plot_density,
-                plot_contours=opts.plot_contours,
+                    plot_density=opts.plot_density,
+                    plot_contours=opts.plot_contours,
                     density_cmap=opts.density_cmap,
-                    contour_color=opts.contour_color,
+                    contour_color=contour_color,
+                    hist_color=hist_color,
+                    line_color=contour_color,
+                    fill_color=fill_color,
                     use_kombine=opts.use_kombine_kde,
-                mins=mins, maxs=maxs,
-                expected_parameters=expected_parameters,
-                expected_parameters_color=opts.expected_parameters_color)
+                    mins=mins, maxs=maxs,
+                    expected_parameters=expected_parameters,
+                    expected_parameters_color=opts.expected_parameters_color)
+
+# add legend to upper right for input files
+if opts.input_file_labels:
+    handles = []
+    for color, label in zip(hist_colors, opts.input_file_labels):
+        handles.append(patches.Patch(color=color, label=label))
+    fig.legend(loc="upper right", handles=handles,
+               labels=opts.input_file_labels)
 
 # save
 fig.savefig(opts.output_file, bbox_inches='tight', dpi=200)

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -38,11 +38,12 @@ import matplotlib
 import sys
 if not 'matplotlib.backends' in sys.modules:
     matplotlib.use('agg')
+from matplotlib import offsetbox
 from matplotlib import pyplot
 import matplotlib.gridspec as gridspec
 from pycbc.results import str_utils
 from pycbc.io import FieldArray
-#pyplot.rcParams.update({'text.usetex': True})
+import matplotlib as mpl
 
 def create_axes_grid(parameters, labels=None, height_ratios=None,
         width_ratios=None, no_diagonals=False):
@@ -284,8 +285,8 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
 
 
 def create_marginalized_hist(ax, values, label, percentiles=None,
-        color='k', fillcolor='gray', linecolor='navy', title=True,
-        expected_value=None, expected_color='red',
+        color='k', fillcolor='gray', linecolor='navy',
+        title=True, expected_value=None, expected_color='red',
         rotated=False, plot_min=None, plot_max=None):
     """Plots a 1D marginalized histogram of the given param from the given
     samples.
@@ -353,12 +354,17 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
         values_max = values.max()
         negerror = values_med - values_min
         poserror = values_max - values_med
+        mpl.rcParams['text.latex.preamble'] = [r'\usepackage{xcolor}']
         fmt = '$' + str_utils.format_value(values_med, negerror,
               plus_error=poserror, ndecs=2) + '$'
+
         if rotated:
             ax.yaxis.set_label_position("right")
-            ax.set_ylabel('{} = {}'.format(label, fmt), rotation=-90,
-                labelpad=26, fontsize=18)
+
+            # sets colored title for marginal histogram
+            set_marginal_histogram_title(ax, fmt, color,
+                                         label=label, rotated=rotated)
+
             # Remove x-ticks
             ax.set_xticks([])
             # turn off x-labels
@@ -370,8 +376,12 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
             if plot_max is not None:
                 ymax = plot_max
             ax.set_ylim(ymin, ymax)
+
         else:
-            ax.set_title('{} = {}'.format(label, fmt), fontsize=18, y=1.04)
+
+            # sets colored title for marginal histogram
+            set_marginal_histogram_title(ax, fmt, color, label=label)
+
             # Remove y-ticks
             ax.set_yticks([])
             # turn off y-label
@@ -385,16 +395,91 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
             ax.set_xlim(xmin, xmax)
 
 
+def set_marginal_histogram_title(ax, fmt, color, label=None, rotated=False):
+    """ Sets the title of the marginal histograms.
+
+    Parameters
+    ----------
+    ax : Axes
+        The `Axes` instance for the plot.
+    fmt : str
+        The string to add to the title.
+    color : str
+        The color of the text to add to the title.
+    label : str
+        If title does not exist, then include label at beginning of the string.
+    rotated : bool
+        If `True` then rotate the text 270 degrees for sideways title.
+    """
+
+    # get rotation angle of the title
+    rotation = 270 if rotated else 0
+
+    # get how much to displace title on axes
+    xscale = 1.05 if rotated else 0.0
+    if rotated:
+        yscale = 1.0
+    elif len(ax.get_figure().axes) > 1:
+        yscale = 1.15
+    else:
+        yscale = 1.05
+
+    # get class that packs text boxes vertical or horizonitally
+    packer_class = offsetbox.VPacker if rotated else offsetbox.HPacker
+
+    # if no title exists
+    if not hasattr(ax, "title_boxes"):
+
+        # create a text box
+        title = "{} = {}".format(label, fmt)
+        tbox1 = offsetbox.TextArea(
+                   title,
+                   textprops=dict(color=color, size=15, rotation=rotation,
+                                  ha='left', va='bottom'))
+
+        # save a list of text boxes as attribute for later
+        ax.title_boxes = [tbox1]
+
+        # pack text boxes
+        ybox = packer_class(children=ax.title_boxes,
+                            align="bottom", pad=0, sep=5)
+
+    # else append existing title
+    else:
+
+        # delete old title
+        ax.title_anchor.remove()
+
+        # add new text box to list
+        tbox1 = offsetbox.TextArea(
+                   " {}".format(fmt),
+                   textprops=dict(color=color, size=15, rotation=rotation,
+                                  ha='left', va='bottom'))
+        ax.title_boxes = ax.title_boxes + [tbox1]
+
+        # pack text boxes
+        ybox = packer_class(children=ax.title_boxes,
+                            align="bottom", pad=0, sep=5)
+
+    # add new title and keep reference to instance as an attribute
+    anchored_ybox = offsetbox.AnchoredOffsetbox(
+                      loc=2, child=ybox, pad=0.,
+                      frameon=False, bbox_to_anchor=(xscale, yscale),
+                      bbox_transform=ax.transAxes, borderpad=0.)
+    ax.title_anchor = ax.add_artist(anchored_ybox)
+
+
 def create_multidim_plot(parameters, samples, labels=None,
                 mins=None, maxs=None, expected_parameters=None,
                 expected_parameters_color='r',
-                plot_marginal=True,
-                plot_scatter=True,
-                    zvals=None, show_colorbar=True, cbar_label=None,
-                    vmin=None, vmax=None, scatter_cmap='plasma',
+                plot_marginal=True, plot_scatter=True,
+                zvals=None, show_colorbar=True, cbar_label=None,
+                vmin=None, vmax=None, scatter_cmap='plasma',
                 plot_density=False, plot_contours=True,
-                    density_cmap='viridis', contour_color=None,
-                    use_kombine=False):
+                density_cmap='viridis',
+                contour_color=None, hist_color='black',
+                line_color=None, fill_color='gray',
+                use_kombine=False, fig=None, axis_dict=None):
     """Generate a figure with several plots and histograms.
 
     Parameters
@@ -519,9 +604,11 @@ def create_multidim_plot(parameters, samples, labels=None,
             maxs[param] = maxs[param] - float(offset)
 
     # create the axis grid
-    fig, axis_dict = create_axes_grid(parameters, labels=labels,
-        width_ratios=width_ratios, height_ratios=height_ratios,
-        no_diagonals=not plot_marginal)
+    if fig is None and axis_dict is None:
+        fig, axis_dict = create_axes_grid(
+            parameters, labels=labels,
+            width_ratios=width_ratios, height_ratios=height_ratios,
+            no_diagonals=not plot_marginal)
 
 
     # Diagonals...
@@ -540,8 +627,8 @@ def create_multidim_plot(parameters, samples, labels=None,
             else:
                 expected_value = None
             create_marginalized_hist(ax, samples[param], label=labels[param],
-                color='k', fillcolor='gray', linecolor='navy', title=True,
-                expected_value=expected_value,
+                color=hist_color, fillcolor=fill_color, linecolor=line_color,
+                title=True, expected_value=expected_value,
                 expected_color=expected_parameters_color,
                 rotated=rotated, plot_min=mins[param], plot_max=maxs[param])
 

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -43,7 +43,6 @@ from matplotlib import pyplot
 import matplotlib.gridspec as gridspec
 from pycbc.results import str_utils
 from pycbc.io import FieldArray
-import matplotlib as mpl
 
 def create_axes_grid(parameters, labels=None, height_ratios=None,
         width_ratios=None, no_diagonals=False):
@@ -354,7 +353,6 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
         values_max = values.max()
         negerror = values_med - values_min
         poserror = values_max - values_med
-        mpl.rcParams['text.latex.preamble'] = [r'\usepackage{xcolor}']
         fmt = '$' + str_utils.format_value(values_med, negerror,
               plus_error=poserror, ndecs=2) + '$'
 


### PR DESCRIPTION
Adds capability to plot multiple posteriors from different files on top of each other. This feature has been requested by a few people.

Example of PR so far: https://sugwg-jobs.phy.syr.edu/~cbiwer/projects/inference_multi_io/test/test.png

Want to make the colors in the titles of the histograms match the contour colors but matplotlib apparently doesn't have very good support for LaTeX colors so I'll get back to this.

Also need to scale histograms over all inputs instead of the last one plotted.