### PR TITLE
Bug-fix for pycbc_page_foreground

### DIFF
--- a/bin/hdfcoinc/pycbc_page_foreground
+++ b/bin/hdfcoinc/pycbc_page_foreground
@@ -1,4 +1,4 @@
-#/usr/bin/python
+#!/usr/bin/env python
 """
 Make table of the foreground coincident events. Also includes ability to 
 write FARs and p-values for intermediary hierarchical removal steps.


### PR DESCRIPTION
Not sure how this happened or didn't get picked up in automated tests, but `pycbc_page_foreground` is not currently a python executable.