### PR TITLE
add test volcano likelihood

### DIFF
--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -619,7 +619,7 @@ class TestVolcano(BaseLikelihoodEvaluator):
 
     .. math::
         \Theta = \sqrt{\theta_{1}^{2} + \theta_{2}^{2}}
-        \log \mathcal{L}(\Theta) = 5(e^{-\Theta} + \frac{50}{2\sqrt{2\pi}} e^{-\frac{(\Theta-5)^{2}}{8}}
+        \log \mathcal{L}(\Theta) = 5(e^{-\Theta} + \frac{50}{2\sqrt{2\pi}} e^{-\frac{(\Theta-5)^{2}}{8}})
 
     Parameters
     ----------

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -646,7 +646,8 @@ class TestVolcano(BaseLikelihoodEvaluator):
     def loglikelihood(self, **params):
         """Returns the log pdf of the 2D volcano function.
         """
-        r = numpy.sqrt(sum([p**2 for p in self.variable_args]))
+        p = [params[p] for p in self.variable_args]
+        r = numpy.sqrt(p[0]**2 + p[1]**2)
         mu, sigma = 5.0, 2.0
         return 5 * (numpy.exp(-r) + 50. / (sigma * numpy.sqrt(2 * numpy.pi)) * \
                    numpy.exp(-0.5 * ((r - mu) / sigma) ** 2))

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -646,8 +646,7 @@ class TestVolcano(BaseLikelihoodEvaluator):
     def loglikelihood(self, **params):
         """Returns the log pdf of the 2D volcano function.
         """
-        p = [params[p] for p in self.variable_args]
-        r = numpy.sqrt(p[0]**2 + p[1]**2)
+        r = numpy.sqrt(sum([p**2 for p in self.variable_args]))
         mu, sigma = 5.0, 2.0
         return 5 * (numpy.exp(-r) + 50. / (sigma * numpy.sqrt(2 * numpy.pi)) * \
                    numpy.exp(-0.5 * ((r - mu) / sigma) ** 2))

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -614,6 +614,44 @@ class TestRosenbrock(BaseLikelihoodEvaluator):
             l -= ((1 - p[i])**2 + 100 * (p[i+1] - p[i]**2)**2)
         return l
 
+class TestVolcano(BaseLikelihoodEvaluator):
+    r"""The test distribution is a two-dimensional 'volcano' function:
+
+    .. math::
+        \Theta = \sqrt{\theta_{1}^{2} + \theta_{2}^{2}}
+        \log \mathcal{L}(\Theta) = 5(e^{-\Theta} + \frac{50}{2\sqrt{2\pi}} e^{-\frac{(\Theta-5)^{2}}{8}}
+
+    Parameters
+    ----------
+    variable_args : (tuple of) string(s)
+        A tuple of parameter names that will be varied. Must have length 2.
+    \**kwargs :
+        All other keyword arguments are passed to ``BaseLikelihoodEvaluator``.
+
+    """
+    name = "test_volcano"
+
+    def __init__(self, variable_args, **kwargs):
+        # set up base likelihood parameters
+        super(TestVolcano, self).__init__(variable_args, **kwargs)
+
+        # make sure there are exactly two variable args
+        if len(self.variable_args) != 2:
+            raise ValueError("TestVolcano distribution requires exactly "
+                             "two variable args")
+
+        # set the lognl to 0 since there is no data
+        self.set_lognl(0.)
+
+    def loglikelihood(self, **params):
+        """Returns the log pdf of the 2D volcano function.
+        """
+        p = [params[p] for p in self.variable_args]
+        r = numpy.sqrt(p[0]**2 + p[1]**2)
+        mu, sigma = 5.0, 2.0
+        return 5 * (numpy.exp(-r) + 50. / (sigma * numpy.sqrt(2 * numpy.pi)) * \
+                   numpy.exp(-0.5 * ((r - mu) / sigma) ** 2))
+
 #
 # =============================================================================
 #
@@ -927,7 +965,8 @@ class GaussianLikelihood(BaseLikelihoodEvaluator):
 likelihood_evaluators = {TestEggbox.name: TestEggbox,
                          TestNormal.name: TestNormal,
                          TestRosenbrock.name: TestRosenbrock,
+                         TestVolcano.name: TestVolcano,
                          GaussianLikelihood.name: GaussianLikelihood}
 
-__all__ = ['BaseLikelihoodEvaluator', 'TestNormal', 'TestEggbox',
+__all__ = ['BaseLikelihoodEvaluator', 'TestNormal', 'TestEggbox', 'TestVolcano',
            'TestRosenbrock', 'GaussianLikelihood', 'likelihood_evaluators']


### PR DESCRIPTION
This patch adds a likelihood evaluator in which the likelihood function is a two-dimensional 'volcano' function, e.g.
![volcano2d](https://user-images.githubusercontent.com/22331074/32923514-fb5f86c8-cb05-11e7-9783-92b554395946.png)
Example:
using config file
```
[variable_args]
x =
y =

[prior-x]
name = uniform
min-x = -20
max-x = 20

[prior-y]
name = uniform
min-y = -20
max-y = 20
```
and arguments
```
pycbc_inference --config-files volcano2d.ini --output-file test_volcano2d.hdf --sampler kombine --verbose --likelihood-evaluator test_volcano --niterations 100 --nwalkers 2000
```
yields [volcano2d_posterior](https://sugwg-jobs.phy.syr.edu/~daniel.finstad/inference/analytic_likelihoods/volcano2d_posterior.png)