### PR TITLE
Get travis working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ script:
     sudo chown -R $UID . ;
     sudo chown -R $UID ~/.ssh ;
   else
-    ./tools/docker_build_and_test.sh ;
+    travis_wait 60 ./tools/docker_build_and_test.sh ;
   fi
 after_success:
   - if [ "x${TRAVIS_SECURE_ENV_VARS}" == "xtrue" ] && [ "x${PYCBC_CONTAINER}" == "xpycbc_docker" ] ; then


### PR DESCRIPTION
Travis has been repeatedly failing in the last week. This is for two reasons:

 * The inference tests (all of them!?) are failing
 * The docker_build_and_test runs are timing out

The first issue I propose a temporary patch by disabling the tests while no maintainers are available. I will open a pull request to revert this and we should not allow inference-related patches until this is resolved. But inference being broken should not hold up needed development towards an IMBH release.

The second issue I seem to have resolved by using the travis_wait command to allow more time for this to run. @titodalcanton I'm assigning this to you.