### PR TITLE
rescale test_volcano likelihood evaluator

### DIFF
--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -649,8 +649,8 @@ class TestVolcano(BaseLikelihoodEvaluator):
         p = [params[p] for p in self.variable_args]
         r = numpy.sqrt(p[0]**2 + p[1]**2)
         mu, sigma = 5.0, 2.0
-        return 5 * (numpy.exp(-r) + 50. / (sigma * numpy.sqrt(2 * numpy.pi)) * \
-                   numpy.exp(-0.5 * ((r - mu) / sigma) ** 2))
+        return 25 * (numpy.exp(-r/35) + 1 / (sigma * numpy.sqrt(2 * numpy.pi)) \
+                     * numpy.exp(-0.5 * ((r - mu) / sigma) ** 2))
 
 #
 # =============================================================================

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -619,7 +619,7 @@ class TestVolcano(BaseLikelihoodEvaluator):
 
     .. math::
         \Theta = \sqrt{\theta_{1}^{2} + \theta_{2}^{2}}
-        \log \mathcal{L}(\Theta) = 5(e^{-\Theta} + \frac{50}{2\sqrt{2\pi}} e^{-\frac{(\Theta-5)^{2}}{8}})
+        \log \mathcal{L}(\Theta) = 25(e^{\frac{-\Theta}{35}} + \frac{1}{2\sqrt{2\pi}} e^{-\frac{(\Theta-5)^{2}}{8}})
 
     Parameters
     ----------


### PR DESCRIPTION
This patch rescales the test_volcano distribution so that the ratio of likelihood on the rim to that in the central depression is less so that the posterior contains samples in the central region.
The rescaled distribution:
![shallow_volcano](https://user-images.githubusercontent.com/22331074/33795663-c154840a-dcb3-11e7-9574-e759dc332f7f.png)
A minimal example using config file:
```
[variable_args]
x =
y =

[prior-x]
name = uniform
min-x = -20
max-x = 20

[prior-y]
name = uniform
min-y = -20
max-y = 20
```
and arguments:
```
pycbc_inference --config-files volcano2d.ini --output-file test_volcano2d.hdf --sampler kombine --verbose --likelihood-evaluator test_volcano --niterations 100 --nwalkers 2000
```
gives [shallow_volcano_posterior](https://sugwg-jobs.phy.syr.edu/~daniel.finstad/inference/analytic_likelihoods/shallow_volcano.png).

And a fully burned-in run gives [shallow_volcano_longrun_posterior](https://sugwg-jobs.phy.syr.edu/~daniel.finstad/inference/analytic_likelihoods/emcee_pt_shallow_volcano_longrun.png).