### PR TITLE
Add option to choose percentiles in pycbc_inference_plot_posterior

### DIFF
--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -163,6 +163,7 @@ for i, (p, l, s) in enumerate(zip(parameters, labels, samples)):
     fig, axis_dict = create_multidim_plot(
                     p, s, labels=l, fig=fig, axis_dict=axis_dict,
                     plot_marginal=opts.plot_marginal,
+                    marg_percentiles=opts.marg_percentiles,
                     plot_scatter=opts.plot_scatter,
                     zvals=zvals[i] if zvals is not None else None,
                     show_colorbar=show_colorbar,
@@ -171,6 +172,7 @@ for i, (p, l, s) in enumerate(zip(parameters, labels, samples)):
                     scatter_cmap=opts.scatter_cmap,
                     plot_density=opts.plot_density,
                     plot_contours=opts.plot_contours,
+                    contour_percentiles=opts.contour_percentiles,
                     density_cmap=opts.density_cmap,
                     contour_color=contour_color,
                     hist_color=hist_color,

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -163,7 +163,7 @@ for i, (p, l, s) in enumerate(zip(parameters, labels, samples)):
     fig, axis_dict = create_multidim_plot(
                     p, s, labels=l, fig=fig, axis_dict=axis_dict,
                     plot_marginal=opts.plot_marginal,
-                    marg_percentiles=opts.marg_percentiles,
+                    marginal_percentiles=opts.marginal_percentiles,
                     plot_scatter=opts.plot_scatter,
                     zvals=zvals[i] if zvals is not None else None,
                     show_colorbar=show_colorbar,

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -714,7 +714,7 @@ def add_plot_posterior_option_group(parser):
     pgroup.add_argument('--plot-marginal', action='store_true', default=False,
                         help="Plot 1D marginalized distributions on the "
                              "diagonal axes.")
-    pgroup.add_argument('--marg-percentiles', nargs='+', default=None,
+    pgroup.add_argument('--marginal-percentiles', nargs='+', default=None,
                         type=float,
                         help="Percentiles to draw lines at on the 1D "
                              "histograms.")

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -714,6 +714,10 @@ def add_plot_posterior_option_group(parser):
     pgroup.add_argument('--plot-marginal', action='store_true', default=False,
                         help="Plot 1D marginalized distributions on the "
                              "diagonal axes.")
+    pgroup.add_argument('--marg-percentiles', nargs='+', default=None,
+                        type=float,
+                        help="Percentiles to draw lines at on the 1D "
+                             "histograms.")
     pgroup.add_argument("--plot-scatter", action='store_true', default=False,
                         help="Plot each sample point as a scatter plot.")
     pgroup.add_argument("--plot-density", action="store_true", default=False,
@@ -721,6 +725,10 @@ def add_plot_posterior_option_group(parser):
     pgroup.add_argument("--plot-contours", action="store_true", default=False,
                         help="Draw contours showing the 50th and 90th "
                              "percentile confidence regions.")
+    pgroup.add_argument('--contour-percentiles', nargs='+', default=None,
+                        type=float,
+                        help="Percentiles to draw contours if different "
+                             "than 50th and 90th.")
     # add mins, maxs options
     pgroup.add_argument('--mins', nargs='+', metavar='PARAM:VAL', default=[],
                         help="Specify minimum parameter values to plot. This "

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -214,7 +214,7 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
     """
     if percentiles is None:
         percentiles = numpy.array([50., 90.])
-    percentiles = 100. - percentiles
+    percentiles = 100. - numpy.array(percentiles)
     percentiles.sort()
 
     if ax is None and fig is None:
@@ -471,6 +471,7 @@ def create_multidim_plot(parameters, samples, labels=None,
                 mins=None, maxs=None, expected_parameters=None,
                 expected_parameters_color='r',
                 plot_marginal=True, plot_scatter=True,
+                marg_percentiles=None, contour_percentiles=None,
                 zvals=None, show_colorbar=True, cbar_label=None,
                 vmin=None, vmax=None, scatter_cmap='plasma',
                 plot_density=False, plot_contours=True,
@@ -507,6 +508,13 @@ def create_multidim_plot(parameters, samples, labels=None,
         diagonal axes will be turned off.
     plot_scatter : {True, bool}
         Plot each sample point as a scatter plot.
+    marg_percentiles : {None, array}
+        What percentiles to draw lines at on the 1D histograms.
+        If None, will draw lines at `[5, 50, 95]` (i.e., the bounds on the
+        upper 90th percentile and the median).
+    contour_percentiles : {None, array}
+        What percentile contours to draw on the scatter plots. If None,
+        will plot the 50th and 90th percentiles.
     zvals : {None, array}
         An array to use for coloring the scatter plots. If None, scatter points
         will be the same color.
@@ -628,7 +636,8 @@ def create_multidim_plot(parameters, samples, labels=None,
                 color=hist_color, fillcolor=fill_color, linecolor=line_color,
                 title=True, expected_value=expected_value,
                 expected_color=expected_parameters_color,
-                rotated=rotated, plot_min=mins[param], plot_max=maxs[param])
+                rotated=rotated, plot_min=mins[param], plot_max=maxs[param],
+                percentiles=marg_percentiles)
 
     # Off-diagonals...
     for px, py in axis_dict:
@@ -654,6 +663,7 @@ def create_multidim_plot(parameters, samples, labels=None,
                 exclude_region = None
             create_density_plot(px, py, samples, plot_density=plot_density,
                     plot_contours=plot_contours, cmap=density_cmap,
+                    percentiles=contour_percentiles,
                     contour_color=contour_color, xmin=mins[px], xmax=maxs[px],
                     ymin=mins[py], ymax=maxs[py],
                     exclude_region=exclude_region, ax=ax,

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -471,7 +471,7 @@ def create_multidim_plot(parameters, samples, labels=None,
                 mins=None, maxs=None, expected_parameters=None,
                 expected_parameters_color='r',
                 plot_marginal=True, plot_scatter=True,
-                marg_percentiles=None, contour_percentiles=None,
+                marginal_percentiles=None, contour_percentiles=None,
                 zvals=None, show_colorbar=True, cbar_label=None,
                 vmin=None, vmax=None, scatter_cmap='plasma',
                 plot_density=False, plot_contours=True,
@@ -508,7 +508,7 @@ def create_multidim_plot(parameters, samples, labels=None,
         diagonal axes will be turned off.
     plot_scatter : {True, bool}
         Plot each sample point as a scatter plot.
-    marg_percentiles : {None, array}
+    marginal_percentiles : {None, array}
         What percentiles to draw lines at on the 1D histograms.
         If None, will draw lines at `[5, 50, 95]` (i.e., the bounds on the
         upper 90th percentile and the median).
@@ -637,7 +637,7 @@ def create_multidim_plot(parameters, samples, labels=None,
                 title=True, expected_value=expected_value,
                 expected_color=expected_parameters_color,
                 rotated=rotated, plot_min=mins[param], plot_max=maxs[param],
-                percentiles=marg_percentiles)
+                percentiles=marginal_percentiles)
 
     # Off-diagonals...
     for px, py in axis_dict:


### PR DESCRIPTION
When plotting two or three posterior distributions on the same plot it can get a bit messy with all the 50% and 90% contours and lines (see https://www.atlas.aei.uni-hannover.de/~miriam.cabero/LSC/plots/area_theorem/tst2.pdf).
With this patch, one can choose which confidence levels to plot, for instance to remove the 50% contour and line
https://www.atlas.aei.uni-hannover.de/~miriam.cabero/LSC/plots/area_theorem/O1_ringdown_posteriors.pdf
or to use completely different confidence levels, like 66% and 99%
https://www.atlas.aei.uni-hannover.de/~miriam.cabero/LSC/plots/area_theorem/tst.pdf