### PR TITLE
be explicity about not using a relative import

### DIFF
--- a/pycbc/events/simd_threshold.py
+++ b/pycbc/events/simd_threshold.py
@@ -16,7 +16,7 @@
 from __future__ import absolute_import
 from pycbc import WEAVE_FLAGS
 from pycbc.types import zeros, complex64, float32
-from weave import inline
+from pycbc.weave import inline
 import numpy as _np
 import pycbc.opt
 from pycbc.opt import omp_support, omp_libs, omp_flags

--- a/pycbc/events/threshold_cpu.py
+++ b/pycbc/events/threshold_cpu.py
@@ -24,7 +24,7 @@
 from __future__ import absolute_import
 import numpy
 from pycbc import WEAVE_FLAGS
-from weave import inline
+from pycbc.weave import inline
 from .simd_threshold import thresh_cluster_support, default_segsize
 from .events import _BaseThresholdCluster
 from pycbc.opt import omp_libs, omp_flags

--- a/pycbc/filter/matchedfilter_cpu.py
+++ b/pycbc/filter/matchedfilter_cpu.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import
 import numpy
 from pycbc.opt import omp_libs, omp_flags
 from pycbc import WEAVE_FLAGS
-from weave import inline
+from pycbc.weave import inline
 from .simd_correlate import default_segsize, corr_parallel_code, corr_support
 from .matchedfilter import _BaseCorrelator
 

--- a/pycbc/filter/simd_correlate.py
+++ b/pycbc/filter/simd_correlate.py
@@ -15,7 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 from __future__ import absolute_import
 from pycbc.types import float32
-from weave import inline
+from pycbc.weave import inline
 from pycbc import WEAVE_FLAGS
 import numpy as _np
 import pycbc.opt

--- a/pycbc/types/array_cpu.py
+++ b/pycbc/types/array_cpu.py
@@ -28,7 +28,7 @@ import numpy as _np
 from pycbc.types.array import common_kind, complex128, float64
 from . import aligned as _algn
 from scipy.linalg import blas
-from weave import inline
+from pycbc.weave import inline
 from pycbc.opt import omp_libs, omp_flags
 from pycbc import WEAVE_FLAGS
 from pycbc.types import real_same_precision_as

--- a/pycbc/vetoes/chisq_cpu.py
+++ b/pycbc/vetoes/chisq_cpu.py
@@ -24,7 +24,7 @@
 from __future__ import absolute_import
 import numpy, pycbc
 from pycbc.types import real_same_precision_as
-from weave import inline
+from pycbc.weave import inline
 from pycbc import WEAVE_FLAGS
 
 if pycbc.HAVE_OMP:

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -28,7 +28,7 @@ import lalsimulation, lal, numpy, logging, h5py
 from pycbc import pnutils, filter
 from pycbc.opt import omp_libs, omp_flags
 from pycbc import WEAVE_FLAGS
-from weave import inline
+from pycbc.weave import inline
 from scipy import interpolate
 from pycbc.types import FrequencySeries, zeros, complex_same_precision_as, real_same_precision_as
 from pycbc.waveform import utils

--- a/pycbc/waveform/spa_tmplt_cpu.py
+++ b/pycbc/waveform/spa_tmplt_cpu.py
@@ -20,7 +20,7 @@ import lal
 import pycbc
 from pycbc.types import Array, float32, FrequencySeries
 from pycbc.waveform.spa_tmplt import spa_tmplt_precondition
-from weave import inline
+from pycbc.weave import inline
 
 support = """
     #include <stdio.h>

--- a/pycbc/waveform/utils.py
+++ b/pycbc/waveform/utils.py
@@ -33,7 +33,7 @@ import numpy
 import copy
 from pycbc.opt import omp_libs, omp_flags
 from pycbc import WEAVE_FLAGS
-from weave import inline
+from pycbc.weave import inline
 
 def ceilpow2(n):
     """convenience function to determine a power-of-2 upper frequency limit"""

--- a/pycbc/weave.py
+++ b/pycbc/weave.py
@@ -62,7 +62,7 @@ def pycbc_compile_function(code,arg_names,local_dict,global_dict,
     return func
 
 inline_tools.compile_function = pycbc_compile_function
-from pycbc.weave import inline
+from weave import inline
 
 def insert_weave_option_group(parser):
     """

--- a/pycbc/weave.py
+++ b/pycbc/weave.py
@@ -62,6 +62,7 @@ def pycbc_compile_function(code,arg_names,local_dict,global_dict,
     return func
 
 inline_tools.compile_function = pycbc_compile_function
+from pycbc.weave import inline
 
 def insert_weave_option_group(parser):
     """


### PR DESCRIPTION
It seems that on some platforms (or maybe just within cvmfs.. more testing needed to verify) the import order is such that local imports are *not* preferred over absolute ones. This causes the weave package to be picked up instead of pycbc.weave and so in executables that didn't explicitly do an import of pycbc.weave, the file locking is not always enabled. 