### PR TITLE
Allow for different sized kde

### DIFF
--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -227,7 +227,7 @@ class KombineSampler(BaseMCMCSampler):
         except KeyError:
             # dataset doesn't exist yet
             fp.create_dataset(dataset_name, shape,
-                              maxshape=(self.nwalkers,
+                              maxshape=(self._sampler._kde_size,
                                         len(self.variable_args)),
                               dtype=float)
             fp[dataset_name][:] = kde.data


### PR DESCRIPTION
When saving kombine's kde dataset when checkpointing the number of walkers are used to set the maximum size. However, kombine may use more points in its kde than the number of walkers. This means our checkpointing will break if, e.g., Ben pushes [this branch](https://github.com/bfarr/kombine/commit/0d8d72dce5475d17f2a75239625c7b653c402d2b) to kombine's master. This patch future proofs this by using the sampler's kde size.