### PR TITLE
Fix the psd start/end times in the inference docs

### DIFF
--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -482,8 +482,8 @@ Now run::
     GPS_END_TIME=$((${TRIGGER_TIME_INT} + ${SEARCH_AFTER} + ${PSD_INVLEN}))
 
     # start and end time of data to read in for PSD estimation
-    PSD_START_TIME=$((${GPS_START_TIME} - ${PSD_DATA_LEN}/2))
-    PSD_END_TIME=$((${GPS_END_TIME} + ${PSD_DATA_LEN}/2))
+    PSD_START_TIME=$((${TRIGGER_TIME_INT} - ${PSD_DATA_LEN}/2))
+    PSD_END_TIME=$((${TRIGGER_TIME_INT} + ${PSD_DATA_LEN}/2))
 
     # run sampler
     # specifies the number of threads for OpenMP


### PR DESCRIPTION
@micamu just pointed out to me that the PSD start/end times in the inference docs are using a larger time than expected. The PSD start time should be the trigger time +/- the desired PSD data length (1024s) / 2. The way the script sets it up now, however, it uses the gps start/end time -/+ the data length / 2, giving a total data length of 1024s + 16s. This isn't terrible, it just results in using slightly more time than what you might expect. Still, better to fix to be obvious.