### PR TITLE
Use recent version of pyOpenSSL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,9 @@ requests>=1.2.1
 beautifulsoup4>=4.6.0
 astropy>=2.0.1
 
+# Ensure pyOpenSSL is recent enough
+pyOpenSSL==17.2.0
+
 # Needed for Parameter Estimation Tasks
 kombine>=0.8.2
 emcee>=2.2.0


### PR DESCRIPTION
This is required to ensure that an old version of pyOpenSSL doesn't get installed, which is breaking the Travis build. This patch should be reverted when dqsegdb declares that it requires a later-than-version X version of pyOpenSSL.