### PR TITLE
add test eggbox likelihood

### DIFF
--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -568,6 +568,7 @@ class TestEggbox(BaseLikelihoodEvaluator):
     def __init__(self, variable_args, **kwargs):
         # set up base likelihood parameters
         super(TestEggbox, self).__init__(variable_args, **kwargs)
+
         # set the lognl to 0 since there is no data
         self.set_lognl(0.)
 

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -547,7 +547,10 @@ class TestNormal(BaseLikelihoodEvaluator):
 
 class TestEggbox(BaseLikelihoodEvaluator):
     r"""The test distribution is an 'eggbox' function:
-    $$f(\Theta)=-\left[2+\prod_{i=1}^{n}\cos\left(\frac{\theta_{i}}{2}\right)\right]^{5}$$
+
+    .. math::
+
+        \log \mathcal{L}(\Theta) = \left[2+\prod_{i=1}^{n}\cos\left(\frac{\theta_{i}}{2}\right)\right]^{5}
 
     The number of dimensions is set by the number of ``variable_args`` that are
     passed.
@@ -571,8 +574,8 @@ class TestEggbox(BaseLikelihoodEvaluator):
     def loglikelihood(self, **params):
         """Returns the log pdf of the eggbox function.
         """
-        l = (2 + numpy.prod([numpy.cos(p/2.) for p in params.values()])) ** 5
-        return l
+        return (2 + numpy.prod(numpy.cos([params[p]/2. for p in
+                                          self.variable_args])))**5
 
 
 #

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -545,6 +545,34 @@ class TestNormal(BaseLikelihoodEvaluator):
         """
         return self._dist.logpdf([params[p] for p in self.variable_args])
 
+class TestEggbox(BaseLikelihoodEvaluator):
+    r"""The test distribution is an 'eggbox' function:
+    $$f(\Theta)=-\left[2+\prod_{i=1}^{n}\cos\left(\frac{\theta_{i}}{2}\right)\right]^{5}$$
+
+    The number of dimensions is set by the number of ``variable_args`` that are
+    passed.
+
+    Parameters
+    ----------
+    variable_args : (tuple of) string(s)
+        A tuple of parameter names that will be varied.
+    \**kwargs :
+        All other keyword arguments are passed to ``BaseLikelihoodEvaluator``.
+
+    """
+    name = "test_eggbox"
+
+    def __init__(self, variable_args, **kwargs):
+        # set up base likelihood parameters
+        super(TestEggbox, self).__init__(variable_args, **kwargs)
+        # set the lognl to 0 since there is no data
+        self.set_lognl(0.)
+
+    def loglikelihood(self, **params):
+        """Returns the log pdf of the eggbox function.
+        """
+        l = (2 + numpy.prod([numpy.cos(p/2.) for p in params.values()])) ** 5
+        return l
 
 
 #
@@ -857,8 +885,9 @@ class GaussianLikelihood(BaseLikelihoodEvaluator):
                                   logjacobian=lj)
 
 
-likelihood_evaluators = {TestNormal.name: TestNormal,
+likelihood_evaluators = {TestEggbox.name: TestEggbox,
+                         TestNormal.name: TestNormal,
                          GaussianLikelihood.name: GaussianLikelihood}
 
-__all__ = ['BaseLikelihoodEvaluator', 'TestNormal', 'GaussianLikelihood',
-           'likelihood_evaluators']
+__all__ = ['BaseLikelihoodEvaluator', 'TestNormal', 'TestEggbox',
+           'GaussianLikelihood', 'likelihood_evaluators']


### PR DESCRIPTION
This patch adds a likelihood evaluator in which the likelihood function is the pdf of an 'eggbox function' as defined here: https://arxiv.org/pdf/1312.5638.pdf
e.g.
![eggbox2d](https://user-images.githubusercontent.com/22331074/32738486-1b92caec-c86b-11e7-8956-fd52b06463c3.png)

Example:

With config file:
```
[variable_args]
x =
y =

[prior-x]
name = uniform
min-x = 0
max-x = 31.5

[prior-y]
name = uniform
min-y = 0
max-y = 31.5
```
and arguments:
```
pycbc_inference --config-files eggbox2d.ini --output-file test_eggbox2d.hdf --sampler kombine --verbose --likelihood-evaluator test_eggbox --niterations 100 --nwalkers 2000
```
we get: [eggbox2d_posterior](https://sugwg-jobs.phy.syr.edu/~daniel.finstad/inference/analytic_likelihoods/eggbox2d_likelihood.png)