### PR TITLE
Save burn-in state to file

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -303,8 +303,8 @@ with ctx:
         burn_in_eval.burn_in_functions.pop("use_sampler")
         with InferenceFile(opts.output_file, "a") as fp:
             logging.info("Running sampler's burn in function")
-            burnidx = burn_in.use_sampler(sampler, fp)
-            sampler.write_burn_in_iterations(fp, burnidx)
+            burnidx, is_burned_in = burn_in.use_sampler(sampler, fp)
+            sampler.write_burn_in_iterations(fp, burnidx, is_burned_in)
             # write the burn in results
             n_sampler_burn_in = burnidx.max()
             if max_iterations is not None:
@@ -373,7 +373,10 @@ with ctx:
             # update nsamples for next loop
             if opts.n_independent_samples is not None:
                 with InferenceFile(opts.output_file, 'r') as fp:
-                    nsamples = fp.n_independent_samples
+                    if fp.is_burned_in:
+                        nsamples = fp.n_independent_samples
+                    else:
+                        nsamples = 0
                 logging.info("Have {} independent samples".format(nsamples))
             else:
                 nsamples += interval

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -249,7 +249,6 @@ class BurnIn(object):
             is_burned_in = numpy.zeros(fp.nwalkers, dtype=bool)
         if self.burn_in_functions != {}:
             newidx = []
-            is_burned_in = None
             for func in self.burn_in_functions.values():
                 idx, state = func(sampler, fp)
                 newidx.append(idx)
@@ -257,7 +256,7 @@ class BurnIn(object):
             newidx = numpy.vstack(newidx).max(axis=0)
             mask = burnidx < newidx
             burnidx[mask] = newidx[mask]
-        mask = burnidx < self.min_iterations
+        mask = burnidx <= self.min_iterations
         burnidx[mask] = self.min_iterations
         is_burned_in[mask] = self.min_iterations < fp.niterations
         return burnidx, is_burned_in
@@ -276,5 +275,5 @@ class BurnIn(object):
         """
         burnidx, is_burned_in = self.evaluate(sampler, fp)
         sampler.burn_in_iterations = burnidx
-        sampler.write_burn_in_iterations(fp, burnidx)
+        sampler.write_burn_in_iterations(fp, burnidx, is_burned_in)
 

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -190,7 +190,7 @@ class _BaseSampler(object):
         fp.attrs['dlog_evidence'] = dlnz
 
     @staticmethod
-    def write_burn_in_iterations(fp, burn_in_iterations):
+    def write_burn_in_iterations(fp, burn_in_iterations, is_burned_in=None):
         """Writes the burn in iterations to the given file.
 
         Parameters
@@ -199,12 +199,20 @@ class _BaseSampler(object):
             A file handler to an open inference file.
         burn_in_iterations : array
             Array of values giving the iteration of the burn in of each walker.
+        is_burned_in : array
+            Array of booleans indicating which chains are burned in.
         """
         try:
             fp['burn_in_iterations'][:] = burn_in_iterations
         except KeyError:
             fp['burn_in_iterations'] = burn_in_iterations
         fp.attrs['burn_in_iterations'] = burn_in_iterations.max()
+        if is_burned_in is not None:
+            try:
+                fp['is_burned_in'][:] = is_burned_in
+            except KeyError:
+                fp['is_burned_in'] = is_burned_in
+            fp.attrs['is_burned_in'] = is_burned_in.all()
 
 class BaseMCMCSampler(_BaseSampler):
     """This class is used to construct the MCMC sampler from the kombine-like

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -207,6 +207,12 @@ class InferenceFile(h5py.File):
         return self.attrs["burn_in_iterations"]
 
     @property
+    def is_burned_in(self):
+        """Returns whether or not the sampler is burned in.
+        """
+        return self.attrs["is_burned_in"]
+
+    @property
     def nwalkers(self):
         """Returns number of walkers used.
 


### PR DESCRIPTION
Currently, when using `n-independent-samples` in `pycbc_inference`, you need to specify a number larger than the number of walkers, otherwise the code will just quit after the first checkpoint. Specifying a number larger than the number of walkers means that an ACL must be calculated so that more than one sample can be retrieved from each walker. Getting an ACL can lead to running for a very long time after burn in has finished.

This patch fixes this by adding an `is_burned_in` array and attribute to inference files. This records whether or not each chain (and for the attribute, whether all chains) are burned in. When `n-independent-samples` is used, `pycbc_inference` will only count samples if `is_burned_in` is True. This allows the desired number of samples to be the same as the number of walkers; in that case, `pycbc_inference` will quit at the first checkpoint after all of the walkers have burned in.

The burn-in functions return the `is_burned_in` array. The only function for which this array is not just all True is `max_posterior`, since this is the only one that has a well-defined test to determine if a chain is not burned in.

I'm running a test with GW150914 now; will update when it's done.

