### PR TITLE
Add test gaussian likelihood

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -181,6 +181,7 @@ if 'data' in likelihood_class.required_kwargs:
     strain_dict, stilde_dict, psd_dict = option_utils.data_from_cli(opts)
     low_frequency_cutoff_dict = option_utils.low_frequency_cutoff_from_cli(opts)
     likelihood_args['f_lower'] = low_frequency_cutoff_dict.values()[0]
+    likelihood_args['psds'] = psd_dict
 else:
     strain_dict = stilde_dict = psd_dict = low_frequency_cutoff_dict = None
 
@@ -253,13 +254,13 @@ with ctx:
 
     # construct class that will return the natural logarithm of likelihood
     likelihood = likelihood_class(variable_args,
-                        waveform_generator=waveform_generator, data=stilde_dict,
-                        psds=psd_dict, prior=prior_eval,
-                        sampling_parameters=sampling_parameters,
-                        replace_parameters=replace_parameters,
-                        sampling_transforms=sampling_transforms,
-                        waveform_transforms=waveform_transforms,
-                        **likelihood_args)
+                                  waveform_generator=waveform_generator,
+                                  data=stilde_dict, prior=prior_eval,
+                                  sampling_parameters=sampling_parameters,
+                                  replace_parameters=replace_parameters,
+                                  sampling_transforms=sampling_transforms,
+                                  waveform_transforms=waveform_transforms,
+                                  **likelihood_args)
 
     burn_in_eval = burn_in.BurnIn(opts.burn_in_function,
                                 min_iterations=opts.min_burn_in)

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -324,7 +324,9 @@ with ctx:
             if max_iterations is not None:
                 max_iterations += n_sampler_burn_in
             logging.info("Writing burn in samples to file")
-            sampler.write_results(fp, max_iterations=max_iterations)
+            sampler.write_results(fp, max_iterations=max_iterations,
+                                  static_args=static_args,
+                                  ifos=opts.instruments)
             try:
                 sampler.write_state(fp)
             except NotImplementedError:
@@ -363,7 +365,9 @@ with ctx:
             logging.info("Writing results to file")
             sampler.write_results(fp, start_iteration=start,
                                   end_iteration=end,
-                                  max_iterations=max_iterations)
+                                  max_iterations=max_iterations,
+                                  static_args=static_args,
+                                  ifos=opts.instruments)
             logging.info("Writing state to file")
             fp.write_random_state()
 

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -47,7 +47,7 @@ parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
                                  description=__doc__)
 
 # add data options
-parser.add_argument("--instruments", type=str, nargs="+", required=True,
+parser.add_argument("--instruments", type=str, nargs="+",
                     help="IFOs, eg. H1 L1.")
 option_utils.add_low_frequency_cutoff_opt(parser)
 parser.add_argument("--psd-start-time", type=float, default=None,
@@ -151,6 +151,10 @@ else:
 # setup log
 pycbc.init_logging(opts.verbose)
 
+# get likelihood class
+likelihood_class = inference.likelihood_evaluators[opts.likelihood_evaluator]
+likelihood_args = {}
+
 # warn user about options that will be removed
 if opts.skip_burn_in:
     logging.warning("DEPRECATION WARNING: Option --skip-burn-in has been "
@@ -172,9 +176,13 @@ ctx = scheme.from_cli(opts)
 fft.from_cli(opts)
 
 # get the data and psd
-logging.info("Loading data")
-strain_dict, stilde_dict, psd_dict = option_utils.data_from_cli(opts)
-low_frequency_cutoff_dict = option_utils.low_frequency_cutoff_from_cli(opts)
+if 'data' in likelihood_class.required_kwargs:
+    logging.info("Loading data")
+    strain_dict, stilde_dict, psd_dict = option_utils.data_from_cli(opts)
+    low_frequency_cutoff_dict = option_utils.low_frequency_cutoff_from_cli(opts)
+    likelihood_args['f_lower'] = low_frequency_cutoff_dict.values()[0]
+else:
+    strain_dict = stilde_dict = psd_dict = low_frequency_cutoff_dict = None
 
 with ctx:
 
@@ -223,30 +231,35 @@ with ctx:
     # select generator that will generate waveform for a single IFO
     # for likelihood evaluator
     logging.info("Setting up sampler")
-    generator_function = generator.select_waveform_generator(
-                                                    static_args["approximant"])
 
     # get gates for templates
     gates = gate.gates_from_cli(opts)
 
-    # construct class that will generate waveforms
-    generated_waveform = generator.FDomainDetFrameGenerator(
-                       generator_function, epoch=stilde_dict.values()[0].epoch,
-                       variable_args=variable_args, detectors=opts.instruments,
-                       delta_f=stilde_dict.values()[0].delta_f,
-                       delta_t=strain_dict.values()[0].delta_t,
-                       recalib=recalib, gates=gates,
-                       **static_args)
+    if 'waveform_generator' in likelihood_class.required_kwargs:
+        generator_function = generator.select_waveform_generator(
+                                                        static_args["approximant"])
+
+        # construct class that will generate waveforms
+        waveform_generator = generator.FDomainDetFrameGenerator(
+                           generator_function, epoch=stilde_dict.values()[0].epoch,
+                           variable_args=variable_args, detectors=opts.instruments,
+                           delta_f=stilde_dict.values()[0].delta_f,
+                           delta_t=strain_dict.values()[0].delta_t,
+                           recalib=recalib, gates=gates,
+                           **static_args)
+
+    else:
+        waveform_generator = None
 
     # construct class that will return the natural logarithm of likelihood
-    likelihood = inference.likelihood_evaluators[opts.likelihood_evaluator](
-                        generated_waveform, stilde_dict,
-                        low_frequency_cutoff_dict.values()[0],
+    likelihood = likelihood_class(variable_args,
+                        waveform_generator=waveform_generator, data=stilde_dict,
                         psds=psd_dict, prior=prior_eval,
                         sampling_parameters=sampling_parameters,
                         replace_parameters=replace_parameters,
                         sampling_transforms=sampling_transforms,
-                        waveform_transforms=waveform_transforms)
+                        waveform_transforms=waveform_transforms,
+                        **likelihood_args)
 
     burn_in_eval = burn_in.BurnIn(opts.burn_in_function,
                                 min_iterations=opts.min_burn_in)

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -531,7 +531,7 @@ class TestNormal(BaseLikelihoodEvaluator):
         self.set_lognl(0.)
         # store the pdf
         if mean is None:
-            mean = [0.]*len(variable_args) 
+            mean = [0.]*len(variable_args)
         if cov is None:
             cov = [1.]*len(variable_args)
         self._dist = stats.multivariate_normal(mean=mean, cov=cov)

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -531,7 +531,9 @@ class TestNormal(BaseLikelihoodEvaluator):
         self.set_lognl(0.)
         # store the pdf
         if mean is None:
-            mean = [None]*len(variable_args) 
+            mean = [0.]*len(variable_args) 
+        if cov is None:
+            cov = [1.]*len(variable_args)
         self._dist = stats.multivariate_normal(mean=mean, cov=cov)
         # check that the dimension is correct
         if self._dist.dim != len(variable_args):

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -532,8 +532,6 @@ class TestNormal(BaseLikelihoodEvaluator):
         # store the pdf
         if mean is None:
             mean = [None]*len(variable_args) 
-        if cov is None:
-            cov = [None]*len(variable_args)
         self._dist = stats.multivariate_normal(mean=mean, cov=cov)
         # check that the dimension is correct
         if self._dist.dim != len(variable_args):

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -29,6 +29,7 @@ from pycbc.io.inference_hdf import InferenceFile
 from pycbc.io.inference_txt import InferenceTXTFile
 from pycbc.inference import likelihood
 from pycbc.workflow import WorkflowConfigParser
+from pycbc.workflow import ConfigParser
 from pycbc.pool import choose_pool
 from pycbc.psd import from_cli_multi_ifos as psd_from_cli_multi_ifos
 from pycbc.strain import from_cli_multi_ifos as strain_from_cli_multi_ifos
@@ -123,9 +124,12 @@ def read_args_from_config(cp, section_group=None, prior_section='prior'):
         raise KeyError("You are missing a priors section in the config file.")
 
     # get parameters that do not change in sampler
-    static_args = dict([(key,cp.get_opt_tags(
-        "{}static_args".format(section_prefix), key, []))
-        for key in cp.options("{}static_args".format(section_prefix))])
+    try:
+        static_args = dict([(key,cp.get_opt_tags(
+            "{}static_args".format(section_prefix), key, []))
+            for key in cp.options("{}static_args".format(section_prefix))])
+    except ConfigParser.NoSectionError:
+        static_args = {}
     # try converting values to float
     for key,val in static_args.iteritems():
         try:
@@ -329,7 +333,7 @@ def add_low_frequency_cutoff_opt(parser):
     # FIXME: this just uses the same frequency cutoff for every instrument for
     # now. We should allow for different frequency cutoffs to be used; that
     # will require (minor) changes to the Likelihood class
-    parser.add_argument("--low-frequency-cutoff", type=float, required=True,
+    parser.add_argument("--low-frequency-cutoff", type=float,
                         help="Low frequency cutoff for each IFO.")
 
 

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -61,11 +61,6 @@ class _BaseSampler(object):
         raise NotImplementedError("from_cli function not set")
 
     @property
-    def ifos(self):
-        """Returns the ifos that were sampled over."""
-        return self.likelihood_evaluator.waveform_generator.detector_names
-
-    @property
     def variable_args(self):
         """Returns the variable args used by the likelihood evaluator.
         """
@@ -150,7 +145,7 @@ class _BaseSampler(object):
                                   "calculation")
 
     # write and read functions
-    def write_metadata(self, fp):
+    def write_metadata(self, fp, **kwargs):
         """Writes metadata about this sampler to the given file. Metadata is
         written to the file's `attrs`.
 
@@ -158,18 +153,29 @@ class _BaseSampler(object):
         ----------
         fp : InferenceFile
             A file handler to an open inference file.
+        \**kwargs :
+            All keyword arguments are saved as separate arguments in the
+            file attrs. If any keyword argument is a dictionary, the keyword
+            will point to the list of keys in the the file's ``attrs``. Each
+            key is then stored as a separate attr with its corresponding value.
         """
         fp.attrs['sampler'] = self.name
         fp.attrs['likelihood_evaluator'] = self.likelihood_evaluator.name
-        fp.attrs['ifos'] = self.ifos
         fp.attrs['variable_args'] = list(self.variable_args)
         fp.attrs['sampling_args'] = list(self.sampling_args)
         fp.attrs["niterations"] = self.niterations
         fp.attrs["lognl"] = self.likelihood_evaluator.lognl
-        sargs = self.likelihood_evaluator.waveform_generator.static_args
-        fp.attrs["static_args"] = sargs.keys()
-        for arg, val in sargs.items():
-            fp.attrs[arg] = val
+        for arg, val in kwargs.items():
+            if val is None:
+                val = str(None)
+            if isinstance(val, dict):
+                fp.attrs[arg] = val.keys()
+                for key,item in val.items():
+                    if item is None:
+                        item = str(None)
+                    fp.attrs[key] = item
+            else:
+                fp.attrs[arg] = val
 
     @staticmethod
     def write_logevidence(fp, lnz, dlnz):
@@ -349,7 +355,7 @@ class BaseMCMCSampler(_BaseSampler):
         return FieldArray.from_kwargs(**arrays).transpose()
 
     # write and read functions
-    def write_metadata(self, fp):
+    def write_metadata(self, fp, **kwargs):
         """Writes metadata about this sampler to the given file. Metadata is
         written to the file's `attrs`.
 
@@ -357,8 +363,10 @@ class BaseMCMCSampler(_BaseSampler):
         ----------
         fp : InferenceFile
             A file handler to an open inference file.
+        \**kwargs :
+            All keyword args are written to the file's ``attrs``.
         """
-        super(BaseMCMCSampler, self).write_metadata(fp)
+        super(BaseMCMCSampler, self).write_metadata(fp, **kwargs)
         # add info about walkers, burn in
         fp.attrs["nwalkers"] = self.nwalkers
 
@@ -569,7 +577,7 @@ class BaseMCMCSampler(_BaseSampler):
                 acf[start_iteration:end_iteration]
 
     def write_results(self, fp, start_iteration=0, end_iteration=None,
-                      max_iterations=None):
+                      max_iterations=None, **metadata):
         """Writes metadata, samples, likelihood stats, and acceptance fraction
         to the given file. Also computes and writes the autocorrleation lengths
         of the chains. See the various write function for details.
@@ -587,8 +595,10 @@ class BaseMCMCSampler(_BaseSampler):
             to. Only applies if the acceptance fraction has not previously been
             written to the file. The default (None) is to use the maximum size
             allowed by h5py.
+        \**metadata :
+            All other keyword arguments are passed to ``write_metadata``.
         """
-        self.write_metadata(fp)
+        self.write_metadata(fp, **metadata)
         self.write_chain(fp, start_iteration=start_iteration,
                          end_iteration=end_iteration,
                          max_iterations=max_iterations)

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -67,7 +67,7 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
         if likelihood_call is None:
             likelihood_call = likelihood_evaluator
 
-        ndim = len(likelihood_evaluator.waveform_generator.variable_args)
+        ndim = len(likelihood_evaluator.variable_args)
         sampler = emcee.EnsembleSampler(nwalkers, ndim,
                                         likelihood_call,
                                         pool=pool)
@@ -191,7 +191,7 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
         return fp[group][wmask]
 
     def write_results(self, fp, start_iteration=0, end_iteration=None,
-                      max_iterations=None):
+                      max_iterations=None, **metadata):
         """Writes metadata, samples, likelihood stats, and acceptance fraction
         to the given file. See the write function for each of those for
         details.
@@ -209,8 +209,10 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
             to. Only applies if the samples have not previously been written
             to file. The default (None) is to use the maximum size allowed by
             h5py.
+        \**metadata :
+            All other keyword arguments are passed to ``write_metadata``.
         """
-        self.write_metadata(fp)
+        self.write_metadata(fp, **metadata)
         self.write_chain(fp, start_iteration=start_iteration,
                          end_iteration=end_iteration,
                          max_iterations=max_iterations)
@@ -425,7 +427,7 @@ class EmceePTSampler(BaseMCMCSampler):
     # read/write functions
 
     # add ntemps and betas to metadata
-    def write_metadata(self, fp):
+    def write_metadata(self, fp, **kwargs):
         """Writes metadata about this sampler to the given file. Metadata is
         written to the file's `attrs`.
 
@@ -433,8 +435,13 @@ class EmceePTSampler(BaseMCMCSampler):
         ----------
         fp : InferenceFile
             A file handler to an open inference file.
+        \**kwargs :
+            All keyword arguments are saved as separate arguments in the
+            file attrs. If any keyword argument is a dictionary, the keyword
+            will point to the list of keys in the the file's ``attrs``. Each
+            key is then stored as a separate attr with its corresponding value.
         """
-        super(EmceePTSampler, self).write_metadata(fp)
+        super(EmceePTSampler, self).write_metadata(fp, **kwargs)
         fp.attrs["ntemps"] = self.ntemps
         fp.attrs["betas"] = self._sampler.betas
 
@@ -575,7 +582,8 @@ class EmceePTSampler(BaseMCMCSampler):
                         fp[dataset_name][fa:fb] = samples[param][tk, wi, ma:mb]
 
     def write_results(self, fp, start_iteration=0, end_iteration=None,
-                      max_iterations=None):
+                      max_iterations=None,
+                      **metadata):
         """Writes metadata, samples, likelihood stats, and acceptance fraction
         to the given file. See the write function for each of those for
         details.
@@ -593,8 +601,10 @@ class EmceePTSampler(BaseMCMCSampler):
             to. Only applies if the samples have not previously been written
             to file. The default (None) is to use the maximum size allowed by
             h5py.
+        \**metadata :
+            All other keyword arguments are passed to ``write_metadata``.
         """
-        self.write_metadata(fp)
+        self.write_metadata(fp, **metadata)
         self.write_chain(fp, start_iteration=start_iteration,
                          end_iteration=end_iteration,
                          max_iterations=max_iterations)

--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -76,7 +76,7 @@ class KombineSampler(BaseMCMCSampler):
             likelihood_call = likelihood_evaluator
 
         # construct sampler for use in KombineSampler
-        ndim = len(likelihood_evaluator.waveform_generator.variable_args)
+        ndim = len(likelihood_evaluator.variable_args)
         count = 1 if pool is None else pool.count
         sampler = kombine.Sampler(nwalkers, ndim, likelihood_call,
                                   transd=transd, pool=pool,

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -133,7 +133,7 @@ class TestSamplers(unittest.TestCase):
     def get_likelihood_evaluator(self, waveform_gen, data, prior_eval):
         """ Returns the likelihood evaluator class.
         """
-        likelihood_eval = likelihood.GaussianLikelihood(
+        likelihood_eval = likelihood.GaussianLikelihood(waveform_gen.variable_args,
                                              waveform_gen, data, self.fmin,
                                              psds=self.psds, prior=prior_eval,
                                              return_meta=False)


### PR DESCRIPTION
This patch adds a likelihood evaluator in which the likelihood function is the pdf of a multivariate normal distribution. The number of dimensions in the distribution is set by the number of variable args in the config file.

Example:

With config file:
```
[variable_args]
x =
y =

[prior-x]
name = uniform
min-x = -10
max-x = 10

[prior-y]
name = uniform
min-y = -10
max-y = 10
```
And arguments:
```
pycbc_inference --config-files normal2d.ini --output-file test_normal2d.hdf --sampler kombine --verbose --likelihood-evaluator test_normal --niterations 10 --nwalkers 2000 
```
Yields: [2D norm posterior](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/scratch/2dnorm.png).

You can also do 1D, although I found that kombine fails with a 1D p0 (this appears to be a kombine error, so not addressing here).

I've also tested with `emcee` and `emcee_pt`.

Since analytic likelihoods do not use data nor a waveform generator, I had to move some attributes from `BaseLikelihoodEvaluator` to `GaussianLikelihood`.