### PR TITLE
Check InferenceFile integrity

### DIFF
--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -517,7 +517,7 @@ class BaseMCMCSampler(_BaseSampler):
                 istop = istart + niterations
                 fp.create_dataset(dataset_name, (nwalkers, istop),
                                   maxshape=(nwalkers, max_iterations),
-                                  dtype=float)
+                                  dtype=float, fletcher32=True)
             fp[dataset_name][:,istart:istop] = samples[param]
 
     def write_chain(self, fp, start_iteration=None, max_iterations=None):
@@ -645,7 +645,7 @@ class BaseMCMCSampler(_BaseSampler):
             istop = istart + acf.size
             fp.create_dataset(dataset_name, (istop,),
                               maxshape=(max_iterations,),
-                              dtype=acf.dtype)
+                              dtype=acf.dtype, fletcher32=True)
             fp[dataset_name][istart:istop] = acf
 
     def write_results(self, fp, start_iteration=None,

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -599,7 +599,7 @@ class EmceePTSampler(BaseMCMCSampler):
                 istop = istart + niterations
                 fp.create_dataset(dataset_name, (ntemps, nwalkers, istop),
                                   maxshape=(ntemps, nwalkers, max_iterations),
-                                  dtype=float)
+                                  dtype=float, fletcher32=True)
             fp[dataset_name][:,:,istart:istop] = samples[param]
 
     def write_results(self, fp, start_iteration=None, max_iterations=None,

--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -229,7 +229,7 @@ class KombineSampler(BaseMCMCSampler):
             fp.create_dataset(dataset_name, shape,
                               maxshape=(self._sampler._kde_size,
                                         len(self.variable_args)),
-                              dtype=float)
+                              dtype=float, fletcher32=True)
             fp[dataset_name][:] = kde.data
 
     def write_state(self, fp):

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -25,6 +25,7 @@
 inference samplers generate.
 """
 
+import os
 import sys
 import h5py
 import numpy
@@ -700,3 +701,52 @@ class InferenceFile(h5py.File):
             other.attrs['burn_in_iterations'] = 0
             other.attrs['niterations'] = samples.shape[-1]
         return other
+
+
+def check_integrity(filename):
+    """Checks the integrity of an InferenceFile.
+
+    Checks done are:
+    
+        * can the file open?
+        * do all of the datasets in the samples group have the same shape?
+        * can the first and last sample in all of the datasets in the samples
+          group be read?
+
+    If any of these checks fail, an IOError is raised.
+
+    Parameters
+    ----------
+    filename: str
+        Name of an InferenceFile to check.
+    
+    Raises
+    ------
+    ValueError
+        If the given file does not exist.
+    KeyError
+        If the samples group does not exist.
+    IOError
+        If any of the checks fail.
+    """
+    # check that the file exists
+    if not os.path.exists(filename):
+        raise ValueError("file {} does not exist".format(filename))
+    # if the file is corrupted such that it cannot be opened, the next line
+    # will raise an IOError
+    with InferenceFile(filename, 'r') as fp:
+        # check that all datasets in samples have the same shape
+        parameters = fp[fp.samples_group].keys()
+        group = fp.samples_group + '/{}'
+        # use the first parameter as a reference shape
+        ref_shape = fp[group.format(parameters[0])].shape
+        if not all(fp[group.format(param)].shape == ref_shape
+                   for param in parameters):
+            raise IOError("not all datasets in the samples group have the same "
+                          "shape")
+        # check that we can read the first/last sample
+        firstidx = tuple([0]*len(ref_shape))
+        lastidx = tuple([-1]*len(ref_shape))
+        for param in parameters:
+            fp[group.format(param)][firstidx]
+            fp[group.format(param)][lastidx]

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -707,7 +707,7 @@ def check_integrity(filename):
     """Checks the integrity of an InferenceFile.
 
     Checks done are:
-    
+
         * can the file open?
         * do all of the datasets in the samples group have the same shape?
         * can the first and last sample in all of the datasets in the samples
@@ -748,5 +748,5 @@ def check_integrity(filename):
         firstidx = tuple([0]*len(ref_shape))
         lastidx = tuple([-1]*len(ref_shape))
         for param in parameters:
-            fp[group.format(param)][firstidx]
-            fp[group.format(param)][lastidx]
+            _ = fp[group.format(param)][firstidx]
+            _ = fp[group.format(param)][lastidx]

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -719,7 +719,7 @@ def check_integrity(filename):
     ----------
     filename: str
         Name of an InferenceFile to check.
-    
+
     Raises
     ------
     ValueError

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -546,7 +546,8 @@ class InferenceFile(h5py.File):
         if group in self:
             self[dataset_name][:] = arr
         else:
-            self[dataset_name] = arr
+            self.create_dataset(dataset_name, arr.shape, fletcher32=True)
+            self[dataset_name][:] = arr
         self[dataset_name].attrs["s"] = s
         self[dataset_name].attrs["pos"] = pos
         self[dataset_name].attrs["has_gauss"] = has_gauss


### PR DESCRIPTION
This adds a function to do some simple integrity checks on an inference file to ensure it was not corrupted when written. The checks that are done are:
- can the file open?
- do all of the datasets in the samples group have the same shape?
- can the first and last sample in all of the datasets in the samples group be read?

Errors are raised if any of these fail; otherwise, the function just returns. If we want to add more checks in the future, they can just be added to this function.

This also turns on a [checksum](http://docs.h5py.org/en/latest/high/dataset.html#fletcher32-filter) on all data sets, which is h5py's way of checking for corruption. (Unfortunately, the docs don't indicate what error will be raised if a corrupted segment is detected, and I was unable to produce a single corrupted data set to test.)