### PR TITLE
Numpy scheme

### DIFF
--- a/pycbc/filter/matchedfilter_numpy.py
+++ b/pycbc/filter/matchedfilter_numpy.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2017 Ian Harry
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import numpy
+
+def correlate(x, y, z):
+    z.data[:] = numpy.conjugate(x.data)[:]
+    z *= y

--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -148,6 +148,8 @@ class MKLScheme(CPUScheme):
         if not pycbc.HAVE_MKL:
             raise RuntimeError("Can't find MKL libraries")
 
+class ShortFFTScheme(CPUScheme):
+
 class DefaultScheme(CPUScheme):
     pass
 
@@ -156,6 +158,7 @@ mgr.state = default_context
 scheme_prefix = {CUDAScheme: "cuda",
                  CPUScheme: "cpu",
                  MKLScheme: "mkl",
+                 ShortFFTScheme: "numpy",
                  DefaultScheme: 'cpu'}
 
 def current_prefix():

--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -149,6 +149,7 @@ class MKLScheme(CPUScheme):
             raise RuntimeError("Can't find MKL libraries")
 
 class ShortFFTScheme(CPUScheme):
+    pass
 
 class DefaultScheme(CPUScheme):
     pass

--- a/pycbc/scheme.py
+++ b/pycbc/scheme.py
@@ -148,7 +148,7 @@ class MKLScheme(CPUScheme):
         if not pycbc.HAVE_MKL:
             raise RuntimeError("Can't find MKL libraries")
 
-class ShortFFTScheme(CPUScheme):
+class NumpyScheme(CPUScheme):
     pass
 
 class DefaultScheme(CPUScheme):
@@ -159,7 +159,7 @@ mgr.state = default_context
 scheme_prefix = {CUDAScheme: "cuda",
                  CPUScheme: "cpu",
                  MKLScheme: "mkl",
-                 ShortFFTScheme: "numpy",
+                 NumpyScheme: "numpy",
                  DefaultScheme: 'cpu'}
 
 def current_prefix():


### PR DESCRIPTION
As Alex and I discussed on Mattermost some time ago, there are times and cases where optimizations being used for the 256 * 2048 length FFTs, that we use regularly in analysis are highly sub-optimal when performing much shorter FFTs (1 * 2048 for example).

These shorter FFTs are regularly used in applications such as:

 * sbank
 * Brute-force PE
 * Banksim
 * Faithsim

Where one can greatly reduce the frequency spacing of waveforms before computing a match. Such codes can be slowed down by using the standard CPU scheme, so here I add a numpy scheme, as discussed, that is designed to be optimal, and used for, the short FFT cases.