### PR TITLE
add gw170814, use requests which is more robust

### DIFF
--- a/pycbc/catalog/__init__.py
+++ b/pycbc/catalog/__init__.py
@@ -83,13 +83,20 @@ class Merger(object):
         strain: pycbc.types.TimeSeries
             Strain around the event.
         """
-        import urllib
+        import tempfile, requests, shutil
         from pycbc.frame import read_frame
         
         channel = '%s:LOSC-STRAIN' % ifo
         url = self.data['frames'][ifo]
-        fname, _ = urllib.urlretrieve(url)
-        return read_frame(fname, channel)
+        f = tempfile.NamedTemporaryFile(suffix='.gwf')
+        r = requests.get(url, stream=True)
+
+        if r.status_code != 200:
+            raise ValueError("Could not download file, %s", r.status_code)
+
+        shutil.copyfileobj(r.raw, f)
+        f.flush()
+        return read_frame(f.name, channel)
 
 class Catalog(object):
     """Manage a set of binary mergers"""

--- a/pycbc/catalog/catalog.py
+++ b/pycbc/catalog/catalog.py
@@ -95,7 +95,11 @@ d["redshift"] = (0.18, -0.07, +0.08)
 #https://dcc.ligo.org/LIGO-P170814/public/main
 event = "GW170814"
 data[event] = e = {}
-e['time'] = 1186741861
+e['time'] = 1186741861.53
+e['frames'] = {"H1":"https://dcc.ligo.org/public/0146/P1700341/001/H-H1_LOSC_CLN_4_V1-1186741845-32.gwf",
+               "L1":"https://dcc.ligo.org/public/0146/P1700341/001/L-L1_LOSC_CLN_4_V1-1186741845-32.gwf",
+               "V1":"https://dcc.ligo.org/public/0146/P1700341/001/V-V1_LOSC_CLN_4_V1-1186741845-32.gwf",
+              }
 e["median1d"] = d = {}
 d["mass1"] = (30.5, -3.0, +5.7)
 d["mass2"] = (25.3, -4.2, +2.8)


### PR DESCRIPTION
Make the data retrieval a bit more robust to work in places like Azure notebooks. Now all events prior to GW170814 are accessible this way. The change in server after this point seems to be causing some remaining issue, but I think solving that requires coordination with LOSC. 

