### PR TITLE
Add tidal terms support

### DIFF
--- a/pycbc/tmpltbank/calc_moments.py
+++ b/pycbc/tmpltbank/calc_moments.py
@@ -97,7 +97,7 @@ def determine_eigen_directions(metricParams, preserveMoments=False,
     for item in list:
         # Here we convert the moments into a form easier to use here
         Js = {}
-        for i in xrange(-1,18):
+        for i in xrange(-7,18):
             Js[i] = metricParams.moments['J%d'%(i)][item]
 
         logJs = {}
@@ -234,7 +234,7 @@ def get_moments(metricParams, vary_fmax=False, vary_density=None):
     # Do all the J moments
     moments = {}
     moments['I7'] = I7
-    for i in xrange(-1,18):
+    for i in xrange(-7,18):
         funct = lambda x: x**((-i+7)/3.)
         moments['J%d' %(i)] = calculate_moment(new_f, new_amp, \
                                 metricParams.fLow, metricParams.fUpper, \

--- a/pycbc/tmpltbank/coord_utils.py
+++ b/pycbc/tmpltbank/coord_utils.py
@@ -291,7 +291,9 @@ def get_random_mass(numPoints, massRangeParams):
 
     return mass1, mass2, spin1z, spin2z
 
-def get_cov_params(mass1, mass2, spin1z, spin2z, metricParams, fUpper):
+def get_cov_params(mass1, mass2, spin1z, spin2z, metricParams, fUpper,
+                   lambda1=None, lambda2=None, quadparam1=None,
+                   quadparam2=None):
     """
     Function to convert between masses and spins and locations in the xi
     parameter space. Xi = Cartesian metric and rotated to principal components.
@@ -324,12 +326,16 @@ def get_cov_params(mass1, mass2, spin1z, spin2z, metricParams, fUpper):
     """
 
     # Do this by doing masses - > lambdas -> mus
-    mus = get_conv_params(mass1, mass2, spin1z, spin2z, metricParams, fUpper)
+    mus = get_conv_params(mass1, mass2, spin1z, spin2z, metricParams, fUpper,
+                          lambda1=lambda1, lambda2=lambda2,
+                          quadparam1=quadparam1, quadparam2=quadparam2)
     # and then mus -> xis
     xis = get_covaried_params(mus, metricParams.evecsCV[fUpper])
     return xis
 
-def get_conv_params(mass1, mass2, spin1z, spin2z, metricParams, fUpper):
+def get_conv_params(mass1, mass2, spin1z, spin2z, metricParams, fUpper,
+                    lambda1=None, lambda2=None, quadparam1=None,
+                    quadparam2=None):
     """
     Function to convert between masses and spins and locations in the mu
     parameter space. Mu = Cartesian metric, but not principal components.
@@ -362,7 +368,9 @@ def get_conv_params(mass1, mass2, spin1z, spin2z, metricParams, fUpper):
 
     # Do this by masses -> lambdas
     lambdas = get_chirp_params(mass1, mass2, spin1z, spin2z,
-                               metricParams.f0, metricParams.pnOrder)
+                               metricParams.f0, metricParams.pnOrder,
+                               lambda1=lambda1, lambda2=lambda2,
+                               quadparam1=quadparam1, quadparam2=quadparam2)
     # and lambdas -> mus
     mus = get_mu_params(lambdas, metricParams, fUpper)
     return mus

--- a/pycbc/tmpltbank/lambda_mapping.py
+++ b/pycbc/tmpltbank/lambda_mapping.py
@@ -33,6 +33,9 @@ pycbcValidOrdersHelpDescriptions="""
      * threePN: Will include orbit terms to 3PN and spin terms to 2.5PN.
      * threePointFivePN: Include orbit terms to 3.5PN and spin terms to 2.5PN
 """
+# FIXME:
+# Add to above when support for lambdas is added in template bank front-ends
+# * tidalTerms: As threePointFivePN, but includes 5 and 6PN tidal terms
 
 
 def generate_mapping(order):
@@ -79,7 +82,7 @@ def generate_mapping(order):
     mapping['Lambda7'] = 7
     if order == 'threePointFivePN':
         return mapping
-    if order == 'tidalTesting':
+    if order == 'tidalTerms':
         mapping['Lambda10'] = 8
         mapping['Lambda12'] = 9
         return mapping
@@ -96,7 +99,7 @@ def generate_inverse_mapping(order):
     generate_mapping gives dict[key] = item this will give
     dict[item] = key. Valid PN orders are:
     {}
-    
+
     Parameters
     ----------
     order : string
@@ -120,7 +123,7 @@ generate_inverse_mapping.__doc__ = \
 
 def get_ethinca_orders():
     """
-    Returns the dictionary mapping TaylorF2 PN order names to twice-PN 
+    Returns the dictionary mapping TaylorF2 PN order names to twice-PN
     orders (powers of v/c)
     """
     ethinca_orders = {"zeroPN"           : 0,
@@ -135,13 +138,13 @@ def get_ethinca_orders():
 
 def ethinca_order_from_string(order):
     """
-    Returns the integer giving twice the post-Newtonian order 
+    Returns the integer giving twice the post-Newtonian order
     used by the ethinca calculation. Currently valid only for TaylorF2 metric
 
     Parameters
     ----------
     order : string
-    
+
     Returns
     -------
     int
@@ -159,7 +162,7 @@ def get_chirp_params_new(mass1, mass2, spin1z, spin2z, f0, order,
     Take a set of masses and spins and convert to the various lambda
     coordinates that describe the orbital phase. Accepted PN orders are:
     {}
- 
+
     Parameters
     ----------
     mass1 : float or array
@@ -269,7 +272,7 @@ def get_chirp_params_old(mass1, mass2, spin1z, spin2z, f0, order):
     Take a set of masses and spins and convert to the various lambda
     coordinates that describe the orbital phase. Accepted PN orders are:
     {}
- 
+
     Parameters
     ----------
     mass1 : float or array
@@ -340,7 +343,7 @@ def get_chirp_params_old(mass1, mass2, spin1z, spin2z, f0, order):
             lambda6 = lambda6 * 3./(128.*eta) * (pi * totmass * f0)**(1/3.)
             lambdas.append(lambda6)
         elif mapping[idx] == 'LogLambda6':
-            loglambda6 =  -( 6848./21) 
+            loglambda6 =  -( 6848./21)
             loglambda6 = loglambda6 * 3./(128.*eta)\
                          * (pi * totmass * f0)**(1/3.)
             lambdas.append(loglambda6)
@@ -352,7 +355,7 @@ def get_chirp_params_old(mass1, mass2, spin1z, spin2z, f0, order):
         else:
             err_msg = "Do not understand term {}.".format(mapping[idx])
             raise ValueError(err_msg)
-                 
+
     return lambdas
 
 get_chirp_params_old.__doc__ = \


### PR DESCRIPTION
This commit adds the ability to use tidal terms in the internals of the pycbc.tmpltbank module.

This is the first step towards being able to use these terms for template bank construction. The next step would be to add support for choosing the necessary lambda parameters, adding that into the front-end codes, and then enabling "tidalTerms" as a valid order.

Note that with this patch we now move from the internally coded F2 terms to those in lalsimulation. This has been in preparation for a while, does come with a speed penalty, but I'm not going to go and code up the tidal terms *again*. At some point we still need to write a "Generate_f2_terms_for_input_array" function in C, which would fix the speed issue.