### PR TITLE
Save injection parameters to InferenceFile

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -41,6 +41,7 @@ from pycbc.inference import option_utils
 from pycbc.inference import prior
 from pycbc.inference import burn_in
 from pycbc import gate
+import h5py
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
@@ -185,6 +186,28 @@ if 'data' in likelihood_class.required_kwargs:
 else:
     strain_dict = stilde_dict = psd_dict = low_frequency_cutoff_dict = None
 
+# Get injection parameters if reading an injection file
+if opts.injection_file:
+    # Check if it's an hdf file
+    filename = opts.injection_file.values()[0]
+    if filename.endswith('.hdf') or filename.endswith('.h5'):
+        injfile = h5py.File(filename, 'r')
+        injparams = injfile.keys()
+        injvalues = {param: injfile[param][:] for param in injparams}
+        num_of_injs = len(injvalues.values()[0])
+        # Check if there are any static args in file
+        try :
+            static_args = injfile.attrs['static_args']
+        except KeyError:
+            static_args = []
+        injparams.extend(static_args)
+        # Read any static args in injection file
+        # The static args would be the same for all the injections
+        for x in static_args:
+            injvalues[x] = numpy.repeat(injfile.attrs[x], num_of_injs)
+    else :
+        injvalues = None
+
 with ctx:
 
     # read configuration file
@@ -276,6 +299,9 @@ with ctx:
                       stilde_dict=stilde_dict if opts.save_stilde else None,
                       psd_dict=psd_dict if opts.save_psd else None,
                       low_frequency_cutoff_dict=low_frequency_cutoff_dict)
+        if injvalues is not None :
+            logging.info("Writing injection parameters to output file")
+            fp.write_inj_params(injvalues)
 
     # set the walkers initial positions from a pre-existing InferenceFile
     # or a specific initial distribution listed in the configuration file

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -399,7 +399,7 @@ class InferenceFile(h5py.File):
         """
         subgroup = "{ifo}/strain"
         if group is None:
-            group = subgroup 
+            group = subgroup
         else:
             group = '/'.join([group, subgroup])
         for ifo,strain in strain_dict.items():
@@ -421,7 +421,7 @@ class InferenceFile(h5py.File):
         """
         subgroup = "{ifo}/stilde"
         if group is None:
-            group = subgroup 
+            group = subgroup
         else:
             group = '/'.join([group, subgroup])
         for ifo,stilde in stilde_dict.items():
@@ -445,7 +445,7 @@ class InferenceFile(h5py.File):
         """
         subgroup = "{ifo}/psds/0"
         if group is None:
-            group = subgroup 
+            group = subgroup
         else:
             group = '/'.join([group, subgroup])
         self.attrs["low_frequency_cutoff"] = min(low_frequency_cutoff.values())
@@ -465,7 +465,7 @@ class InferenceFile(h5py.File):
         stilde_dict : {None, dict}
             A dictionary of stilde. If None, no stilde will be written.
         psd_dict : {None, dict}
-            A dictionary of psds. If None, psds will be written.
+            A dictionary of psds. If None, no psds will be written.
         low_freuency_cutoff_dict : {None, dict}
             A dictionary of low frequency cutoffs used for each detector in
             `psd_dict`; must be provided if `psd_dict` is not None.
@@ -496,6 +496,20 @@ class InferenceFile(h5py.File):
         if strain_dict is not None:
             self.write_strain(strain_dict, group=group)
 
+    def write_inj_params(self, injvalues):
+        """Write injection parameters to file.
+
+        Parameters
+        ----------
+        injvalues : A dictionary of injection parameters.
+        """
+        group = "injection_parameters"
+        self.create_group(group)
+        for param in injvalues :
+            try:
+                self[group][param][:] = injvalues[param]
+            except:
+                self[group][param] = injvalues[param]
 
     def write_command_line(self):
         """Writes command line to attributes.
@@ -578,7 +592,7 @@ class InferenceFile(h5py.File):
 
     def copy_metadata(self, other):
         """Copies all metadata from this file to the other file.
-        
+
         Metadata is defined as all data that is not in either the samples or
         stats group.
 


### PR DESCRIPTION
This PR allows the injection parameters to be saved to the Inference file under a group `injection_parameters`, if pycbc_inference is using an injection file. This is only implemented for injection files in hdf/h5 format.