### PR TITLE
Simplify writing samples to inference file

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -351,9 +351,7 @@ with ctx:
         with InferenceFile(opts.output_file, "a") as fp:
 
             logging.info("Writing results to file")
-            sampler.write_results(fp, start_iteration=start,
-                                  end_iteration=end,
-                                  max_iterations=max_iterations,
+            sampler.write_results(fp, max_iterations=max_iterations,
                                   static_args=static_args,
                                   ifos=opts.instruments)
             logging.info("Writing state to file")

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -417,7 +417,7 @@ class BaseMCMCSampler(_BaseSampler):
         start_iteration : int, optional
             Write results to the file's datasets starting at the given
             iteration. Default is to append after the last iteration in the
-            file. 
+            file.
         max_iterations : int, optional
             Set the maximum size that the arrays in the hdf file may be resized
             to. Only applies if the samples have not previously been written

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -474,7 +474,7 @@ class BaseMCMCSampler(_BaseSampler):
         start_iteration : int, optional
             Write results to the file's datasets starting at the given
             iteration. Default is to append after the last iteration in the
-            file. 
+            file.
         max_iterations : int, optional
             Set the maximum size that the arrays in the hdf file may be resized
             to. Only applies if the samples have not previously been written
@@ -512,7 +512,7 @@ class BaseMCMCSampler(_BaseSampler):
         start_iteration : int, optional
             Write results to the file's datasets starting at the given
             iteration. Default is to append after the last iteration in the
-            file. 
+            file.
         max_iterations : int, optional
             Set the maximum size that the arrays in the hdf file may be resized
             to. Only applies if the samples have not previously been written

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -393,8 +393,7 @@ class BaseMCMCSampler(_BaseSampler):
 
     @staticmethod
     def write_samples_group(fp, samples_group, parameters, samples,
-                            start_iteration=0, end_iteration=None,
-                            index_offset=0, max_iterations=None):
+                            start_iteration=None, max_iterations=None):
         """Writes samples to the given file.
 
         Results are written to:
@@ -415,61 +414,49 @@ class BaseMCMCSampler(_BaseSampler):
         samples : FieldArray
             The samples to write. Should be a FieldArray with fields containing
             the samples to write and shape nwalkers x niterations.
-        start_iteration : {0, int}
-            Write results starting from the given iteration.
-        end_iteration : {None, int}
-            Write results up to the given iteration.
-        index_offset : int, optional
-            Write the samples to the arrays on disk starting at
-            `start_iteration` + `index_offset`. For example, if
-            `start_iteration=0`, `end_iteration=1000` and `index_offset=500`,
-            then `samples[0:1000]` will be written to indices `500:1500` in the
-            arrays on disk. This is needed if you are adding new samples to
-            a chain that was previously written to file, and you want to
-            preserve the history (e.g., after a checkpoint). Default is 0.
+        start_iteration : int, optional
+            Write results to the file's datasets starting at the given
+            iteration. Default is to append after the last iteration in the
+            file. 
         max_iterations : int, optional
             Set the maximum size that the arrays in the hdf file may be resized
             to. Only applies if the samples have not previously been written
             to file. The default (None) is to use the maximum size allowed by
             h5py.
         """
-        # due to clearing memory, there can be a difference between indices in
-        # memory and on disk
         nwalkers, niterations = samples.shape
-        niterations += index_offset
-        fa = start_iteration # file start index
-        if end_iteration is None:
-            end_iteration = niterations
-        fb = end_iteration # file end index
-        ma = fa - index_offset # memory start index
-        mb = fb - index_offset # memory end index
-
         if max_iterations is not None and max_iterations < niterations:
             raise IndexError("The provided max size is less than the "
                              "number of iterations")
-
         group = samples_group + '/{name}/walker{wi}'
-
         # loop over number of dimensions
         widx = numpy.arange(nwalkers)
         for param in parameters:
             # loop over number of walkers
             for wi in widx:
                 dataset_name = group.format(name=param, wi=wi)
+                istart = start_iteration
                 try:
-                    if fb > fp[dataset_name].size:
+                    if istart is None:
+                        istart = fp[dataset_name].size
+                    istop = istart + niterations
+                    if istop > fp[dataset_name].size:
                         # resize the dataset
-                        fp[dataset_name].resize(fb, axis=0)
-                    fp[dataset_name][fa:fb] = samples[param][wi, ma:mb]
+                        fp[dataset_name].resize(istop, axis=0)
+                    fp[dataset_name][istart:istop] = samples[param][wi, :]
                 except KeyError:
                     # dataset doesn't exist yet
-                    fp.create_dataset(dataset_name, (fb,),
+                    if istart is not None or istart != 0:
+                        raise ValueError("non-zero start_iteration provided, "
+                                         "but dataset doesn't exist yet")
+                    istart = 0
+                    istop = istart + niterations
+                    fp.create_dataset(dataset_name, (istop,),
                                       maxshape=(max_iterations,),
                                       dtype=samples[param].dtype)
-                    fp[dataset_name][fa:fb] = samples[param][wi, ma:mb]
+                    fp[dataset_name][istart:istop] = samples[param][wi, :]
 
-    def write_chain(self, fp, start_iteration=0, end_iteration=None,
-                    max_iterations=None):
+    def write_chain(self, fp, start_iteration=None, max_iterations=None):
         """Writes the samples from the current chain to the given file.
         
         Results are written to:
@@ -484,10 +471,10 @@ class BaseMCMCSampler(_BaseSampler):
         -----------
         fp : InferenceFile
             A file handler to an open inference file.
-        start_iteration : {0, int}
-            Write results starting from the given iteration.
-        end_iteration : {None, int}
-            Write results up to the given iteration.
+        start_iteration : int, optional
+            Write results to the file's datasets starting at the given
+            iteration. Default is to append after the last iteration in the
+            file. 
         max_iterations : int, optional
             Set the maximum size that the arrays in the hdf file may be resized
             to. Only applies if the samples have not previously been written
@@ -501,14 +488,11 @@ class BaseMCMCSampler(_BaseSampler):
         parameters = self.variable_args
         samples_group = fp.samples_group
         # write data
-        self.write_samples_group(
-                         fp, samples_group, parameters, samples,
-                         start_iteration=start_iteration,
-                         end_iteration=end_iteration,
-                         index_offset=self._lastclear,
-                         max_iterations=max_iterations)
+        self.write_samples_group(fp, samples_group, parameters, samples,
+                                 start_iteration=start_iteration,
+                                 max_iterations=max_iterations)
 
-    def write_likelihood_stats(self, fp, start_iteration=0, end_iteration=None,
+    def write_likelihood_stats(self, fp, start_iteration=None,
                                max_iterations=None):
         """Writes the `likelihood_stats` to the given file.
         
@@ -525,10 +509,10 @@ class BaseMCMCSampler(_BaseSampler):
         -----------
         fp : InferenceFile
             A file handler to an open inference file.
-        start_iteration : {0, int}
-            Write results starting from the given iteration.
-        end_iteration : {None, int}
-            Write results up to the given iteration.
+        start_iteration : int, optional
+            Write results to the file's datasets starting at the given
+            iteration. Default is to append after the last iteration in the
+            file. 
         max_iterations : int, optional
             Set the maximum size that the arrays in the hdf file may be resized
             to. Only applies if the samples have not previously been written
@@ -550,16 +534,13 @@ class BaseMCMCSampler(_BaseSampler):
         parameters = samples.fieldnames
         samples_group = fp.stats_group
         # write data
-        self.write_samples_group(
-                         fp, samples_group, parameters, samples,
-                         start_iteration=start_iteration,
-                         end_iteration=end_iteration,
-                         index_offset=self._lastclear,
-                         max_iterations=max_iterations)
+        self.write_samples_group(fp, samples_group, parameters, samples,
+                                 start_iteration=start_iteration,
+                                 max_iterations=max_iterations)
         return samples
 
-    def write_acceptance_fraction(self, fp, start_iteration=0,
-                                  end_iteration=None, max_iterations=None):
+    def write_acceptance_fraction(self, fp, start_iteration=None,
+                                  max_iterations=None):
         """Write acceptance_fraction data to file. Results are written to
         `fp[acceptance_fraction]`.
 
@@ -567,6 +548,10 @@ class BaseMCMCSampler(_BaseSampler):
         -----------
         fp : InferenceFile
             A file handler to an open inference file.
+        start_iteration : int, optional
+            Write results to the file's datasets starting at the given
+            iteration. Default is to append after the last iteration in the
+            file.
         max_iterations : int, optional
             Set the maximum size that the arrays in the hdf file may be resized
             to. Only applies if the acceptance fraction has not previously been
@@ -575,29 +560,31 @@ class BaseMCMCSampler(_BaseSampler):
         """
         dataset_name = "acceptance_fraction"
         acf = self.acceptance_fraction
-
-        if end_iteration is None:
-            end_iteration = acf.size
-
         if max_iterations is not None and max_iterations < acf.size:
             raise IndexError("The provided max size is less than the "
                              "number of iterations")
-
+        istart = start_iteration
         try:
-            if end_iteration > fp[dataset_name].size:
+            if istart is None:
+                istart = fp[dataset_name].size
+            istop = istart + acf.size
+            if istop > fp[dataset_name].size:
                 # resize the dataset
-                fp[dataset_name].resize(end_iteration, axis=0)
-            fp[dataset_name][start_iteration:end_iteration] = \
-                acf[start_iteration:end_iteration]
+                fp[dataset_name].resize(istop, axis=0)
+            fp[dataset_name][istart:istop] = acf
         except KeyError:
             # dataset doesn't exist yet
-            fp.create_dataset(dataset_name, (end_iteration,),
+            if istart is not None or istart != 0:
+                raise ValueError("non-zero start_iteration provided, "
+                                 "but dataset doesn't exist yet")
+            istart = 0
+            istop = istart + acf.size
+            fp.create_dataset(dataset_name, (istop,),
                               maxshape=(max_iterations,),
                               dtype=acf.dtype)
-            fp[dataset_name][start_iteration:end_iteration] = \
-                acf[start_iteration:end_iteration]
+            fp[dataset_name][istart:istop] = acf
 
-    def write_results(self, fp, start_iteration=0, end_iteration=None,
+    def write_results(self, fp, start_iteration=None,
                       max_iterations=None, **metadata):
         """Writes metadata, samples, likelihood stats, and acceptance fraction
         to the given file. Also computes and writes the autocorrleation lengths
@@ -607,10 +594,10 @@ class BaseMCMCSampler(_BaseSampler):
         -----------
         fp : InferenceFile
             A file handler to an open inference file.
-        start_iteration : {0, int}
-            Write results starting from the given iteration.
-        end_iteration : {None, int}
-            Write results up to the given iteration.
+        start_iteration : int, optional
+            Write results to the file's datasets starting at the given
+            iteration. Default is to append after the last iteration in the
+            file.
         max_iterations : int, optional
             Set the maximum size that the arrays in the hdf file may be resized
             to. Only applies if the acceptance fraction has not previously been
@@ -621,13 +608,10 @@ class BaseMCMCSampler(_BaseSampler):
         """
         self.write_metadata(fp, **metadata)
         self.write_chain(fp, start_iteration=start_iteration,
-                         end_iteration=end_iteration,
                          max_iterations=max_iterations)
         self.write_likelihood_stats(fp, start_iteration=start_iteration,
-                                    end_iteration=end_iteration,
                                     max_iterations=max_iterations)
         self.write_acceptance_fraction(fp, start_iteration=start_iteration,
-                                    end_iteration=end_iteration,
                                     max_iterations=max_iterations)
 
 

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -446,7 +446,7 @@ class BaseMCMCSampler(_BaseSampler):
                     fp[dataset_name][istart:istop] = samples[param][wi, :]
                 except KeyError:
                     # dataset doesn't exist yet
-                    if istart is not None or istart != 0:
+                    if istart is not None and istart != 0:
                         raise ValueError("non-zero start_iteration provided, "
                                          "but dataset doesn't exist yet")
                     istart = 0
@@ -574,7 +574,7 @@ class BaseMCMCSampler(_BaseSampler):
             fp[dataset_name][istart:istop] = acf
         except KeyError:
             # dataset doesn't exist yet
-            if istart is not None or istart != 0:
+            if istart is not None and istart != 0:
                 raise ValueError("non-zero start_iteration provided, "
                                  "but dataset doesn't exist yet")
             istart = 0
@@ -611,8 +611,8 @@ class BaseMCMCSampler(_BaseSampler):
                          max_iterations=max_iterations)
         self.write_likelihood_stats(fp, start_iteration=start_iteration,
                                     max_iterations=max_iterations)
-        self.write_acceptance_fraction(fp, start_iteration=start_iteration,
-                                    max_iterations=max_iterations)
+        self.write_acceptance_fraction(fp, start_iteration=0,
+                                       max_iterations=max_iterations)
 
 
     @staticmethod

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -233,7 +233,7 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
             wmask[walkers] = True
         return fp[group][wmask]
 
-    def write_results(self, fp, start_iteration=0, end_iteration=None,
+    def write_results(self, fp, start_iteration=None,
                       max_iterations=None, **metadata):
         """Writes metadata, samples, likelihood stats, and acceptance fraction
         to the given file. See the write function for each of those for
@@ -243,10 +243,10 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
         -----------
         fp : InferenceFile
             A file handler to an open inference file.
-        start_iteration : {0, int}
-            Write results starting from the given iteration.
-        end_iteration : {None, int}
-            Write results up to the given iteration.
+        start_iteration : int, optional
+            Write results to the file's datasets starting at the given
+            iteration. Default is to append after the last iteration in the
+            file.
         max_iterations : int, optional
             Set the maximum size that the arrays in the hdf file may be resized
             to. Only applies if the samples have not previously been written
@@ -257,10 +257,8 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
         """
         self.write_metadata(fp, **metadata)
         self.write_chain(fp, start_iteration=start_iteration,
-                         end_iteration=end_iteration,
                          max_iterations=max_iterations)
         self.write_likelihood_stats(fp, start_iteration=start_iteration,
-                                    end_iteration=end_iteration,
                                     max_iterations=max_iterations)
         self.write_acceptance_fraction(fp)
 
@@ -569,7 +567,7 @@ class EmceePTSampler(BaseMCMCSampler):
         start_iteration : int, optional
             Write results to the file's datasets starting at the given
             iteration. Default is to append after the last iteration in the
-            file. 
+            file.
         max_iterations : int, optional
             Set the maximum size that the arrays in the hdf file may be resized
             to. Only applies if the samples have not previously been written
@@ -603,7 +601,7 @@ class EmceePTSampler(BaseMCMCSampler):
                             samples[param][tk, wi, :]
                     except KeyError:
                         # dataset doesn't exist yet
-                        if istart is not None or istart != 0:
+                        if istart is not None and istart != 0:
                             raise ValueError("non-zero start_iteration "
                                              "provided, but dataset doesn't "
                                              "exist yet")
@@ -615,8 +613,7 @@ class EmceePTSampler(BaseMCMCSampler):
                         fp[dataset_name][istart:istop] = \
                             samples[param][tk, wi, :]
 
-    def write_results(self, fp, start_iteration=0, end_iteration=None,
-                      max_iterations=None,
+    def write_results(self, fp, start_iteration=None, max_iterations=None,
                       **metadata):
         """Writes metadata, samples, likelihood stats, and acceptance fraction
         to the given file. See the write function for each of those for
@@ -626,10 +623,10 @@ class EmceePTSampler(BaseMCMCSampler):
         -----------
         fp : InferenceFile
             A file handler to an open inference file.
-        start_iteration : {0, int}
-            Write results starting from the given iteration.
-        end_iteration : {None, int}
-            Write results up to the given iteration.
+        start_iteration : int, optional
+            Write results to the file's datasets starting at the given
+            iteration. Default is to append after the last iteration in the
+            file.
         max_iterations : int, optional
             Set the maximum size that the arrays in the hdf file may be resized
             to. Only applies if the samples have not previously been written
@@ -640,10 +637,8 @@ class EmceePTSampler(BaseMCMCSampler):
         """
         self.write_metadata(fp, **metadata)
         self.write_chain(fp, start_iteration=start_iteration,
-                         end_iteration=end_iteration,
                          max_iterations=max_iterations)
         self.write_likelihood_stats(fp, start_iteration=start_iteration,
-                                    end_iteration=end_iteration,
                                     max_iterations=max_iterations)
         self.write_acceptance_fraction(fp)
 


### PR DESCRIPTION
This simplifies the inputs to the `write_{results/chain/samples_group}` functions in the inference samplers. Currently these functions take optional `start_iteration`, `end_iteration`, and `index_offset` keyword arguments. The start/end iteration specify the start/end iteration of the chain in memory to write, while the index offset is used to write to a different set of indices in the file. This is more machinery than we need. We always write all data in memory to the file. The only thing we need to make sure of is that we append new data to the end of the dataset that is stored in the file.

This patch removes all of these keyword arguments, keeping only `start_iteration`. Now, `start_iteration` gives the index of the dataset in the file from which to start writing. If this is set to None, the data will be appended. Now, no keywords need to be specified at each checkpoint, since all of the data since the last checkpoint will be appended to the file by default.

I tested with kombine, emcee, and emcee_pt. See mp4s showing sampler evolution, [here](https://www.atlas.aei.uni-hannover.de/~cdcapano/public_scratch/pycbc_prs/1964/).

This patch lays the ground work for allowing for automatic re-starts without losing data after a failure or condor puts the job on hold. That's coming next.