### PR TITLE
fallback if backend not available

### DIFF
--- a/pycbc/fft/backend_cpu.py
+++ b/pycbc/fft/backend_cpu.py
@@ -24,7 +24,7 @@ _backend_list = ['fftw','mkl','numpy']
 
 _alist, _adict = _list_available(_backend_list, _backend_dict)
 
-cpu_backend = 'fftw'
+cpu_backend = None
 
 def set_backend(backend_list):
     global cpu_backend
@@ -36,3 +36,5 @@ def set_backend(backend_list):
 def get_backend():
     return _adict[cpu_backend]
 
+# Set the default backend
+set_backend(_backend_list)


### PR DESCRIPTION
This is a simple change which fixes #1879, and allows by default the fft package to work with fftw. Since we check for that already, this simply puts in the plumbing for the default to be the first working backend.