### PR TITLE
Minor change to fix display of FAP for PyGRB results

### DIFF
--- a/pycbc/results/legacy_grb.py
+++ b/pycbc/results/legacy_grb.py
@@ -577,10 +577,10 @@ def write_exclusion_distances(page , trial, injList, massbins, reduced=False,
     FAPS = []
     for line in file:
         line = line.replace('\n','')
-        if float(line) == -2:
+        if line == "-2":
             FAPS.append('No event')
         else:
-            FAPS.append(float(line))
+            FAPS.append(line)
 
     file.close()
 


### PR DESCRIPTION
This is a very small change that allows PyGRB results to show the FAP as an upper bound when the on-source event is louder than all background.

See also: ligo-cbc/pycbc-pylal#44