### PR TITLE
Do not raise an error if an unrecognized parameter is passed to the CBC generator

### DIFF
--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -180,9 +180,9 @@ class BaseCBCGenerator(BaseGenerator):
         unused_args = all_args.difference(params_used) \
                               .difference(self.possible_args)
         if len(unused_args):
-            logging.warning("The following args are not being used for "
-                         "waveform generation: {opts}".format(
-                         opts=unused_args))
+            logging.warning("WARNING: The following args are not being used "
+                            "for waveform generation: {opts}".format(
+                            opts=', '.join(unused_args)))
 
 
 class FDomainCBCGenerator(BaseCBCGenerator):

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -36,6 +36,7 @@ from pycbc.waveform.utils import apply_fd_time_shift, taper_timeseries, \
 from pycbc.detector import Detector
 import lal as _lal
 from pycbc import gate
+import logging
 
 #
 #   Generator for CBC waveforms
@@ -179,8 +180,9 @@ class BaseCBCGenerator(BaseGenerator):
         unused_args = all_args.difference(params_used) \
                               .difference(self.possible_args)
         if len(unused_args):
-            raise ValueError("The following args are not being used: "
-                             "{opts}".format(opts=unused_args))
+            logging.warning("The following args are not being used for "
+                         "waveform generation: {opts}".format(
+                         opts=unused_args))
 
 
 class FDomainCBCGenerator(BaseCBCGenerator):


### PR DESCRIPTION
Right now, if a parameter exists in the variable args that are passed to `CBCGenerator` that is not recognized in the list of parameters, an error is raised. This unnecessarily limits the freedom to try out new changes to the waveforms code, and prevents being able to provide priors on arbitrary functions of parameters. This patch causes a warning to be printed instead if an unrecognized parameter is passed.