### PR TITLE
add test Rosenbrock likelihood

### DIFF
--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -579,7 +579,7 @@ class TestEggbox(BaseLikelihoodEvaluator):
                                           self.variable_args])))**5
 
 class TestRosenbrock(BaseLikelihoodEvaluator):
-    r"""The test distribution is an 'eggbox' function:
+    r"""The test distribution is the Rosenbrock function:
 
     .. math::
 

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -578,6 +578,41 @@ class TestEggbox(BaseLikelihoodEvaluator):
         return (2 + numpy.prod(numpy.cos([params[p]/2. for p in
                                           self.variable_args])))**5
 
+class TestRosenbrock(BaseLikelihoodEvaluator):
+    r"""The test distribution is an 'eggbox' function:
+
+    .. math::
+
+        \log \mathcal{L}(\Theta) = -\sum_{i=1}^{n-1}[(1-\theta_{i})^{2}+100(\theta_{i+1} - \theta_{i}^{2})^{2}]
+
+    The number of dimensions is set by the number of ``variable_args`` that are
+    passed.
+
+    Parameters
+    ----------
+    variable_args : (tuple of) string(s)
+        A tuple of parameter names that will be varied.
+    \**kwargs :
+        All other keyword arguments are passed to ``BaseLikelihoodEvaluator``.
+
+    """
+    name = "test_rosenbrock"
+
+    def __init__(self, variable_args, **kwargs):
+        # set up base likelihood parameters
+        super(TestRosenbrock, self).__init__(variable_args, **kwargs)
+
+        # set the lognl to 0 since there is no data
+        self.set_lognl(0.)
+
+    def loglikelihood(self, **params):
+        """Returns the log pdf of the Rosenbrock function.
+        """
+        l = 0
+        p = [params[p] for p in self.variable_args]
+        for i in range(len(p) - 1):
+            l -= ((1 - p[i])**2 + 100 * (p[i+1] - p[i]**2)**2)
+        return l
 
 #
 # =============================================================================
@@ -891,7 +926,8 @@ class GaussianLikelihood(BaseLikelihoodEvaluator):
 
 likelihood_evaluators = {TestEggbox.name: TestEggbox,
                          TestNormal.name: TestNormal,
+                         TestRosenbrock.name: TestRosenbrock,
                          GaussianLikelihood.name: GaussianLikelihood}
 
 __all__ = ['BaseLikelihoodEvaluator', 'TestNormal', 'TestEggbox',
-           'GaussianLikelihood', 'likelihood_evaluators']
+           'TestRosenbrock', 'GaussianLikelihood', 'likelihood_evaluators']


### PR DESCRIPTION
This patch adds a likelihood evaluator in which the likelihood function is the pdf of the Rosenbrock function as defined here: https://arxiv.org/pdf/1312.5638.pdf
e.g.
![rosenbrock2d](https://user-images.githubusercontent.com/22331074/32755907-78d590a6-c8a5-11e7-8f0f-460859a3cc66.png)
Example
Using config file:
```
[variable_args]
x =
y =

[prior-x]
name = uniform
min-x = -20
max-x = 20

[prior-y]
name = uniform
min-y = -20
max-y = 20
```
and arguments:
```
pycbc_inference --config-files rosenbrock2d.ini --output-file test_rosenbrock2d.hdf --sampler kombine --verbose --likelihood-evaluator test_rosenbrock --niterations 100 --nwalkers 2000
```
yields: [Rosenbrock2d_posterior](https://sugwg-jobs.phy.syr.edu/~daniel.finstad/inference/analytic_likelihoods/rosenbrock2d_likelihood.png)