### PR TITLE
Has pycbc_live only check access to GraceDB if upload enabled

### DIFF
--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -317,7 +317,7 @@ ifos, followup_ifos = list(ifos), list(followup_ifos)
 advancing_ifos = (ifos + followup_ifos) if evnt.rank == 0 else ifos
 
 # make sure we can talk to GraceDB
-if evnt.rank == 0:
+if evnt.rank == 0 and args.enable_gracedb_upload == True:
     logging.info('Testing access to GraceDB')
     from ligo.gracedb.rest import GraceDb
     gdb_client = GraceDb(args.gracedb_server) if args.gracedb_server else GraceDb()

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -317,7 +317,7 @@ ifos, followup_ifos = list(ifos), list(followup_ifos)
 advancing_ifos = (ifos + followup_ifos) if evnt.rank == 0 else ifos
 
 # make sure we can talk to GraceDB
-if evnt.rank == 0 and args.enable_gracedb_upload == True:
+if evnt.rank == 0 and args.enable_gracedb_upload:
     logging.info('Testing access to GraceDB')
     from ligo.gracedb.rest import GraceDb
     gdb_client = GraceDb(args.gracedb_server) if args.gracedb_server else GraceDb()


### PR DESCRIPTION
This makes it so pycbc_live only checks the connection to gracedb if the executable is set to upload triggers. This default had caused the program to fail in testing mode, when no upload was desired, and no connection was available. 