### PR TITLE
Update lalsuite hash to 95ad957

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
 - if [ "x${PYCBC_CONTAINER}" == "xbuild_and_test" ] ; then
     ./tools/travis_build_and_test.sh ;
   elif [ "x${PYCBC_CONTAINER}" == "xpycbc_docker" ] ; then
-    dh -h ;
+    df -h ;
     sudo chown -R 1000:1000 . ;
     sudo chown -R 1000:1000 ~/.ssh ;
     docker run --name pycbc_inst --cidfile /tmp/docker.cid -d -e USERID=$UID -v ~/.ssh:/home/pycbc/.ssh -v `pwd`:/pycbc:rw ${DOCKER_IMG}-tmp /bin/bash -lc 'tail -f /dev/null' || exit 1 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ script:
     travis_retry docker exec -it pycbc_inst /bin/bash -lc "mkdir -p ~/src && cd ~/src && git clone https://github.com/ligo-cbc/pycbc.git || exit 1" || exit 1 ;
     if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then
       LAL_EXTRA_TAG="e02dab8c" ; 
-      travis_retry docker exec -it pycbc_inst /bin/bash -lc "mkdir -p ~/pycbc-software/share/lal-data && rsync --exclude='SEOBNRv1ROM*' --exclude='SEOBNRv2ROM_DS_HI_v1.0.hdf5' -ravz pycbc@sugwg-condor.phy.syr.edu:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/${LAL_EXTRA_TAG}/share/lalsimulation/ /home/pycbc/pycbc-software/share/lal-data/ && exit $?" &&
+      travis_retry docker exec -it pycbc_inst /bin/bash -lc "mkdir -p ~/pycbc-software/share/lal-data && rsync --exclude='SEOBNRv1ROM*' --exclude='SEOBNRv2ROM_DS_HI_v1.0.hdf5' --exclude='NRSur4d2s_FDROM.hdf5' -ravz pycbc@sugwg-condor.phy.syr.edu:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/${LAL_EXTRA_TAG}/share/lalsimulation/ /home/pycbc/pycbc-software/share/lal-data/ && exit $?" &&
       docker exec -it pycbc_inst /bin/bash -lc 'echo "export LAL_DATA_PATH=/home/pycbc/pycbc-software/share/lal-data/" >> /home/pycbc/.bash_profile' || exit 1 ;
     fi ;
     sleep 10 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
     - libfreetype6-dev
     - libdb-dev
     - libopenblas-dev
+    - sudo
 env:
   global:
   - secure: xlIlPHEm1gN6HCR9tnAWE/Nc9tuX9slCSTbEEcIW+XM1KgZLrH6I+nfvWyUGIgQJ+VVZYyYNNSQaGa7rS06eq6hXtdfhC6Qr9kyDkgCkcLhowXEf/8vdrJlTsLA7FuPdJh+mWIIW3vemMVQaz4fG7pf29zcepbUKM3f1bcJTa36sDU4fltPBb8vMwYkgso9R7M/b/G7fCPKr/oQedYNgCXX0AUijUPV60xaZ9VLrLpwYFGTvcXhTySM7Ut+4WxsqPDuqNkQvqZh6ytUu+vUXhuB913HnDqNx2UxrLiIg0Bv34NYNQ+6J9UUTK9XqhTIcSZR91LUYZZnLu9YhPk3QaeShgQSPcF6fLtVX59DPyUEcegVi4DvsDCrGYwejj8Vy7M8sB0gm/quRnXXwykktVnvWBodCWF3XuwvDZhMfqjvjKBhokeTXAg66e2GDC4VqEyTscMgNZz9DZr6A2uHRmMFCs0xwFWfVHRsZOAccbWACcVyw4rqfElBqStLSl9AWqPcFOQDHh4+tVNrdgDL+M5kjc9AGC0jZ8R7+cJevaUssVh381RHHry5Sm9vqvtMf3EpoUMkP/oMPwoKmT+49OJEWOavDHOtX4zDkFlYCSClSpPx9F1hV/kOHEe2zo1eLzmk0v+NbLAyX5AVVuDfXn/t134JiRFsgxMFZXvU9zno=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-language: python
 sudo: false
 addons:
   apt:
@@ -42,22 +41,27 @@ env:
 matrix:
   include:
   - env: PYCBC_CONTAINER=pycbc_rhel_virtualenv DOCKER_IMG=ligo/lalsuite-dev:el7
+    language: minimal
     sudo: required
     services:
     - docker
   - env: PYCBC_CONTAINER=pycbc_debian_virtualenv DOCKER_IMG=ligo/lalsuite-dev:jessie
+    language: minimal
     sudo: required
     services:
     - docker
   - env: PYCBC_CONTAINER=pycbc_inspiral_bundle DOCKER_IMG=pycbc/sl6-travis
+    language: minimal
     sudo: required
     services:
     - docker
   - env: PYCBC_CONTAINER=pycbc_docker DOCKER_IMG=pycbc/pycbc-el7
+    language: minimal
     sudo: required
     services:
     - docker
   - env: PYCBC_CONTAINER=build_and_test
+    language: python
 
 before_install:
 - if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINER}" == "xpycbc_debian_virtualenv" ] || [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ]; then docker pull $DOCKER_IMG; fi
@@ -86,10 +90,10 @@ script:
     df -h ;
     sudo chown -R 1000:1000 . ;
     sudo chown -R 1000:1000 ~/.ssh ;
-    docker run --name pycbc_inst --cidfile /tmp/docker.cid -d -e USERID=$UID -v ~/.ssh:/home/pycbc/.ssh -v `pwd`:/pycbc:rw ${DOCKER_IMG}-tmp /bin/bash -lc 'tail -f /dev/null' || exit 1 ;
+    docker run --name pycbc_inst --cidfile docker.cid -d -e USERID=$UID -v ~/.ssh:/home/pycbc/.ssh -v `pwd`:/pycbc:rw ${DOCKER_IMG}-tmp /bin/bash -lc 'tail -f /dev/null' || exit 1 ;
     sleep 10 ;
     docker ps -a || exit 1 ;
-    TMP_CONTAINER_ID=$(cat /tmp/docker.cid) ;
+    TMP_CONTAINER_ID=$(cat docker.cid) ;
     travis_retry docker exec -it pycbc_inst /bin/bash -lc "df -h || exit 1" || exit 1 ;
     travis_retry docker exec -it pycbc_inst /bin/bash -lc "id; ls -al /pycbc; cd /pycbc && pip install -r requirements.txt && python setup.py install || exit 1" || exit 1 ;
     travis_retry docker exec -it pycbc_inst /bin/bash -lc "mkdir -p ~/src && cd ~/src && git clone https://github.com/ligo-cbc/pycbc.git || exit 1" || exit 1 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,37 +83,37 @@ script:
 - if [ "x${PYCBC_CONTAINER}" == "xbuild_and_test" ] ; then
     ./tools/travis_build_and_test.sh ;
   elif [ "x${PYCBC_CONTAINER}" == "xpycbc_docker" ] ; then
-    sudo chown -R 1000:1000 . ;
-    sudo chown -R 1000:1000 ~/.ssh ;
-    docker run --name pycbc_inst --cidfile /tmp/docker.cid -d -e USERID=$UID -v ~/.ssh:/home/pycbc/.ssh -v `pwd`:/pycbc:rw ${DOCKER_IMG}-tmp /bin/bash -lc 'tail -f /dev/null' ;
-    sleep 10 ;
-    docker ps -a ;
-    TMP_CONTAINER_ID=$(cat /tmp/docker.cid) ;
-    travis_retry docker exec -it pycbc_inst /bin/bash -lc "id; ls -al /pycbc; cd /pycbc && pip install -r requirements.txt && python setup.py install || exit 1" ;
-    travis_retry docker exec -it pycbc_inst /bin/bash -lc "mkdir -p ~/src && cd ~/src && git clone https://github.com/ligo-cbc/pycbc.git || exit 1" ;
+    sudo chown -R 1000:1000 . && \
+    sudo chown -R 1000:1000 ~/.ssh && \
+    docker run --name pycbc_inst --cidfile /tmp/docker.cid -d -e USERID=$UID -v ~/.ssh:/home/pycbc/.ssh -v `pwd`:/pycbc:rw ${DOCKER_IMG}-tmp /bin/bash -lc 'tail -f /dev/null' && \
+    sleep 10 && \
+    docker ps -a && \
+    TMP_CONTAINER_ID=$(cat /tmp/docker.cid) && \
+    travis_retry docker exec -it pycbc_inst /bin/bash -lc "id; ls -al /pycbc; cd /pycbc && pip install -r requirements.txt && python setup.py install || exit 1" && \
+    travis_retry docker exec -it pycbc_inst /bin/bash -lc "mkdir -p ~/src && cd ~/src && git clone https://github.com/ligo-cbc/pycbc.git || exit 1" || exit 1 ;
     if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then
       LAL_EXTRA_TAG="e02dab8c" ; 
-      travis_retry docker exec -it pycbc_inst /bin/bash -lc "mkdir -p ~/pycbc-software/share/lal-data && rsync --exclude='SEOBNRv1ROM*' --exclude='SEOBNRv2ROM_DS_HI_v1.0.hdf5' -ravz pycbc@sugwg-condor.phy.syr.edu:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/${LAL_EXTRA_TAG}/share/lalsimulation/ /home/pycbc/pycbc-software/share/lal-data/ && exit $?" ;
-      docker exec -it pycbc_inst /bin/bash -lc 'echo "export LAL_DATA_PATH=/home/pycbc/pycbc-software/share/lal-data/" >> /home/pycbc/.bash_profile; exit $?' ;
+      travis_retry docker exec -it pycbc_inst /bin/bash -lc "mkdir -p ~/pycbc-software/share/lal-data && rsync --exclude='SEOBNRv1ROM*' --exclude='SEOBNRv2ROM_DS_HI_v1.0.hdf5' -ravz pycbc@sugwg-condor.phy.syr.edu:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/${LAL_EXTRA_TAG}/share/lalsimulation/ /home/pycbc/pycbc-software/share/lal-data/ && exit $?" &&
+      docker exec -it pycbc_inst /bin/bash -lc 'echo "export LAL_DATA_PATH=/home/pycbc/pycbc-software/share/lal-data/" >> /home/pycbc/.bash_profile' || exit 1 ;
     fi ;
     sleep 10 ;
-    docker stop pycbc_inst ;
-    docker ps -a ;
-    docker commit $TMP_CONTAINER_ID $DOCKER_IMG ;
-    sudo chown -R $UID . ;
-    sudo chown -R $UID ~/.ssh ;
+    docker stop pycbc_inst &&
+    docker ps -a &&
+    docker commit $TMP_CONTAINER_ID $DOCKER_IMG &&
+    sudo chown -R $UID . &&
+    sudo chown -R $UID ~/.ssh || exit 1 ;
   else
     ./tools/docker_build_and_test.sh ;
   fi
 after_success:
   - if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] && [ "x${PYCBC_CONTAINER}" == "xpycbc_docker" ] ; then
-      docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" ;
+      docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" || exit 1
       if [ "x${TRAVIS_TAG}"  == "x" ] ; then
-        docker tag ${DOCKER_IMG} ${DOCKER_IMG}:latest ;
-        docker push ${DOCKER_IMG}:latest ;
+        docker tag ${DOCKER_IMG} ${DOCKER_IMG}:latest && \
+        docker push ${DOCKER_IMG}:latest || exit 1
       else
-        docker tag ${DOCKER_IMG} ${DOCKER_IMG}:${TRAVIS_TAG} ;
-        docker push ${DOCKER_IMG}:${TRAVIS_TAG} ;
+        docker tag ${DOCKER_IMG} ${DOCKER_IMG}:${TRAVIS_TAG} && \
+        docker push ${DOCKER_IMG}:${TRAVIS_TAG} || exit 1
       fi ;
     fi
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ addons:
     - libfreetype6-dev
     - libdb-dev
     - libopenblas-dev
-    - sudo
 env:
   global:
   - secure: xlIlPHEm1gN6HCR9tnAWE/Nc9tuX9slCSTbEEcIW+XM1KgZLrH6I+nfvWyUGIgQJ+VVZYyYNNSQaGa7rS06eq6hXtdfhC6Qr9kyDkgCkcLhowXEf/8vdrJlTsLA7FuPdJh+mWIIW3vemMVQaz4fG7pf29zcepbUKM3f1bcJTa36sDU4fltPBb8vMwYkgso9R7M/b/G7fCPKr/oQedYNgCXX0AUijUPV60xaZ9VLrLpwYFGTvcXhTySM7Ut+4WxsqPDuqNkQvqZh6ytUu+vUXhuB913HnDqNx2UxrLiIg0Bv34NYNQ+6J9UUTK9XqhTIcSZR91LUYZZnLu9YhPk3QaeShgQSPcF6fLtVX59DPyUEcegVi4DvsDCrGYwejj8Vy7M8sB0gm/quRnXXwykktVnvWBodCWF3XuwvDZhMfqjvjKBhokeTXAg66e2GDC4VqEyTscMgNZz9DZr6A2uHRmMFCs0xwFWfVHRsZOAccbWACcVyw4rqfElBqStLSl9AWqPcFOQDHh4+tVNrdgDL+M5kjc9AGC0jZ8R7+cJevaUssVh381RHHry5Sm9vqvtMf3EpoUMkP/oMPwoKmT+49OJEWOavDHOtX4zDkFlYCSClSpPx9F1hV/kOHEe2zo1eLzmk0v+NbLAyX5AVVuDfXn/t134JiRFsgxMFZXvU9zno=
@@ -84,37 +83,37 @@ script:
 - if [ "x${PYCBC_CONTAINER}" == "xbuild_and_test" ] ; then
     ./tools/travis_build_and_test.sh ;
   elif [ "x${PYCBC_CONTAINER}" == "xpycbc_docker" ] ; then
-    sudo chown -R 1000:1000 . && \
-    sudo chown -R 1000:1000 ~/.ssh && \
-    docker run --name pycbc_inst --cidfile /tmp/docker.cid -d -e USERID=$UID -v ~/.ssh:/home/pycbc/.ssh -v `pwd`:/pycbc:rw ${DOCKER_IMG}-tmp /bin/bash -lc 'tail -f /dev/null' && \
-    sleep 10 && \
-    docker ps -a && \
-    TMP_CONTAINER_ID=$(cat /tmp/docker.cid) && \
-    travis_retry docker exec -it pycbc_inst /bin/bash -lc "id; ls -al /pycbc; cd /pycbc && pip install -r requirements.txt && python setup.py install || exit 1" && \
+    sudo chown -R 1000:1000 . ;
+    sudo chown -R 1000:1000 ~/.ssh ;
+    docker run --name pycbc_inst --cidfile /tmp/docker.cid -d -e USERID=$UID -v ~/.ssh:/home/pycbc/.ssh -v `pwd`:/pycbc:rw ${DOCKER_IMG}-tmp /bin/bash -lc 'tail -f /dev/null' || exit 1 ;
+    sleep 10 ;
+    docker ps -a || exit 1 ;
+    TMP_CONTAINER_ID=$(cat /tmp/docker.cid) ;
+    travis_retry docker exec -it pycbc_inst /bin/bash -lc "id; ls -al /pycbc; cd /pycbc && pip install -r requirements.txt && python setup.py install || exit 1" || exit 1 ;
     travis_retry docker exec -it pycbc_inst /bin/bash -lc "mkdir -p ~/src && cd ~/src && git clone https://github.com/ligo-cbc/pycbc.git || exit 1" || exit 1 ;
     if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then
       LAL_EXTRA_TAG="e02dab8c" ; 
-      travis_retry docker exec -it pycbc_inst /bin/bash -lc "mkdir -p ~/pycbc-software/share/lal-data && rsync --exclude='SEOBNRv1ROM*' --exclude='SEOBNRv2ROM_DS_HI_v1.0.hdf5' --exclude='NRSur4d2s_FDROM.hdf5' -ravz pycbc@sugwg-condor.phy.syr.edu:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/${LAL_EXTRA_TAG}/share/lalsimulation/ /home/pycbc/pycbc-software/share/lal-data/ && exit $?" &&
+      travis_retry docker exec -it pycbc_inst /bin/bash -lc "mkdir -p ~/pycbc-software/share/lal-data && rsync --exclude='SEOBNRv1ROM*' --exclude='SEOBNRv2ROM_DS_HI_v1.0.hdf5' --exclude='NRSur4d2s_FDROM.hdf5' -ravz pycbc@sugwg-condor.phy.syr.edu:/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/${LAL_EXTRA_TAG}/share/lalsimulation/ /home/pycbc/pycbc-software/share/lal-data/ && exit $?" || exit 1 ;
       docker exec -it pycbc_inst /bin/bash -lc 'echo "export LAL_DATA_PATH=/home/pycbc/pycbc-software/share/lal-data/" >> /home/pycbc/.bash_profile' || exit 1 ;
     fi ;
     sleep 10 ;
-    docker stop pycbc_inst &&
-    docker ps -a &&
-    docker commit $TMP_CONTAINER_ID $DOCKER_IMG &&
-    sudo chown -R $UID . &&
-    sudo chown -R $UID ~/.ssh || exit 1 ;
+    docker stop pycbc_inst || exit 1 ;
+    docker ps -a ;
+    docker commit $TMP_CONTAINER_ID $DOCKER_IMG || exit 1 ;
+    sudo chown -R $UID . ;
+    sudo chown -R $UID ~/.ssh ;
   else
     ./tools/docker_build_and_test.sh ;
   fi
 after_success:
   - if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] && [ "x${PYCBC_CONTAINER}" == "xpycbc_docker" ] ; then
-      docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" || exit 1
+      docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" || exit 1 ;
       if [ "x${TRAVIS_TAG}"  == "x" ] ; then
-        docker tag ${DOCKER_IMG} ${DOCKER_IMG}:latest && \
-        docker push ${DOCKER_IMG}:latest || exit 1
+        docker tag ${DOCKER_IMG} ${DOCKER_IMG}:latest || exit 1 ;
+        docker push ${DOCKER_IMG}:latest || exit 1 ;
       else
-        docker tag ${DOCKER_IMG} ${DOCKER_IMG}:${TRAVIS_TAG} && \
-        docker push ${DOCKER_IMG}:${TRAVIS_TAG} || exit 1
+        docker tag ${DOCKER_IMG} ${DOCKER_IMG}:${TRAVIS_TAG} || exit 1 ;
+        docker push ${DOCKER_IMG}:${TRAVIS_TAG} || exit 1 ;
       fi ;
     fi
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,12 +83,14 @@ script:
 - if [ "x${PYCBC_CONTAINER}" == "xbuild_and_test" ] ; then
     ./tools/travis_build_and_test.sh ;
   elif [ "x${PYCBC_CONTAINER}" == "xpycbc_docker" ] ; then
+    dh -h ;
     sudo chown -R 1000:1000 . ;
     sudo chown -R 1000:1000 ~/.ssh ;
     docker run --name pycbc_inst --cidfile /tmp/docker.cid -d -e USERID=$UID -v ~/.ssh:/home/pycbc/.ssh -v `pwd`:/pycbc:rw ${DOCKER_IMG}-tmp /bin/bash -lc 'tail -f /dev/null' || exit 1 ;
     sleep 10 ;
     docker ps -a || exit 1 ;
     TMP_CONTAINER_ID=$(cat /tmp/docker.cid) ;
+    travis_retry docker exec -it pycbc_inst /bin/bash -lc "df -h || exit 1" || exit 1 ;
     travis_retry docker exec -it pycbc_inst /bin/bash -lc "id; ls -al /pycbc; cd /pycbc && pip install -r requirements.txt && python setup.py install || exit 1" || exit 1 ;
     travis_retry docker exec -it pycbc_inst /bin/bash -lc "mkdir -p ~/src && cd ~/src && git clone https://github.com/ligo-cbc/pycbc.git || exit 1" || exit 1 ;
     if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,10 +90,10 @@ script:
     df -h ;
     sudo chown -R 1000:1000 . ;
     sudo chown -R 1000:1000 ~/.ssh ;
-    docker run --name pycbc_inst --cidfile docker.cid -d -e USERID=$UID -v ~/.ssh:/home/pycbc/.ssh -v `pwd`:/pycbc:rw ${DOCKER_IMG}-tmp /bin/bash -lc 'tail -f /dev/null' || exit 1 ;
+    docker run --name pycbc_inst --cidfile /tmp/docker.cid -d -e USERID=$UID -v ~/.ssh:/home/pycbc/.ssh -v `pwd`:/pycbc:rw ${DOCKER_IMG}-tmp /bin/bash -lc 'tail -f /dev/null' || exit 1 ;
     sleep 10 ;
     docker ps -a || exit 1 ;
-    TMP_CONTAINER_ID=$(cat docker.cid) ;
+    TMP_CONTAINER_ID=$(cat /tmp/docker.cid) ;
     travis_retry docker exec -it pycbc_inst /bin/bash -lc "df -h || exit 1" || exit 1 ;
     travis_retry docker exec -it pycbc_inst /bin/bash -lc "id; ls -al /pycbc; cd /pycbc && pip install -r requirements.txt && python setup.py install || exit 1" || exit 1 ;
     travis_retry docker exec -it pycbc_inst /bin/bash -lc "mkdir -p ~/src && cd ~/src && git clone https://github.com/ligo-cbc/pycbc.git || exit 1" || exit 1 ;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pycbc/pycbc-base-el7:v1.5-539c8700
+FROM pycbc/pycbc-base-el7:v1.6-95ad957
 
 USER pycbc
 WORKDIR /home/pycbc

--- a/docs/install_lalsuite.rst
+++ b/docs/install_lalsuite.rst
@@ -125,7 +125,7 @@ If you are running a pipeline that uses the old LALApps programs ``lalapps_inspi
 .. code-block:: bash
 
     cd $VIRTUAL_ENV/src/lalsuite/lalapps
-    LIBS="-lhdf5_hl -lhdf5 -ldl -lz" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-static-binaries --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic --disable-lalxml
+    LIBS="-lhdf5_hl -lhdf5 -lcrypto -lssl -ldl -lz -lstdc++" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-static-binaries --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic --disable-lalxml
     cd $VIRTUAL_ENV/src/lalsuite/lalapps/src/lalapps
     make
     cd $VIRTUAL_ENV/src/lalsuite/lalapps/src/inspiral

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -181,9 +181,6 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
   cd $VIRTUAL_ENV/src/lalsuite/lalapps/src/inspiral
   make lalapps_inspinj
   cp lalapps_inspinj $VIRTUAL_ENV/bin
-  cd $VIRTUAL_ENV/src/lalsuite/lalapps/src/ring
-  make lalapps_coh_PTF_inspiral
-  cp lalapps_coh_PTF_inspiral $VIRTUAL_ENV/bin
 
   echo -e "\\n>> [`date`] Install matplotlib 1.5.3"
   pip install 'matplotlib==1.5.3'
@@ -194,9 +191,6 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
 
   echo -e "\\n>> [`date`] Installing PyCBC from source"
   python setup.py install
-
-  echo -e "\\n>> [`date`] Installing PyCBC PyLAL 1.0.2"
-  pip install "pycbc-pylal==1.0.2"
 
   echo -e "\\n>> [`date`] Installing modules needed to build documentation"
   pip install "Sphinx>=1.5.0"

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -172,9 +172,9 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
   source ${VENV_PATH}/bin/activate
   cd $VIRTUAL_ENV/src/lalsuite/lalapps
   if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] ; then
-    LIBS="-lhdf5_hl -lhdf5 -ldl -lz" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-static-binaries --disable-lalxml --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
+    LIBS="-lhdf5_hl -lhdf5 -ldl -lz" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-static-binaries --disable-lalxml --disable-lalframe --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
   elif [ "x${PYCBC_CONTAINER}" == "xpycbc_debian_virtualenv" ] ; then
-    LIBS="-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl -lhdf5 -ldl -lz" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-static-binaries --disable-lalxml --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
+    LIBS="-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl -lhdf5 -ldl -lz" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-static-binaries --disable-lalxml --disable-lalframe --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
   fi
   cd $VIRTUAL_ENV/src/lalsuite/lalapps/src/lalapps
   make -j 2 2>&1 | grep Entering

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -70,7 +70,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   # run the einstein at home build and test script
   echo -e "\\n>> [`date`] Running pycbc_build_eah.sh"
   pushd ${BUILD}
-  /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/raw/710a51f4770cbba77f61dfb798472bebe6c43d38/travis --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
+  /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/raw/710a51f4770cbba77f61dfb798472bebe6c43d38/travis --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
 
   if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then
     echo -e "\\n>> [`date`] Deploying pycbc_inspiral bundle"

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -70,7 +70,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   # run the einstein at home build and test script
   echo -e "\\n>> [`date`] Running pycbc_build_eah.sh"
   pushd ${BUILD}
-  /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/raw/710a51f4770cbba77f61dfb798472bebe6c43d38/travis --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
+  /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/raw/710a51f4770cbba77f61dfb798472bebe6c43d38/travis --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
 
   if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then
     echo -e "\\n>> [`date`] Deploying pycbc_inspiral bundle"

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -72,7 +72,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   # run the einstein at home build and test script
   echo -e "\\n>> [`date`] Running pycbc_build_eah.sh"
   pushd ${BUILD}
-  /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/raw/710a51f4770cbba77f61dfb798472bebe6c43d38/travis --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
+  /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=539c8700af92eb6dd00e0e91b9dbaf5bae51f004 ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/raw/710a51f4770cbba77f61dfb798472bebe6c43d38/travis --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
 
   if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then
     echo -e "\\n>> [`date`] Deploying pycbc_inspiral bundle"

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -48,8 +48,6 @@ fi
 if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   echo -e "\\n>> [`date`] Building pycbc_inspiral bundle for CentOS 6"
 
-  yum -y install strace
-
   # create working dir for build script
   BUILD=/pycbc/build
   mkdir -p ${BUILD}

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -70,7 +70,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   # run the einstein at home build and test script
   echo -e "\\n>> [`date`] Running pycbc_build_eah.sh"
   pushd ${BUILD}
-  /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=539c8700af92eb6dd00e0e91b9dbaf5bae51f004 ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/raw/710a51f4770cbba77f61dfb798472bebe6c43d38/travis --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
+  /pycbc/tools/einsteinathome/pycbc_build_eah.sh --lalsuite-commit=${LALSUITE_HASH} ${PYCBC_CODE} --clean-pycbc --silent-build --download-url=https://git.ligo.org/ligo-cbc/pycbc-software/raw/710a51f4770cbba77f61dfb798472bebe6c43d38/travis --with-extra-approximant='SPAtmplt:mtotal<4' --with-extra-approximant='SEOBNRv4_ROM:else'  --with-extra-approximant=--use-compressed-waveforms --with-extra-libs=file:///pycbc/composer_xe_2015.0.090.tar.gz --processing-scheme=mkl --with-extra-bank=/pycbc/testbank_TF2v4ROM.hdf
 
   if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] ; then
     echo -e "\\n>> [`date`] Deploying pycbc_inspiral bundle"

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -102,7 +102,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
     yum clean all
     yum makecache
     yum -y update
-    yum -y install openssl-devel
+    yum -y install openssl-devel openssl-static
     yum -y install pegasus
     yum -y install ligo-proxy-utils
     yum -y install ecp-cookie-init
@@ -172,9 +172,9 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
   source ${VENV_PATH}/bin/activate
   cd $VIRTUAL_ENV/src/lalsuite/lalapps
   if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] ; then
-    LIBS="-lhdf5_hl -lhdf5 -ldl -lz" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-static-binaries --disable-lalxml --disable-lalframe --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
+    LIBS="-lhdf5_hl -lhdf5 -lcrypto -lssl -ldl -lz -lstdc++" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-static-binaries --disable-lalxml --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
   elif [ "x${PYCBC_CONTAINER}" == "xpycbc_debian_virtualenv" ] ; then
-    LIBS="-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl -lhdf5 -ldl -lz" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-static-binaries --disable-lalxml --disable-lalframe --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
+    LIBS="-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl -lhdf5 -lcrypto -lssl -ldl -lz -lstdc++" ./configure --prefix=${VIRTUAL_ENV}/opt/lalsuite --enable-static-binaries --disable-lalxml --disable-lalinference --disable-lalburst --disable-lalpulsar --disable-lalstochastic 2>&1 | grep -v checking
   fi
   cd $VIRTUAL_ENV/src/lalsuite/lalapps/src/lalapps
   make -j 2 2>&1 | grep Entering

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -21,7 +21,7 @@ else
 fi
 
 # set the lalsuite checkout to use
-LALSUITE_HASH="539c8700af92eb6dd00e0e91b9dbaf5bae51f004"
+LALSUITE_HASH="95ad957cee1a37b7fc3128883d8b723556f9ec38"
 
 if [ "x$TRAVIS_TAG" == "x" ] ; then
   TRAVIS_TAG="master"
@@ -222,7 +222,7 @@ elif [ -f /ldcg/intel/2017u0/compilers_and_libraries_2017.0.098/linux/mkl/bin/mk
   . /ldcg/intel/2017u0/compilers_and_libraries_2017.0.098/linux/mkl/bin/mklvars.sh intel64
 fi
 
-# Use the revison 11 ROM data from CVMFS
+# Use the ROM data from CVMFS
 export LAL_DATA_PATH=/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/lalsuite-extra/e02dab8c/share/lalsimulation
 EOF
 

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -201,6 +201,9 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
   pip install ipython
   pip install jupyter
   pip install hide_code
+  jupyter nbextension install --sys-prefix --py hide_code
+  jupyter nbextension enable --sys-prefix --py hide_code
+  jupyter serverextension enable --sys-prefix --py hide_code
 
   cat << EOF >> $VIRTUAL_ENV/bin/activate
 

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -48,6 +48,8 @@ fi
 if [ "x${PYCBC_CONTAINER}" == "xpycbc_inspiral_bundle" ] ; then
   echo -e "\\n>> [`date`] Building pycbc_inspiral bundle for CentOS 6"
 
+  yum -y install strace
+
   # create working dir for build script
   BUILD=/pycbc/build
   mkdir -p ${BUILD}

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1430,7 +1430,7 @@ do
 #        "$ENVIRONMENT/dist/pycbc_inspiral/pycbc_inspiral" $args 2>&1|
 #          awk '{if ((!/Filtering template|points above|power chisq|point chisq|Found chisq|generating SEOBNR|generating SPA/) || (/segment 1/ && NR % 50 == 0) || / 0: generating/ || / 1: generating/ ) print}'
 #    else
-        strace "$ENVIRONMENT/dist/pycbc_inspiral/pycbc_inspiral" $args
+        "$ENVIRONMENT/dist/pycbc_inspiral/pycbc_inspiral" $args
 #    fi
 done
 

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -142,7 +142,6 @@ elif grep -q "Scientific Linux CERN SLC release 6" /etc/redhat-release 2>/dev/nu
     build_python=true
     build_hdf5=true
     build_pegasus=false
-    build_fftw=false
     build_gsl=false
     build_ssl=false
     build_lapack=false

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -89,6 +89,7 @@ use_pycbc_pyinstaller_hooks=true
 build_onefile_bundles=false
 run_analysis=true
 silent_build=false
+lal_pulsar="--enable-lalpulsar"
 
 if echo ".$WORKSPACE" | grep CYGWIN64_FRONTEND >/dev/null; then
     # hack to use the script as a frontend for a Cygwin build slave for a Jenkins job
@@ -148,6 +149,7 @@ elif grep -q "Scientific Linux CERN SLC release 6" /etc/redhat-release 2>/dev/nu
     build_lapack=false
     build_freetype=false
     build_zlib=false
+    lal_pulsar="--disable-lal-pulsar"
     build_wrapper=false
     build_fstab=false
     pyinstaller_lsb="--no-lsb"
@@ -907,7 +909,7 @@ EOF
     cd lalsuite-build
     echo -e "\\n\\n>> [`date`] Configuring lalsuite" >&3
     ../lalsuite/configure CPPFLAGS="$lal_cppflags $CPPFLAGS" --disable-gcc-flags $shared $static --prefix="$PREFIX" --disable-silent-rules \
-        --disable-all-lal --enable-lalframe --enable-lalmetaio --enable-lalsimulation --enable-lalinspiral --enable-lalpulsar --enable-swig-python
+        --disable-all-lal --enable-lalframe --enable-lalmetaio --enable-lalsimulation --enable-lalinspiral ${lal_pulsar} --enable-swig-python
     if $build_dlls; then
 	echo '#include "/usr/include/stdlib.h"
 extern int setenv(const char *name, const char *value, int overwrite);

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1426,12 +1426,12 @@ do
       --approximant ${approx_array[$i]} \
       --bank-file ${bank_array[$i]} \
       --verbose"
-#    if $silent_build; then
-#        "$ENVIRONMENT/dist/pycbc_inspiral/pycbc_inspiral" $args 2>&1|
-#          awk '{if ((!/Filtering template|points above|power chisq|point chisq|Found chisq|generating SEOBNR|generating SPA/) || (/segment 1/ && NR % 50 == 0) || / 0: generating/ || / 1: generating/ ) print}'
-#    else
+    if $silent_build; then
+        "$ENVIRONMENT/dist/pycbc_inspiral/pycbc_inspiral" $args 2>&1|
+          awk '{if ((!/Filtering template|points above|power chisq|point chisq|Found chisq|generating SEOBNR|generating SPA/) || (/segment 1/ && NR % 50 == 0) || / 0: generating/ || / 1: generating/ ) print}'
+    else
         "$ENVIRONMENT/dist/pycbc_inspiral/pycbc_inspiral" $args
-#    fi
+    fi
 done
 
 # test for GW150914

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1430,7 +1430,7 @@ do
 #        "$ENVIRONMENT/dist/pycbc_inspiral/pycbc_inspiral" $args 2>&1|
 #          awk '{if ((!/Filtering template|points above|power chisq|point chisq|Found chisq|generating SEOBNR|generating SPA/) || (/segment 1/ && NR % 50 == 0) || / 0: generating/ || / 1: generating/ ) print}'
 #    else
-        "$ENVIRONMENT/dist/pycbc_inspiral/pycbc_inspiral" $args
+        strace "$ENVIRONMENT/dist/pycbc_inspiral/pycbc_inspiral" $args
 #    fi
 done
 

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1379,7 +1379,7 @@ for (( i=0; i<${n_runs}; i++ ))
 do
     rm -f H1-INSPIRAL-OUT.hdf
     echo "\
->> [`date`] pycbc_inspiral using
+>> [`date`] Running pycbc_inspiral using
 >>   --bank-file ${bank_array[$i]}
 >>   --approximant ${approx_array[$i]}
 >>   ROM data from $lal_data_path"

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -142,6 +142,7 @@ elif grep -q "Scientific Linux CERN SLC release 6" /etc/redhat-release 2>/dev/nu
     build_python=true
     build_hdf5=true
     build_pegasus=false
+    build_fftw=false
     build_gsl=false
     build_ssl=false
     build_lapack=false

--- a/tools/einsteinathome/pycbc_build_eah.sh
+++ b/tools/einsteinathome/pycbc_build_eah.sh
@@ -1426,12 +1426,12 @@ do
       --approximant ${approx_array[$i]} \
       --bank-file ${bank_array[$i]} \
       --verbose"
-    if $silent_build; then
-        "$ENVIRONMENT/dist/pycbc_inspiral/pycbc_inspiral" $args 2>&1|
-          awk '{if ((!/Filtering template|points above|power chisq|point chisq|Found chisq|generating SEOBNR|generating SPA/) || (/segment 1/ && NR % 50 == 0) || / 0: generating/ || / 1: generating/ ) print}'
-    else
+#    if $silent_build; then
+#        "$ENVIRONMENT/dist/pycbc_inspiral/pycbc_inspiral" $args 2>&1|
+#          awk '{if ((!/Filtering template|points above|power chisq|point chisq|Found chisq|generating SEOBNR|generating SPA/) || (/segment 1/ && NR % 50 == 0) || / 0: generating/ || / 1: generating/ ) print}'
+#    else
         "$ENVIRONMENT/dist/pycbc_inspiral/pycbc_inspiral" $args
-    fi
+#    fi
 done
 
 # test for GW150914

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -11,7 +11,7 @@ else
 fi
 
 # set the lalsuite checkout to use
-LALSUITE_CODE="--lalsuite-commit=95ad957cee1a37b7fc3128883d8b723556f9ec38
+LALSUITE_CODE="--lalsuite-commit=95ad957cee1a37b7fc3128883d8b723556f9ec38"
 
 echo -e "\\n>> [`date`] Ubuntu build"
 

--- a/tools/install_travis.sh
+++ b/tools/install_travis.sh
@@ -11,7 +11,7 @@ else
 fi
 
 # set the lalsuite checkout to use
-LALSUITE_CODE="--lalsuite-commit=539c8700af92eb6dd00e0e91b9dbaf5bae51f004"
+LALSUITE_CODE="--lalsuite-commit=95ad957cee1a37b7fc3128883d8b723556f9ec38
 
 echo -e "\\n>> [`date`] Ubuntu build"
 


### PR DESCRIPTION
This updates the PyCBC build to use the lalsuite commit https://github.com/lscsoft/lalsuite/commit/95ad957cee1a37b7fc3128883d8b723556f9ec38

It also removes PyLAL from the PyCBC virtual environment.

To avoid hitting Travis disk space limits, I also reduced the disk space needed in the Travis build by using ``language: minimal`` for all of the builds that run inside Docker containers.

This patch makes the Docker image build more robust by adding ``|| exit 1`` in the Travis script so that Travis will fail if Docker commands fail.

The new lalsuite build requires that lalapps be configured with the additional flags ``-lcrypto -lssl -lstdc++`` and installs ``openssl-static`` needed by these commands.

It enables the ``hide_code`` jupyter extension, which was previously installed by not turned on.

[``pycbc_build_eah``](https://github.com/ligo-cbc/pycbc/pull/1914/files#diff-76e4bb5a50e2f2a6da1556a79d3cf244) has been patched so that the static ``pycbc_inspiral`` invocation on Travis/SL6 does not build LALPulsar. It seems that code in here calls the single-precision FFTW libraries directly, rather than going through the LAL FFT interface leading to an error:
```
./.libs/liblalpulsar.so: undefined reference to `fftwf_import_wisdom_from_filename'
```