### PR TITLE
Ignore the egg-info directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pycbc_inspiralc
 build/
 *.pyc
 docs/Makefile
+PyCBC.egg-info


### PR DESCRIPTION
This one's pretty simple: Add the `PyCBC.egg-info` directory to .gitignore so git status doesn't list this.