### PR TITLE
Save injection tag and filename to InferenceFile

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -282,16 +282,13 @@ with ctx:
         # save injection parameters
         if opts.injection_file:
             for ifo in opts.instruments:
-                logging.info("Writing %s injections to output file", ifo)
                 if ifo in opts.injection_file.keys():
-                    inj_file = opts.injection_file[ifo]
-                elif len(opts.injection_file) == 1:
-                    inj_file = opts.injection_file.values()[0]
+                    logging.info("Writing %s injections to output file", ifo)
+                    inj_files = opts.injection_file[ifo]
+                    fp.write_injections(inj_files, ifo)
                 else:
                     logging.warn("Could not find injections for %s", ifo)
                     continue
-                fp.write_injections(inj_file, ifo)
-
 
     # set the walkers initial positions from a pre-existing InferenceFile
     # or a specific initial distribution listed in the configuration file

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -290,7 +290,7 @@ with ctx:
                 else:
                     logging.warn("Could not find injections for %s", ifo)
                     continue
-                fp.write_injections(opts.injection_file.values()[0], ifo)
+                fp.write_injections(inj_file, ifo)
 
 
     # set the walkers initial positions from a pre-existing InferenceFile

--- a/bin/inference/pycbc_inference_plot_inj_intervals
+++ b/bin/inference/pycbc_inference_plot_inj_intervals
@@ -55,10 +55,10 @@ logging.info("Plotting")
 for input_file, input_fp, input_parameters, input_samples in zip(
                                     opts.input_file, fp, parameters, samples):
 
-    # Injection file tag 
+    # Injection file tag
     injs_tag = input_fp[opts.injection_hdf_group].keys()
     injection_hdf_group = opts.injection_hdf_group + '/' + injs_tag[0]
-  
+
     # read injections from HDF input file
     injs = inject.InjectionSet(input_file, hdf_group=injection_hdf_group)
 

--- a/bin/inference/pycbc_inference_plot_inj_intervals
+++ b/bin/inference/pycbc_inference_plot_inj_intervals
@@ -35,7 +35,7 @@ opts = parser.parse_args()
 pycbc.init_logging(opts.verbose)
 
 # read results
-_, parameters, labels, samples = option_utils.results_from_cli(opts)
+fp, parameters, labels, samples = option_utils.results_from_cli(opts)
 
 # create figure
 fig = plt.figure()
@@ -52,11 +52,15 @@ inj_outside = {p : opts.quantiles.size * [0] for p in parameters[0]}
 
 # loop over input files and its samples
 logging.info("Plotting")
-for input_file, input_parameters, input_samples in zip(
-                                        opts.input_file, parameters, samples):
+for input_file, input_fp, input_parameters, input_samples in zip(
+                                    opts.input_file, fp, parameters, samples):
 
+    # Injection file tag 
+    injs_tag = input_fp[opts.injection_hdf_group].keys()
+    injection_hdf_group = opts.injection_hdf_group + '/' + injs_tag[0]
+  
     # read injections from HDF input file
-    injs = inject.InjectionSet(input_file, hdf_group=opts.injection_hdf_group)
+    injs = inject.InjectionSet(input_file, hdf_group=injection_hdf_group)
 
     # check if need extra parameters than parameters stored in injection file
     _, ts = transforms.get_common_cbc_transforms(opts.parameters,

--- a/bin/inference/pycbc_inference_plot_inj_intervals
+++ b/bin/inference/pycbc_inference_plot_inj_intervals
@@ -55,38 +55,37 @@ logging.info("Plotting")
 for input_file, input_fp, input_parameters, input_samples in zip(
                                     opts.input_file, fp, parameters, samples):
 
-    # Injection file tag
-    injs_tag = input_fp[opts.injection_hdf_group].keys()
-    injection_hdf_group = opts.injection_hdf_group + '/' + injs_tag[0]
+    for injs_tag in input_fp[opts.injection_hdf_group].keys():
+        injection_hdf_group = opts.injection_hdf_group + '/' + injs_tag
 
-    # read injections from HDF input file
-    injs = inject.InjectionSet(input_file, hdf_group=injection_hdf_group)
+        # read injections from HDF input file
+        injs = inject.InjectionSet(input_file, hdf_group=injection_hdf_group)
 
-    # check if need extra parameters than parameters stored in injection file
-    _, ts = transforms.get_common_cbc_transforms(opts.parameters,
-                                                 injs.table.fieldnames)
+        # check if need extra parameters than parameters stored in injection file
+        _, ts = transforms.get_common_cbc_transforms(opts.parameters,
+                                                     injs.table.fieldnames)
 
-    # add parameters not included in injection file
-    inj_parameters = transforms.apply_transforms(injs.table, ts)
+        # add parameters not included in injection file
+        inj_parameters = transforms.apply_transforms(injs.table, ts)
 
-    # loop over parameters and quantiles
-    for p in input_parameters:
-        for i, q in enumerate(opts.quantiles):
+        # loop over parameters and quantiles
+        for p in input_parameters:
+            for i, q in enumerate(opts.quantiles):
 
-            # compute quantiles of sampled results
-            q *= 100
-            low = 50 - q / 2.0
-            high = 50 + q / 2.0
-            low_val, high_val = numpy.array([numpy.percentile(input_samples[p], q)
-                                             for q in [low, high]])
+                # compute quantiles of sampled results
+                q *= 100
+                low = 50 - q / 2.0
+                high = 50 + q / 2.0
+                low_val, high_val = numpy.array([numpy.percentile(input_samples[p], q)
+                                                 for q in [low, high]])
 
-            # determine if inside or outside interval
-            injected_vals = inj_parameters[p]
-            for inj_val in injected_vals:
-                if inj_val > low_val and inj_val < high_val:
-                    inj_inside[p][i] += 1
-                else:
-                    inj_outside[p][i] += 1
+                # determine if inside or outside interval
+                injected_vals = inj_parameters[p]
+                for inj_val in injected_vals:
+                    if inj_val > low_val and inj_val < high_val:
+                        inj_inside[p][i] += 1
+                    else:
+                        inj_outside[p][i] += 1
 
 # determine the fraction found within each credible interval
 fractions = {p : numpy.zeros(opts.quantiles.size) for p in inj_inside.keys()}

--- a/bin/inference/pycbc_inference_plot_inj_recovery
+++ b/bin/inference/pycbc_inference_plot_inj_recovery
@@ -83,8 +83,12 @@ logging.info("Plotting")
 for i, (input_file, input_fp, input_samples) in enumerate(zip(opts.input_file,
                                                               fp, samples)):
 
+    # Injection file tag 
+    injs_tag = input_fp[opts.injection_hdf_group].keys()
+    injection_hdf_group = opts.injection_hdf_group + '/' + injs_tag[0]
+
     # read injections from HDF input file
-    injs = inject.InjectionSet(input_file, hdf_group=opts.injection_hdf_group)
+    injs = inject.InjectionSet(input_file, hdf_group=injection_hdf_group)
 
     # check if need extra parameters than parameters stored in injection file
     _, ts = transforms.get_common_cbc_transforms(opts.parameters,

--- a/bin/inference/pycbc_inference_plot_inj_recovery
+++ b/bin/inference/pycbc_inference_plot_inj_recovery
@@ -82,47 +82,45 @@ if opts.z_arg:
 logging.info("Plotting")
 for i, (input_file, input_fp, input_samples) in enumerate(zip(opts.input_file,
                                                               fp, samples)):
+    for injs_tag in input_fp[opts.injection_hdf_group].keys():
+        injection_hdf_group = opts.injection_hdf_group + '/' + injs_tag
 
-    # Injection file tag
-    injs_tag = input_fp[opts.injection_hdf_group].keys()
-    injection_hdf_group = opts.injection_hdf_group + '/' + injs_tag[0]
+        # read injections from HDF input file
+        injs = inject.InjectionSet(input_file, hdf_group=injection_hdf_group)
 
-    # read injections from HDF input file
-    injs = inject.InjectionSet(input_file, hdf_group=injection_hdf_group)
+        # check if need extra parameters than parameters stored in injection file
+        _, ts = transforms.get_common_cbc_transforms(opts.parameters,
+                                                     injs.table.fieldnames)
 
-    # check if need extra parameters than parameters stored in injection file
-    _, ts = transforms.get_common_cbc_transforms(opts.parameters,
-                                                 injs.table.fieldnames)
+        # add parameters not included in injection file
+        inj_parameters = transforms.apply_transforms(injs.table, ts)
 
-    # add parameters not included in injection file
-    inj_parameters = transforms.apply_transforms(injs.table, ts)
+        # get paramter values
+        sampled_vals = input_samples[parameter]
+        injected_vals = inj_parameters[parameter]
 
-    # get paramter values
-    sampled_vals = input_samples[parameter]
-    injected_vals = inj_parameters[parameter]
+        # compute quantiles of sampled results
+        quantiles = numpy.array([numpy.percentile(sampled_vals, 100 * q)
+                                for q in opts.quantiles])
 
-    # compute quantiles of sampled results
-    quantiles = numpy.array([numpy.percentile(sampled_vals, 100 * q)
-                             for q in opts.quantiles])
+        # get median and lowest and highest quntiles for plotting
+        med = numpy.median(sampled_vals) - injected_vals
+        high = quantiles.max() - injected_vals
+        low = quantiles.min() - injected_vals
 
-    # get median and lowest and highest quntiles for plotting
-    med = numpy.median(sampled_vals) - injected_vals
-    high = quantiles.max() - injected_vals
-    low = quantiles.min() - injected_vals
+        # get color
+        if opts.z_arg:
+            color = cmap(norm(zvals[i]))
+        else:
+            color = "black"
 
-    # get color
-    if opts.z_arg:
-        color = cmap(norm(zvals[i]))
-    else:
-        color = "black"
-
-    # plot a point for each injection
-    if len(injected_vals) > 1:
-        logging.warn("More than one injection in file %s", input_file)
-    ax.errorbar([injected_vals],
-                [med],
-                yerr=[[med - low], [high - med]],
-                ecolor=color, linestyle="None", zorder=10)
+        # plot a point for each injection
+        if len(injected_vals) > 1:
+            logging.warn("More than one injection in file %s", input_file)
+        ax.errorbar([injected_vals],
+                    [med],
+                    yerr=[[med - low], [high - med]],
+                    ecolor=color, linestyle="None", zorder=10)
 
 # create a colorbar
 if opts.z_arg:

--- a/bin/inference/pycbc_inference_plot_inj_recovery
+++ b/bin/inference/pycbc_inference_plot_inj_recovery
@@ -83,7 +83,7 @@ logging.info("Plotting")
 for i, (input_file, input_fp, input_samples) in enumerate(zip(opts.input_file,
                                                               fp, samples)):
 
-    # Injection file tag 
+    # Injection file tag
     injs_tag = input_fp[opts.injection_hdf_group].keys()
     injection_hdf_group = opts.injection_hdf_group + '/' + injs_tag[0]
 

--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -179,7 +179,7 @@ def write_to_xml(filename, samples, write_args, static_args=None):
                                            gz=filename.endswith('gz'))
 
 
-def write_to_hdf(filename, samples, write_args, static_args=None, tag=None):
+def write_to_hdf(filename, samples, write_args, static_args=None):
     """Writes the injection samples to the given hdf file.
     """
     fp = h5py.File(filename, 'w')
@@ -192,8 +192,6 @@ def write_to_hdf(filename, samples, write_args, static_args=None, tag=None):
         fp.attrs[arg] = val
     for field in write_args:
         fp[field] = samples[field]
-    if tag is not None:
-        fp.attrs["tag"] = tag
     return fp
 
 
@@ -213,8 +211,6 @@ parser.add_argument('--output-file', required=True,
                          'injections will be written to a sim_inspiral table '
                          'in an xml file. Otherwise, results will be written '
                          'to an hdf file.')
-parser.add_argument('--injection-file-tag', type=str, default=None,
-                    help="A tag for the injection output file. Eg.: inj_file0")
 parser.add_argument("--force", action="store_true", default=False,
                     help="If the output-file already exists, overwrite it. "
                          "Otherwise, an OSError is raised.")
@@ -269,4 +265,4 @@ logging.info("Writing results")
 if opts.output_file.endswith('.xml') or opts.output_file.endswith('.xml.gz'):
     write_to_xml(opts.output_file, samples, write_args, static_args)
 else:
-    write_to_hdf(opts.output_file, samples, write_args, static_args, opts.injection_file_tag)
+    write_to_hdf(opts.output_file, samples, write_args, static_args)

--- a/bin/pycbc_create_injections
+++ b/bin/pycbc_create_injections
@@ -179,7 +179,7 @@ def write_to_xml(filename, samples, write_args, static_args=None):
                                            gz=filename.endswith('gz'))
 
 
-def write_to_hdf(filename, samples, write_args, static_args=None):
+def write_to_hdf(filename, samples, write_args, static_args=None, tag=None):
     """Writes the injection samples to the given hdf file.
     """
     fp = h5py.File(filename, 'w')
@@ -192,6 +192,8 @@ def write_to_hdf(filename, samples, write_args, static_args=None):
         fp.attrs[arg] = val
     for field in write_args:
         fp[field] = samples[field]
+    if tag is not None:
+        fp.attrs["tag"] = tag
     return fp
 
 
@@ -211,6 +213,8 @@ parser.add_argument('--output-file', required=True,
                          'injections will be written to a sim_inspiral table '
                          'in an xml file. Otherwise, results will be written '
                          'to an hdf file.')
+parser.add_argument('--injection-file-tag', type=str, default=None,
+                    help="A tag for the injection output file. Eg.: inj_file0")
 parser.add_argument("--force", action="store_true", default=False,
                     help="If the output-file already exists, overwrite it. "
                          "Otherwise, an OSError is raised.")
@@ -265,4 +269,4 @@ logging.info("Writing results")
 if opts.output_file.endswith('.xml') or opts.output_file.endswith('.xml.gz'):
     write_to_xml(opts.output_file, samples, write_args, static_args)
 else:
-    write_to_hdf(opts.output_file, samples, write_args, static_args)
+    write_to_hdf(opts.output_file, samples, write_args, static_args, opts.injection_file_tag)

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -469,7 +469,6 @@ class InjectionSet(object):
     """
 
     def __init__(self, sim_file, **kwds):
-        filenames = [os.path.basename(x) for x in sim_file]
         exts = [os.path.splitext(x)[1] for x in sim_file]
         if all([ext == exts[0] for ext in exts]):
             if all([ext in ('.xml', '.xml.gz', '.xmlgz') for ext in exts]):
@@ -479,7 +478,7 @@ class InjectionSet(object):
                 self._injhandler = _HDFInjectionSet(sim_file, **kwds)
             else:
                 raise ValueError("Unsupported template bank file extension "
-                                 "{}".format(filenames))
+                                 "{}".format(exts[0]))
         else :
             raise ValueError("All injections files should be in the same format ")
         self.table = self._injhandler.table

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -470,7 +470,8 @@ class InjectionSet(object):
 
     def __init__(self, sim_file, **kwds):
         filenames = [os.path.basename(x) for x in sim_file]
-        exts = [x.rsplit('.',1)[1] for x in filenames]
+        exts = [os.path.splitext(x)[0] for x in sim_file]
+        print(exts)
         if all([ext == exts[0] for ext in exts]):
             if all([ext in ('xml', 'xml.gz', 'xmlgz') for ext in exts]):
                 self._injhandler = _XMLInjectionSet(sim_file, **kwds)

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -470,13 +470,12 @@ class InjectionSet(object):
 
     def __init__(self, sim_file, **kwds):
         filenames = [os.path.basename(x) for x in sim_file]
-        exts = [os.path.splitext(x)[0] for x in sim_file]
-        print(exts)
+        exts = [os.path.splitext(x)[1] for x in sim_file]
         if all([ext == exts[0] for ext in exts]):
-            if all([ext in ('xml', 'xml.gz', 'xmlgz') for ext in exts]):
+            if all([ext in ('.xml', '.xml.gz', '.xmlgz') for ext in exts]):
                 self._injhandler = _XMLInjectionSet(sim_file, **kwds)
                 self.indoc = self._injhandler.indoc
-            elif all([ext in ('hdf', 'h5') for ext in exts]):
+            elif all([ext in ('.hdf', '.h5') for ext in exts]):
                 self._injhandler = _HDFInjectionSet(sim_file, **kwds)
             else:
                 raise ValueError("Unsupported template bank file extension "

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -469,6 +469,7 @@ class InjectionSet(object):
     """
 
     def __init__(self, sim_file, **kwds):
+        sim_file = [sim_file] if not isinstance(sim_file, list) else sim_file
         exts = [os.path.splitext(x)[1] for x in sim_file]
         if all([ext == exts[0] for ext in exts]):
             if all([ext in ('.xml', '.xml.gz', '.xmlgz') for ext in exts]):

--- a/pycbc/inject/inject.py
+++ b/pycbc/inject/inject.py
@@ -63,7 +63,7 @@ def legacy_approximant_name(apx):
         order = -1
     name = sim.GetStringFromApproximant(sim.GetApproximantFromString(apx))
     return name, order
-    
+
 
 class _HDFInjectionSet(object):
     """Manages sets of injections: reads injections from hdf files
@@ -146,8 +146,8 @@ class _HDFInjectionSet(object):
             Low-frequency cutoff for injected signals. If None, use value
             provided by each injection.
         distance_scale: {1, float}, optional
-            Factor to scale the distance of an injection with. The default is 
-            no scaling. 
+            Factor to scale the distance of an injection with. The default is
+            no scaling.
         simulation_ids: iterable, optional
             If given, only inject signals with the given simulation IDs.
         inj_filter_rejector: InjFilterRejector instance; optional, default=None
@@ -168,7 +168,7 @@ class _HDFInjectionSet(object):
             raise TypeError("Strain dtype must be float32 or float64, not " \
                     + str(strain.dtype))
 
-        lalstrain = strain.lal()    
+        lalstrain = strain.lal()
         earth_travel_time = lal.REARTH_SI / lal.C_SI
         t0 = float(strain.start_time) - earth_travel_time
         t1 = float(strain.end_time) + earth_travel_time
@@ -200,7 +200,7 @@ class _HDFInjectionSet(object):
                      detector_name, f_lower=f_l, distance_scale=distance_scale)
             if float(signal.start_time) > t1:
                 continue
-            
+
             signal = signal.astype(strain.dtype)
             signal_lal = signal.lal()
             add_injection(lalstrain, signal_lal, None)
@@ -214,7 +214,7 @@ class _HDFInjectionSet(object):
         if inj_filter_rejector is not None:
             inj_filter_rejector.injection_params = injected
         return injected
-       
+
     def make_strain_from_inj_object(self, inj, delta_t, detector_name,
                                     f_lower=None, distance_scale=1):
         """Make a h(t) strain time-series from an injection object.
@@ -233,8 +233,8 @@ class _HDFInjectionSet(object):
             Low-frequency cutoff for injected signals. If None, use value
             provided by each injection.
         distance_scale: {1, float}, optional
-            Factor to scale the distance of an injection with. The default is 
-            no scaling. 
+            Factor to scale the distance of an injection with. The default is
+            no scaling.
 
         Returns
         --------
@@ -270,7 +270,7 @@ class _HDFInjectionSet(object):
                              inj.ra, inj.dec, inj.polarization)
 
         return signal
-        
+
     def end_times(self):
         """Return the end times of all injections"""
         return self.table.tc
@@ -315,8 +315,8 @@ class _XMLInjectionSet(object):
             Low-frequency cutoff for injected signals. If None, use value
             provided by each injection.
         distance_scale: {1, float}, optional
-            Factor to scale the distance of an injection with. The default is 
-            no scaling. 
+            Factor to scale the distance of an injection with. The default is
+            no scaling.
         simulation_ids: iterable, optional
             If given, only inject signals with the given simulation IDs.
         inj_filter_rejector: InjFilterRejector instance; optional, default=None
@@ -337,7 +337,7 @@ class _XMLInjectionSet(object):
             raise TypeError("Strain dtype must be float32 or float64, not " \
                     + str(strain.dtype))
 
-        lalstrain = strain.lal()    
+        lalstrain = strain.lal()
         earth_travel_time = lal.REARTH_SI / lal.C_SI
         t0 = float(strain.start_time) - earth_travel_time
         t1 = float(strain.end_time) + earth_travel_time
@@ -370,11 +370,11 @@ class _XMLInjectionSet(object):
                      detector_name, f_lower=f_l, distance_scale=distance_scale)
             if float(signal.start_time) > t1:
                 continue
-            
+
             signal = signal.astype(strain.dtype)
             signal_lal = signal.lal()
             add_injection(lalstrain, signal_lal, None)
-            injection_parameters.append(inj)                            
+            injection_parameters.append(inj)
             if inj_filter_rejector is not None:
                 sid = inj.simulation_id
                 inj_filter_rejector.generate_short_inj_from_inj(signal, sid)
@@ -387,7 +387,7 @@ class _XMLInjectionSet(object):
         if inj_filter_rejector is not None:
             inj_filter_rejector.injection_params = injected
         return injected
-       
+
     def make_strain_from_inj_object(self, inj, delta_t, detector_name,
                                     f_lower=None, distance_scale=1):
         """Make a h(t) strain time-series from an injection object as read from
@@ -405,8 +405,8 @@ class _XMLInjectionSet(object):
             Low-frequency cutoff for injected signals. If None, use value
             provided by each injection.
         distance_scale: {1, float}, optional
-            Factor to scale the distance of an injection with. The default is 
-            no scaling. 
+            Factor to scale the distance of an injection with. The default is
+            no scaling.
 
         Returns
         --------
@@ -443,15 +443,15 @@ class _XMLInjectionSet(object):
                              inj.longitude, inj.latitude, inj.polarization)
 
         return signal
-        
+
     def end_times(self):
         """Return the end times of all injections"""
-        return [inj.get_time_geocent() for inj in self.table]      
+        return [inj.get_time_geocent() for inj in self.table]
 
 
 class InjectionSet(object):
     """Manages sets of injections and injects them into time series.
-    
+
     Injections are read from either LIGOLW XML files or HDF files.
 
     Parameters

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -506,14 +506,20 @@ class InferenceFile(h5py.File):
         ifo : str
             IFO name.
         """
-        subgroup = "{ifo}/injections"
-        self.create_group(subgroup.format(ifo=ifo))
+        injection_file_tag = "inj_file0"
+        injection_file_name = injection_file.rsplit('/',1)[-1]
         try:
             with h5py.File(injection_file, "r") as fp:
+                if fp.attrs["tag"]:
+                    injection_file_tag = fp.attrs["tag"]
+                subgroup = "{ifo}/injections/{injection_file_tag}"
+                self.create_group(subgroup.format(
+                              ifo=ifo, injection_file_tag=injection_file_tag))
                 for param in fp.keys():
-                    self[subgroup.format(ifo=ifo)][param] = fp[param][:]
+                    self[subgroup.format(ifo=ifo, injection_file_tag=injection_file_tag)][param] = fp[param][:]
                 for key in fp.attrs.keys():
-                    self[subgroup.format(ifo=ifo)].attrs[key] = fp.attrs[key]
+                    self[subgroup.format(ifo=ifo, injection_file_tag=injection_file_tag)].attrs[key] = fp.attrs[key]
+                self[subgroup.format(ifo=ifo, injection_file_tag=injection_file_tag)].attrs["injection_file_name"] = injection_file_name
         except IOError:
             logging.warn("Could not read %s as an HDF file", injection_file)
 

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -518,10 +518,19 @@ class InferenceFile(h5py.File):
                     self.create_group(subgroup.format(
                             ifo=ifo, injection_file_tag=injection_file_tag))
                     for param in fp.keys():
-                        self[subgroup.format(ifo=ifo, injection_file_tag=injection_file_tag)][param] = fp[param][:]
+                        self[subgroup.format(
+                                ifo=ifo,
+                                injection_file_tag=injection_file_tag
+                                )][param] = fp[param][:]
                     for key in fp.attrs.keys():
-                        self[subgroup.format(ifo=ifo, injection_file_tag=injection_file_tag)].attrs[key] = fp.attrs[key]
-                    self[subgroup.format(ifo=ifo, injection_file_tag=injection_file_tag)].attrs["injection_file_name"] = injection_file_name
+                        self[subgroup.format(
+                                ifo=ifo,
+                                injection_file_tag=injection_file_tag
+                                )].attrs[key] = fp.attrs[key]
+                    self[subgroup.format(
+                            ifo=ifo,
+                            injection_file_tag=injection_file_tag
+                            )].attrs["injection_file_name"] = injection_file_name
             except IOError:
                 logging.warn("Could not read %s as an HDF file", injection_file)
 

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -509,9 +509,7 @@ class InferenceFile(h5py.File):
         """
         if not isinstance(injection_files, list):
             injection_files = [injection_files]
-            print(injection_files)
         for i, injection_file in enumerate(injection_files):
-            #injection_file_name = injection_file.rsplit('/',1)[-1]
             try:
                 with h5py.File(injection_file, "r") as fp:
                     injection_file_name = os.path.basename(injection_file)

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -513,7 +513,7 @@ class InferenceFile(h5py.File):
             try:
                 with h5py.File(injection_file, "r") as fp:
                     injection_file_name = os.path.basename(injection_file)
-                    injection_file_tag = "inj_file" + str(i)
+                    injection_file_tag = "inj_file_" + str(i)
                     subgroup = "{ifo}/injections/{injection_file_tag}"
                     self.create_group(subgroup.format(
                             ifo=ifo, injection_file_tag=injection_file_tag))

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -191,8 +191,8 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
     ----------
     opt : object
         Result of parsing the CLI with OptionParser, or any object with the
-        required attributes  (gps-start-time, gps-end-time, strain-high-pass, 
-        pad-data, sample-rate, (frame-cache or frame-files), channel-name, 
+        required attributes  (gps-start-time, gps-end-time, strain-high-pass,
+        pad-data, sample-rate, (frame-cache or frame-files), channel-name,
         fake-strain, fake-strain-seed, fake-strain-from-file, gating_file).
     dyn_range_fac : {float, 1}, optional
         A large constant to reduce the dynamic range of the strain.
@@ -222,7 +222,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             sieve = opt.frame_sieve
         else:
             sieve = None
-        
+
         if opt.frame_type:
             strain = query_and_read_frame(opt.frame_type, opt.channel_name,
                                           start_time=opt.gps_start_time-opt.pad_data,
@@ -323,7 +323,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                 witness = (witness * dyn_range_fac).astype(strain.dtype)
                 tf = pycbc.types.load_frequencyseries(opt.witness_tf_file, group=key)
                 tf = tf.astype(stilde.dtype)
-                
+
                 flen = int(opt.witness_filter_length * strain.sample_rate)
                 tf = pycbc.psd.interpolate(tf, stilde.delta_f)
 
@@ -332,12 +332,12 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
                 tf_time[0:flen] *= window[flen:]
                 tf_time[len(tf_time)-flen:] *= window[0:flen]
                 tf = tf_time.to_frequencyseries()
-                
+
                 kmax = min(len(tf), len(stilde)-1)
                 stilde[:kmax] -= tf[:kmax] * witness.to_frequencyseries()[:kmax]
-                
+
             strain = stilde.to_timeseries()
-                
+
 
         logging.info("Remove Padding")
         start = opt.pad_data*opt.sample_rate
@@ -370,7 +370,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
             from pycbc.noise.reproduceable import colored_noise
             strain = colored_noise(strain_psd, opt.gps_start_time,
                                           opt.gps_end_time,
-                                          seed=opt.fake_strain_seed, 
+                                          seed=opt.fake_strain_seed,
                                           low_frequency_cutoff=opt.strain_high_pass)
             strain = resample_to_delta_t(strain, 1.0/opt.sample_rate)
 
@@ -416,7 +416,7 @@ def from_cli(opt, dyn_range_fac=1, precision='single',
         strain.injections = injections
     strain.gating_info = gating_info
 
-    return strain  
+    return strain
 
 def from_cli_single_ifo(opt, ifo, **kwargs):
     """
@@ -455,7 +455,7 @@ def insert_strain_option_group(parser, gps_times=True):
                   " if the --psd-estimation option is given.")
 
     # Required options
-    
+
     if gps_times:
         data_reading_group.add_argument("--gps-start-time",
                                 help="The gps start time of the data "
@@ -463,8 +463,8 @@ def insert_strain_option_group(parser, gps_times=True):
         data_reading_group.add_argument("--gps-end-time",
                                 help="The gps end time of the data "
                                      " (integer seconds)", type=int)
-                                     
-                                 
+
+
     data_reading_group.add_argument("--strain-high-pass", type=float,
                             help="High pass frequency")
     data_reading_group.add_argument("--pad-data",
@@ -487,7 +487,7 @@ def insert_strain_option_group(parser, gps_times=True):
                             type=str, nargs="+",
                             help="list of frame files")
 
-    #Use datafind to get frame files 
+    #Use datafind to get frame files
     data_reading_group.add_argument("--frame-type",
                             type=str,
                             help="(optional), replaces frame-files. Use datafind "
@@ -569,7 +569,7 @@ def insert_strain_option_group(parser, gps_times=True):
     data_reading_group.add_argument("--zpk-k", type=float,
                     help="(optional) Zero-pole-gain (zpk) filter strain. "
                         "Transfer function gain")
-                        
+
     # Options to apply to subtract noise from a witness channel and known
     # transfer function.
     data_reading_group.add_argument("--witness-frame-type", type=str,
@@ -784,8 +784,8 @@ def verify_strain_options(opts, parser):
     ----------
     opt : object
         Result of parsing the CLI with OptionParser, or any object with the
-        required attributes (gps-start-time, gps-end-time, strain-high-pass, 
-        pad-data, sample-rate, frame-cache, channel-name, fake-strain, 
+        required attributes (gps-start-time, gps-end-time, strain-high-pass,
+        pad-data, sample-rate, frame-cache, channel-name, fake-strain,
         fake-strain-seed).
     parser : object
         OptionParser instance.
@@ -804,8 +804,8 @@ def verify_strain_options_multi_ifo(opts, parser, ifos):
     ----------
     opt : object
         Result of parsing the CLI with OptionParser, or any object with the
-        required attributes (gps-start-time, gps-end-time, strain-high-pass, 
-        pad-data, sample-rate, frame-cache, channel-name, fake-strain, 
+        required attributes (gps-start-time, gps-end-time, strain-high-pass,
+        pad-data, sample-rate, frame-cache, channel-name, fake-strain,
         fake-strain-seed).
     parser : object
         OptionParser instance.
@@ -820,7 +820,7 @@ def verify_strain_options_multi_ifo(opts, parser, ifos):
 
 def gate_data(data, gate_params):
     """Apply a set of gating windows to a time series.
-    
+
     Each gating window is
     defined by a central time, a given duration (centered on the given
     time) to zero out, and a given duration of smooth tapering on each side of
@@ -971,7 +971,7 @@ class StrainSegments(object):
         ana_end = int((seg_len - seg_end_pad) * strain.sample_rate)
         ana_slice = slice(ana_start, ana_end)
         self.analyze_slices.append(ana_slice)
-        
+
         self.full_segment_slices = copy.deepcopy(self.segment_slices)
 
         #Remove segments that are outside trig start and end
@@ -981,7 +981,7 @@ class StrainSegments(object):
         trig_end_idx = (trigger_end - int(strain.start_time)) * strain.sample_rate
 
         if filter_inj_only and hasattr(strain, 'injections'):
-            end_times = strain.injections.end_times()   
+            end_times = strain.injections.end_times()
             end_times = [time for time in end_times if float(time) < trigger_end and float(time) > trigger_start]
             inj_idx = [(float(time) - float(strain.start_time)) * strain.sample_rate for time in end_times]
 
@@ -1196,7 +1196,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                  data_quality_flags=None,
                  dq_padding=0):
         """ Class to produce overwhitened strain incrementally
-        
+
         Parameters
         ----------
         frame_src: str of list of strings
@@ -1204,7 +1204,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             list of frame files, a glob, etc.
         channel_name: str
             Name of the channel to read from the frame files
-        start_time: 
+        start_time:
             Time to start reading from.
         max_buffer: {int, 512}, Optional
             Length of the buffer in seconds
@@ -1249,7 +1249,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             the relative change in the inspiral range from the previous PSD
             to trigger a re-estimatoin of the PSD.
         force_update_cache: {boolean, True}, Optional
-            Re-check the filesystem for frame files on every attempt to 
+            Re-check the filesystem for frame files on every attempt to
             read more data.
         analyze_flags: list of strs
             The flags that must be on to mark the current data as valid for
@@ -1263,7 +1263,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             is an alternate to the forced updated of the frame cache, and
             apptempts to predict the next frame file name without probing the
             filesystem.
-        """ 
+        """
         super(StrainBuffer, self).__init__(frame_src, channel_name, start_time,
                                            max_buffer=max_buffer,
                                            force_update_cache=force_update_cache,
@@ -1326,7 +1326,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
 
         strain_len = int(sample_rate * self.raw_buffer.delta_t * len(self.raw_buffer))
         self.strain = TimeSeries(zeros(strain_len, dtype=numpy.float32),
-                                 delta_t=1.0/self.sample_rate, 
+                                 delta_t=1.0/self.sample_rate,
                                  epoch=start_time-max_buffer)
 
         # Determine the total number of corrupted samples for highpass
@@ -1351,7 +1351,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
 
         self.reduced_pad = int(self.total_corruption - self.trim_padding)
         self.segments = {}
-        
+
         # time to ignore output of frame (for initial buffering)
         self.add_hard_count()
         self.taper_immediate_strain = True
@@ -1380,8 +1380,8 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         self.psds = {}
 
     def recalculate_psd(self):
-        """ Recalculate the psd 
-        """ 
+        """ Recalculate the psd
+        """
 
         seg_len = self.sample_rate * self.psd_segment_length
         e = len(self.strain)
@@ -1396,21 +1396,21 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                 logging.info("Skipping recalculation of %s PSD, %s-%s",
                              self.detector, self.psd.dist, psd.dist)
                 return True
-        
+
         # If the new psd is *really* different than the old one, return an error
         if self.psd and self.psd_abort_difference:
             if abs(self.psd.dist - psd.dist) / self.psd.dist > self.psd_abort_difference:
                 logging.info("%s PSD is CRAZY, aborting!!!!, %s-%s",
                              self.detector, self.psd.dist, psd.dist)
                 self.psd = psd
-                self.psds = {}  
+                self.psds = {}
                 return False
 
         # If the new estimate replaces the current one, invalide the ineterpolate PSDs
         self.psd = psd
         self.psds = {}
         logging.info("Recalculating %s PSD, %s", self.detector, psd.dist)
-        return True   
+        return True
 
     def overwhitened_data(self, delta_f):
         """ Return overwhitened data
@@ -1419,7 +1419,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         ----------
         delta_f: float
             The sample step to generate overwhitened frequency domain data for
-        
+
         Returns
         -------
         htilde: FrequencySeries
@@ -1435,7 +1435,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
             # we haven't calculate a resample psd for this delta_f
             if delta_f not in self.psds:
                 psdt = pycbc.psd.interpolate(self.psd, fseries.delta_f)
-                psdt = pycbc.psd.inverse_spectrum_truncation(psdt, 
+                psdt = pycbc.psd.inverse_spectrum_truncation(psdt,
                                        int(self.sample_rate * self.psd_inverse_length),
                                        low_frequency_cutoff=self.low_frequency_cutoff)
                 psdt._delta_f = fseries.delta_f
@@ -1469,9 +1469,9 @@ class StrainBuffer(pycbc.frame.DataBuffer):
 
             fseries_trimmed.psd = psd
             self.segments[delta_f] = fseries_trimmed
-            
+
         stilde = self.segments[delta_f]
-        return stilde  
+        return stilde
 
     def near_hwinj(self):
         """Check that the current set of triggers could be influenced by
@@ -1504,10 +1504,10 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         # We should roll this off at some point too...
         self.strain[len(self.strain) - csize + self.corruption:] = 0
         self.strain.start_time += blocksize
-        
+
         # The next time we need strain will need to be tapered
         self.taper_immediate_strain = True
-       
+
     def advance(self, blocksize, timeout=10):
         """Advanced buffer blocksize seconds.
 
@@ -1522,7 +1522,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
         Returns
         -------
         status: boolean
-            Returns True if this block is analyzable.         
+            Returns True if this block is analyzable.
         """
         ts = super(StrainBuffer, self).attempt_advance(blocksize, timeout=timeout)
         self.blocksize = blocksize
@@ -1553,7 +1553,7 @@ class StrainBuffer(pycbc.frame.DataBuffer):
 
         # Also advance the dq vector in lockstep
         if self.dq:
-            self.dq.advance(blocksize)            
+            self.dq.advance(blocksize)
 
         self.segments = {}
 
@@ -1570,13 +1570,13 @@ class StrainBuffer(pycbc.frame.DataBuffer):
                                        self.highpass_samples,
                                        beta=self.beta)
         strain = (strain * self.dyn_range_fac).astype(numpy.float32)
-        
-        strain = pycbc.filter.resample_to_delta_t(strain, 
+
+        strain = pycbc.filter.resample_to_delta_t(strain,
                                            1.0/self.sample_rate, method='ldas')
 
         # remove corruption at beginning
         strain = strain[self.corruption:]
-        
+
         # taper beginning if needed
         if self.taper_immediate_strain:
             logging.info("Tapering start of %s strain block", self.detector)

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -683,7 +683,7 @@ def insert_strain_option_group_multi_ifo(parser):
 
     #optional
     data_reading_group_multi.add_argument("--injection-file", type=str,
-                            nargs="+", action=MultiDetOptionAction,
+                            nargs="+", action=MultiDetOptionAppendAction,
                             metavar='IFO:FILE',
                             help="(optional) Injection file used to add "
                             "waveforms into the strain")


### PR DESCRIPTION
This PR allows saving an injection tag and filename to InferenceFile to help identifying the injection sets with their files. The main changes made are :
* make `pycbc_create_injections` have an option to save a tag for the injection file as an attribute in the injection file
*When running `pycbc_inference`, the tag is read from the in from the injections file and saved as a key under `{ifo}/injections`.
* The injection filename is saved as an attribute.

Let me know if this works. Another option to read in the index or the tag for the injection file is maybe as an input argument provided to `pycbc_inference`.