### PR TITLE
Add new waveform example

### DIFF
--- a/docs/waveform.rst
+++ b/docs/waveform.rst
@@ -17,6 +17,13 @@ Plotting Time Domain Waveforms
 .. plot:: ../examples/waveform/plot_waveform.py
    :include-source:
 
+==============================================
+Generating one waveform in multiple detectors
+==============================================
+
+.. plot:: ../examples/waveform/plot_detwaveform.py
+   :include-source:
+
 =======================================
 Calculating the match between waveforms
 =======================================

--- a/examples/waveform/plot_detwaveform.py
+++ b/examples/waveform/plot_detwaveform.py
@@ -1,0 +1,43 @@
+import pylab
+from pycbc.waveform import get_td_waveform
+from pycbc.detector import Detector
+
+apx = 'SEOBNRv4'
+# NOTE: Inclination runs from 0 to pi, with poles at 0 and pi
+#       coa_phase runs from 0 to 2 pi.
+hp, hc = get_td_waveform(approximant=apx,
+                         mass1=10,
+                         mass2=10,
+                         spin1z=0.9,
+                         spin2z=0.4,
+                         inclination=1.23,
+                         coa_phase=2.45,
+                         delta_t=1.0/4096,
+                         f_lower=40)
+
+det_h1 = Detector('H1')
+det_l1 = Detector('L1')
+det_v1 = Detector('V1')
+
+# Choose a GPS end time, sky location, and polarization phase for the merger
+# NOTE: Right ascension and polarization phase runs from 0 to 2pi
+#       Declination runs from pi/2. to -pi/2 with the poles at pi/2. and -pi/2.
+end_time = 1192529720
+declination = 0.65
+right_ascension = 4.67
+polarization = 2.34
+hp.start_time += end_time
+hc.start_time += end_time
+
+signal_h1 = det_h1.project_wave(hp, hc,  right_ascension, declination, polarization)
+signal_l1 = det_l1.project_wave(hp, hc,  right_ascension, declination, polarization)
+signal_v1 = det_v1.project_wave(hp, hc,  right_ascension, declination, polarization)
+
+pylab.plot(signal_h1.sample_times, signal_h1, label='H1')
+pylab.plot(signal_l1.sample_times, signal_l1, label='L1')
+pylab.plot(signal_v1.sample_times, signal_v1, label='V1')
+
+pylab.ylabel('Strain')
+pylab.xlabel('Time (s)')
+pylab.legend()
+pylab.show()


### PR DESCRIPTION
It was pointed out to me this morning that we have no example in the documentation for generating a single waveform and projecting it into H1, L1, V1, ... This is easily fixed:

https://galahad.aei.mpg.de/~spxiwh/pycbc_docs/waveform.html#generating-one-waveform-in-multiple-detectors

(also adding notes about ra,dec,inclination,coa_phase conventions, as dec and inclination use different conventions).