### PR TITLE
Fix zero-found-injections failures

### DIFF
--- a/bin/hdfcoinc/pycbc_page_coinc_snrchi
+++ b/bin/hdfcoinc/pycbc_page_coinc_snrchi
@@ -109,7 +109,7 @@ else:
     inj_chisq = numpy.array([])
 
 # Catch not enough found injections case
-if len(coloring[args.colorbar_choice][0]) < 2:
+if len(coloring[args.colorbar_choice][0]) == 0:
     coloring[args.colorbar_choice] = (None, None, None)
 
 pylab.scatter(inj_snr, inj_chisq, c=coloring[args.colorbar_choice][0],

--- a/bin/hdfcoinc/pycbc_page_coinc_snrchi
+++ b/bin/hdfcoinc/pycbc_page_coinc_snrchi
@@ -108,6 +108,10 @@ else:
     inj_snr = numpy.array([])
     inj_chisq = numpy.array([])
 
+# Catch not enough found injections case
+if len(coloring[args.colorbar_choice][0]) < 2:
+    coloring[args.colorbar_choice] = (None, None, None)
+
 pylab.scatter(inj_snr, inj_chisq, c=coloring[args.colorbar_choice][0],
               norm=coloring[args.colorbar_choice][2],
               marker='^', linewidth=0, label="Injections", 
@@ -133,7 +137,7 @@ ax.set_yscale('log')
 try:
     cb = pylab.colorbar()
     cb.set_label(coloring[args.colorbar_choice][1], size='large')
-except TypeError:
+except (TypeError, ZeroDivisionError):
     # Catch case of no injection triggers
     if len(inj_chisq):
         raise

--- a/bin/hdfcoinc/pycbc_page_foundmissed
+++ b/bin/hdfcoinc/pycbc_page_foundmissed
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """ Plot found and missed injections.
 """
 import h5py, numpy, logging, os.path, argparse, sys, matplotlib
@@ -131,6 +131,8 @@ else:
     fvals = fvals[csort]
     fdval = fdvals[csort]
     color = color[csort]
+    if len(color) < 2:
+        color=None
 
     mpoints = plot.scatter(vals[args.axis_type][missed], mdvals,
                            marker='x', color='red', label='missed', zorder=zmissed)
@@ -144,7 +146,7 @@ else:
     try:
         c = plot.colorbar()
         c.set_label('False Alarm Rate $(yr^{-1})$, %s' % far_title)
-    except TypeError:
+    except (TypeError, ZeroDivisionError):
         # Can't make colorbar if no quiet found injections
         if len(fvals):
             raise
@@ -162,16 +164,17 @@ plot.grid()
 if args.log_x:
     # log x axis may fail for some choices, eg effective spin
     ax.set_xscale('log')
-    xmax = 1.4 * max(vals[args.axis_type][missed].max(),
-                     vals[args.axis_type][found].max())
-    xmin = 0.7 * min(vals[args.axis_type][missed].min(),
-                     vals[args.axis_type][found].min())
+    tmpxvals = list(vals[args.axis_type][missed])
+    tmpxvals += list(vals[args.axis_type][found])
+    xmax = 1.4 * max(tmpxvals)
+    xmin = 0.7 * min(tmpxvals)
     plot.xlim(xmin, xmax)
 if args.log_distance:
     ax.set_yscale('log')
 
-ymax = 1.2 * max(fdvals.max(), mdvals.max())
-ymin = 0.9 * min(fdvals.min(), mdvals.min())
+tmpyvals = list(fdvals) + list(mdvals)
+ymax = 1.2 * max(tmpyvals)
+ymin = 0.9 * min(tmpyvals)
 if args.plot_all_distance:
     # note: ymin=0 will clash with args.log_distance
     # in that case it *should* throw an error!
@@ -196,9 +199,8 @@ if ('.html' in args.output_file):
                                                     alpha_unsel=0.1)
     mpld3.plugins.connect(fig, legend)
 
-pycbc.results.save_fig_with_metadata(fig, args.output_file,
-                     fig_kwds=fig_kwds,
-                     title='%s: %s vs %s' % (fig_title, args.axis_type, args.distance_type),
-                     cmd=' '.join(sys.argv),
-                     caption=caption)
+pycbc.results.save_fig_with_metadata\
+    (fig, args.output_file, fig_kwds=fig_kwds,
+     title='%s: %s vs %s' % (fig_title, args.axis_type, args.distance_type),
+     cmd=' '.join(sys.argv), caption=caption)
 

--- a/bin/hdfcoinc/pycbc_page_injtable
+++ b/bin/hdfcoinc/pycbc_page_injtable
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """ Make a table of found injection information
 """
 import argparse, h5py, numpy, pycbc.results, pycbc.detector, sys

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -190,7 +190,7 @@ def newsnr(snr, reduced_x2, q=6., n=2.):
     ind = numpy.where(reduced_x2 > 1.)[0]
     newsnr[ind] *= ( 0.5 * (1. + reduced_x2[ind] ** (q/n)) ) ** (-1./q)
 
-    # If input was floats, return a float. Otherwise return numpy array.
+    # If snr input is float, return a float. Otherwise return numpy array.
     if hasattr(snr, '__len__'):
         return newsnr
     else:
@@ -206,7 +206,7 @@ def newsnr_sgveto(snr, bchisq, sgchisq):
     if len(t) > 0:
         nsnr[t] = nsnr[t] / (sgchisq[t] / 4.0) ** 0.5
 
-    # If input was floats, return a float. Otherwise return numpy array.
+    # If snr input is float, return a float. Otherwise return numpy array.
     if hasattr(snr, '__len__'):
         return nsnr
     else:
@@ -220,7 +220,7 @@ def effsnr(snr, reduced_x2, fac=250.):
     rchisq = numpy.array(reduced_x2, ndmin=1, dtype=numpy.float64)
     effsnr = snr / (1 + snr ** 2 / fac) ** 0.25 / rchisq ** 0.25
 
-    # If input was floats, return a float. Otherwise return numpy array.
+    # If snr input is float, return a float. Otherwise return numpy array.
     if hasattr(snr, '__len__'):
         return effsnr
     else:

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -190,7 +190,8 @@ def newsnr(snr, reduced_x2, q=6., n=2.):
     ind = numpy.where(reduced_x2 > 1.)[0]
     newsnr[ind] *= ( 0.5 * (1. + reduced_x2[ind] ** (q/n)) ) ** (-1./q)
 
-    if len(newsnr) > 1:
+    # If input was floats, return a float. Otherwise return numpy array.
+    if hasattr(snr, '__len__'):
         return newsnr
     else:
         return newsnr[0]
@@ -205,7 +206,8 @@ def newsnr_sgveto(snr, bchisq, sgchisq):
     if len(t) > 0:
         nsnr[t] = nsnr[t] / (sgchisq[t] / 4.0) ** 0.5
 
-    if len(nsnr) > 1:
+    # If input was floats, return a float. Otherwise return numpy array.
+    if hasattr(snr, '__len__'):
         return nsnr
     else:
         return nsnr[0]
@@ -218,7 +220,8 @@ def effsnr(snr, reduced_x2, fac=250.):
     rchisq = numpy.array(reduced_x2, ndmin=1, dtype=numpy.float64)
     effsnr = snr / (1 + snr ** 2 / fac) ** 0.25 / rchisq ** 0.25
 
-    if len(effsnr) > 1:
+    # If input was floats, return a float. Otherwise return numpy array.
+    if hasattr(snr, '__len__'):
         return effsnr
     else:
         return effsnr[0]


### PR DESCRIPTION
I saw some failures in plotting jobs in an IMBH testing run, which was due to there being 0 found injections in the 300 + 300 injection set. The code should be able to handle this. A few tweaks are needed to allow this.

Note that some codes declare `/usr/bin/python` as the executable. This should always be `/usr/bin/env python` but I only fixed this in the codes that I touched (lots of cases have this wrong, but the EGG installation prevents this from being a problem in most cases).

Note also the events.py had some weird bit of code to allow one (I think!) to specify floats as input to the newsnr/effective SNR routines. This caused failures if the inputs were empty arrays (or length one arrays in many cases), so I've now fixed this to return output in the same format as the input (ie. if you give floats as inputs you get floats back, but give arrays of length 1 as input and you get arrays of length 1 back).