### PR TITLE
Allow extract samples to write CSV.

### DIFF
--- a/bin/inference/pycbc_inference_extract_samples
+++ b/bin/inference/pycbc_inference_extract_samples
@@ -35,6 +35,7 @@ import numpy
 import pycbc
 from pycbc.inference import option_utils
 from pycbc.io.inference_hdf import InferenceFile
+from pycbc.io.inference_txt import InferenceTXTFile
 
 parser = argparse.ArgumentParser(description=__doc__)
 
@@ -52,9 +53,6 @@ parser.add_argument("--posterior-only", action="store_true", default=False,
                          "all walkers in {samples_group/{param}/. Default is "
                          "for the copied file to have the same structure "
                          "as the input file.")
-parser.add_argument("--csv", action="store_true",
-                    help="Save output file as a CSV file instead of "
-                         "an HDF file.")
 option_utils.add_inference_results_option_group(parser)
 parser.add_argument("--temperature", nargs="+", default=None,
                     help="For parallel-tempered samplers, which temperature "
@@ -84,21 +82,20 @@ if opts.temperature is not None:
         temps = map(int, temps)
     sampler_kwargs['temps'] = temps
 
-# save CSV file
-if opts.csv:
-    fp, parameters, labels, samples = option_utils.results_from_cli(
+# save TXT file
+if option_utils.get_file_type(opts.output_file) == InferenceTXTFile:
+    _, parameters, labels, samples = option_utils.results_from_cli(
                                                         opts, **sampler_kwargs)
-    COMMENTS = ""
-    DELIMITER = " "
-    header = DELIMITER.join(labels)
-    numpy.savetxt(opts.output_file, samples.to_array(fields=parameters).T,
-                  comments=COMMENTS, header=header, delimiter=DELIMITER)
+    InferenceTXTFile.write(opts.output_file,
+                           samples.to_array(fields=parameters).T, labels)
 
 # otherwise save HDF file
 else:
 
     # open the input and parse parameters
-    source = InferenceFile(opts.input_file)
+    if len(opts.input_file) > 1:
+        raise ValueError("Too many input files.")
+    source = InferenceFile(opts.input_file[0])
     parameters, pnames = option_utils.parse_parameters_opt(opts.parameters)
 
     # copy to output

--- a/bin/inference/pycbc_inference_extract_samples
+++ b/bin/inference/pycbc_inference_extract_samples
@@ -84,10 +84,19 @@ if opts.temperature is not None:
 
 # save TXT file
 if option_utils.get_file_type(opts.output_file) == InferenceTXTFile:
-    _, parameters, labels, samples = option_utils.results_from_cli(
+    fp, parameters, labels, samples = option_utils.results_from_cli(
                                                         opts, **sampler_kwargs)
-    InferenceTXTFile.write(opts.output_file,
-                           samples.to_array(fields=parameters).T, labels)
+    likelihood_stats = fp.read_likelihood_stats(
+                           thin_start=opts.thin_start,
+                           thin_end=opts.thin_end,
+                           thin_interval=opts.thin_interval,
+                           iteration=opts.iteration)
+    stat_names = fp[fp.stats_group].keys()
+    n_cols = len(parameters) + len(stat_names)
+    n_rows = samples.size
+    out = numpy.hstack([samples.to_array(fields=parameters).T,
+                        likelihood_stats.to_array(fields=stat_names).T])
+    InferenceTXTFile.write(opts.output_file, out, labels + stat_names)
 
 # otherwise save HDF file
 else:

--- a/bin/inference/pycbc_inference_extract_samples
+++ b/bin/inference/pycbc_inference_extract_samples
@@ -38,8 +38,6 @@ from pycbc.io.inference_hdf import InferenceFile
 
 parser = argparse.ArgumentParser(description=__doc__)
 
-parser.add_argument("--input-file", type=str, required=True,
-    help="Path to input HDF file.")
 parser.add_argument("--output-file", type=str, required=True,
                     help="Output file to create.")
 parser.add_argument("--force", action="store_true", default=False,
@@ -54,33 +52,11 @@ parser.add_argument("--posterior-only", action="store_true", default=False,
                          "all walkers in {samples_group/{param}/. Default is "
                          "for the copied file to have the same structure "
                          "as the input file.")
-# options for down selecting parameters
-parser.add_argument("--parameters", type=str, nargs="+",
-    metavar="PARAM[:NAME]",
-    help="Name of parameters to copy. If none provided will copy all of "
-         "the variable_args in the input file. If provided, the "
-         "parameters can be any of the variable args in "
-         "the input file, derived parameters from them, or any function "
-         "of them. Syntax for functions is python; any math functions in "
-         "the numpy libary may be used. Can optionally also specify a "
-         "name for each parameter, in which case the parameter will be "
-         "saved with the given name in the output file.")
-parser.add_argument("--thin-start", type=int, default=None,
-    help="Sample number to start collecting samples to plot. If none "
-         "provided, will start at the end of the burn-in.")
-parser.add_argument("--thin-interval", type=int,
-    default=None,
-    help="Interval to use for thinning samples. If none provided, will "
-         "use the auto-correlation length found in the file.")
-parser.add_argument("--thin-end", type=int, default=None,
-    help="Sample number to stop collecting samples to plot. If none "
-         "provided, will stop at the last sample from the sampler.")
-parser.add_argument("--iteration", type=int, default=None,
-    help="Only retrieve the given iteration. To load the last n-th sampe "
-         "use -n, e.g., -1 will load the last iteration. This overrides "
-         "the thin-start/interval/end options.")
-# add additional, sampler-specific options
-parser.add_argument("--temperature", nargs='+',
+parser.add_argument("--csv", action="store_true",
+                    help="Save output file as a CSV file instead of "
+                         "an HDF file.")
+option_utils.add_inference_results_option_group(parser)
+parser.add_argument("--temperature", nargs="+", default=None,
                     help="For parallel-tempered samplers, which temperature "
                          "chain(s) to extract. Options are 'all', or one or "
                          "more indices indicating the temperature chain "
@@ -108,17 +84,29 @@ if opts.temperature is not None:
         temps = map(int, temps)
     sampler_kwargs['temps'] = temps
 
-# open the input and parse parameters
-source = InferenceFile(opts.input_file)
-parameters, pnames = option_utils.parse_parameters_opt(opts.parameters)
+# save CSV file
+if opts.csv:
+    fp, parameters, labels, samples = option_utils.results_from_cli(
+                                                        opts, **sampler_kwargs)
+    COMMENTS = ""
+    DELIMITER = " "
+    header = DELIMITER.join(labels)
+    numpy.savetxt(opts.output_file, samples.to_array(fields=parameters).T,
+                  comments=COMMENTS, header=header, delimiter=DELIMITER)
 
-# copy to output
-target = source.copy(opts.output_file, parameters=parameters,
-                     parameter_names=pnames,
-                     posterior_only=opts.posterior_only,
-                     thin_start=opts.thin_start, thin_end=opts.thin_end,
-                     thin_interval=opts.thin_interval,
-                     iteration=opts.iteration,
-                     **sampler_kwargs) 
+# otherwise save HDF file
+else:
 
-target.close()
+    # open the input and parse parameters
+    source = InferenceFile(opts.input_file)
+    parameters, pnames = option_utils.parse_parameters_opt(opts.parameters)
+
+    # copy to output
+    target = source.copy(opts.output_file, parameters=parameters,
+                         parameter_names=pnames,
+                         posterior_only=opts.posterior_only,
+                         thin_start=opts.thin_start, thin_end=opts.thin_end,
+                         thin_interval=opts.thin_interval,
+                         iteration=opts.iteration,
+                         **sampler_kwargs)
+    target.close()

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -564,6 +564,8 @@ def results_from_cli(opts, load_samples=True, **kwargs):
         input_files = [input_files]
 
     # loop over all input files
+    input_files = [opts.input_file] if isinstance(opts.input_file, str) \
+                                                           else opts.input_file
     for input_file in input_files:
         logging.info("Reading input file %s", input_file)
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -461,7 +461,7 @@ def add_inference_results_option_group(parser):
         help="Group in the HDF InferenceFile to look for parameters.")
     results_reading_group.add_argument("--parameters", type=str, nargs="+",
         metavar="PARAM[:LABEL]",
-        help="Name of parameters to plot. If none provided will load all of "
+        help="Name of parameters to load. If none provided will load all of "
              "the variable args in the input-file. If provided, the "
              "parameters can be any of the variable args or posteriors in "
              "the input file, derived parameters from them, or any function "

--- a/pycbc/io/__init__.py
+++ b/pycbc/io/__init__.py
@@ -1,3 +1,2 @@
 from pycbc.io.hdf import *
 from pycbc.io.record import *
-from pycbc.io.inference_hdf import *

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -104,6 +104,7 @@ class InferenceFile(h5py.File):
     mode : {None, str}
         The mode to open the file, eg. "w" for write and "r" for read.
     """
+    name = "hdf"
     samples_group = 'samples'
     stats_group = 'likelihood_stats'
     sampler_group = 'sampler_states'

--- a/pycbc/io/inference_txt.py
+++ b/pycbc/io/inference_txt.py
@@ -20,7 +20,7 @@ import numpy
 
 class InferenceTXTFile(object):
     """ A class that has extra functions for handling reading the samples
-    from posterior-only CSV files.
+    from posterior-only TXT files.
 
     Parameters
     -----------
@@ -41,7 +41,7 @@ class InferenceTXTFile(object):
         if mode in ["r", "rb"]:
             self.mode = mode
         else:
-            raise ValueError("Mode for InferenceCSVFile must be 'r' or 'rb'.")
+            raise ValueError("Mode for InferenceTXTFile must be 'r' or 'rb'.")
 
     @classmethod
     def write(cls, output_file, samples, labels, delimiter=None):

--- a/pycbc/io/inference_txt.py
+++ b/pycbc/io/inference_txt.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2017 Christopher M. Biwer
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# self.option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+""" This modules defines functions for reading and samples that the
+inference samplers generate and are stored in an ASCII TXT file.
+"""
+
+import numpy
+
+class InferenceTXTFile(object):
+   """ A class that has extra functions for handling reading the samples
+    from posterior-only CSV files.
+
+   Parameters
+   -----------
+   path : str
+       The path to the TXT file.
+   mode : {None, str}
+       The mode to open the file. Only accepts "r" or "rb" for reading.
+   delimiter : str
+       Delimiter to use for TXT file. Default is space-delimited.
+   """
+   name = "txt"
+   comments = ""
+   delimiter = " "
+
+   def __init__(self, path, mode=None, delimiter=None):
+       self.path = path
+       self.delimiter = delimiter if delimiter is not None else self.delimiter
+       if mode in ["r", "rb"]:
+           self.mode = mode
+       else:
+           raise ValueError("Mode for InferenceCSVFile must be 'r' or 'rb'.")
+
+   @classmethod
+   def write(cls, output_file, samples, labels, delimiter=None):
+       """ Writes a text file with samples.
+
+       Parameters
+       -----------
+       output_file : str
+           The path of the file to write.
+       samples : FieldArray
+           Samples to write to file.
+       labels : list
+           A list of strings to include as header in TXT file.
+       delimiter : str
+           Delimiter to use in TXT file.
+       """
+       delimiter = delimiter if delimiter is not None else cls.delimiter
+       header = delimiter.join(labels)
+       numpy.savetxt(output_file, samples,
+                     comments=cls.comments, header=header,
+                     delimiter=delimiter)
+

--- a/pycbc/io/inference_txt.py
+++ b/pycbc/io/inference_txt.py
@@ -19,48 +19,48 @@ inference samplers generate and are stored in an ASCII TXT file.
 import numpy
 
 class InferenceTXTFile(object):
-   """ A class that has extra functions for handling reading the samples
+    """ A class that has extra functions for handling reading the samples
     from posterior-only CSV files.
 
-   Parameters
-   -----------
-   path : str
-       The path to the TXT file.
-   mode : {None, str}
-       The mode to open the file. Only accepts "r" or "rb" for reading.
-   delimiter : str
-       Delimiter to use for TXT file. Default is space-delimited.
-   """
-   name = "txt"
-   comments = ""
-   delimiter = " "
+    Parameters
+    -----------
+    path : str
+        The path to the TXT file.
+    mode : {None, str}
+        The mode to open the file. Only accepts "r" or "rb" for reading.
+    delimiter : str
+        Delimiter to use for TXT file. Default is space-delimited.
+    """
+    name = "txt"
+    comments = ""
+    delimiter = " "
 
-   def __init__(self, path, mode=None, delimiter=None):
-       self.path = path
-       self.delimiter = delimiter if delimiter is not None else self.delimiter
-       if mode in ["r", "rb"]:
-           self.mode = mode
-       else:
-           raise ValueError("Mode for InferenceCSVFile must be 'r' or 'rb'.")
+    def __init__(self, path, mode=None, delimiter=None):
+        self.path = path
+        self.delimiter = delimiter if delimiter is not None else self.delimiter
+        if mode in ["r", "rb"]:
+            self.mode = mode
+        else:
+            raise ValueError("Mode for InferenceCSVFile must be 'r' or 'rb'.")
 
-   @classmethod
-   def write(cls, output_file, samples, labels, delimiter=None):
-       """ Writes a text file with samples.
+    @classmethod
+    def write(cls, output_file, samples, labels, delimiter=None):
+        """ Writes a text file with samples.
 
-       Parameters
-       -----------
-       output_file : str
-           The path of the file to write.
-       samples : FieldArray
-           Samples to write to file.
-       labels : list
-           A list of strings to include as header in TXT file.
-       delimiter : str
-           Delimiter to use in TXT file.
-       """
-       delimiter = delimiter if delimiter is not None else cls.delimiter
-       header = delimiter.join(labels)
-       numpy.savetxt(output_file, samples,
-                     comments=cls.comments, header=header,
-                     delimiter=delimiter)
+        Parameters
+        -----------
+        output_file : str
+            The path of the file to write.
+        samples : FieldArray
+            Samples to write to file.
+        labels : list
+            A list of strings to include as header in TXT file.
+        delimiter : str
+            Delimiter to use in TXT file.
+        """
+        delimiter = delimiter if delimiter is not None else cls.delimiter
+        header = delimiter.join(labels)
+        numpy.savetxt(output_file, samples,
+                      comments=cls.comments, header=header,
+                      delimiter=delimiter)
 


### PR DESCRIPTION
Makes it easier for people to write CSV files from inference results.

Example command is:
```
pycbc_inference_extract_samples --input-file ${INPUT_FILE} --parameters mass1:m1 mass2:m2 --iteration 1000 --output-file test.dat --csv
```

The header of the CSV file will be the label from the ``--parameters PARAM:LABEL``.

Will write a CSV file where each row is an independent sample, eg. from above command:
```
m1 m2
1 1
2 2
3 3
```