### PR TITLE
Add omega scans to workflow

### DIFF
--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -168,6 +168,12 @@ for num_event in range(num_events):
                                 time, args.output_dir,
                                 data_segments=insp_data_seglists[single.ifo],
                                 tags=args.tags + [str(num_event)])
+
+        files += mini.make_qscan_plot(workflow, single.ifo, time,
+                                      args.output_dir,
+                                      data_segments=insp_data_seglists,
+                                      tags=args.tags + [str(num_event)])
+
     
     layouts += list(layout.grouper(files, 2))
     num_event += 1

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -169,12 +169,12 @@ for num_event in range(num_events):
                                 data_segments=insp_data_seglists[single.ifo],
                                 tags=args.tags + [str(num_event)])
 
-        files += mini.make_qscan_plot(workflow, single.ifo, time,
-                                      args.output_dir,
-                                      data_segments=insp_data_seglists,
-                                      tags=args.tags + [str(num_event)])
+        files += mini.make_qscan_plot\
+            (workflow, single.ifo, time, args.output_dir,
+             data_segments=insp_data_seglists[single.ifo],
+             tags=args.tags + [str(num_event)])
 
-    
+
     layouts += list(layout.grouper(files, 2))
     num_event += 1
 

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -170,6 +170,13 @@ for num_event in range(num_events):
                                 data_segments=insp_data_seglists[single.ifo],
                                 tags=args.tags + [str(num_event)])
 
+        files += mini.make_qscan_plot(workflow, single.ifo, time,
+                                      args.output_dir,
+                                      data_segments=insp_data_seglists,
+                                      injection_file=injection_xml_file,
+                                      tags=args.tags + [str(num_event)])
+
+
     files += mini.make_single_template_plots(workflow, insp_segs,
                             args.inspiral_data_read_name,
                             args.inspiral_data_analyzed_name, inj_params,

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -170,11 +170,11 @@ for num_event in range(num_events):
                                 data_segments=insp_data_seglists[single.ifo],
                                 tags=args.tags + [str(num_event)])
 
-        files += mini.make_qscan_plot(workflow, single.ifo, time,
-                                      args.output_dir,
-                                      data_segments=insp_data_seglists,
-                                      injection_file=injection_xml_file,
-                                      tags=args.tags + [str(num_event)])
+        files += mini.make_qscan_plot\
+            (workflow, single.ifo, time, args.output_dir,
+             data_segments=insp_data_seglists[single.ifo],
+             injection_file=injection_xml_file,
+             tags=args.tags + [str(num_event)])
 
 
     files += mini.make_single_template_plots(workflow, insp_segs,

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -228,14 +228,20 @@ for num_event in range(num_events):
                             args.output_dir, 
                             tags=args.tags+[str(num_event)])
 
+    files += mini.make_plot_waveform_plot(workflow, curr_params,
+                                        args.output_dir, [args.instrument],
+                                        tags=args.tags + [str(num_event)])
+
+
     files += mini.make_singles_timefreq(workflow, sngl_file, tmpltbank_file, 
                             time, args.output_dir,
                             data_segments=insp_data_seglists,
                             tags=args.tags + [str(num_event)])                 
 
-    files += mini.make_plot_waveform_plot(workflow, curr_params,
-                                        args.output_dir, [args.instrument],
-                                        tags=args.tags + [str(num_event)])
+    files += mini.make_qscan_plot(workflow, args.instrument, time,
+                                  args.output_dir,
+                                  data_segments=insp_data_seglists,
+                                  tags=args.tags + [str(num_event)])
 
     layouts += list(layout.grouper(files, 2))
     num_event += 1

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -108,9 +108,9 @@ for curr_idx in range(len(wins)):
     curr_win = wins[curr_idx]
     # Catch the case that not enough data is available.
     if opts.center_time - curr_win[0] < strain.start_time:
-        curr_win[0] = opts.center_time - strain.start_time - 0.01
+        curr_win[0] = float(opts.center_time - strain.start_time - 0.01)
     if opts.center_time + curr_win[1] > strain.end_time:
-        curr_win[1] = strain.end_time - opts.center_time - 0.01
+        curr_win[1] = float(strain.end_time - opts.center_time - 0.01)
     strain_zoom = strain.time_slice(opts.center_time - curr_win[0],
                                     opts.center_time + curr_win[1])
 

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -34,12 +34,24 @@ import pycbc.strain
 import pycbc.version
 import pycbc.results
 
+# https://stackoverflow.com/questions/9978880/python-argument-parser-list-of-list-or-tuple-of-tuples
+def t_window(s):
+    try:
+        start, end = map(float, s.split(','))
+        return [start, end]
+    except:
+        raise argparse.ArgumentTypeError("Input must be start,end start,end")
+
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--output-file', required=True, help='Output plot')
 parser.add_argument('--center-time', type=float,
                     help='Center plot on the given GPS time')
+parser.add_argument('--time-windows', required=True, type=t_window,
+                    nargs='+',
+                    help='Use these set of times for time windows. Should '
+                         'be provided as start1,end1 start2,end2 ...')
 
 parser.add_argument('--qtransform-delta-t', default=0.001, type=float,
                     help='The time resolution to interpolate to (optional)')
@@ -67,9 +79,9 @@ parser.add_argument('--qtransform-mismatch', default=0.2, type=float,
 parser.add_argument('--linear-y-axis', dest='log_y', default=True, 
                     action='store_false',
                     help='Use a linear y-axis. By default a log axis is used.')
-parser.add_argument('--log-colorbar', dest='log_colorbar', default=False,
-                    action='store_true',
-                    help='Use a logarithmic colorbar scale.')
+parser.add_argument('--linear-colorbar', dest='log_colorbar', default=True,
+                    action='store_false',
+                    help='Use a linear colorbar scale.')
 parser.add_argument('--plot-title',
                     help="If given, use this as the plot title")
 parser.add_argument('--plot-caption',
@@ -101,8 +113,11 @@ else:
 
 strain = strain.whiten(4, 4)
 
-wins = [[50,10],[10,1],[1,1]]
+wins = opts.time_windows
 fig, axes = plt.subplots(len(wins),1)
+times_all = []
+freqs_all = []
+qvals_all = []
 
 for curr_idx in range(len(wins)):
     curr_win = wins[curr_idx]
@@ -119,12 +134,22 @@ for curr_idx in range(len(wins)):
          logfsteps=opts.qtransform_logfsteps, frange=curr_frange,
          qrange=(opts.qtransform_qrange_lower, opts.qtransform_qrange_upper),
          mismatch=opts.qtransform_mismatch)
+    times_all.append(times)
+    freqs_all.append(freqs)
+    qvals_all.append(qvals)
 
+max_qval = max([qvals.max() for qvals in qvals_all])
+
+for curr_idx in range(len(wins)):
     ax = axes[curr_idx]
+    times = times_all[curr_idx]
+    freqs = freqs_all[curr_idx]
+    qvals = qvals_all[curr_idx]
+    curr_win = wins[curr_idx]
 
     norm=None
     if opts.log_colorbar:
-        norm=LogNorm(vmin=1, vmax=qvals.max())
+        norm=LogNorm(vmin=1, vmax=max_qval)
 
     im = ax.pcolormesh(times - opts.center_time, freqs, qvals, norm=norm)
     ax.set_xlim(-curr_win[0], curr_win[1])
@@ -139,6 +164,10 @@ plt.tick_params(labelcolor='none', top='off', bottom='off', left='off',
 plt.grid(False)
 plt.xlabel('Time from {} (s)'.format(opts.center_time))
 plt.ylabel('Frequency (Hz)')
+
+# https://stackoverflow.com/questions/13784201/matplotlib-2-subplots-1-colorbar
+cb = fig.colorbar(im, ax=axes.ravel().tolist())
+cb.set_label('What should this say?')
 
 if opts.plot_title is None:
     opts.plot_title = 'Q-transform plot'

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -46,7 +46,7 @@ parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--version", action="version",
                     version=pycbc.version.git_verbose_msg)
 parser.add_argument('--output-file', required=True, help='Output plot')
-parser.add_argument('--center-time', type=float,
+parser.add_argument('--center-time', type=float, required=True,
                     help='Center plot on the given GPS time')
 parser.add_argument('--time-windows', required=True, type=t_window,
                     nargs='+',
@@ -72,7 +72,7 @@ parser.add_argument('--qtransform-qrange-lower', default=4, type=float,
                          'default=4')
 parser.add_argument('--qtransform-qrange-upper', default=64, type=float,
                     help='Upper limit of the range of q to consider, '
-                         'default=4')
+                         'default=64')
 parser.add_argument('--qtransform-mismatch', default=0.2, type=float,
                     help='Mismatch between frequency tiles, default=0.2')
 
@@ -162,15 +162,15 @@ fig.add_subplot(111, frameon=False)
 plt.tick_params(labelcolor='none', top='off', bottom='off', left='off',
                 right='off')
 plt.grid(False)
-plt.xlabel('Time from {} (s)'.format(opts.center_time))
+plt.xlabel('Time from {:.3f} (s)'.format(opts.center_time))
 plt.ylabel('Frequency (Hz)')
 
 # https://stackoverflow.com/questions/13784201/matplotlib-2-subplots-1-colorbar
 cb = fig.colorbar(im, ax=axes.ravel().tolist())
-cb.set_label('What should this say?')
+cb.set_label('Normalized power')
 
 if opts.plot_title is None:
-    opts.plot_title = 'Q-transform plot'
+    opts.plot_title = 'Q-transform plot around {:.3f}'.format(opts.center_time)
 if opts.plot_caption is None:
     # FIXME: Someone please improve!
     opts.plot_caption = ("This shows the Q-transform as a function of time and "

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -42,32 +42,35 @@ parser.add_argument('--output-file', required=True, help='Output plot')
 parser.add_argument('--center-time', type=float,
                     help='Center plot on the given GPS time')
 
-parser.add_argument('--qtransform-delta-t', default=None,
+parser.add_argument('--qtransform-delta-t', default=0.001, type=float,
                     help='The time resolution to interpolate to (optional)')
-parser.add_argument('--qtransform-delta-f', default=None,
+parser.add_argument('--qtransform-delta-f', default=None, type=float,
                     help='Frequency resolution to interpolate to (optional)')
-parser.add_argument('--qtransform-logfsteps', type=int, default=None,
+parser.add_argument('--qtransform-logfsteps', type=int, default=200,
                     help='Do a log interpolation (incompatible with '
                          '--qtransform-delta-f option) and set the number '
                          'of steps to take')
-parser.add_argument('--qtransform-frange-lower', default=None,
+parser.add_argument('--qtransform-frange-lower', default=None, type=float,
                     help='Lower frequency at which to compute qtransform. '
-                         'Optional, default=30')
-parser.add_argument('--qtransform-frange-upper', default=None,
+                         'Optional, default=10')
+parser.add_argument('--qtransform-frange-upper', default=None, type=float,
                     help='Upper frequency at which to compute qtransform. '
                          'Optional, default=Half of Nyquist')
-parser.add_argument('--qtransform-qrange-lower', default=4,
+parser.add_argument('--qtransform-qrange-lower', default=4, type=float,
                     help='Lower limit of the range of q to consider, '
                          'default=4')
-parser.add_argument('--qtransform-qrange-upper', default=64,
+parser.add_argument('--qtransform-qrange-upper', default=64, type=float,
                     help='Upper limit of the range of q to consider, '
                          'default=4')
-parser.add_argument('--qtransform-mismatch', default=0.2,
+parser.add_argument('--qtransform-mismatch', default=0.2, type=float,
                     help='Mismatch between frequency tiles, default=0.2')
 
 parser.add_argument('--linear-y-axis', dest='log_y', default=True, 
                     action='store_false',
                     help='Use a linear y-axis. By default a log axis is used.')
+parser.add_argument('--log-colorbar', dest='log_colorbar', default=False,
+                    action='store_true',
+                    help='Use a logarithmic colorbar scale.')
 parser.add_argument('--plot-title',
                     help="If given, use this as the plot title")
 parser.add_argument('--plot-caption',
@@ -97,42 +100,46 @@ elif opts.qtransform_frange_upper is None or \
 else:
     curr_frange = (opts.qtransform_frange_lower, opts.qtransform_frange_upper)
 
-times, freqs, qvals = strain.qtransform\
-    (delta_t=opts.qtransform_delta_t, delta_f = opts.qtransform_delta_f,
-     logfsteps=opts.qtransform_logfsteps, frange=curr_frange,
-     qrange=(opts.qtransform_qrange_lower, opts.qtransform_qrange_upper),
-     mismatch=opts.qtransform_mismatch)
-delay_time = opts.center_time - opts.gps_start_time
-time_start_idx = int(opts.sample_rate * (delay_time - 1))
-time_end_idx = int(opts.sample_rate * (delay_time + 1))
-rqvals = qvals[:,time_start_idx:time_end_idx]
-rtimes = times[time_start_idx:time_end_idx]
-rtimes = rtimes - rtimes[0] - 1
+strain = strain.whiten(4, 4)
 
-if opts.log_y:
-    # This is a PITA. The Y-axis is not tied to the image at all. So we use a
-    # log scale with values running between the desired limits.
-    freqs = numpy.log(freqs)
-    min_val = min(freqs)
-    max_val = max(freqs)
-    freqs = freqs * (curr_frange[1] - curr_frange[0]) / (max_val - min_val)
-    freqs = freqs - freqs[0] + curr_frange[0]
+wins = [[50,10],[10,1],[1,1]]
+fig, axes = plt.subplots(len(wins),1)
 
-fig = plt.figure()
-ax = fig.gca()
-im = NonUniformImage(ax, interpolation='nearest',
-                     extent=(-1, 1, curr_frange[0], curr_frange[1]),
-                     norm=LogNorm(vmin=1, vmax=rqvals.max()))
-im.set_data(rtimes, freqs, rqvals) 
-ax.images.append(im)
-ax.set_xlim(-1,1)
-ax.set_ylim(10,512)
-if opts.log_y:
-    ax.set_yscale('log')
-ax.set_xlabel('Time from {} (s)'.format(opts.center_time))
-ax.set_ylabel('Frequency (Hz)')
-cbar = fig.colorbar(im)
-cbar.ax.set_ylabel('Normalized energy frequency (Hz)')
+for curr_idx in range(len(wins)):
+    curr_win = wins[curr_idx]
+    # Catch the case that not enough data is available.
+    if opts.center_time - curr_win[0] < strain.start_time:
+        curr_win[0] = opts.center_time - strain.start_time - 0.01
+    if opts.center_time + curr_win[1] > strain.end_time:
+        curr_win[1] = strain.end_time - opts.center_time - 0.01
+    strain_zoom = strain.time_slice(opts.center_time - curr_win[0],
+                                    opts.center_time + curr_win[1])
+
+    times, freqs, qvals = strain_zoom.qtransform\
+        (delta_t=opts.qtransform_delta_t, delta_f = opts.qtransform_delta_f,
+         logfsteps=opts.qtransform_logfsteps, frange=curr_frange,
+         qrange=(opts.qtransform_qrange_lower, opts.qtransform_qrange_upper),
+         mismatch=opts.qtransform_mismatch)
+
+    ax = axes[curr_idx]
+
+    norm=None
+    if opts.log_colorbar:
+        norm=LogNorm(vmin=1, vmax=qvals.max())
+
+    im = ax.pcolormesh(times - opts.center_time, freqs, qvals, norm=norm)
+    ax.set_xlim(-curr_win[0], curr_win[1])
+    ax.set_ylim(curr_frange[0], curr_frange[1])
+    if opts.log_y:
+        ax.set_yscale('log')
+
+# https://stackoverflow.com/questions/6963035/pyplot-axes-labels-for-subplots
+fig.add_subplot(111, frameon=False)
+plt.tick_params(labelcolor='none', top='off', bottom='off', left='off',
+                right='off')
+plt.grid(False)
+plt.xlabel('Time from {} (s)'.format(opts.center_time))
+plt.ylabel('Frequency (Hz)')
 
 if opts.plot_title is None:
     opts.plot_title = 'Q-transform plot'

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -29,7 +29,6 @@ import matplotlib
 matplotlib.use('Agg')
 from matplotlib import pyplot as plt
 from matplotlib.colors import LogNorm
-from matplotlib.image import NonUniformImage
 
 import pycbc.strain
 import pycbc.version

--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2018 Ian Harry
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+Plot single-detector qscan of strain data
+"""
+
+import sys
+import argparse
+import logging
+import numpy
+
+import matplotlib
+matplotlib.use('Agg')
+from matplotlib import pyplot as plt
+from matplotlib.colors import LogNorm
+from matplotlib.image import NonUniformImage
+
+import pycbc.strain
+import pycbc.version
+import pycbc.results
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--version", action="version",
+                    version=pycbc.version.git_verbose_msg)
+parser.add_argument('--output-file', required=True, help='Output plot')
+parser.add_argument('--center-time', type=float,
+                    help='Center plot on the given GPS time')
+
+parser.add_argument('--qtransform-delta-t', default=None,
+                    help='The time resolution to interpolate to (optional)')
+parser.add_argument('--qtransform-delta-f', default=None,
+                    help='Frequency resolution to interpolate to (optional)')
+parser.add_argument('--qtransform-logfsteps', type=int, default=None,
+                    help='Do a log interpolation (incompatible with '
+                         '--qtransform-delta-f option) and set the number '
+                         'of steps to take')
+parser.add_argument('--qtransform-frange-lower', default=None,
+                    help='Lower frequency at which to compute qtransform. '
+                         'Optional, default=30')
+parser.add_argument('--qtransform-frange-upper', default=None,
+                    help='Upper frequency at which to compute qtransform. '
+                         'Optional, default=Half of Nyquist')
+parser.add_argument('--qtransform-qrange-lower', default=4,
+                    help='Lower limit of the range of q to consider, '
+                         'default=4')
+parser.add_argument('--qtransform-qrange-upper', default=64,
+                    help='Upper limit of the range of q to consider, '
+                         'default=4')
+parser.add_argument('--qtransform-mismatch', default=0.2,
+                    help='Mismatch between frequency tiles, default=0.2')
+
+parser.add_argument('--linear-y-axis', dest='log_y', default=True, 
+                    action='store_false',
+                    help='Use a linear y-axis. By default a log axis is used.')
+parser.add_argument('--plot-title',
+                    help="If given, use this as the plot title")
+parser.add_argument('--plot-caption',
+                    help="If given, use this as the plot caption")
+
+pycbc.strain.insert_strain_option_group(parser)
+opts = parser.parse_args()
+
+logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
+
+#opts.low_frequency_cutoff = opts.f_low
+strain = pycbc.strain.from_cli(opts, pycbc.DYN_RANGE_FAC)
+
+if opts.center_time is None:
+    center_time = (opts.gps_start_time + opts.gps_end_time) / 2.
+else:
+    center_time = opts.center_time
+
+if opts.qtransform_frange_upper is None and \
+        opts.qtransform_frange_lower is None:
+    curr_frange = (30, opts.sample_rate / 4.)
+elif opts.qtransform_frange_upper is None or \
+        opts.qtransform_frange_lower is None:
+    err_msg = 'Must provide either both --qtransfor-frange-upper and '
+    err_msg += '--qtransfor-frange-lower or neither option.'
+    raise ValueError(err_msg)
+else:
+    curr_frange = (opts.qtransform_frange_lower, opts.qtransform_frange_upper)
+
+times, freqs, qvals = strain.qtransform\
+    (delta_t=opts.qtransform_delta_t, delta_f = opts.qtransform_delta_f,
+     logfsteps=opts.qtransform_logfsteps, frange=curr_frange,
+     qrange=(opts.qtransform_qrange_lower, opts.qtransform_qrange_upper),
+     mismatch=opts.qtransform_mismatch)
+delay_time = opts.center_time - opts.gps_start_time
+time_start_idx = int(opts.sample_rate * (delay_time - 1))
+time_end_idx = int(opts.sample_rate * (delay_time + 1))
+rqvals = qvals[:,time_start_idx:time_end_idx]
+rtimes = times[time_start_idx:time_end_idx]
+rtimes = rtimes - rtimes[0] - 1
+
+if opts.log_y:
+    # This is a PITA. The Y-axis is not tied to the image at all. So we use a
+    # log scale with values running between the desired limits.
+    freqs = numpy.log(freqs)
+    min_val = min(freqs)
+    max_val = max(freqs)
+    freqs = freqs * (curr_frange[1] - curr_frange[0]) / (max_val - min_val)
+    freqs = freqs - freqs[0] + curr_frange[0]
+
+fig = plt.figure()
+ax = fig.gca()
+im = NonUniformImage(ax, interpolation='nearest',
+                     extent=(-1, 1, curr_frange[0], curr_frange[1]),
+                     norm=LogNorm(vmin=1, vmax=rqvals.max()))
+im.set_data(rtimes, freqs, rqvals) 
+ax.images.append(im)
+ax.set_xlim(-1,1)
+ax.set_ylim(10,512)
+if opts.log_y:
+    ax.set_yscale('log')
+ax.set_xlabel('Time from {} (s)'.format(opts.center_time))
+ax.set_ylabel('Frequency (Hz)')
+cbar = fig.colorbar(im)
+cbar.ax.set_ylabel('Normalized energy frequency (Hz)')
+
+if opts.plot_title is None:
+    opts.plot_title = 'Q-transform plot'
+if opts.plot_caption is None:
+    # FIXME: Someone please improve!
+    opts.plot_caption = ("This shows the Q-transform as a function of time and "
+                        "frequency")
+
+pycbc.results.save_fig_with_metadata\
+    (fig, opts.output_file, cmd=' '.join(sys.argv), fig_kwds={'dpi': 150},
+     title=opts.plot_title, caption=opts.plot_caption)

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -632,12 +632,11 @@ def make_qscan_plot(workflow, ifo, trig_time, out_dir, injection_file=None,
 
     node.add_opt('--gps-start-time', int(start))
     node.add_opt('--gps-end-time', int(end))
-    node.add_opt('--center-time', int(trig_time))
+    node.add_opt('--center-time', trig_time)
 
     if injection_file is not None:
         node.add_input_opt('--injection-file', injection_file)
 
-    node.add_opt('--detector', single.ifo)
     node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
     workflow += node
     return node.output_files
@@ -733,7 +732,7 @@ def make_singles_timefreq(workflow, single, bank_file, trig_time, out_dir,
 
     node.add_opt('--gps-start-time', int(start))
     node.add_opt('--gps-end-time', int(end))
-    node.add_opt('--center-time', int(trig_time))
+    node.add_opt('--center-time', trig_time)
     
     if veto_file:
         node.add_input_opt('--veto-file', veto_file)

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -304,6 +304,13 @@ class SingleTimeFreqExecutable(PlotExecutable):
     PlotExecutable but adds the file_input_options.
     """
     file_input_options = ['--gating-file']
+
+class PlotQScanExecutable(PlotExecutable):
+    """Class to be used for to create workflow.Executable instances for the
+    pycbc_plot_qscan executable. Basically inherits directly from
+    PlotExecutable but adds the file_input_options.
+    """
+    file_input_options = ['--gating-file']
     
 
 def make_single_template_plots(workflow, segs, data_read_name, analyzed_name,
@@ -550,7 +557,91 @@ def make_trigger_timeseries(workflow, singles, ifo_times, out_dir, special_tids=
         files += node.output_files
     return files
 
-    
+def make_qscan_plot(workflow, ifo, trig_time, out_dir, injection_file=None,
+                    data_segments=None, time_window=100, tags=None):
+    """ Generate a make_qscan node and add it to workflow.
+
+    This function generates a single node of the singles_timefreq executable
+    and adds it to the current workflow. Parent/child relationships are set by
+    the input/output files automatically.
+
+    Parameters
+    -----------
+    workflow: pycbc.workflow.core.Workflow
+        The workflow class that stores the jobs that will be run.
+    ifo: str
+        Which interferometer are we using?
+    trig_time: int
+        The time of the trigger being followed up.
+    out_dir: str
+        Location of directory to output to
+    injection_file: pycbc.workflow.File (optional, default=None)
+        If given, add the injections in the file to strain before making the
+        plot.
+    data_segments: glue.segments.segmentlist (optional, default=None)
+        The list of segments for which data exists and can be read in. If given
+        the start/end times given to singles_timefreq will be adjusted if
+        [trig_time - time_window, trig_time + time_window] does not completely
+        lie within a valid data segment. A ValueError will be raised if the
+        trig_time is not within a valid segment, or if it is not possible to
+        find 2*time_window (plus the padding) of continuous data around the
+        trigger. This **must** be coalesced.
+    time_window: int (optional, default=None)
+        The amount of data (not including padding) that will be read in by the
+        singles_timefreq job. The default value of 100s should be fine for most
+        cases.
+    tags: list (optional, default=None)
+        List of tags to add to the created nodes, which determine file naming.
+    """
+    tags = [] if tags is None else tags
+    makedir(out_dir)
+    name = 'plot_qscan'
+
+    curr_exe = PlotQScanExecutable(workflow.cp, name, ifos=[ifo],
+                          out_dir=out_dir, tags=tags)
+    node = curr_exe.create_node()
+
+    # Determine start/end times, using data segments if needed.
+    # Begin by choosing "optimal" times
+    start = trig_time - time_window
+    end = trig_time + time_window
+    # Then if data_segments is available, check against that, and move if
+    # needed
+    if data_segments is not None:
+        # Assumes coalesced, so trig_time can only be within one segment
+        for seg in data_segments:
+            if trig_time in seg:
+                data_seg = seg
+                break
+        else:
+            err_msg = "Trig time {} ".format(trig_time)
+            err_msg += "does not seem to lie within any data segments. "
+            err_msg += "This shouldn't be possible, please ask for help!"
+            raise ValueError(err_msg)
+        # Check for pad-data
+        if curr_exe.has_opt('pad-data'):
+            pad_data = int(curr_exe.get_opt('pad-data'))
+        else:
+            pad_data = 0
+        # We only read data that's available. The code must handle the case
+        # of not much data being available.
+        if end > (data_seg[1] - pad_data):
+            end = data_seg[1] - pad_data
+        if start < (data_seg[0] + pad_data):
+            start = data_seg[0] + pad_data
+
+    node.add_opt('--gps-start-time', int(start))
+    node.add_opt('--gps-end-time', int(end))
+    node.add_opt('--center-time', int(trig_time))
+
+    if injection_file is not None:
+        node.add_input_opt('--injection-file', injection_file)
+
+    node.add_opt('--detector', single.ifo)
+    node.new_output_file_opt(workflow.analysis_time, '.png', '--output-file')
+    workflow += node
+    return node.output_files
+
 def make_singles_timefreq(workflow, single, bank_file, trig_time, out_dir,
                           veto_file=None, time_window=10, data_segments=None,
                           tags=None):

--- a/setup.py
+++ b/setup.py
@@ -471,6 +471,7 @@ setup (
                'bin/inference/pycbc_inference_plot_samples',
                'bin/inference/pycbc_inference_table_summary',
                'bin/plotting/pycbc_plot_waveform',
+               'bin/plotting/pycbc_plot_qscan',
                'bin/plotting/pycbc_banksim_plot_eff_fitting_factor',
                'bin/plotting/pycbc_banksim_table_point_injs',
                'bin/plotting/pycbc_banksim_plot_fitting_factors',


### PR DESCRIPTION
This patch adds an omega scans executable to PyCBC and implements it within the PyCBC workflow. An example of this is here:

https://ldas-jobs.ligo.caltech.edu/~spxiwh/aLIGO/O2/analyses/O2_chunk19_HM/run3B/3._single_triggers/3.07_H1_loudest_noncoinc_time/

These new plots will appear in injection, single and coincident minifollowups.

This requires some minor changes to configuration files to add the new executable and options. Please advise on what file I should add those changes to?