### PR TITLE
Fix FromFile's from_config function

### DIFF
--- a/pycbc/distributions/arbitrary.py
+++ b/pycbc/distributions/arbitrary.py
@@ -312,6 +312,7 @@ class FromFile(Arbitrary):
         BoundedDist
             A distribution instance from the pycbc.inference.prior module.
         """
-        return super(FromFile, cls).from_config(cp, section, variable_args)
+        return bounded.bounded_from_config(cls, cp, section, variable_args,
+                                           bounds_required=False)
 
 __all__ = ['Arbitrary', 'FromFile']


### PR DESCRIPTION
As pointed out in issue #1882, `FromFile`'s `from_config` function is currently broken. This was due to changes in PR #1704; when `FromFile`'s parent class was changed from `BoundedDist` to `Arbitrary`, the `from_config` no longer worked. This patch fixes this by just calling the `bounded.bounded_from_config` function directly.