### PR TITLE
Give meaningful error when priors section missing

### DIFF
--- a/examples/distributions/example.ini
+++ b/examples/distributions/example.ini
@@ -15,15 +15,15 @@ v6b =
 v7 =
 v8 =
 v9 =
-v10 =
-mass1 =
-mass2 =
-chi_eff =
-chi_a =
-xi1 =
-xi2 =
-phi_a =
-phi_s =
+;v10 =
+;mass1 =
+;mass2 =
+;chi_eff =
+;chi_a =
+;xi1 =
+;xi2 =
+;phi_a =
+;phi_s =
 
 [prior-v0]
 name = uniform

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -119,9 +119,11 @@ def read_args_from_config(cp, section_group=None, prior_section='prior'):
     variable_args = cp.options("{}variable_args".format(section_prefix))
     subsections = cp.get_subsections("{}{}".format(section_prefix,
                                                    prior_section))
-    tags = numpy.concatenate([tag.split("+") for tag in subsections])
-    if not any(param in tags for param in variable_args):
-        raise KeyError("You are missing a priors section in the config file.")
+    tags = set([p for tag in subsections for p in tag.split('+')])
+    missing_prior = set(variable_args) - tags
+    if any(missing_prior):
+        raise KeyError("You are missing a priors section in the config file "
+                       "for parameter(s): {}".format(', '.join(missing_prior)))
 
     # get parameters that do not change in sampler
     try:

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -110,6 +110,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ] || [ "x${PYCBC_CONTAINE
   elif [ "x${PYCBC_CONTAINER}" == "xpycbc_debian_virtualenv" ] ; then
     echo -e "\\n>> [`date`] Building pycbc virtual environment for Debian"
     ENV_OS="x86_64_deb_8"
+    apt-get update
     apt-get -y install python-pip
     apt-get -y install curl
     echo "deb http://software.ligo.org/gridtools/debian jessie main" > /etc/apt/sources.list.d/gridtools.list


### PR DESCRIPTION
If a prior section is missing for one or more variable arg, raise an error stating which parameter the prior is missing for. This is to address issue #1950.