### PR TITLE
Fix error in Travis test script

### DIFF
--- a/tools/travis_build_and_test.sh
+++ b/tools/travis_build_and_test.sh
@@ -67,7 +67,6 @@ if test $? -ne 0 ; then
     echo -e "    FAILED!"
     echo -e "---------------------------------------------------------"
 else
-    RESULT=0
     echo -e "    Pass."
 fi
 


### PR DESCRIPTION
#1941 introduces a change that requires a fairly recent lalsuite version for the Travis tests to pass. From the current Travis configuration it looks like the lalsuite version is older than the requirement, but nevertheless Travis passes for #1941. If you go to the Travis log, you clearly see all template bank tests failing, but the end result marked as a success nevertheless. This may be the culprit.