### PR TITLE
Fix bugs introduced in plot movie

### DIFF
--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -191,6 +191,10 @@ samples = fp.read_samples(file_parameters, thin_start=thin_start,
                           thin_interval=thinint, thin_end=thin_end,
                           iteration=itermask, flatten=False)
 samples = transforms.apply_transforms(samples, trans)
+if samples.ndim > 2:
+    # multi-tempered samplers will return a 3 dims, so flatten
+    _, ii, jj = samples.shape
+    samples = samples.reshape((ii, jj))
 
 # Get z-values
 if opts.z_arg is not None:
@@ -198,6 +202,9 @@ if opts.z_arg is not None:
     likelihood_stats = fp.read_likelihood_stats(thin_start=thin_start,
         thin_end=thin_end, thin_interval=thinint, iteration=itermask,
         flatten=False)
+    if likelihood_stats.ndim > 2:
+        _, ii, jj = likelihood_stats.shape
+        likelihood_stats = likelihood_stats.reshape((ii, jj))
     zvals, zlbl = option_utils.get_zvalues(fp, opts.z_arg, likelihood_stats)
     show_colorbar = True
     # Set common min and max for colorbar in all plots

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -559,8 +559,12 @@ def results_from_cli(opts, load_samples=True, **kwargs):
     labels_all = []
     samples_all = []
 
+    input_files = opts.input_file
+    if isinstance(input_files, str):
+        input_files = [input_files]
+
     # loop over all input files
-    for input_file in opts.input_file:
+    for input_file in input_files:
         logging.info("Reading input file %s", input_file)
 
         # read input file
@@ -603,7 +607,7 @@ def results_from_cli(opts, load_samples=True, **kwargs):
             samples = None
 
         # add results to lists from all input files
-        if len(opts.input_file) > 1:
+        if len(input_files) > 1:
             fp_all.append(fp)
             parameters_all.append(parameters)
             labels_all.append(labels)


### PR DESCRIPTION
PR #1892 broke `pycbc_inference_plot_movie`: `option_utils` now expects `opts.input_file` to be a list, but the `opts.input_file` in `plot_movie` is a string, as it can only handle a single file. (I suppose we might change this in the future; not sure.) This patch to `option_utils` fixes that. The patch to `pycbc_inference_plot_movie` also fixes a pre-existing bug that prevented it from working on `emcee_pt` results.