### PR TITLE
Add waveform transforms, and CustomTransform

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -204,7 +204,8 @@ with ctx:
         sampling_parameters = replace_parameters = sampling_transforms = None
 
     # get waveform transformations
-    if cp.has_section('waveform_transforms'):
+    if any(cp.get_subsections('waveform_transforms')):
+        logging.info("Loading waveform transforms")
         waveform_transforms = transforms.read_transforms_from_config(cp,
             'waveform_transforms')
     else:

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -203,6 +203,13 @@ with ctx:
     else:
         sampling_parameters = replace_parameters = sampling_transforms = None
 
+    # get waveform transformations
+    if cp.has_section('waveform_transforms'):
+        waveform_transforms = transforms.read_transforms_from_config(cp,
+            'waveform_transforms')
+    else:
+        waveform_transforms = None
+
     # get ifo-specific instances of calibration model
     if cp.has_section('calibration'):
         logging.info("Initializing calibration model")
@@ -233,7 +240,8 @@ with ctx:
                         psds=psd_dict, prior=prior_eval,
                         sampling_parameters=sampling_parameters,
                         replace_parameters=replace_parameters,
-                        sampling_transforms=sampling_transforms)
+                        sampling_transforms=sampling_transforms,
+                        waveform_transforms=waveform_transforms)
 
     burn_in_eval = burn_in.BurnIn(opts.burn_in_function,
                                 min_iterations=opts.min_burn_in)

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -499,7 +499,7 @@ class BaseLikelihoodEvaluator(object):
             f = getattr(self, callfunc)
         else:
             f = self._callfunc
-        return f(**self._prior.apply_boundary_conditions(**params))
+        return f(**params)
 
     __call__ = evaluate
 

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -128,6 +128,9 @@ class BaseLikelihoodEvaluator(object):
     sampling_transforms : list, optional
         List of transforms to use to go between the variable args and the
         sampling parameters. Required if ``sampling_parameters`` is not None.
+    waveform_transforms : list, optional
+        List of transforms to use to go from the variable args to parameters
+        understood by the waveform generator.
 
     Attributes
     ----------
@@ -223,7 +226,7 @@ class BaseLikelihoodEvaluator(object):
         else:
             self._sampling_args = self._variable_args
             self._sampling_transforms = None
-        self._waveform_transforms = None
+        self._waveform_transforms = waveform_transforms
 
     @property
     def waveform_generator(self):
@@ -582,6 +585,18 @@ class GaussianLikelihood(BaseLikelihoodEvaluator):
         will be used.
     prior : callable
         A callable class or function that computes the prior.
+    sampling_parameters : list, optional
+        Replace one or more of the variable args with the given parameters
+        for sampling.
+    replace_parameters : list, optional
+        The variable args to replace with sampling parameters. Must be the
+        same length as ``sampling_parameters``.
+    sampling_transforms : list, optional
+        List of transforms to use to go between the variable args and the
+        sampling parameters. Required if ``sampling_parameters`` is not None.
+    waveform_transforms : list, optional
+        List of transforms to use to go from the variable args to parameters
+        understood by the waveform generator.
     return_meta : {True, bool}
         If True, ``logposterior`` and ``logplr`` will return the value of the
         prior and the loglikelihood ratio, along with the posterior/plr.

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -204,7 +204,7 @@ class CustomTransform(BaseTransform):
         # evaluate the functions
         out = {p: self._scratch[func][0]
                for p,func in self.transform_functions.items()}
-        return self.format_return(maps, out)
+        return self.format_output(maps, out)
             
     def jacobian(self, maps):
         if self._jacobian is None:
@@ -239,6 +239,8 @@ class CustomTransform(BaseTransform):
         s = '-'.join([section, tag])
         if cp.has_option(s, 'jacobian'):
             jacobian = cp.get_opt_tag(section, 'jacobian', tag)
+        else:
+            jacobian = None
         return cls(inputs, outputs, transform_functions, jacobian=jacobian)
 
 
@@ -1153,6 +1155,7 @@ Logit.inverse = Logistic
 
 # dictionary of all transforms
 transforms = {
+    CustomTransform.name : CustomTransform,
     MchirpQToMass1Mass2.name : MchirpQToMass1Mass2,
     Mass1Mass2ToMchirpQ.name : Mass1Mass2ToMchirpQ,
     SphericalSpin1ToCartesianSpin1.name : SphericalSpin1ToCartesianSpin1,

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -217,9 +217,11 @@ class CustomTransform(BaseTransform):
     def from_config(cls, cp, section, outputs):
         """Loads a CustomTransform from the given config file.
 
-        Example:
+        Example section:
 
-            [section-outputs]
+        .. code-block:: ini
+
+            [{section}-outvar1+outvar2]
             name = custom
             inputs = inputvar1, inputvar2
             outvar1 = func1(inputs)

--- a/pycbc/transforms.py
+++ b/pycbc/transforms.py
@@ -160,6 +160,46 @@ class BaseTransform(object):
         return out
 
 
+class CustomTransform(BaseTransform):
+    """Allows for any transform to be defined.
+    """
+    name = "custom"
+
+    def __init__(self, input_args, output_args, transform_functions=None,
+                 inverse_functions=None, jacobian=None,
+                 inverse_jacobian=None):
+        if isinstance(input_args, str) or isinstance(input_args, unicode):
+            input_args = [input_args]
+        if isinstance(output_args, str) or isinstance(output_args, unicode):
+            output_args = [output_args]
+        self.inputs = set(input_args)
+        self.outputs = set(output_args)
+        if transform_functions is not None:
+            if not isinstance(transform_functions, list):
+                transform_functions = [transform_functions]
+        self.transform_functions = transform_functions
+        if inverse_functions is not None:
+            if not isinstance(inverse_functions, list):
+                inverse_functions = [inverse_functions]
+        self.inverse_functions = inverse_functions
+        self.jacobian = jacobian
+        self.inverse_jacobian = inverse_jacobian
+        # we'll create a scratch FieldArray space to do transforms on
+        self._scratch = record.FieldArray(1, dtype=[(p, float)
+            for p in self.inputs+self.outputs])
+
+    def transform(self, maps):
+        if self.transform_functions is None:
+            raise NotImplementedError("no tansform function(s) provided")
+        # copy values to scratch
+        for p in self.inputs:
+            self._scratch[p] = maps[p]
+        # evaluate the functions
+        out = {}
+        for func in self.transform_functions:
+            vals = self.scratch[func]
+            out.update({
+            
 #
 # =============================================================================
 #

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -489,7 +489,7 @@ class FDomainDetFrameGenerator(object):
         """
         self.current_params.update(kwargs)
         rfparams = {param: self.current_params[param]
-            for param in self.rframe_generator.variable_args}
+            for param in kwargs if param not in self.location_args}
         hp, hc = self.rframe_generator.generate(**rfparams)
         if isinstance(hp, TimeSeries):
             df = self.current_params['delta_f']


### PR DESCRIPTION
This patch does two things: adds a `CustomTransform` class, and the ability to specify `waveform_transforms` in the ini file.

The `waveform_transforms` can be used to specify transforms to go from the variable args to parameters understood by the waveform generator. (This is different from the sampling transforms, which provide transforms to go to/from variable args to sampling args.)

The `CustomTransform` class can be used to define custom transforms in the config file using functions in `FieldArray`'s `functionlib`. At the moment it doesn't support inverse transports, but what's there now is enough to use with the waveform transforms.

Example for the inference ini file:
```
[waveform_transforms-dquad_mon1]
name = custom
inputs = lambda1
dquad_mon1 = dquadmon_from_lambda(lambda1)
```