### PR TITLE
Move acceptance fraction from BaseMCMC class

### DIFF
--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -102,13 +102,6 @@ class _BaseSampler(object):
         return self.chain.shape[-2] + self._lastclear
 
     @property
-    def acceptance_fraction(self):
-        """This function should return the fraction of walkers that accepted
-        each step as an array.
-        """
-        return NotImplementedError("acceptance_fraction function not set.")
-
-    @property
     def lnpost(self):
         """This function should return the natural logarithm of the likelihood
         function used by the sampler as an
@@ -326,12 +319,6 @@ class BaseMCMCSampler(_BaseSampler):
         return self._nwalkers
 
     @property
-    def acceptance_fraction(self):
-        """Get the fraction of walkers that accepted each step as an array.
-        """
-        return self._sampler.acceptance_fraction
-
-    @property
     def samples(self):
         """Returns the samples in the chain as a FieldArray.
 
@@ -539,56 +526,9 @@ class BaseMCMCSampler(_BaseSampler):
                                  max_iterations=max_iterations)
         return samples
 
-    def write_acceptance_fraction(self, fp, start_iteration=None,
-                                  max_iterations=None):
-        """Write acceptance_fraction data to file. Results are written to
-        `fp[acceptance_fraction]`.
-
-        Parameters
-        -----------
-        fp : InferenceFile
-            A file handler to an open inference file.
-        start_iteration : int, optional
-            Write results to the file's datasets starting at the given
-            iteration. Default is to append after the last iteration in the
-            file.
-        max_iterations : int, optional
-            Set the maximum size that the arrays in the hdf file may be resized
-            to. Only applies if the acceptance fraction has not previously been
-            written to the file. The default (None) is to use the maximum size
-            allowed by h5py.
-        """
-        dataset_name = "acceptance_fraction"
-        acf = self.acceptance_fraction
-        if max_iterations is not None and max_iterations < acf.size:
-            raise IndexError("The provided max size is less than the "
-                             "number of iterations")
-        istart = start_iteration
-        try:
-            if istart is None:
-                istart = fp[dataset_name].size
-            istop = istart + acf.size
-            if istop > fp[dataset_name].size:
-                # resize the dataset
-                fp[dataset_name].resize(istop, axis=0)
-            fp[dataset_name][istart:istop] = acf
-        except KeyError:
-            # dataset doesn't exist yet
-            if istart is not None and istart != 0:
-                raise ValueError("non-zero start_iteration provided, "
-                                 "but dataset doesn't exist yet")
-            istart = 0
-            istop = istart + acf.size
-            fp.create_dataset(dataset_name, (istop,),
-                              maxshape=(max_iterations,),
-                              dtype=acf.dtype)
-            fp[dataset_name][istart:istop] = acf
-
     def write_results(self, fp, start_iteration=None,
                       max_iterations=None, **metadata):
-        """Writes metadata, samples, likelihood stats, and acceptance fraction
-        to the given file. Also computes and writes the autocorrleation lengths
-        of the chains. See the various write function for details.
+        """Writes metadata, samples, and likelihood stats to the given file.
 
         Parameters
         -----------
@@ -599,10 +539,10 @@ class BaseMCMCSampler(_BaseSampler):
             iteration. Default is to append after the last iteration in the
             file.
         max_iterations : int, optional
-            Set the maximum size that the arrays in the hdf file may be resized
-            to. Only applies if the acceptance fraction has not previously been
-            written to the file. The default (None) is to use the maximum size
-            allowed by h5py.
+            Set the maximum size that the arrays in the hdf file may be
+            resized to. Only applies if data have not previously been written
+            to the file. The default (None) is to use the maximum size allowed
+            by h5py.
         \**metadata :
             All other keyword arguments are passed to ``write_metadata``.
         """
@@ -611,9 +551,6 @@ class BaseMCMCSampler(_BaseSampler):
                          max_iterations=max_iterations)
         self.write_likelihood_stats(fp, start_iteration=start_iteration,
                                     max_iterations=max_iterations)
-        self.write_acceptance_fraction(fp, start_iteration=0,
-                                       max_iterations=max_iterations)
-
 
     @staticmethod
     def _read_fields(fp, fields_group, fields, array_class,
@@ -757,52 +694,6 @@ class BaseMCMCSampler(_BaseSampler):
         # we'll just read a single parameter from the file
         samples = cls.read_samples(fp, fp.variable_args[0])
         return samples.size
-
-    @staticmethod
-    def read_acceptance_fraction(fp, thin_start=None, thin_interval=None,
-                                 thin_end=None, iteration=None):
-        """Reads the acceptance fraction from the given file.
-
-        Parameters
-        -----------
-        fp : InferenceFile
-            An open file handler to read the samples from.
-        walkers : {None, (list of) int}
-            The walker index (or a list of indices) to retrieve. If None,
-            samples from all walkers will be obtained.
-        thin_start : int
-            Index of the sample to begin returning samples. Default is to read
-            samples after burn in. To start from the beginning set thin_start
-            to 0.
-        thin_interval : int
-            Interval to accept every i-th sample. Default is to use the
-            `fp.acl`. If `fp.acl` is not set, then use all samples
-            (set thin_interval to 1).
-        thin_end : int
-            Index of the last sample to read. If not given then
-            `fp.niterations` is used.
-        iteration : int
-            Get a single iteration. If provided, will override the
-            `thin_{start/interval/end}` arguments.
-
-        Returns
-        -------
-        array
-            Array of acceptance fractions with shape (requested iterations,).
-        """
-        # get the slice to use
-        if iteration is not None:
-            get_index = iteration
-        else:
-            if thin_end is None:
-                # use the number of current iterations
-                thin_end = fp.niterations
-            get_index = fp.get_slice(thin_start=thin_start, thin_end=thin_end,
-                                     thin_interval=thin_interval)
-        acfs = fp['acceptance_fraction'][get_index]
-        if iteration is not None:
-            acfs = numpy.array([acfs])
-        return acfs
 
     @classmethod
     def compute_acfs(cls, fp, start_index=None, end_index=None,

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -102,6 +102,13 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
                    pool=pool, likelihood_call=likelihood_call)
 
     @property
+    def acceptance_fraction(self):
+        """An nwalkers-length array of the fraction of steps accepted for
+        each walker.
+        """
+        return self._sampler.acceptance_fraction
+
+    @property
     def lnpost(self):
         """Get the natural logarithm of the likelihood as an
         nwalkers x niterations array.
@@ -236,8 +243,9 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
     def write_results(self, fp, start_iteration=None,
                       max_iterations=None, **metadata):
         """Writes metadata, samples, likelihood stats, and acceptance fraction
-        to the given file. See the write function for each of those for
-        details.
+        to the given file.
+        
+        See the write function for each of those for details.
 
         Parameters
         -----------
@@ -248,18 +256,16 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
             iteration. Default is to append after the last iteration in the
             file.
         max_iterations : int, optional
-            Set the maximum size that the arrays in the hdf file may be resized
-            to. Only applies if the samples have not previously been written
-            to file. The default (None) is to use the maximum size allowed by
-            h5py.
+            Set the maximum size that the arrays in the hdf file may be
+            resized to. Only applies if data have not previously been written
+            to the file. The default (None) is to use the maximum size allowed
+            by h5py.
         \**metadata :
             All other keyword arguments are passed to ``write_metadata``.
         """
-        self.write_metadata(fp, **metadata)
-        self.write_chain(fp, start_iteration=start_iteration,
-                         max_iterations=max_iterations)
-        self.write_likelihood_stats(fp, start_iteration=start_iteration,
-                                    max_iterations=max_iterations)
+        super(EmceeEnsembleSampler, self).write_results(fp,
+            start_iteration=start_iteration, max_iterations=max_iterations,
+            **metadata)
         self.write_acceptance_fraction(fp)
 
 # This is needed for two reason
@@ -353,6 +359,13 @@ class EmceePTSampler(BaseMCMCSampler):
     @property
     def ntemps(self):
         return self._ntemps
+
+    @property
+    def acceptance_fraction(self):
+        """Array of shape ntemps x nwalkers giving the fraction of steps
+        accepted for each walker.
+        """
+        return self._sampler.acceptance_fraction
 
     @property
     def chain(self):
@@ -616,8 +629,9 @@ class EmceePTSampler(BaseMCMCSampler):
     def write_results(self, fp, start_iteration=None, max_iterations=None,
                       **metadata):
         """Writes metadata, samples, likelihood stats, and acceptance fraction
-        to the given file. See the write function for each of those for
-        details.
+        to the given file.
+        
+        See the various write functions for details.
 
         Parameters
         -----------
@@ -628,18 +642,16 @@ class EmceePTSampler(BaseMCMCSampler):
             iteration. Default is to append after the last iteration in the
             file.
         max_iterations : int, optional
-            Set the maximum size that the arrays in the hdf file may be resized
-            to. Only applies if the samples have not previously been written
-            to file. The default (None) is to use the maximum size allowed by
-            h5py.
+            Set the maximum size that the arrays in the hdf file may be
+            resized to. Only applies if data have not previously been written
+            to the file. The default (None) is to use the maximum size allowed
+            by h5py.
         \**metadata :
             All other keyword arguments are passed to ``write_metadata``.
         """
-        self.write_metadata(fp, **metadata)
-        self.write_chain(fp, start_iteration=start_iteration,
-                         max_iterations=max_iterations)
-        self.write_likelihood_stats(fp, start_iteration=start_iteration,
-                                    max_iterations=max_iterations)
+        super(EmceePTSampler, self).write_results(fp,
+            start_iteration=start_iteration, max_iterations=max_iterations,
+            **metadata)
         self.write_acceptance_fraction(fp)
 
 

--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -334,11 +334,11 @@ class KombineSampler(BaseMCMCSampler):
                       max_iterations=None, **metadata):
         """Writes metadata, samples, likelihood stats, and acceptance fraction
         to the given file.
-        
+
         See the various write functions for details.
 
         Parameters
-        -----------
+        ----------
         fp : InferenceFile
             A file handler to an open inference file.
         start_iteration : int, optional

--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -109,7 +109,8 @@ class KombineSampler(BaseMCMCSampler):
 
     @property
     def acceptance_fraction(self):
-        """Get the fraction of walkers that accepted each step as an array.
+        """An niterations-length array giving the fraction of walkers that
+        accepted each step.
         """
         return self._sampler.acceptance_fraction
 

--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -107,6 +107,12 @@ class KombineSampler(BaseMCMCSampler):
                    likelihood_call=likelihood_call,
                    pool=pool, update_interval=opts.update_interval)
 
+    @property
+    def acceptance_fraction(self):
+        """Get the fraction of walkers that accepted each step as an array.
+        """
+        return self._sampler.acceptance_fraction
+
     def run(self, niterations, **kwargs):
         """Advance the sampler for a number of samples.
 
@@ -180,6 +186,52 @@ class KombineSampler(BaseMCMCSampler):
         # clear the blobs
         self._sampler._blobs = []
 
+    @staticmethod
+    def read_acceptance_fraction(fp, thin_start=None, thin_interval=None,
+                                 thin_end=None, iteration=None):
+        """Reads the acceptance fraction from the given file.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            An open file handler to read the samples from.
+        walkers : {None, (list of) int}
+            The walker index (or a list of indices) to retrieve. If None,
+            samples from all walkers will be obtained.
+        thin_start : int
+            Index of the sample to begin returning samples. Default is to read
+            samples after burn in. To start from the beginning set thin_start
+            to 0.
+        thin_interval : int
+            Interval to accept every i-th sample. Default is to use the
+            `fp.acl`. If `fp.acl` is not set, then use all samples
+            (set thin_interval to 1).
+        thin_end : int
+            Index of the last sample to read. If not given then
+            `fp.niterations` is used.
+        iteration : int
+            Get a single iteration. If provided, will override the
+            `thin_{start/interval/end}` arguments.
+
+        Returns
+        -------
+        array
+            Array of acceptance fractions with shape (requested iterations,).
+        """
+        # get the slice to use
+        if iteration is not None:
+            get_index = iteration
+        else:
+            if thin_end is None:
+                # use the number of current iterations
+                thin_end = fp.niterations
+            get_index = fp.get_slice(thin_start=thin_start, thin_end=thin_end,
+                                     thin_interval=thin_interval)
+        acfs = fp['acceptance_fraction'][get_index]
+        if iteration is not None:
+            acfs = numpy.array([acfs])
+        return acfs
+
     def burn_in(self):
         """Use kombine's `burnin` routine to advance the sampler.
 
@@ -231,6 +283,80 @@ class KombineSampler(BaseMCMCSampler):
                                         len(self.variable_args)),
                               dtype=float)
             fp[dataset_name][:] = kde.data
+
+    def write_acceptance_fraction(self, fp, start_iteration=None,
+                                  max_iterations=None):
+        """Write acceptance_fraction data to file. Results are written to
+        `fp[acceptance_fraction]`.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        start_iteration : int, optional
+            Write results to the file's datasets starting at the given
+            iteration. Default is to append after the last iteration in the
+            file.
+        max_iterations : int, optional
+            Set the maximum size that the arrays in the hdf file may be resized
+            to. Only applies if the acceptance fraction has not previously been
+            written to the file. The default (None) is to use the maximum size
+            allowed by h5py.
+        """
+        dataset_name = "acceptance_fraction"
+        acf = self.acceptance_fraction
+        if max_iterations is not None and max_iterations < acf.size:
+            raise IndexError("The provided max size is less than the "
+                             "number of iterations")
+        istart = start_iteration
+        try:
+            if istart is None:
+                istart = fp[dataset_name].size
+            istop = istart + acf.size
+            if istop > fp[dataset_name].size:
+                # resize the dataset
+                fp[dataset_name].resize(istop, axis=0)
+            fp[dataset_name][istart:istop] = acf
+        except KeyError:
+            # dataset doesn't exist yet
+            if istart is not None and istart != 0:
+                raise ValueError("non-zero start_iteration provided, "
+                                 "but dataset doesn't exist yet")
+            istart = 0
+            istop = istart + acf.size
+            fp.create_dataset(dataset_name, (istop,),
+                              maxshape=(max_iterations,),
+                              dtype=acf.dtype)
+            fp[dataset_name][istart:istop] = acf
+
+    def write_results(self, fp, start_iteration=None,
+                      max_iterations=None, **metadata):
+        """Writes metadata, samples, likelihood stats, and acceptance fraction
+        to the given file.
+        
+        See the various write functions for details.
+
+        Parameters
+        -----------
+        fp : InferenceFile
+            A file handler to an open inference file.
+        start_iteration : int, optional
+            Write results to the file's datasets starting at the given
+            iteration. Default is to append after the last iteration in the
+            file.
+        max_iterations : int, optional
+            Set the maximum size that the arrays in the hdf file may be
+            resized to. Only applies if data has not previously been written
+            to the file. The default (None) is to use the maximum size allowed
+            by h5py.
+        \**metadata :
+            All other keyword arguments are passed to ``write_metadata``.
+        """
+        super(KombineSampler, self).write_results(fp,
+            start_iteration=start_iteration, max_iterations=max_iterations,
+            **metadata)
+        self.write_acceptance_fraction(fp, start_iteration=0,
+                                       max_iterations=max_iterations)
 
     def write_state(self, fp):
         """Saves the state of the sampler in a file.

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -319,13 +319,13 @@ class InferenceFile(h5py.File):
         numpy.array
             The acceptance fraction.
         """
-        return self.sampler.read_acceptance_fraction(self, **kwargs)
+        return self.sampler_class.read_acceptance_fraction(self, **kwargs)
 
     def read_acls(self):
         """Returns all of the individual chains' acls. See the `read_acls`
         function of this file's sampler for more details.
         """
-        return self.sampler.read_acls(self)
+        return self.sampler_class.read_acls(self)
 
     def read_label(self, parameter, error_on_none=False):
         """Returns the label for the parameter.


### PR DESCRIPTION
Currently `acceptance_fraction` is defined in the BaseMCMCSampler. However, this seems to be something unique to ensemble samplers like kombine and emcee. In fact, even kombine and emcee define these differently (necessitating different functions for emcee to read/write). This removes acceptance fraction from `BaseMCMCSampler`, instead making it attributes specific to `KombineSampler` and `Emcee(Ensemble/PT)Sampler`.

This also fixes a bug in `InferenceFile` that caused an error when either `read_acceptance_fraction` or `read_acls` was called.

Putting on hold until #1964 is merged, since this patch depends on that.

@vivienr I decided do this after seeing your work on adding an MCMC sampler. Let me know if there are other things you think should be moved out of the `BaseMCMCSampler` class. Also, it occurs to me that a lot of the things that are currently in `EmceePTSampler` are generic to any parallel-tempered sampler (like writing multiple temperature chains to file). Once you get to writing your parallel tempered sampler, I think we should define a `BaseParallelTemperedSampler` with these common functions in them, then have your class and `EmceePTSampler` inherit from that.