### PR TITLE
Avoid trying to do scatter plot if not enough parameters

### DIFF
--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -567,6 +567,9 @@ def create_multidim_plot(parameters, samples, labels=None,
     else:
         width_ratios = height_ratios = None
 
+    # only plot scatter if more than one parameter
+    plot_scatter = plot_scatter and nparams > 1
+
     # Sort zvals to get higher values on top in scatter plots
     if plot_scatter:
         if zvals is not None:
@@ -644,7 +647,7 @@ def create_multidim_plot(parameters, samples, labels=None,
         if px == py:
             continue
         ax, _, _ = axis_dict[px, py]
-        if plot_scatter and nparams > 1:
+        if plot_scatter:
             if plot_density:
                 alpha = 0.3
             else:
@@ -691,7 +694,7 @@ def create_multidim_plot(parameters, samples, labels=None,
             ax.set_xticks(reduce_ticks(ax, 'x', maxticks=3))
             ax.set_yticks(reduce_ticks(ax, 'y', maxticks=3))
 
-    if plot_scatter and show_colorbar and nparams > 1:
+    if plot_scatter and show_colorbar:
         # compute font size based on fig size
         scale_fac = get_scale_fac(fig)
         fig.subplots_adjust(right=0.85, wspace=0.03)

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -644,7 +644,7 @@ def create_multidim_plot(parameters, samples, labels=None,
         if px == py:
             continue
         ax, _, _ = axis_dict[px, py]
-        if plot_scatter:
+        if plot_scatter and nparams > 1:
             if plot_density:
                 alpha = 0.3
             else:
@@ -691,7 +691,7 @@ def create_multidim_plot(parameters, samples, labels=None,
             ax.set_xticks(reduce_ticks(ax, 'x', maxticks=3))
             ax.set_yticks(reduce_ticks(ax, 'y', maxticks=3))
 
-    if plot_scatter and show_colorbar:
+    if plot_scatter and show_colorbar and nparams > 1:
         # compute font size based on fig size
         scale_fac = get_scale_fac(fig)
         fig.subplots_adjust(right=0.85, wspace=0.03)


### PR DESCRIPTION
Right now when you call the ``scatter_histogram`` module to create a plot, if you give 1 parameter and ask for a scatter plot it fails. This PR makes sure than only when there is more than 1 parameter, then it will plot a scatter plot.