### PR TITLE
add some basic classes for accessing information about cbc events

### DIFF
--- a/pycbc/catalog/__init__.py
+++ b/pycbc/catalog/__init__.py
@@ -22,7 +22,7 @@
 #
 # =============================================================================
 #
-""" This package provides information about LIGO/Virgo detections of 
+""" This package provides information about LIGO/Virgo detections of
 compact binary mergers
 """
 import numpy
@@ -32,10 +32,10 @@ class Merger(object):
     """Informaton about a specific compact binary merger"""
     def __init__(self, name):
         """ Return the information of a merger
-        
+
         Parameters
         ----------
-        name: str 
+        name: str
             The name (GW prefixed date) of the merger event.
         """
         self.data = catalog.data[name]
@@ -45,10 +45,10 @@ class Merger(object):
             setattr(self, key, self.data['median1d'][key][0])
 
         self.time = self.data['time']
-            
+
     def median1d(self, name, return_errors=False):
         """ Return median 1d marginalized parameters
-        
+
         Parameters
         ----------
         name: str
@@ -69,15 +69,15 @@ class Merger(object):
             
     def strain(self, ifo):
         """ Return strain around the event
-        
+
         Currently this will return the strain around the event in the smallest
         format available. Selection of other data is not yet available.
-        
+
         Parameters
         ----------
         ifo: str
             The name of the observatory you want strain for. Ex. H1, L1, V1
-        
+
         Returns
         -------
         strain: pycbc.types.TimeSeries
@@ -95,19 +95,31 @@ class Catalog(object):
     """Manage a set of binary mergers"""
     def __init__(self):
         """ Return the set of detected mergers
-        
+
         The set of detected mergers. At some point this may have some selection
         abilities.
         """
-        self.mergers = [Merger(name) for name in catalog.data]
-        self.names = catalog.data.keys()
-        
+        self.mergers = {name: Merger(name) for name in catalog.data}
+        self.names = self.mergers.keys()
+
     def __len__(self):
         return len(self.mergers)
-        
+
+    def __getitem__(self, key):
+        return self.mergers[key]
+
+    def __setitem__(self, key, value):
+        self.mergers[key] = value
+
+    def __delitem__(self, key):
+        del self.mergers[key]
+
+    def __iter__(self):
+        return iter(self.mergers)
+
     def median1d(self, param, return_errors=False):
         """ Return median 1d marginalized parameters
-        
+
         Parameters
         ----------
         name: str
@@ -115,13 +127,13 @@ class Catalog(object):
         return_errors: Optional, {bool, False}
             If true, return a second and third parameter that represents the
             lower and upper 90% error on the parameter.
-            
+
         Returns
         -------
         param: nump.ndarray or tuple
             The requested parameter
         """
-        v = [m.median1d(param, return_errors=return_errors) for m in self.mergers]  
+        v = [self.mergers[m].median1d(param, return_errors=return_errors) for m in self.mergers]
         if return_errors:
             value, merror, perror = zip(*v)
             return numpy.array(value), numpy.array(merror), numpy.array(perror)

--- a/pycbc/catalog/__init__.py
+++ b/pycbc/catalog/__init__.py
@@ -1,0 +1,129 @@
+# Copyright (C) 2017  Alex Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+""" This package provides information about LIGO/Virgo detections of 
+compact binary mergers
+"""
+import numpy
+from . import catalog
+
+class Merger(object):
+    """Informaton about a specific compact binary merger"""
+    def __init__(self, name):
+        """ Return the information of a merger
+        
+        Parameters
+        ----------
+        name: str 
+            The name (GW prefixed date) of the merger event.
+        """
+        self.data = catalog.data[name]
+        
+        # Set some basic params from the dataset
+        for key in self.data['median1d']:
+            setattr(self, key, self.data['median1d'][key][0])
+
+        self.time = self.data['time']
+            
+    def median1d(self, name, return_errors=False):
+        """ Return median 1d marginalized parameters
+        
+        Parameters
+        ----------
+        name: str
+            The name of the parameter requested
+        return_errors: Optional, {bool, False}
+            If true, return a second and third parameter that represents the
+            lower and upper 90% error on the parameter.
+            
+        Returns
+        -------
+        param: float or tuple
+            The requested parameter
+        """
+        if return_errors:
+            return self.data['median1d'][name]
+        else:
+            return self.data['median1d'][name][0]
+            
+    def strain(self, ifo):
+        """ Return strain around the event
+        
+        Currently this will return the strain around the event in the smallest
+        format available. Selection of other data is not yet available.
+        
+        Parameters
+        ----------
+        ifo: str
+            The name of the observatory you want strain for. Ex. H1, L1, V1
+        
+        Returns
+        -------
+        strain: pycbc.types.TimeSeries
+            Strain around the event.
+        """
+        import urllib
+        from pycbc.frame import read_frame
+        
+        channel = '%s:LOSC-STRAIN' % ifo
+        url = self.data['frames'][ifo]
+        fname, _ = urllib.urlretrieve(url)
+        return read_frame(fname, channel)
+
+class Catalog(object):
+    """Manage a set of binary mergers"""
+    def __init__(self):
+        """ Return the set of detected mergers
+        
+        The set of detected mergers. At some point this may have some selection
+        abilities.
+        """
+        self.mergers = [Merger(name) for name in catalog.data]
+        self.names = catalog.data.keys()
+        
+    def __len__(self):
+        return len(self.mergers)
+        
+    def median1d(self, param, return_errors=False):
+        """ Return median 1d marginalized parameters
+        
+        Parameters
+        ----------
+        name: str
+            The name of the parameter requested
+        return_errors: Optional, {bool, False}
+            If true, return a second and third parameter that represents the
+            lower and upper 90% error on the parameter.
+            
+        Returns
+        -------
+        param: nump.ndarray or tuple
+            The requested parameter
+        """
+        v = [m.median1d(param, return_errors=return_errors) for m in self.mergers]  
+        if return_errors:
+            value, merror, perror = zip(*v)
+            return numpy.array(value), numpy.array(merror), numpy.array(perror)
+        else:
+            return numpy.array(v)

--- a/pycbc/catalog/catalog.py
+++ b/pycbc/catalog/catalog.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2017  Alex Nitz
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+""" This modules contains information about the announced LIGO/Virgo
+compact binary mergers
+"""
+
+# For the time being all quantities are the 1-d median value
+# FIXME with posteriors when available and we can just post-process that
+data = {}
+
+# O1 events, source https://arxiv.org/pdf/1606.04856v3.pdf
+event = "GW150914"
+data[event] = e = {}
+e['time'] = 1126259462.4
+
+# Maybe support multiple data types later and add selection to the accessing class
+e['frames'] = {"H1":'https://losc.ligo.org/s/events/GW150914/H-H1_LOSC_4_V2-1126259446-32.gwf',
+               "L1":'https://losc.ligo.org/s/events/GW150914/L-L1_LOSC_4_V2-1126259446-32.gwf',
+              }
+e["median1d"] = d = {}
+d["mass1"] = (36.2, -3.8, +5.2)
+d["mass2"] = (29.1, -4.4, +3.7)
+d["mchirp"] = (28.1, -1.5, +1.8)
+d["mtotal"] = (65.3, -3.4, +4.1)
+d["chi_eff"] = (-.06, -.14, +.14)
+d["redshift"] = (0.09, -.04, +.03)
+
+
+event = "GW151226"
+data[event] = e = {}
+e['time'] = 1135136350.65
+e['frames'] = {"H1":'https://losc.ligo.org/s/events/GW151226/H-H1_LOSC_4_V2-1135136334-32.gwf',
+               "L1":'https://losc.ligo.org/s/events/GW151226/L-L1_LOSC_4_V2-1135136334-32.gwf',
+              }
+e["median1d"] = d = {}
+d["mass1"] = (14.2, -3.7, +8.3)
+d["mass2"] = (7.5, -2.3, +2.3)
+d["mchirp"] = (8.9, -.3, +.3)
+d["mtotal"] = (21.8, -1.7, +5.9)
+d["chi_eff"] = (-.21, -.10, +.20)
+d["redshift"] = (0.09, -.04, +.03)
+
+event = "LVT151012"
+data[event] = e = {}
+e['time'] = 1128678900.44
+e['frames'] = {"H1":'https://losc.ligo.org/s/events/LVT151012/H-H1_LOSC_4_V2-1128678884-32.gwf',
+               "L1":'https://losc.ligo.org/s/events/LVT151012/L-L1_LOSC_4_V2-1128678884-32.gwf',
+              }
+e["median1d"] = d = {}
+d["mass1"] = (23, -6., +18.)
+d["mass2"] = (13, -5., +4.)
+d["mchirp"] = (15.1, -1.1, +1.4)
+d["mtotal"] = (37, -4., +13.)
+d["chi_eff"] = (0.0, -0.2, +0.3)
+d["redshift"] = (0.20, -0.09, +0.09)
+
+# O2 Events
+#https://journals.aps.org/prl/pdf/10.1103/PhysRevLett.118.221101
+event = "GW170104"
+data[event] = e = {}
+e['time'] = 1167559936.6
+e['frames'] = {"H1":'https://losc.ligo.org/s/events/GW170104/H-H1_LOSC_4_V1-1167559920-32.gwf',
+               "L1":'https://losc.ligo.org/s/events/GW170104/L-L1_LOSC_4_V1-1167559920-32.gwf',
+              }
+e["median1d"] = d = {}
+d["mass1"] = (31.2, -6.0, +8.4)
+d["mass2"] = (19.4, -5.9, +5.3)
+d["mchirp"] = (21.1, -2.7, +2.4)
+d["mtotal"] = (50.7, -5.0, +5.9)
+d["chi_eff"] = (-0.12, -0.30, +0.21)
+d["redshift"] = (0.18, -0.07, +0.08)
+
+#https://dcc.ligo.org/LIGO-P170814/public/main
+event = "GW170814"
+data[event] = e = {}
+e['time'] = 1186741861
+e["median1d"] = d = {}
+d["mass1"] = (30.5, -3.0, +5.7)
+d["mass2"] = (25.3, -4.2, +2.8)
+d["mchirp"] = (24.1, -1.1, +1.4)
+d["mtotal"] = (55.9, -2.7, +3.4)
+d["chi_eff"] = (0.06, -.12, +.12)
+d["redshift"] = (.11, -.04, +0.03)

--- a/setup.py
+++ b/setup.py
@@ -495,6 +495,7 @@ setup (
                'pycbc.inference',
                'pycbc.inject',
                'pycbc.frame',
+               'pycbc.catalog',
                ],
      package_data = {'pycbc.workflow': find_package_data('pycbc/workflow'),
 	             'pycbc.results': find_package_data('pycbc/results'),


### PR DESCRIPTION
This allows things like. 

```
import pylab
import pycbc.catalog
c = pycbc.catalog.Catalog()
print c.names
pylab.scatter(c.median1d('mass1'), c.median1d('mass2'))
pylab.show()
```
>>>['GW170814', 'GW150914', 'LVT151012', 'GW151226', 'GW170104']
![download 4](https://user-images.githubusercontent.com/2206534/31041396-0258ba1c-a595-11e7-9419-3f8951d8b889.png)

and

```
m = pycbc.catalog.Merger("GW150914")
ts = m.strain("H1").whiten(3, 3)
ts = ts.highpass_fir(35, 512).lowpass_fir(250, 512)
ts = ts.time_slice(m.time-.2, m.time+.15)
pylab.plot(ts.sample_times, ts)
pylab.show()
```
![download 5](https://user-images.githubusercontent.com/2206534/31041398-180ba310-a595-11e7-9cf2-4baecd0602f4.png)

