### PR TITLE
remove phenomb_chi 

### DIFF
--- a/bin/hdfcoinc/pycbc_page_coinc_snrchi
+++ b/bin/hdfcoinc/pycbc_page_coinc_snrchi
@@ -6,7 +6,7 @@ from matplotlib import colors
 matplotlib.use('Agg')
 import pylab, pycbc.results
 from pycbc.io import get_chisq_from_file_choice, chisq_choices
-from pycbc import pnutils
+from pycbc import conversions
 import pycbc.version
 
 def snr_from_chisq(chisq, newsnr, q=6.):
@@ -77,8 +77,9 @@ inj_idx = f['found_after_vetoes/injection_index'][:]
 eff_dist = f['injections'][eff_map[ifo]][:][inj_idx]
 m1, m2 = f['injections/mass1'][:][inj_idx], f['injections/mass2'][:][inj_idx]
 s1, s2 = f['injections/spin1z'][:][inj_idx], f['injections/spin2z'][:][inj_idx]
-mchirp, eta = pnutils.mass1_mass2_to_mchirp_eta(m1, m2)
-weighted_spin = pnutils.phenomb_chi(m1, m2, s1, s2)
+mchirp = conversions.mchirp_from_mass1_mass2(m1, m2)
+eta = conversions.eta_from_mass1_mass2(m1, m2)
+weighted_spin = conversions.chi_eff(m1, m2, s1, s2)
 redshift = f['injections/redshift'][:][inj_idx] if args.colorbar_choice == \
                                                            'redshift' else None
 

--- a/pycbc/events/triggers.py
+++ b/pycbc/events/triggers.py
@@ -19,7 +19,7 @@ from the command line.
 
 import h5py
 import numpy
-from pycbc import types, pnutils
+from pycbc import types, conversions
 from pycbc.events import coinc
 from pycbc.io import hdf
 import pycbc.detector
@@ -272,11 +272,11 @@ def get_found_param(injfile, bankfile, trigfile, param, ifo):
         b = bankfile
         found_param_dict = {
           "mtotal" : (b['mass1'][:] + b['mass2'][:])[foundtmp],
-          "mchirp" : pnutils.mass1_mass2_to_mchirp_eta(b['mass1'][:],
-                     b['mass2'][:])[0][foundtmp],
-          "eta"    : pnutils.mass1_mass2_to_mchirp_eta(b['mass1'][:],
-                     b['mass2'][:])[1][foundtmp],
-          "effective_spin" : pnutils.phenomb_chi(b['mass1'][:],
+          "mchirp" : conversions.mchirp_from_mass1_mass2(b['mass1'][:],
+                     b['mass2'][:])[foundtmp],
+          "eta"    : conversions.eta_from_mass1_mass2(b['mass1'][:],
+                     b['mass2'][:])[foundtmp],
+          "effective_spin" : conversions.chi_eff(b['mass1'][:],
                                                  b['mass2'][:],
                                                  b['spin1z'][:],
                                                  b['spin2z'][:])[foundtmp]
@@ -312,11 +312,11 @@ def get_inj_param(injfile, param, ifo):
         return inj["injections/"+param]
     inj_param_dict = {
         "mtotal" : inj['mass1'][:] + inj['mass2'][:],
-        "mchirp" : pnutils.mass1_mass2_to_mchirp_eta(inj['mass1'][:],
-                                                     inj['mass2'][:])[0],
-        "eta" : pnutils.mass1_mass2_to_mchirp_eta(inj['mass1'][:],
-                                                  inj['mass2'][:])[1],
-        "effective_spin" : pnutils.phenomb_chi(inj['mass1'][:],
+        "mchirp" : conversions.mchirp_from_mass1_mass2(inj['mass1'][:],
+                                                     inj['mass2'][:]),
+        "eta" : conversions.eta_from_mass1_mass2(inj['mass1'][:],
+                                                  inj['mass2'][:]),
+        "effective_spin" : conversions.chi_eff(inj['mass1'][:],
                                                inj['mass2'][:],
                                                inj['spin1z'][:],
                                                inj['spin2z'][:]),

--- a/pycbc/io/hdf.py
+++ b/pycbc/io/hdf.py
@@ -19,7 +19,7 @@ from pycbc_glue.ligolw.utils import process as ligolw_process
 from pycbc import version as pycbc_version
 from pycbc.tmpltbank import return_search_summary
 from pycbc.tmpltbank import return_empty_sngl
-from pycbc import events, pnutils
+from pycbc import events, conversions, pnutils
 
 class HFile(h5py.File):   
     """ Low level extensions to the capabilities of reading an hdf5 File
@@ -504,20 +504,16 @@ class SingleDetTriggers(object):
 
     @property
     def mchirp(self):
-        mchirp, _ = pnutils.mass1_mass2_to_mchirp_eta(
-            self.mass1, self.mass2)
-        return mchirp
+        return conversions.mchirp_from_mass1_mass2(self.mass1, self.mass2)
 
     @property
     def eta(self):
-        _, eta = pnutils.mass1_mass2_to_mchirp_eta(
-            self.mass1, self.mass2)
-        return eta
+        return conversions.eta_from_mass1_mass2(self.mass1, self.mass2)
 
     @property
     def effective_spin(self):
         # FIXME assumes aligned spins
-        return pnutils.phenomb_chi(self.mass1, self.mass2,
+        return conversions.chi_eff(self.mass1, self.mass2,
                                    self.spin1z, self.spin2z)
 
     # IMPROVEME: would like to have a way to access all get_freq and/or

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -183,15 +183,6 @@ def get_beta_sigma_from_aligned_spins(eta, spin1z, spin2z):
     gamma += (732985. / 2268. + 140. / 9. * eta) * delta * chiA
     return beta, sigma, gamma
 
-def _get_phenomb_chi(m1, m2, s1z, s2z):
-    """
-    Wrapper of standard Phenom effective spin calculation
-    """
-    return lalsimulation.SimIMRPhenomBComputeChi(float(m1) * lal.MSUN_SI,
-             float(m2) * lal.MSUN_SI, float(s1z), float(s2z))
-
-phenomb_chi = numpy.vectorize(_get_phenomb_chi)
-
 def solar_mass_to_kg(solar_masses):
     return solar_masses * lal.MSUN_SI
 


### PR DESCRIPTION
The conversions module is replacing functions in pnutils. This removes the phenomb_chi function which called into lalsimulation in favor of the existing pure python version. 