### PR TITLE
Optimal_snr quick fix

### DIFF
--- a/bin/pycbc_optimal_snr
+++ b/bin/pycbc_optimal_snr
@@ -223,8 +223,7 @@ if __name__ == '__main__':
     for inj in proc_injs:
         out_sim_inspiral.append(inj)
 
-    out_sim_inspiral = sorted(out_sim_inspiral,
-                              key=lambda x: x.geocent_end_time)
+    out_sim_inspiral.sort(key=lambda x: x.geocent_end_time)
 
     logging.info('Writing output')
     llw_doc = injections.indoc


### PR DESCRIPTION
I broke optimal SNR because I used `sorted`, which returns a list, when I needed to keep the object as a sim_inspiral table. `sort` is a much better choice here anyway and swapping to that fixes the issue (tested on ongoing NR injection IMBH tests).