### PR TITLE
Rationalize Docker containers used by PyCBC Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
     sudo: required
     services:
     - docker
-  - env: PYCBC_CONTAINER=pycbc_inspiral_bundle DOCKER_IMG=quay.io/pypa/manylinux1_x86_64
+  - env: PYCBC_CONTAINER=pycbc_inspiral_bundle DOCKER_IMG=pycbc/sl6-travis
     sudo: required
     services:
     - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
   - secure: oey1B+mhqfwhGgbnKFohJe56pPbvvdYA8Li6xdX2eCes9El3Sw0vNoyU9DTml9wnT2B+JKxw14l1ELHO8ugljJdXM+M5XCeDAloX661oP9c4mc0AB8KKmkDs7n5o681fp70YLesX2/ZZ8X1NRg8zayFQHwF+oQilgLXvfzEHBPqWnq6Kq/sxomkXPYR0paisTLuPzjMDv127DdZH60cYF3mEKnJvflgJWqfvUV11D06v8CKRRFZXFIhhnQ2kdF2hHA2orhcjM64HMJPOaEftEs07TWWYvdaUxUasAeUkEZhqBq/Z2DbKk3oiGuRNXOmFk+etu+YliabePsFAMFjnDdeONWNiPDarxQhrG8EZi5cv+pxbtsbPFlkPiDgIuFTZLj8SmO/5iPu9tBTPriY59xz6Eud5t6wuaiOHEat0uYmG8vHlpxeE1d7EFBeo9kvnyWOPRiPPD5g7frQ7aPQw/x+J+D1TzclrHgRfQ3K2yALnIeAeo1f7yJIMppZxHEhkLLg300Or2HtjPVbOhj6wUvhnL6+SP054NHzdXb8UjRv1lIduPJxopUxjaRc9XHgmFRa5RP+q42pMrUp5O2sHVvjMKtka57T4HukzoAQuIeqYopZjh7qUTLtjOvAh0tScUiHJh9GDQv9i8KffXAA89785Pgi22K80/Nn+dNc8xP0=
 matrix:
   include:
-  - env: PYCBC_CONTAINER=pycbc_rhel_virtualenv DOCKER_IMG=pycbc/ldg-el7:v1.1
+  - env: PYCBC_CONTAINER=pycbc_rhel_virtualenv DOCKER_IMG=ligo/lalsuite-dev:el7
     sudo: required
     services:
     - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
     sudo: required
     services:
     - docker
-  - env: PYCBC_CONTAINER=pycbc_inspiral_bundle DOCKER_IMG=pycbc/sl6-travis
+  - env: PYCBC_CONTAINER=pycbc_inspiral_bundle DOCKER_IMG=quay.io/pypa/manylinux1_x86_64
     sudo: required
     services:
     - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN yum -q -y install lscsoft-epel-config
 RUN yum -q -y install lscsoft-ius-config
 RUN yum clean all
 RUN yum makecache
-RUN yum -q -y install git2u-all lscsoft-all
+RUN yum -q -y install git2u-all
 RUN yum -q -y install zlib-devel libpng-devel libjpeg-devel libsqlite3-dev sqlite-devel db4-devel
 RUN yum -q -y install tkinter libpng-devel lynx telnet
 RUN yum -q -y install compat-glibc compat-glibc-headers

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,9 @@ FROM ligo/lalsuite-dev:el7
 USER root
 
 RUN curl http://download.pegasus.isi.edu/wms/download/rhel/7/pegasus.repo > /etc/yum.repos.d/pegasus.repo
-RUN rpm -ivh http://software.ligo.org/lscsoft/scientific/7.2/x86_64/production/lscsoft-production-config-1.3-1.el7.noarch.rpm
 RUN yum clean all
 RUN yum makecache
-RUN yum update
+RUN yum -y update
 RUN yum -y install lscsoft-backports-config
 RUN yum -y install lscsoft-epel-config
 RUN yum -y install lscsoft-ius-config
@@ -37,6 +36,20 @@ RUN mv htcondor-stable-rhel7.repo /etc/yum.repos.d/htcondor-stable-rhel7.repo
 RUN yum -y install condor condor-classads condor-python condor-procd condor-external-libs
 RUN yum -y install ecp-cookie-init
 RUN yum -y install man-db
+
+# set up cvmfs
+RUN yum -y install osg-oasis
+RUN echo "/cvmfs /etc/auto.cvmfs" > /etc/auto.master
+RUN echo > /etc/cvmfs/default.local <<EOF
+CVMFS_REPOSITORIES="`echo $((echo oasis.opensciencegrid.org;echo cms.cern.ch;ls /cvmfs)|sort -u)|tr ' ' ,`"
+CVMFS_QUOTA_LIMIT=20000
+CVMFS_HTTP_PROXY=DIRECT
+EOF
+RUN systemctl enable autofs
+RUN systemctl start autofs
+
+# uninstall lalsuite
+RUN yum -y uninstall *lal*
 
 # enable ssh
 EXPOSE 22

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,6 @@ RUN yum -y install man-db
 RUN yum -y install osg-oasis
 RUN echo "/cvmfs /etc/auto.cvmfs" > /etc/auto.master
 ADD tools/cvmfs.default.local /etc/cvmfs/default.local
-RUN systemctl enable autofs
-RUN systemctl start autofs
 
 # uninstall lalsuite
 RUN yum -y uninstall *lal*

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,7 @@ RUN yum -y install man-db
 # set up cvmfs
 RUN yum -y install osg-oasis
 RUN echo "/cvmfs /etc/auto.cvmfs" > /etc/auto.master
-RUN echo > /etc/cvmfs/default.local <<EOF
-CVMFS_REPOSITORIES="`echo $((echo oasis.opensciencegrid.org;echo cms.cern.ch;ls /cvmfs)|sort -u)|tr ' ' ,`"
-CVMFS_QUOTA_LIMIT=20000
-CVMFS_HTTP_PROXY=DIRECT
-EOF
+ADD tools/cvmfs.default.local /etc/cvmfs/default.local
 RUN systemctl enable autofs
 RUN systemctl start autofs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,43 +5,43 @@ USER root
 RUN curl http://download.pegasus.isi.edu/wms/download/rhel/7/pegasus.repo > /etc/yum.repos.d/pegasus.repo
 RUN yum clean all
 RUN yum makecache
-RUN yum -y update
-RUN yum -y install lscsoft-backports-config
-RUN yum -y install lscsoft-epel-config
-RUN yum -y install lscsoft-ius-config
+RUN yum -q -y update
+RUN yum -q -y install lscsoft-backports-config
+RUN yum -q -y install lscsoft-epel-config
+RUN yum -q -y install lscsoft-ius-config
 RUN yum clean all
 RUN yum makecache
-RUN yum -y install git2u-all lscsoft-all
-RUN yum install -y zlib-devel libpng-devel libjpeg-devel libsqlite3-dev sqlite-devel db4-devel
-RUN yum -y install tkinter libpng-devel lynx telnet
-RUN yum -y install compat-glibc compat-glibc-headers
-RUN yum -y install gd-devel audit-libs-devel libcap-devel nss-devel
-RUN yum -y install xmlto asciidoc hmaccalc newt-devel 'perl(ExtUtils::Embed)' pesign elfutils-devel binutils-devel numactl-devel pciutils-devel
-RUN yum -y install dejagnu sharutils gcc-gnat libgnat dblatex gmp-devel mpfr-devel libmpc-devel
-RUN yum -y install libuuid-devel netpbm-progs nasm
-RUN yum -y install libstdc++-static
-RUN yum -y install gettext-devel avahi-devel dyninst-devel crash-devel latex2html emacs libvirt-devel
-RUN yum -y install xmlto-tex patch
-RUN yum -y install ant asciidoc xsltproc fop docbook-style-xsl.noarch
-RUN yum -y install vim-enhanced
-RUN yum -y install openssh-server
-RUN yum install -y globus-gsi-cert-utils-progs gsi-openssh-clients osg-ca-certs ligo-proxy-utils
+RUN yum -q -y install git2u-all lscsoft-all
+RUN yum -q -y install zlib-devel libpng-devel libjpeg-devel libsqlite3-dev sqlite-devel db4-devel
+RUN yum -q -y install tkinter libpng-devel lynx telnet
+RUN yum -q -y install compat-glibc compat-glibc-headers
+RUN yum -q -y install gd-devel audit-libs-devel libcap-devel nss-devel
+RUN yum -q -y install xmlto asciidoc hmaccalc newt-devel 'perl(ExtUtils::Embed)' pesign elfutils-devel binutils-devel numactl-devel pciutils-devel
+RUN yum -q -y install dejagnu sharutils gcc-gnat libgnat dblatex gmp-devel mpfr-devel libmpc-devel
+RUN yum -q -y install libuuid-devel netpbm-progs nasm
+RUN yum -q -y install libstdc++-static
+RUN yum -q -y install gettext-devel avahi-devel dyninst-devel crash-devel latex2html emacs libvirt-devel
+RUN yum -q -y install xmlto-tex patch
+RUN yum -q -y install ant asciidoc xsltproc fop docbook-style-xsl.noarch
+RUN yum -q -y install vim-enhanced
+RUN yum -q -y install openssh-server
+RUN yum -q -y install globus-gsi-cert-utils-progs gsi-openssh-clients osg-ca-certs ligo-proxy-utils
 RUN yum -y install wget
 RUN wget http://htcondor.org/yum/RPM-GPG-KEY-HTCondor
 RUN rpm --import RPM-GPG-KEY-HTCondor
 RUN wget http://htcondor.org/yum/repo.d/htcondor-stable-rhel7.repo
 RUN mv htcondor-stable-rhel7.repo /etc/yum.repos.d/htcondor-stable-rhel7.repo
-RUN yum -y install condor condor-classads condor-python condor-procd condor-external-libs
-RUN yum -y install ecp-cookie-init
-RUN yum -y install man-db
+RUN yum -q -y install condor condor-classads condor-python condor-procd condor-external-libs
+RUN yum -q -y install ecp-cookie-init
+RUN yum -q -y install man-db
 
 # set up cvmfs
-RUN yum -y install osg-oasis
+RUN yum -q -y install osg-oasis
 RUN echo "/cvmfs /etc/auto.cvmfs" > /etc/auto.master
 ADD tools/cvmfs.default.local /etc/cvmfs/default.local
 
 # uninstall lalsuite
-RUN yum -y remove "*lal*"
+RUN yum -q -y remove "*lal*"
 
 # enable ssh
 EXPOSE 22

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ RUN yum -y install gettext-devel avahi-devel dyninst-devel crash-devel latex2htm
 RUN yum -y install xmlto-tex patch
 RUN yum -y install ant asciidoc xsltproc fop docbook-style-xsl.noarch
 RUN yum -y install vim-enhanced
-RUN rpm -Uvh https://repo.grid.iu.edu/osg/3.3/osg-3.3-el7-release-latest.rpm
-RUN yum clean all
 RUN yum -y install openssh-server
 RUN yum install -y globus-gsi-cert-utils-progs gsi-openssh-clients osg-ca-certs ligo-proxy-utils
 RUN yum -y install wget

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN echo "/cvmfs /etc/auto.cvmfs" > /etc/auto.master
 ADD tools/cvmfs.default.local /etc/cvmfs/default.local
 
 # uninstall lalsuite
-RUN yum -y uninstall *lal*
+RUN yum -y remove "*lal*"
 
 # enable ssh
 EXPOSE 22

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,103 @@
-FROM pycbc/pycbc-base-el7:v1.5-539c8700
+FROM ligo/lalsuite-dev:el7
 
+USER root
+
+RUN curl http://download.pegasus.isi.edu/wms/download/rhel/7/pegasus.repo > /etc/yum.repos.d/pegasus.repo
+RUN rpm -ivh http://software.ligo.org/lscsoft/scientific/7.2/x86_64/production/lscsoft-production-config-1.3-1.el7.noarch.rpm
+RUN yum clean all
+RUN yum makecache
+RUN yum update
+RUN yum -y install lscsoft-backports-config
+RUN yum -y install lscsoft-epel-config
+RUN yum -y install lscsoft-ius-config
+RUN yum clean all
+RUN yum makecache
+RUN yum -y install git2u-all lscsoft-all
+RUN yum install -y zlib-devel libpng-devel libjpeg-devel libsqlite3-dev sqlite-devel db4-devel
+RUN yum -y install tkinter libpng-devel lynx telnet
+RUN yum -y install compat-glibc compat-glibc-headers
+RUN yum -y install gd-devel audit-libs-devel libcap-devel nss-devel
+RUN yum -y install xmlto asciidoc hmaccalc newt-devel 'perl(ExtUtils::Embed)' pesign elfutils-devel binutils-devel numactl-devel pciutils-devel
+RUN yum -y install dejagnu sharutils gcc-gnat libgnat dblatex gmp-devel mpfr-devel libmpc-devel
+RUN yum -y install libuuid-devel netpbm-progs nasm
+RUN yum -y install libstdc++-static
+RUN yum -y install gettext-devel avahi-devel dyninst-devel crash-devel latex2html emacs libvirt-devel
+RUN yum -y install xmlto-tex patch
+RUN yum -y install ant asciidoc xsltproc fop docbook-style-xsl.noarch
+RUN yum -y install vim-enhanced
+RUN rpm -Uvh https://repo.grid.iu.edu/osg/3.3/osg-3.3-el7-release-latest.rpm
+RUN yum clean all
+RUN yum -y install openssh-server
+RUN yum install -y globus-gsi-cert-utils-progs gsi-openssh-clients osg-ca-certs ligo-proxy-utils
+RUN yum -y install wget
+RUN wget http://htcondor.org/yum/RPM-GPG-KEY-HTCondor
+RUN rpm --import RPM-GPG-KEY-HTCondor
+RUN wget http://htcondor.org/yum/repo.d/htcondor-stable-rhel7.repo
+RUN mv htcondor-stable-rhel7.repo /etc/yum.repos.d/htcondor-stable-rhel7.repo
+RUN yum -y install condor condor-classads condor-python condor-procd condor-external-libs
+RUN yum -y install ecp-cookie-init
+RUN yum -y install man-db
+
+# enable ssh
+EXPOSE 22
+ADD tools/pycbc-sshd /usr/bin/pycbc-sshd
+RUN chmod +x /usr/bin/pycbc-sshd
+RUN mkdir -p /var/run/sshd
+
+# create a regular user account and switch to it
+RUN useradd -ms /bin/bash pycbc
 USER pycbc
 WORKDIR /home/pycbc
+RUN cp -R /etc/skel/.??* ~
+
+RUN pip install virtualenv
+RUN virtualenv pycbc-software ; \
+      source ~/pycbc-software/bin/activate ; \
+      pip install --upgrade pip ; \
+      pip install six packaging appdirs ; \
+      pip install --upgrade setuptools ; \
+      pip install "numpy>=1.6.4" "h5py>=2.5" unittest2 python-cjson Cython decorator ; \
+      pip install "scipy>=0.13.0" ; \
+      SWIG_FEATURES="-cpperraswarn -includeall -I/usr/include/openssl" pip install M2Crypto ; \
+      deactivate
+
+RUN source ~/pycbc-software/bin/activate ; \
+      mkdir -p ~/src ; \
+      cd ~/src ; \
+      git clone https://github.com/lscsoft/lalsuite.git ; \
+      cd ~/src/lalsuite ; \
+      git checkout 539c8700af92eb6dd00e0e91b9dbaf5bae51f004 ; \
+      ./00boot ; \
+      ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-swig-python \
+        --disable-lalstochastic --disable-lalxml --disable-lalinference \
+        --disable-laldetchar --disable-lalapps 2>&1 | grep -v checking ; \
+      make install ; \
+      echo 'source ${VIRTUAL_ENV}/opt/lalsuite/etc/lalsuite-user-env.sh' >> ${VIRTUAL_ENV}/bin/activate ; \
+      deactivate
+
+RUN source ~/pycbc-software/bin/activate ; \
+      cd ~/src/lalsuite/lalapps ; \
+      LIBS="-lhdf5_hl -lhdf5 -ldl -lz" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite \
+         --enable-static-binaries --disable-lalinference \
+         --disable-lalburst --disable-lalpulsar \
+         --disable-lalstochastic ; \
+      cd ~/src/lalsuite/lalapps/src/lalapps ; \
+      make ; \
+      cd ~/src/lalsuite/lalapps/src/inspiral ;\
+      make lalapps_inspinj ; \
+      cp lalapps_inspinj $VIRTUAL_ENV/bin ; \
+      cd ~/src/lalsuite/lalapps/src/ring ; \
+      make lalapps_coh_PTF_inspiral ; \
+      cp lalapps_coh_PTF_inspiral $VIRTUAL_ENV/bin ;\
+      deactivate
+
+RUN source ~/pycbc-software/bin/activate ; \
+        pip install http://download.pegasus.isi.edu/pegasus/4.7.4/pegasus-python-source-4.7.4.tar.gz ; \
+        pip install dqsegdb ; \
+        pip install 'matplotlib==1.5.3' ; \
+        pip install "Sphinx>=1.4.2" numpydoc sphinx-rtd-theme ; \
+        pip install "git+https://github.com/ligo-cbc/sphinxcontrib-programoutput.git#egg=sphinxcontrib-programoutput" ; \
+        pip install ipython jupyter ; \
+        deactivate
+
+RUN echo 'source ${HOME}/pycbc-software/bin/activate' >> ~/.bash_profile

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ corner>=2.0.1
 
 # For LDG service access
 dqsegdb
-http://download.pegasus.isi.edu/pegasus/4.7.5/pegasus-python-source-4.7.5.tar.gz
+http://download.pegasus.isi.edu/pegasus/4.7.4/pegasus-python-source-4.7.4.tar.gz
 
 # For building documentation
 Sphinx>=1.5.0

--- a/tools/cvmfs.default.local
+++ b/tools/cvmfs.default.local
@@ -1,0 +1,3 @@
+CVMFS_REPOSITORIES="`echo $((echo oasis.opensciencegrid.org;echo cms.cern.ch;ls /cvmfs)|sort -u)|tr ' ' ,`"
+CVMFS_QUOTA_LIMIT=20000
+CVMFS_HTTP_PROXY=DIRECT

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -71,7 +71,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   echo -e "\\n>> [`date`] Running pycbc_build_eah.sh"
   pushd ${BUILD}
   cat /etc/issue
-  ls -al /usr/bin/gcc*
+  rpm -qa | grep gcc || /bin/true
   /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/raw/710a51f4770cbba77f61dfb798472bebe6c43d38/travis --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
 
   if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -111,6 +111,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
     yum -y install pegasus
     yum -y install ligo-proxy-utils
     yum -y install ecp-cookie-init
+    yum -y install hdf5-static libxml2-static zlib-static libstdc++-static cfitsio-static glibc-static fftw-static gsl-static
   elif [ "x${PYCBC_CONTAINER}" == "xpycbc_debian_virtualenv" ] ; then
     echo -e "\\n>> [`date`] Building pycbc virtual environment for Debian"
     ENV_OS="x86_64_deb_8"

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -46,9 +46,13 @@ if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then
 fi
 
 if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
-  echo -e "\\n>> [`date`] Building pycbc_inspiral bundle" 
+  echo -e "\\n>> [`date`] Building pycbc_inspiral bundle for pypa/manylinux" 
 
   echo -e "\\n>> [`date`] Installing rpm dependencies" 
+  yum -y install openssl-devel db4-devel
+  ln -s /opt/rh/devtoolset-2/root/usr/bin/gcc /opt/rh/devtoolset-2/root/usr/bin/gcc-4.8.2
+  ln -s /opt/rh/devtoolset-2/root/usr/bin/g++ /opt/rh/devtoolset-2/root/usr/bin/g++-4.8.2
+  ln -s /opt/rh/devtoolset-2/root/usr/bin/gfortran /opt/rh/devtoolset-2/root/usr/bin/gfortran-4.8.2
 
   # create working dir for build script
   BUILD=/pycbc/build

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -98,7 +98,6 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
     ENV_OS="x86_64_rhel_7"
     yum -y install python2-pip
     yum -y install curl
-    rpm -ivh http://software.ligo.org/lscsoft/scientific/7.2/x86_64/production/lscsoft-production-config-1.3-1.el7.noarch.rpm
     curl http://download.pegasus.isi.edu/wms/download/rhel/7/pegasus.repo > /etc/yum.repos.d/pegasus.repo
     yum clean all
     yum makecache

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -49,7 +49,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   echo -e "\\n>> [`date`] Building pycbc_inspiral bundle for pypa/manylinux" 
 
   echo -e "\\n>> [`date`] Installing rpm dependencies" 
-  yum -y install openssl-devel db4-devel
+  yum -y install openssl-devel db4-devel pcre-devel
   ln -s /opt/rh/devtoolset-2/root/usr/bin/gcc /opt/rh/devtoolset-2/root/usr/bin/gcc-4.8.2
   ln -s /opt/rh/devtoolset-2/root/usr/bin/g++ /opt/rh/devtoolset-2/root/usr/bin/g++-4.8.2
   ln -s /opt/rh/devtoolset-2/root/usr/bin/gfortran /opt/rh/devtoolset-2/root/usr/bin/gfortran-4.8.2

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -105,6 +105,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
     yum clean all
     yum makecache
     yum -y update
+    yum -y install openssl-devel
     yum -y install pegasus
     yum -y install ligo-proxy-utils
     yum -y install ecp-cookie-init

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -71,7 +71,6 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   echo -e "\\n>> [`date`] Running pycbc_build_eah.sh"
   pushd ${BUILD}
   cat /etc/issue
-  ls -al /usr/gcc*
   ls -al /usr/bin/gcc*
   /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/raw/710a51f4770cbba77f61dfb798472bebe6c43d38/travis --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
 

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -47,9 +47,16 @@ fi
 
 if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   echo -e "\\n>> [`date`] Building pycbc_inspiral bundle for pypa/manylinux" 
+  wget_opts="-c --passive-ftp --no-check-certificate --tries=5 --timeout=30 --no-verbose"
   
   yum -y install openssl-devel
-  yum -y install compat-db
+  wget $wget_opts  http://download.oracle.com/berkeley-db/db-4.8.30.tar.gz
+  tar zxvf db-4.8.30.tar.gz
+  cd db-4.8.30/build_unix
+  ../dist/configure --prefix=/
+  make
+  make install
+  cd ../..
 
   # create working dir for build script
   BUILD=/pycbc/build
@@ -58,7 +65,6 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   export XDG_CACHE_HOME=${BUILD}/.cache
 
   # get library to build optimized pycbc_inspiral bundle
-  wget_opts="-c --passive-ftp --no-check-certificate --tries=5 --timeout=30 --no-verbose"
   primary_url="https://git.ligo.org/ligo-cbc/pycbc-software/raw/"
   secondary_url="https://www.atlas.aei.uni-hannover.de/~dbrown"
   pushd /pycbc

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -101,7 +101,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
     curl http://download.pegasus.isi.edu/wms/download/rhel/7/pegasus.repo > /etc/yum.repos.d/pegasus.repo
     yum clean all
     yum makecache
-    yum update
+    yum -y update
     yum -y install pegasus
     yum -y install ligo-proxy-utils
     yum -y install ecp-cookie-init

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -104,7 +104,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
   if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] ; then
     echo -e "\\n>> [`date`] Building pycbc virtual environment for CentOS 7"
     ENV_OS="x86_64_rhel_7"
-    yum -y install python2-pip
+    yum -y install python2-pip python-setuptools which
     yum -y install curl
     curl http://download.pegasus.isi.edu/wms/download/rhel/7/pegasus.repo > /etc/yum.repos.d/pegasus.repo
     yum clean all

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -49,6 +49,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   echo -e "\\n>> [`date`] Building pycbc_inspiral bundle for pypa/manylinux" 
   
   yum -y install openssl-devel
+  yum -y install libdb
 
   # create working dir for build script
   BUILD=/pycbc/build

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -173,9 +173,9 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
   source ${VENV_PATH}/bin/activate
   cd $VIRTUAL_ENV/src/lalsuite/lalapps
   if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] ; then
-    LIBS="-lhdf5_hl -lhdf5 -ldl -lz" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-static-binaries --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
+    LIBS="-lhdf5_hl -lhdf5 -ldl -lz" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-static-binaries --disable-lalxml --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
   elif [ "x${PYCBC_CONTAINER}" == "xpycbc_debian_virtualenv" ] ; then
-    LIBS="-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl -lhdf5 -ldl -lz" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-static-binaries --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
+    LIBS="-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl -lhdf5 -ldl -lz" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --disable-lalxml --enable-static-binaries --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
   fi
   cd $VIRTUAL_ENV/src/lalsuite/lalapps/src/lalapps
   make -j 2 2>&1 | grep Entering

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -96,6 +96,16 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
   if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] ; then
     echo -e "\\n>> [`date`] Building pycbc virtual environment for CentOS 7"
     ENV_OS="x86_64_rhel_7"
+    yum -y install python2-pip
+    yum -y install curl
+    rpm -ivh http://software.ligo.org/lscsoft/scientific/7.2/x86_64/production/lscsoft-production-config-1.3-1.el7.noarch.rpm
+    curl http://download.pegasus.isi.edu/wms/download/rhel/7/pegasus.repo > /etc/yum.repos.d/pegasus.repo
+    yum clean all
+    yum makecache
+    yum update
+    yum -y install pegasus
+    yum -y install ligo-proxy-utils
+    yum -y install ecp-cookie-init
   elif [ "x${PYCBC_CONTAINER}" == "xpycbc_debian_virtualenv" ] ; then
     echo -e "\\n>> [`date`] Building pycbc virtual environment for Debian"
     ENV_OS="x86_64_deb_8"

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -50,6 +50,9 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
 
   echo -e "\\n>> [`date`] Installing rpm dependencies" 
   yum -y install openssl-devel db4-devel
+  ln -s /opt/rh/devtoolset-2/root/usr/bin/gcc /opt/rh/devtoolset-2/root/usr/bin/gcc-4.8.2
+  ln -s /opt/rh/devtoolset-2/root/usr/bin/g++ /opt/rh/devtoolset-2/root/usr/bin/g++-4.8.2
+  ln -s /opt/rh/devtoolset-2/root/usr/bin/gfortran /opt/rh/devtoolset-2/root/usr/bin/gfortran-4.8.2
 
   # create working dir for build script
   BUILD=/pycbc/build

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -46,13 +46,9 @@ if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then
 fi
 
 if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
-  echo -e "\\n>> [`date`] Building pycbc_inspiral bundle for pypa/manylinux" 
+  echo -e "\\n>> [`date`] Building pycbc_inspiral bundle" 
 
   echo -e "\\n>> [`date`] Installing rpm dependencies" 
-  yum -y install openssl-devel db4-devel
-  ln -s /opt/rh/devtoolset-2/root/usr/bin/gcc /opt/rh/devtoolset-2/root/usr/bin/gcc-4.8.2
-  ln -s /opt/rh/devtoolset-2/root/usr/bin/g++ /opt/rh/devtoolset-2/root/usr/bin/g++-4.8.2
-  ln -s /opt/rh/devtoolset-2/root/usr/bin/gfortran /opt/rh/devtoolset-2/root/usr/bin/gfortran-4.8.2
 
   # create working dir for build script
   BUILD=/pycbc/build

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -47,16 +47,9 @@ fi
 
 if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   echo -e "\\n>> [`date`] Building pycbc_inspiral bundle for pypa/manylinux" 
-  wget_opts="-c --passive-ftp --no-check-certificate --tries=5 --timeout=30 --no-verbose"
-  
-  yum -y install openssl-devel
-  wget $wget_opts  http://download.oracle.com/berkeley-db/db-4.8.30.tar.gz
-  tar zxvf db-4.8.30.tar.gz
-  cd db-4.8.30/build_unix
-  ../dist/configure --prefix=/
-  make
-  make install
-  cd ../..
+
+  echo -e "\\n>> [`date`] Installing rpm dependencies" 
+  yum -y install openssl-devel db4-devel
 
   # create working dir for build script
   BUILD=/pycbc/build
@@ -65,6 +58,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   export XDG_CACHE_HOME=${BUILD}/.cache
 
   # get library to build optimized pycbc_inspiral bundle
+  wget_opts="-c --passive-ftp --no-check-certificate --tries=5 --timeout=30 --no-verbose"
   primary_url="https://git.ligo.org/ligo-cbc/pycbc-software/raw/"
   secondary_url="https://www.atlas.aei.uni-hannover.de/~dbrown"
   pushd /pycbc

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -47,6 +47,8 @@ fi
 
 if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   echo -e "\\n>> [`date`] Building pycbc_inspiral bundle for pypa/manylinux" 
+  
+  yum -y install openssl-devel
 
   # create working dir for build script
   BUILD=/pycbc/build

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -49,7 +49,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   echo -e "\\n>> [`date`] Building pycbc_inspiral bundle for pypa/manylinux" 
   
   yum -y install openssl-devel
-  yum -y install libdb
+  yum -y install compat-db
 
   # create working dir for build script
   BUILD=/pycbc/build

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -49,7 +49,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   echo -e "\\n>> [`date`] Building pycbc_inspiral bundle for pypa/manylinux" 
 
   echo -e "\\n>> [`date`] Installing rpm dependencies" 
-  yum -y install openssl-devel db4-devel pcre-devel
+  yum -y install openssl-devel db4-devel pcre-devel zip
   ln -s /opt/rh/devtoolset-2/root/usr/bin/gcc /opt/rh/devtoolset-2/root/usr/bin/gcc-4.8.2
   ln -s /opt/rh/devtoolset-2/root/usr/bin/g++ /opt/rh/devtoolset-2/root/usr/bin/g++-4.8.2
   ln -s /opt/rh/devtoolset-2/root/usr/bin/gfortran /opt/rh/devtoolset-2/root/usr/bin/gfortran-4.8.2

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -196,18 +196,12 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
   make lalapps_coh_PTF_inspiral
   cp lalapps_coh_PTF_inspiral $VIRTUAL_ENV/bin
 
-  echo -e "\\n>> [`date`] Installing Pegasus"
-  pip install http://download.pegasus.isi.edu/pegasus/4.7.5/pegasus-python-source-4.7.5.tar.gz
-
-  echo -e "\\n>> [`date`] Installing DQSegDB"
-  pip install dqsegdb
-
-  echo -e "\\n>> [`date`] Install matplotlib 1.5.3"
-  pip install 'matplotlib==1.5.3'
-
   echo -e "\\n>> [`date`] Installing PyCBC dependencies from requirements.txt"
   cd /pycbc
   pip install -r requirements.txt
+
+  echo -e "\\n>> [`date`] Install matplotlib 1.5.3"
+  pip install 'matplotlib==1.5.3'
 
   echo -e "\\n>> [`date`] Installing PyCBC from source"
   python setup.py install

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -46,7 +46,7 @@ if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then
 fi
 
 if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
-  echo -e "\\n>> [`date`] Building pycbc_inspiral bundle for CentOS 6"
+  echo -e "\\n>> [`date`] Building pycbc_inspiral bundle for pypa/manylinux" 
 
   # create working dir for build script
   BUILD=/pycbc/build
@@ -70,6 +70,9 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   # run the einstein at home build and test script
   echo -e "\\n>> [`date`] Running pycbc_build_eah.sh"
   pushd ${BUILD}
+  cat /etc/issue
+  ls -al /usr/gcc*
+  ls -al /usr/bin/gcc*
   /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/raw/710a51f4770cbba77f61dfb798472bebe6c43d38/travis --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
 
   if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -196,8 +196,10 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
   make lalapps_coh_PTF_inspiral
   cp lalapps_coh_PTF_inspiral $VIRTUAL_ENV/bin
 
-  echo -e "\\n>> [`date`] Installing Pegasus and DQSegDB"
+  echo -e "\\n>> [`date`] Installing Pegasus"
   pip install http://download.pegasus.isi.edu/pegasus/4.7.5/pegasus-python-source-4.7.5.tar.gz
+
+  echo -e "\\n>> [`date`] Installing DQSegDB"
   pip install dqsegdb
 
   echo -e "\\n>> [`date`] Install matplotlib 1.5.3"

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -598,7 +598,7 @@ else # if $BUILDDIRNAME-preinst.tgz
 	rm -rf $p
 	tar -xzf $p.tar.gz
 	cd $p
-	./configure $shared $static --prefix="$PREFIX"
+	./configure LIBS="-lm" $shared $static --prefix="$PREFIX"
 	make
 	make install
 	cd ..

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -139,7 +139,7 @@ elif grep -q "CentOS release 5" /etc/redhat-release 2>/dev/null; then # SL6
     test ".$LC_ALL" = "." && export LC_ALL="$LANG"
     link_gcc_version=4.2
     gcc_path="/usr/bin"
-    build_ssl=false
+    build_ssl=true
     build_python=true
     build_wrapper=false
     build_fstab=false

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -134,8 +134,8 @@ elif grep -q "Scientific Linux release 6" /etc/redhat-release 2>/dev/null; then 
     pyinstaller_lsb="--no-lsb"
     build_onefile_bundles=true
     appendix="_Linux64"
-elif grep -q "Scientific Linux CERN SLC release 6" /etc/redhat-release 2>/dev/null; then # SL6
-    echo -e "\\n\\n>> [`date`] Using Scientific Linux CERN SLC release 6 (Carbon) settings"
+elif grep -q "CentOS release 5" /etc/redhat-release 2>/dev/null; then # SL6
+    echo -e "\\n\\n>> [`date`] Using CentOS release 5 settings"
     test ".$LC_ALL" = "." && export LC_ALL="$LANG"
     link_gcc_version=4.4.7
     gcc_path="/usr/bin"

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -141,6 +141,7 @@ elif grep -q "CentOS release 5" /etc/redhat-release 2>/dev/null; then # SL6
     gcc_path="/opt/rh/devtoolset-2/root/usr/bin"
     build_ssl=true
     build_python=true
+    build_subprocess32=true
     build_wrapper=false
     build_fstab=false
     pyinstaller_lsb="--no-lsb"

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -139,6 +139,7 @@ elif grep -q "CentOS release 5" /etc/redhat-release 2>/dev/null; then # SL6
     test ".$LC_ALL" = "." && export LC_ALL="$LANG"
     link_gcc_version=4.2
     gcc_path="/usr/bin"
+    build_ssl=false
     build_python=true
     build_wrapper=false
     build_fstab=false

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -137,17 +137,9 @@ elif grep -q "Scientific Linux release 6" /etc/redhat-release 2>/dev/null; then 
 elif grep -q "CentOS release 5" /etc/redhat-release 2>/dev/null; then # SL6
     echo -e "\\n\\n>> [`date`] Using CentOS release 5 settings"
     test ".$LC_ALL" = "." && export LC_ALL="$LANG"
-    link_gcc_version=4.4.7
+    link_gcc_version=4.2
     gcc_path="/usr/bin"
     build_python=true
-    build_hdf5=true
-    build_pegasus=false
-    build_fftw=false
-    build_gsl=false
-    build_ssl=false
-    build_lapack=false
-    build_freetype=false
-    build_zlib=false
     build_wrapper=false
     build_fstab=false
     pyinstaller_lsb="--no-lsb"

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -126,8 +126,8 @@ elif test ".$1" = ".--force-debian4" ||
 elif grep -q "Scientific Linux release 6" /etc/redhat-release 2>/dev/null; then # SL6
     echo -e "\\n\\n>> [`date`] Using Scientific Linux release 6 (Carbon) settings"
     test ".$LC_ALL" = "." && export LC_ALL="$LANG"
-    link_gcc_version=4.4.7
-    gcc_path="/usr/bin"
+    link_gcc_version=4.8.2
+    gcc_path="/opt/rh/devtoolset-2/root/usr/bin"
     build_ssl=true
     build_python=true
     build_pegasus=false

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -126,8 +126,8 @@ elif test ".$1" = ".--force-debian4" ||
 elif grep -q "Scientific Linux release 6" /etc/redhat-release 2>/dev/null; then # SL6
     echo -e "\\n\\n>> [`date`] Using Scientific Linux release 6 (Carbon) settings"
     test ".$LC_ALL" = "." && export LC_ALL="$LANG"
-    link_gcc_version=4.8.2
-    gcc_path="/opt/rh/devtoolset-2/root/usr/bin"
+    gcc_path="/usr/bin"
+    link_gcc_version=4.4.7
     build_ssl=true
     build_python=true
     build_pegasus=false
@@ -137,8 +137,8 @@ elif grep -q "Scientific Linux release 6" /etc/redhat-release 2>/dev/null; then 
 elif grep -q "CentOS release 5" /etc/redhat-release 2>/dev/null; then # SL6
     echo -e "\\n\\n>> [`date`] Using CentOS release 5 settings"
     test ".$LC_ALL" = "." && export LC_ALL="$LANG"
-    link_gcc_version=4.2
-    gcc_path="/usr/bin"
+    link_gcc_version=4.8.2
+    gcc_path="/opt/rh/devtoolset-2/root/usr/bin"
     build_ssl=true
     build_python=true
     build_wrapper=false
@@ -379,7 +379,6 @@ if [ ".$link_gcc_version" != "." ]; then
                     ln -s "${gcc_path}/$i-$link_gcc_version" $i
                 else
                     echo ERROR: "${gcc_path}/$i-$link_gcc_version" not found
-                    ls -l ${gcc_path}/${i}-*
                     exit 1
                 fi
         done

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -52,7 +52,7 @@ pip install 'setuptools==18.2' --upgrade
 export BOTO_CONFIG=/dev/null
 
 # install pegasus
-pip install http://download.pegasus.isi.edu/pegasus/4.7.5/pegasus-python-source-4.7.5.tar.gz
+pip install http://download.pegasus.isi.edu/pegasus/4.7.4/pegasus-python-source-4.7.4.tar.gz
 
 # install M2Crypto
 SWIG_FEATURES="-cpperraswarn -includeall -I/usr/include/openssl" pip install M2Crypto

--- a/tools/pycbc-sshd
+++ b/tools/pycbc-sshd
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+for key in rsa dsa ecdsa ed25519
+do
+  key_file=/etc/ssh/ssh_host_${key}_key
+  if [ ! -f ${key_file} ] ; then
+    ssh-keygen -f ${key_file} -N '' -t ${key}
+  fi
+done
+
+/usr/sbin/sshd
+
+exit 0


### PR DESCRIPTION
This pull request:

 - Switches Travis to use the LIGO EL7 base container from https://hub.docker.com/r/ligo/lalsuite-dev for the LDG EL7 virtual environment build.
 - Switches Travis to use https://github.com/pypa/manylinux for the ``pycbc_inspiral`` bundle build.
 - Changes the base container for the https://hub.docker.com/r/pycbc/pycbc-el7/ Docker image to https://hub.docker.com/r/ligo/lalsuite-dev

This means that the Docker images:

 - https://github.com/ligo-cbc/docker-ldg-el7
 - https://github.com/ligo-cbc/docker-pycbc-base-el7
 - https://github.com/ligo-cbc/docker-sl6-travis

can be deprecated and those repos deleted.