### PR TITLE
Write samples to arrays instead of groups

### DIFF
--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -38,7 +38,8 @@ def _check_fileformat(read_function):
     """Decorator function for determing which read function to call."""
     def read_wrapper(cls, fp, *args, **kwargs):
         # check for old style
-        if not isinstance(fp[fields_group][fields[0]], h5py.Dataset)):
+        check_group = '{}/{}'.format(fp.samples_group, fp.variable_args[0])
+        if not isinstance(fp[check_group], h5py.Dataset):
             convert_cmd = ("pycbc_inference_extract_sampes --input-file {} "
                            "--thin-start 0 --thin-interval 1 --output-file "
                            "FILE.hdf".format(fp.filename))
@@ -740,10 +741,10 @@ class BaseMCMCSampler(_BaseSampler):
         """
         # walkers to load
         if walkers is not None:
-            wmask = numpy.zeros(fp.nwalkers, dtype=bool)
-            wmask[walkers] = True
+            widx = numpy.zeros(fp.nwalkers, dtype=bool)
+            widx[walkers] = True
         else:
-            wmask = None
+            widx = slice(0, None)
         # get the slice to use
         if iteration is not None:
             get_index = iteration
@@ -757,7 +758,7 @@ class BaseMCMCSampler(_BaseSampler):
         arrays = {}
         group = fields_group + '/{name}'
         for name in fields:
-            arr = fp[group.format(name=name)][wmask, get_index]
+            arr = fp[group.format(name=name)][widx, get_index]
             if flatten:
                 arr = arr.flatten()
             arrays[name] = arr

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -72,8 +72,9 @@ def _check_fileformat(read_function):
 
 def _check_aclfileformat(read_function):
     """Decorator function for determing which read acl function to call."""
-    def read_wrapper(cls, fp):
+    def read_wrapper(fp):
         # check for old style
+        check_group = '{}/{}'.format(fp.samples_group, fp.variable_args[0])
         if 'acls' not in fp.keys() and not isinstance(fp[check_group],
                                                       h5py.Dataset):
             convert_cmd = ("pycbc_inference_extract_samples --input-file {} "
@@ -90,7 +91,7 @@ def _check_aclfileformat(read_function):
                             "doing that now.)\n\n".format(fp.filename,
                             convert_cmd))
             # call oldstyle function instead
-            return cls._oldstyle_read_acls(fp)
+            return fp.sampler_class._oldstyle_read_acls(fp)
         else:
             return read_function(fp)
     return read_wrapper
@@ -500,7 +501,7 @@ class BaseMCMCSampler(_BaseSampler):
             dataset_name = group.format(name=param)
             istart = start_iteration
             try:
-                fp_nwalkers, fp_niterations = fp[dataset_name].shape
+                fp_niterations = fp[dataset_name].shape[-1]
                 if istart is None:
                     istart = fp_niterations
                 istop = istart + niterations

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -40,17 +40,17 @@ def _check_fileformat(read_function):
         # check for old style
         check_group = '{}/{}'.format(fp.samples_group, fp.variable_args[0])
         if not isinstance(fp[check_group], h5py.Dataset):
-            convert_cmd = ("pycbc_inference_extract_sampes --input-file {} "
+            convert_cmd = ("pycbc_inference_extract_samples --input-file {} "
                            "--thin-start 0 --thin-interval 1 --output-file "
                            "FILE.hdf".format(fp.filename))
-            logging.warning("DEPRECATION WARNING: The file {} appears to have "
-                            "been written using an older style file format. "
-                            "Support for this format will be removed in a "
-                            "future update. To convert this file, run: "
+            logging.warning("\n\nDEPRECATION WARNING: The file {} appears to  "
+                            "have been written using an older style file "
+                            "format. Support for this format will be removed "
+                            "in a future update. To convert this file, run: "
                             "\n\n{}\n\n"
                             "where FILE.hdf is the name of the file to "
                             "convert to. (Ignore this warning if you are "
-                            "doing that now.)".format(fp.filename,
+                            "doing that now.)\n\n".format(fp.filename,
                             convert_cmd))
             # we'll replace cls._read_fields with _read_oldstyle_fields, so
             # that when the read_function calls cls._read_fields, it points
@@ -76,17 +76,18 @@ def _check_aclfileformat(read_function):
         # check for old style
         if 'acls' not in fp.keys() and not isinstance(fp[check_group],
                                                       h5py.Dataset):
-            convert_cmd = ("pycbc_inference_extract_sampes --input-file {} "
+            convert_cmd = ("pycbc_inference_extract_samples --input-file {} "
                            "--thin-start 0 --thin-interval 1 --output-file "
                            "FILE.hdf".format(fp.filename))
-            logging.warning("DEPRECATION WARNING: The acls in file {} appear "
+            logging.warning("\n\n"
+                            "DEPRECATION WARNING: The acls in file {} appear "
                             "to have been written using an older style file "
                             "format. Support for this format will be removed "
                             "in a future update. To convert this file, run: "
                             "\n\n{}\n\n"
                             "where FILE.hdf is the name of the file to "
                             "convert to. (Ignore this warning if you are "
-                            "doing that now.)".format(fp.filename,
+                            "doing that now.)\n\n".format(fp.filename,
                             convert_cmd))
             # call oldstyle function instead
             return cls._oldstyle_read_acls(fp)
@@ -1049,10 +1050,12 @@ class BaseMCMCSampler(_BaseSampler):
         # write the individual acls
         for param in acls:
             try:
+                # we need to use the write_direct function because it's
+                # apparently the only way to update scalars in h5py
+                fp[group.format(param)].write_direct(numpy.array(acls[param]))
+            except KeyError:
+                # dataset doesn't exist yet
                 fp[group.format(param)] = acls[param]
-            except RuntimeError:
-                # dataset is not scalar and it already exists
-                fp[group.format(param)][:] = acls[param]
         # write the maximum over all params
         fp.attrs['acl'] = numpy.array(acls.values()).max()
         return fp.attrs['acl']

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -731,20 +731,20 @@ class EmceePTSampler(BaseMCMCSampler):
         """
         # walkers to load
         if walkers is not None:
-            wmask = numpy.zeros(fp.nwalkers, dtype=bool)
-            wmask[walkers] = True
+            widx = numpy.zeros(fp.nwalkers, dtype=bool)
+            widx[walkers] = True
         else:
-            wmask = None
+            widx = slice(None, None)
         # temperatures to load
         if temps is None:
-            tmask = 0
+            tidx = 0
         elif temps == 'all':
-            tmask = None
+            tidx = slice(None, None)
         elif isinstance(temps, int):
-            tmask = temps
+            tidx = temps
         else:
-            tmask = numpy.zeros(fp.ntemps, dtype=bool)
-            tmask[temps] = True
+            tidx = numpy.zeros(fp.ntemps, dtype=bool)
+            tmask[tidx] = True
         # get the slice to use
         if iteration is not None:
             get_index = [iteration]
@@ -758,7 +758,7 @@ class EmceePTSampler(BaseMCMCSampler):
         arrays = {}
         group = fields_group + '/{name}'
         for name in fields:
-            arr = fp[group.format(name=name)][tmask, wmask, get_index]
+            arr = fp[group.format(name=name)][tidx, widx, get_index]
             if flatten:
                 arr = arr.flatten()
             arrays[name] = arr

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -583,7 +583,7 @@ class EmceePTSampler(BaseMCMCSampler):
             dataset_name = group.format(name=param)
             istart = start_iteration
             try:
-                fp_ntemps, fp_nwalkers, fp_niterations = fp[dataset_name].shape
+                fp_niterations = fp[dataset_name].shape[-1]
                 if istart is None:
                     istart = fp_niterations
                 istop = istart + niterations
@@ -747,7 +747,7 @@ class EmceePTSampler(BaseMCMCSampler):
             tidx = [temps]
         else:
             tidx = numpy.zeros(fp.ntemps, dtype=bool)
-            tmask[tidx] = True
+            tidx[tidx] = True
         # get the slice to use
         if iteration is not None:
             # If a single walker is specified, we encase in a list to
@@ -989,6 +989,7 @@ class EmceePTSampler(BaseMCMCSampler):
             acls[param] = these_acls
         return acls
 
+    @staticmethod
     def _oldstyle_read_acls(fp):
         """Deprecated: reads acls from older style files.
 


### PR DESCRIPTION
Currently, we are writing samples to files in `fp['samples/{param}/[temp{k}/]walker{i}]`. It turns out that if we simply saved the (ntemps x) nwalkers x niterations as a multi-dimensional array to `fp['samples/{param}']` (so, basically the same way we hold this in memory) the output files are much smaller, it's faster to read and write, and it might mitigate one of the errors I was seeing when running PP tests.

This patch does exactly that. The write functions now just store the arrays for each parameter as-is to disk, instead of trying to separate walkers/temps into different groups. To preserve backward compatability with older files, I've renamed the old read function `_oldstyle_read_fields`. A decorator around `read_samples`, `_check_fileformat`, is used to figure out which `_read_fields` function to call based on what's in the given inference file. This also allows older file formats to be converted using `pycbc_inference_extract_samples`. I've included a deprecation warning in the decorator giving the command to run to do this. Example:
```
2017-11-11 01:45:41,119 Loading parameters
2017-11-11 01:45:41,119 Reading input file normal2d-0-6.hdf
2017-11-11 01:45:41,121 

DEPRECATION WARNING: The file normal2d-0-6.hdf appears to  have been written using an older style file format. Support for this format will be removed in a future update. To convert this file, run: 

pycbc_inference_extract_samples --input-file normal2d-0-6.hdf --thin-start 0 --thin-interval 1 --output-file FILE.hdf

where FILE.hdf is the name of the file to convert to. (Ignore this warning if you are doing that now.)
```

This patch also simplifies hows acls are saved. Previously, acls were saved to the `attrs` of each parameter/temperature group in `samples`. Now they are saved as a data set to `acls/{param}`. For single-temperature samplers these data sets just store a single value. For multi-tempered samplers these are arrays. The max over all walkers/temperatures is still saved to the file's `attrs['acl']` attribute. Like `_read_fields`, the older style `read_acls` is kept around for backward compatibility, and a decorator is used to redirect as appropriate.

I tested using 5000 walkers for 6 iterations on a 2D gaussian with both `emcee` and `kombine`. The file size went from ~60MB to 1MB, writing went from taking ~15s to taking < 0.1s, and reading went from taking ~3s to <0.1s. Repeating using 3 temperature chains with `emcee_pt`, the file size went from ~140MB to 3MB, writing went from taking ~30s to taking <0.1s, and reading went from taking ~3s to < 0.1s. I haven't tested if the reduction in file size will be the same factor for larger files yet.

I think this should also help reduce incidences of the following error I've been randomly getting when doing PP tests:
```
HDF5: infinite loop closing library
      D,G,A,S,T,F,FD,P,FD,P,FD,P,E,E,SL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL,FL
```
This is apparently a bug with an unknown cause in h5py, but according to [this](https://github.com/h5py/h5py/issues/556) it might be due to having too many attributes in a file.

All-in-all, this simplifies the file format, the code to read/write, and results in better performance and disk usage.