### PR TITLE
Add an ifos argument to plot_psd

### DIFF
--- a/bin/hdfcoinc/pycbc_plot_psd_file
+++ b/bin/hdfcoinc/pycbc_plot_psd_file
@@ -13,6 +13,8 @@ parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument("--psd-files", nargs='+', required=True,
                     help='HDF file(s) containing the PSDs to plot')
+parser.add_argument("--ifos", nargs="+",
+                    help="What ifo(s) to plot.")
 parser.add_argument("--output-file", required=True, help='Output file name')
 parser.add_argument("--memory-limit", default=2., type=float, metavar="X GB",
                     help="Reading in all PSD files can use a lot of memory. "
@@ -35,7 +37,9 @@ y_min = None
 for psd_file in args.psd_files:
     f = h5py.File(psd_file, 'r')
 
-    if "ifo_list" in f.attrs.keys():
+    if args.ifos is not None:
+        ifo_list = args.ifos
+    elif "ifo_list" in f.attrs.keys():
         ifo_list = f.attrs["ifo_list"]
     else:
         ifo_list = [f.keys()[0]]

--- a/bin/hdfcoinc/pycbc_plot_psd_file
+++ b/bin/hdfcoinc/pycbc_plot_psd_file
@@ -14,7 +14,8 @@ parser.add_argument("--version", action="version",
 parser.add_argument("--psd-files", nargs='+', required=True,
                     help='HDF file(s) containing the PSDs to plot')
 parser.add_argument("--ifos", nargs="+",
-                    help="What ifo(s) to plot.")
+                    help="What ifo(s) to plot. If none provided, will look "
+                         "for an 'ifo_list' attribute in the hdf file.")
 parser.add_argument("--output-file", required=True, help='Output file name')
 parser.add_argument("--memory-limit", default=2., type=float, metavar="X GB",
                     help="Reading in all PSD files can use a lot of memory. "


### PR DESCRIPTION
This adds an `--ifos` argument to `plot_psd` to specify what PSDs to plot. This is so that this code can run on `pycbc_inference` result files (which do not have an `ifo_list` attribute, but do store the psds used in the same group format as the search's psd files). If no `--ifos` is provided, the code defaults to its current behavior.