### PR TITLE
Expose threshold_only

### DIFF
--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -757,5 +757,5 @@ class EventManagerMultiDet(EventManager):
 __all__ = ['threshold_and_cluster', 'newsnr', 'effsnr', 'newsnr_sgveto',
            'findchirp_cluster_over_window',
            'threshold', 'cluster_reduce', 'ThresholdCluster',
-           'threshold_real_numpy',
+           'threshold_real_numpy', 'threshold_only',
            'EventManager', 'EventManagerMultiDet']


### PR DESCRIPTION
As discussed some time ago the `threshold` function within events.py uses memory caching which can be confusing. For CPU usage at least, the simple `threshold_only` function will suffice in most cases, and avoids this gotcha.

I would like to expose this for both GRB coherent development and for the HOM search.