### PR TITLE
Patch pycbc_page_IFAR, h_0 level plot

### DIFF
--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -158,14 +158,16 @@ expected_cumnum = fp.attrs['foreground_time'] / expected_ifar / lal.YRJUL_SI
 
 # Use these backgrounds for n-th stage of hierarchical removals
 # and test for backwards compatibility and that stage was written. 
-if h_inc_back_num >= 0 and h_iterations is not None and h_iterations != 0:
-    back_tsid = fp['background_h%s/timeslide_id' % h_inc_back_num][:]
-    back_ifar = fp['background_h%s/ifar' % h_inc_back_num][:]
+if opts.open_box:
+    if h_inc_back_num >= 0 and h_iterations is not None and h_iterations != 0:
+        back_tsid = fp['background_h%s/timeslide_id' % h_inc_back_num][:]
+        back_ifar = fp['background_h%s/ifar' % h_inc_back_num][:]
+
 else :
     # If the box is closed use the background from no hierarchical
     # removals. Results should be agnostic of judgments about
     # whether a hierarchical removal was done.
-    if not opts.open_box and h_iterations > 0:
+    if h_iterations > 0 and h_iterations is not None:
         back_tsid = fp['background_h0/timeslide_id'][:]
         back_ifar = fp['background_h0/ifar'][:]
 

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -91,7 +91,7 @@ opts = parser.parse_args()
 
 # Check that user does not ask for --use-hierarchical-level if the box is
 # not open.
-if args.use_hierarchical_level is not None and args.open_box is False:
+if opts.use_hierarchical_level is not None and opts.open_box is False:
     parser.error("User error: Cannot ask for --use-hierarchical-level " \
                  "when the box is closed (when --open-box is not given. " \
                  "These are conflicting options. Please use --help for " \

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -163,6 +163,10 @@ if opts.open_box:
         back_tsid = fp['background_h%s/timeslide_id' % h_inc_back_num][:]
         back_ifar = fp['background_h%s/ifar' % h_inc_back_num][:]
 
+    else :
+        back_tsid = fp['background/timeslide_id'][:]
+        back_ifar = fp['background/ifar'][:]
+
 else :
     # If the box is closed use the background from no hierarchical
     # removals. Results should be agnostic of judgments about

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -154,11 +154,11 @@ if opts.open_box:
 expected_ifar = numpy.logspace(-8, 2, num=100, endpoint=True, base=10.0)
 expected_cumnum = fp.attrs['foreground_time'] / expected_ifar / lal.YRJUL_SI 
 
-# get background timeslide IDs and IFAR values
+# Get background timeslide IDs and IFAR values.
 
 # Use these backgrounds for n-th stage of hierarchical removals
-# and if the open box option
-if h_inc_back_num >= 0 and opts.open_box and h_iterations is not None and h_iterations != 0:
+# and test for backwards compatibility and that stage was written. 
+if h_inc_back_num >= 0 and h_iterations is not None and h_iterations != 0:
     back_tsid = fp['background_h%s/timeslide_id' % h_inc_back_num][:]
     back_ifar = fp['background_h%s/ifar' % h_inc_back_num][:]
 else :

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -154,7 +154,7 @@ if opts.open_box:
 expected_ifar = numpy.logspace(-8, 2, num=100, endpoint=True, base=10.0)
 expected_cumnum = fp.attrs['foreground_time'] / expected_ifar / lal.YRJUL_SI 
 
-# Get background timeslide IDs and IFAR values.
+# get background timeslide IDs and IFAR values
 
 # Use these backgrounds for n-th stage of hierarchical removals
 # and test for backwards compatibility and that stage was written. 
@@ -163,6 +163,12 @@ if opts.open_box:
         back_tsid = fp['background_h%s/timeslide_id' % h_inc_back_num][:]
         back_ifar = fp['background_h%s/ifar' % h_inc_back_num][:]
 
+    # If the user wants to plot foreground events at h_inc_back_num == 0
+    # and h_iterations == 0 then no hierarchical removals were done and
+    # the line below is safe to use. The other case is the trigger-file
+    # is before hierarchical removals so the else below catches that.
+    # The third case is requesting to plot hierarchical removal level
+    # greater than was done and an empty plot is made earlier in the code.
     else :
         back_tsid = fp['background/timeslide_id'][:]
         back_ifar = fp['background/ifar'][:]

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -131,7 +131,7 @@ if h_inc_back_num > h_iterations:
 # get foreground IFAR values and cumulative number for each IFAR value
 if opts.open_box:
 
-    if h_inc_back_num > 0:
+    if h_inc_back_num >= 0 and h_iterations is not None and h_iterations != 0:
         fore_ifar = fp['foreground_h%s/ifar' % h_inc_back_num][:]
         # Get ifar of hierarchically removed foreground triggers
         supp_fore_ifar = fp['foreground/ifar'][:]
@@ -158,7 +158,7 @@ expected_cumnum = fp.attrs['foreground_time'] / expected_ifar / lal.YRJUL_SI
 
 # Use these backgrounds for n-th stage of hierarchical removals
 # and if the open box option
-if h_inc_back_num > 0 and opts.open_box:
+if h_inc_back_num >= 0 and opts.open_box and h_iterations is not None and h_iterations != 0:
     back_tsid = fp['background_h%s/timeslide_id' % h_inc_back_num][:]
     back_ifar = fp['background_h%s/ifar' % h_inc_back_num][:]
 else :

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -89,14 +89,6 @@ parser.add_argument('--open-box', action='store_true', default=False,
                     help='Show the foreground triggers on the output plot. ')
 opts = parser.parse_args()
 
-# Check that user does not ask for --use-hierarchical-level if the box is
-# not open.
-if opts.use_hierarchical_level is not None and opts.open_box is False:
-    parser.error("User error: Cannot ask for --use-hierarchical-level " \
-                 "when the box is closed (when --open-box is not given. " \
-                 "These are conflicting options. Please use --help for " \
-                 "more information")
-
 # read file
 fp = h5py.File(opts.trigger_file, 'r')
 

--- a/bin/hdfcoinc/pycbc_page_ifar
+++ b/bin/hdfcoinc/pycbc_page_ifar
@@ -89,6 +89,14 @@ parser.add_argument('--open-box', action='store_true', default=False,
                     help='Show the foreground triggers on the output plot. ')
 opts = parser.parse_args()
 
+# Check that user does not ask for --use-hierarchical-level if the box is
+# not open.
+if args.use_hierarchical_level is not None and args.open_box is False:
+    parser.error("User error: Cannot ask for --use-hierarchical-level " \
+                 "when the box is closed (when --open-box is not given. " \
+                 "These are conflicting options. Please use --help for " \
+                 "more information")
+
 # read file
 fp = h5py.File(opts.trigger_file, 'r')
 


### PR DESCRIPTION
There was a bug in the foreground events that were being printed when hierarchical removals were done in the statmap code.

The code previous to this PR would print the correct results for all hierarchical removals, except it was plotting the wrong result for showing no hierarchical removals. The executable wouldn't fail, it just showed the wrong results.

This plot shows the O1 GW's, but at the stage of no hierarchical removal, GW150914 has an IFAR > 10^6 years, whereas GW151226 should display an IFAR of 700 years or so.
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/exclusive_hierarchical_removal_tests_3GWs_O1/ifar_lightning_exclusive_0_open.png

The other plots for running without an option (full results), and hierarchical removal results at stages 1, 2, N, were all correct.

This new patch shows what we should expect for this plot:
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_removal_review/O1_plots/ifar_lightning_all_hier_exclusive_0_open.png

____
It also permits backwards compatibility with other codes.

I've checked the closed and open box plots at https://www.lsc-group.phys.uwm.edu/ligovirgo/cbcnote/PyCBC/hierarchical-removal-project-O2
and they do what one expects.

A quick click through closed boxes shows that they're all identical as they should be:

Running the closed box with statmap file that does no hierarchical removals (this is what should be shown as a closed box)
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_removal_review/O1_plots/ifar_lightning_no_hier_null_closed.png

Running the closed box with a statmap file that did 2 hierarchical removals against the exclusive background. This plot should be exactly the same as the one above.
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_removal_review/O1_plots/ifar_lightning_all_hier_exclusive_null_closed.png

Running the closed box with a statmap file that did 2 hierarchical removals against the inclusive background. This plot should be exactly the same as the one above.
https://sugwg-jobs.phy.syr.edu/~steven.reyes/O2/hierarchical_removal_review/O1_plots/ifar_lightning_all_hier_inclusive_null_closed.png