### PR TITLE
Add newSNR + SG stat

### DIFF
--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -113,7 +113,7 @@ class NewSNRStatistic(Stat):
         """
         return get_newsnr(trigs)
 
-    def coinc(self, s0, s1, slide, step):
+    def coinc(self, s0, s1, slide, step): # pylint:disable=unused-argument
         """Calculate the coincident detection statistic.
 
         Parameters
@@ -150,7 +150,7 @@ class NewSNRSGStatistic(Stat):
         """
         return get_newsnr_sgveto(trigs)
 
-    def coinc(self, s0, s1, slide, step):
+    def coinc(self, s0, s1, slide, step): # pylint:disable=unused-argument
         """Calculate the coincident detection statistic.
 
         Parameters
@@ -201,7 +201,7 @@ class NewSNRCutStatistic(NewSNRStatistic):
         newsnr[numpy.logical_and(newsnr < 10, rchisq > 2)] = -1
         return newsnr
 
-    def coinc(self, s0, s1, slide, step):
+    def coinc(self, s0, s1, slide, step): # pylint:disable=unused-argument
         """Calculate the coincident detection statistic.
 
         Parameters
@@ -413,7 +413,7 @@ class ExpFitStatistic(NewSNRStatistic):
         """Single-detector statistic, here just equal to the log noise rate"""
         return self.lognoiserate(trigs)
 
-    def coinc(self, s0, s1, slide, step):
+    def coinc(self, s0, s1, slide, step): # pylint:disable=unused-argument
         """Calculate the final coinc ranking statistic"""
         # Approximate log likelihood ratio by summing single-ifo negative
         # log noise likelihoods
@@ -454,7 +454,7 @@ class ExpFitCombinedSNR(ExpFitStatistic):
         stat = thresh - (logr_n / self.alpharef)
         return numpy.array(stat, ndmin=1, dtype=numpy.float32)
 
-    def coinc(self, s0, s1, slide, step):
+    def coinc(self, s0, s1, slide, step): # pylint:disable=unused-argument
         # scale by 1/sqrt(2) to resemble network SNR
         return (s0 + s1) / (2.**0.5)
 

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -132,6 +132,7 @@ class NewSNRStatistic(Stat):
         """
         return (s0**2. + s1**2.) ** 0.5
 
+
 class NewSNRSGStatistic(NewSNRStatistic):
 
     """ Calculate the NewSNRSG coincident detection statistic """

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -132,6 +132,43 @@ class NewSNRStatistic(Stat):
         """
         return (s0**2. + s1**2.) ** 0.5
 
+class NewSNRSGStatistic(Stat):
+
+    """ Calculate the NewSNR coincident detection statistic """
+
+    def single(self, trigs):
+        """Calculate the single detector statistic, here equal to newsnr
+
+        Parameters
+        ----------
+        trigs: dict of numpy.ndarrays
+
+        Returns
+        -------
+        numpy.ndarray
+            The array of single detector values
+        """
+        return get_newsnr_sgveto(trigs)
+
+    def coinc(self, s0, s1, slide, step):
+        """Calculate the coincident detection statistic.
+
+        Parameters
+        ----------
+        s0: numpy.ndarray
+            Single detector ranking statistic for the first detector.
+        s1: numpy.ndarray
+            Single detector ranking statistic for the second detector.
+        slide: (unused in this statistic)
+        step: (unused in this statistic)
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of coincident ranking statistic values
+        """
+        return (s0**2. + s1**2.) ** 0.5
+
 
 class NetworkSNRStatistic(NewSNRStatistic):
 
@@ -500,7 +537,8 @@ statistic_dict = {
     'exp_fit_csnr': ExpFitCombinedSNR,
     'phasetd_exp_fit_stat': PhaseTDExpFitStatistic,
     'max_cont_trad_newsnr': MaxContTradNewSNRStatistic,
-    'phasetd_exp_fit_stat_sgveto': PhaseTDExpFitSGStatistic
+    'phasetd_exp_fit_stat_sgveto': PhaseTDExpFitSGStatistic,
+    'newsnr_sgveto': NewSNRSGStatistic
 }
 
 def get_statistic(stat):

--- a/pycbc/events/stat.py
+++ b/pycbc/events/stat.py
@@ -132,9 +132,9 @@ class NewSNRStatistic(Stat):
         """
         return (s0**2. + s1**2.) ** 0.5
 
-class NewSNRSGStatistic(Stat):
+class NewSNRSGStatistic(NewSNRStatistic):
 
-    """ Calculate the NewSNR coincident detection statistic """
+    """ Calculate the NewSNRSG coincident detection statistic """
 
     def single(self, trigs):
         """Calculate the single detector statistic, here equal to newsnr
@@ -149,25 +149,6 @@ class NewSNRSGStatistic(Stat):
             The array of single detector values
         """
         return get_newsnr_sgveto(trigs)
-
-    def coinc(self, s0, s1, slide, step): # pylint:disable=unused-argument
-        """Calculate the coincident detection statistic.
-
-        Parameters
-        ----------
-        s0: numpy.ndarray
-            Single detector ranking statistic for the first detector.
-        s1: numpy.ndarray
-            Single detector ranking statistic for the second detector.
-        slide: (unused in this statistic)
-        step: (unused in this statistic)
-
-        Returns
-        -------
-        numpy.ndarray
-            Array of coincident ranking statistic values
-        """
-        return (s0**2. + s1**2.) ** 0.5
 
 
 class NetworkSNRStatistic(NewSNRStatistic):


### PR DESCRIPTION
There is currently no option to do new SNR *and* SG veto, but *not* use the phase-time stuff. This combination will be useful for testing of higher-order mode search development in the coming months, where phase-time may not be so obvious!

This has been tested on end-to-end runs as part of a short-author paper on higher-order modes. (Although we then realised that SG stat is not published anywhere, so we are not using those results)