### PR TITLE
Fix inference test failure with numpy 1.14

### DIFF
--- a/pycbc/inference/sampler_mcmc.py
+++ b/pycbc/inference/sampler_mcmc.py
@@ -161,7 +161,8 @@ class MCMCSampler(BaseMCMCSampler):
             blob = self._lastblob
 
         self._chain = numpy.empty(niterations,dtype=self.dtype)
-        self._chain[start] = start_sample
+        # numpy >=1.14 only accepts tuples
+        self._chain[start] = tuple(start_sample)
         self._blobs = [None]*niterations
         self._blobs[start] = blob
 

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -811,6 +811,9 @@ class FieldArray(numpy.recarray):
         """Wrap's recarray's setitem to allow attribute-like indexing when
         setting values.
         """
+        if type(item) is int and type(values) is numpy.ndarray:
+            # numpy >=1.14 only accepts tuples
+            values = tuple(values)
         try:
             return super(FieldArray, self).__setitem__(item, values)
         except ValueError:


### PR DESCRIPTION
Numpy 1.14 seems to have changed the way recarrays work, requiring
`__setitem__` to be given a tuple instead of an ndarray. This changes such
operation in a couple places in the inference code. Fixes #2038.

Note that the way I did it for FieldArray may not be the most efficient.