### PR TITLE
Mode array feature passed at wf generator.

### DIFF
--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -359,6 +359,14 @@ numrel_data = Parameter("numrel_data",
                 dtype=str, default="", label=None,
                 description="Sets the NR flags; only needed for NR waveforms.")
 
+mode_array_l = Parameter("mode_array_l",
+                dtype=int, default="2", label=None,
+                description="Sets the l-mode of the NR waveform.")
+
+mode_array_m = Parameter("mode_array_m",
+                dtype=int, default="2", label=None,
+                description="Sets the m-mode of the NR waveforms")
+
 #
 #   General location parameters
 #
@@ -489,7 +497,7 @@ fd_waveform_params = cbc_rframe_params + ParameterList([delta_f]) + \
 
 # the following are parameters needed to generate a TD waveform
 td_waveform_params = cbc_rframe_params + ParameterList([delta_t]) + \
-    common_gen_equal_sampled_params + ParameterList([numrel_data]) + \
+    common_gen_equal_sampled_params + ParameterList([numrel_data, mode_array_l, mode_array_m]) + \
     flags_generation_params
 
 # the following are parameters needed to generate a frequency series waveform

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -122,6 +122,13 @@ def _check_lal_pars(p):
         lalsimulation.SimInspiralWaveformParamsInsertFrameAxis(lal_pars, p['frame_axis'])
     if p['side_bands']:
         lalsimulation.SimInspiralWaveformParamsInsertSideband(lal_pars, p['side_bands'])
+    if p['mode_array_l'] and p['mode_array_m']:
+        if len(p['mode_array_l'])==len(p['mode_array_m']):
+            ma=lalsimulation.SimInspiralCreateModeArray()
+            for idx in range(len(p['mode_array_l'])):
+                print "idx ",idx+1,"/",len(p['mode_array_l'])," l: ",p['mode_array_l'][idx],"  m: ",p['mode_array_m'][idx]," ",p['mode_array_m']
+                lalsimulation.SimInspiralModeArrayActivateMode(ma, abs(int(p['mode_array_l'][idx])),int(p['mode_array_m'][idx]))
+            lalsimulation.SimInspiralWaveformParamsInsertModeArray(lal_pars,ma)
     return lal_pars
 
 def _lalsim_td_waveform(**p):


### PR DESCRIPTION
Add the modearray feature (enables user to load specific l,m modes) when invoking NR waveforms with get_td_waveform().