### PR TITLE
Add function to perform the KS test to indicate if chains are burned in

### DIFF
--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -70,8 +70,7 @@ def ks_test(sampler, fp):
         # read samples for the parameter from the iteration midway along the chain
         samples_chain_midpt = sampler.read_samples(fp, param, iteration=int(niterations/2),
                                                   flatten=True)[param]
-        samples_chain_midpt_sorted = numpy.sort(samples_chain_midpt)
-        _, p_value = ks_2samp(samples_last_iter, samples_chain_midpt_sorted)
+        _, p_value = ks_2samp(samples_last_iter, samples_chain_midpt)
         # check if p_value is within the desired range
         if p_value > 0.1 and p_value < 0.9 :
             is_burned_in_param[param] = True

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -50,7 +50,6 @@ def ks_test(sampler, fp):
         Array of booleans indicating whether each chain is burned in.
     """
     from scipy.stats import ks_2samp
-    #from pycbc.io import FieldArray
     from scipy import interpolate
     nwalkers = fp.nwalkers
     niterations = fp.niterations

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -70,10 +70,7 @@ def ks_test(sampler, fp):
                                                   flatten=True)[param]
         _, p_value = ks_2samp(samples_last_iter, samples_chain_midpt)
         # check if p_value is within the desired range
-        if p_value > 0.1 and p_value < 0.9 :
-            is_burned_in_param[param] = True
-        else :
-            is_burned_in_param[param] = False
+        is_burned_in_param[param] = 0.1 < p_value < 0.9
     # The chains are burned in if the p-value of the KS test lies in the range [0.1,0.9]
     # for all the parameters
     if numpy.all([is_burned_in_param[x] for x in is_burned_in_param]) :

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -52,10 +52,6 @@ def ks_test(sampler, fp):
     """
     nwalkers = fp.nwalkers
     niterations = fp.niterations
-    burn_in_idx = numpy.repeat((niterations-1), nwalkers).astype(int)
-    # The chains should not be burned in by default. So is_burned_in is assigned
-    # a False value for all the walkers by default.
-    is_burned_in = numpy.zeros(nwalkers, dtype=bool)
     # Create a dictionary which would have keys are the variable args and values
     # are booleans indicating whether the p-value for the parameters satisfies
     # the KS test
@@ -72,9 +68,14 @@ def ks_test(sampler, fp):
         # check if p_value is within the desired range
         is_burned_in_param[param] = 0.1 < p_value < 0.9
     # The chains are burned in if the p-value of the KS test lies in the range [0.1,0.9]
-    # for all the parameters
-    if numpy.all([is_burned_in_param[x] for x in is_burned_in_param]) :
-        is_burned_in =  numpy.ones(nwalkers, dtype=bool)
+    # for all the parameters. If the KS test is passed, the chains have burned in at their
+    # mid-way point. 
+    if all(is_burned_in_param.values()):
+        is_burned_in = numpy.ones(nwalkers, dtype=bool)
+        burn_in_idx = numpy.repeat(niterations/2, nwalkers).astype(int)
+    else:
+        is_burned_in = numpy.zeros(nwalkers, dtype=bool)
+        burn_in_idx = numpy.repeat(niterations, nwalkers).astype(int)
     return burn_in_idx, is_burned_in
 
 def max_posterior(sampler, fp):

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -27,6 +27,7 @@ have burned in.
 """
 
 import numpy
+from scipy.stats import ks_2samp
 
 def ks_test(sampler, fp):
     """Burn in based on whether the p-value of the KS test between the samples
@@ -49,8 +50,6 @@ def ks_test(sampler, fp):
     is_burned_in : array
         Array of booleans indicating whether each chain is burned in.
     """
-    from scipy.stats import ks_2samp
-    from scipy import interpolate
     nwalkers = fp.nwalkers
     niterations = fp.niterations
     burn_in_idx = numpy.repeat((niterations-1), nwalkers).astype(int)

--- a/pycbc/inference/burn_in.py
+++ b/pycbc/inference/burn_in.py
@@ -77,7 +77,7 @@ def ks_test(sampler, fp):
             is_burned_in_param[param] = True
         else :
             is_burned_in_param[param] = False
-    # The chain is burned in if the p-value of the KS test lies in the range [0.1,0.9]
+    # The chains are burned in if the p-value of the KS test lies in the range [0.1,0.9]
     # for all the parameters
     if numpy.all([is_burned_in_param[x] for x in is_burned_in_param]) :
         is_burned_in =  numpy.ones(nwalkers, dtype=bool)


### PR DESCRIPTION
This PR adds a function in the burn_in module to calculate the KS test between the samples from the last iteration and those from the midpoint of the portion of the chain being considered for each variable-args parameter, and return the `burn_in_idx` and the `is_burned_in` array to indicate whether the chain is burned in. The chains would be considered to be burned in if the p-value returned by the KS test is > 0.1 and < 0.9 for each of the parameters. The `burn_in_idx` array returned is used to advance the sampler.