### PR TITLE
Fixing style issues in PyCBC

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -15,6 +15,7 @@ pylint:
   - too-many-arguments
   - too-many-locals
   - too-many-branches
+  - too-many-statements
 
 pyflakes:
   disable:

--- a/bin/hdfcoinc/pycbc_plot_Nth_loudest_coinc_omicron.py
+++ b/bin/hdfcoinc/pycbc_plot_Nth_loudest_coinc_omicron.py
@@ -12,12 +12,10 @@ import glob
 from pycbc_glue.ligolw import ligolw, lsctables, table, utils
 import matplotlib
 matplotlib.use('Agg')
-import matplotlib.mlab as mlab
 import matplotlib.pyplot as plt
 import pycbc.pnutils
 import pycbc.events
 from pycbc.waveform import get_td_waveform, frequency_from_polarizations, amplitude_from_polarizations
-import lal
 
 
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
@@ -108,8 +106,8 @@ for era in eras:
             %(args.ifo,args.omicron_channel,era,args.ifo,args.omicron_channel.replace('-','_')))
     
     # Parse trigger files into SNR, time, and frequency for Omicron triggers
-    for file in file_list:
-        omicron_xml = utils.load_filename(file, contenthandler=DefaultContentHandler)
+    for file_name in file_list:
+        omicron_xml = utils.load_filename(file_name, contenthandler=DefaultContentHandler)
         snglburst_table = table.get_table(omicron_xml, lsctables.SnglBurstTable.tableName)
 
         for row in snglburst_table:

--- a/bin/hdfcoinc/pycbc_plot_Nth_loudest_coinc_omicron.py
+++ b/bin/hdfcoinc/pycbc_plot_Nth_loudest_coinc_omicron.py
@@ -28,28 +28,28 @@ lsctables.use_in(DefaultContentHandler)
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--coinc-file', type=str, required=True,
-        help='HDF file containing coincident CBC triggers')
+                    help='HDF file containing coincident CBC triggers')
 parser.add_argument('--single-ifo-trigs', type=str, required=True,
-		help='HDF file containing single IFO CBC triggers')
+                    help='HDF file containing single IFO CBC triggers')
 parser.add_argument('--ifo', type=str, required=True,
-        help='IFO, L1 or H1')    
+                    help='IFO, L1 or H1')    
 parser.add_argument('--tmpltbank-file', type=str, required=True,
-		help='HDF file containing template information for CBC search')
+                    help='HDF file containing template information for CBC search')
 parser.add_argument('--output-file', type=str, required=True,
-        help='Full path to output file')
+                    help='Full path to output file')
 parser.add_argument('--loudest-event-number', type=int, required=True, default=1,
-        help='Script will plot the Nth loudest coincident trigger')
+                    help='Script will plot the Nth loudest coincident trigger')
 parser.add_argument('--omicron-dir', type=str, required=True,
-        help='Directory containing Omicron triggers. Ex: /home/detchar/triggers/ER7/')
+                    help='Directory containing Omicron triggers. Ex: /home/detchar/triggers/ER7/')
 parser.add_argument('--omicron-snr-thresh', type=int, required=False, default=5,
-        help='SNR threshold for choosing which Omicron triggers to plot.')
+                    help='SNR threshold for choosing which Omicron triggers to plot.')
 parser.add_argument('--plot-window', type=float, required=False, default=32,
-        help='Time window to plot around CBC trigger')
+                    help='Time window to plot around CBC trigger')
 parser.add_argument('--omicron-channel',type=str, required=False, default='GDS-CALIB_STRAIN',
-        help='Channel to plot Omicron triggers for, do not include IFO')    
+                    help='Channel to plot Omicron triggers for, do not include IFO')    
 parser.add_argument('--analysis-level', type=str, required=False, default='foreground',
-        choices = ['foreground','background','background_exc'],
-        help='Designates which level of the analysis output to search')
+                    choices = ['foreground','background','background_exc'],
+                    help='Designates which level of the analysis output to search')
 args = parser.parse_args()
 
 logging.info('Reading HDF files')

--- a/pycbc/distributions/joint.py
+++ b/pycbc/distributions/joint.py
@@ -177,14 +177,14 @@ class JointDistribution(object):
             for dist in self.distributions:
                 draw = dist.rvs(1)
                 for param in dist.params:
-                     samples[param] = draw[param][0]
+                    samples[param] = draw[param][0]
             vals = numpy.array([samples[arg] for arg in self.variable_args])
 
             # determine if all parameter values are in prior space
             # if they are then add to output
             if self(**dict(zip(self.variable_args, vals))) > -numpy.inf:
-                 out[n] = vals
-                 n += 1
+                out[n] = vals
+                n += 1
 
         return out
 

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -339,8 +339,8 @@ class EventManager(object):
         indices.append(0)
         for i in xrange(len(tvec)):
             if gps_sec[i] == gps_sec[indices[-1]] and  win[i] == win[indices[-1]]:
-                    if abs(cvec[i]) > abs(cvec[indices[-1]]):
-                        indices[-1] = i
+                if abs(cvec[i]) > abs(cvec[indices[-1]]):
+                    indices[-1] = i
             else:
                 indices.append(i)
 

--- a/pycbc/events/single.py
+++ b/pycbc/events/single.py
@@ -44,9 +44,9 @@ class LiveSingleFarThreshold(object):
         nsnr = newsnr(triggers['snr'][i], rchisq)
         dur = triggers['template_duration'][i]
 
-        if (nsnr > self.newsnr_threshold and
-           rchisq < self.reduced_chisq_threshold and
-            dur > self.duration_threshold):
+        if nsnr > self.newsnr_threshold and \
+                rchisq < self.reduced_chisq_threshold and \
+                dur > self.duration_threshold:
             d = {key: triggers[key][i] for key in triggers}
             d['stat'] = nsnr
             d['ifar'] = self.fixed_ifar

--- a/pycbc/events/trigger_fits.py
+++ b/pycbc/events/trigger_fits.py
@@ -101,8 +101,8 @@ def fit_above_thresh(distr, vals, thresh=None):
 
 fitfn_dict = {
     'exponential' : lambda x, alpha, t : alpha * numpy.exp(-alpha * (x - t)),
-    'rayleigh' : lambda x, alpha, t : alpha * x * \
-                                      numpy.exp(-alpha * (x**2. - t**2.) / 2.),
+    'rayleigh' : lambda x, alpha, t : (alpha * x * \
+                                       numpy.exp(-alpha * (x**2 - t**2) / 2.)),
     'power' : lambda x, alpha, t : (alpha - 1.) * x**(-alpha) * t**(alpha - 1.)
 }
 

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -69,7 +69,7 @@ def _fftw_plan_with_nthreads(nthreads):
     global _fftw_current_nthreads
     if not HAVE_FFTW_THREADED:
         if (nthreads > 1):
-                raise ValueError("Threading is NOT enabled, but {0} > 1 threads specified".format(nthreads))
+            raise ValueError("Threading is NOT enabled, but {0} > 1 threads specified".format(nthreads))
         else:
             _pycbc_current_threads = nthreads
     else:
@@ -390,41 +390,41 @@ _plan_funcs_dict = { ('complex64', 'complex64') : plan_many_c2c_f,
 # classes.
 
 def _fftw_setup(fftobj):
-        n = _np.asarray([fftobj.size], dtype=_np.int32)
-        inembed = _np.asarray([len(fftobj.invec)], dtype=_np.int32)
-        onembed = _np.asarray([len(fftobj.outvec)], dtype=_np.int32)
-        nthreads = _scheme.mgr.state.num_threads
-        if not _fftw_threaded_set:
-            set_threads_backend()
-        if nthreads != _fftw_current_nthreads:
-            _fftw_plan_with_nthreads(nthreads)  
-        mlvl = get_measure_level()
-        aligned = fftobj.invec.data.isaligned and fftobj.outvec.data.isaligned
-        flags = get_flag(mlvl, aligned)
-        plan_func = _plan_funcs_dict[ (str(fftobj.invec.dtype), str(fftobj.outvec.dtype)) ]
-        tmpin = zeros(len(fftobj.invec), dtype = fftobj.invec.dtype)
-        tmpout = zeros(len(fftobj.outvec), dtype = fftobj.outvec.dtype)
-        # C2C, forward
-        if fftobj.forward and (fftobj.outvec.dtype in [complex64, complex128]):
-            plan = plan_func(1, n.ctypes.data, fftobj.nbatch,
-                             tmpin.ptr, inembed.ctypes.data, 1, fftobj.idist,
-                             tmpout.ptr, onembed.ctypes.data, 1, fftobj.odist,
-                             FFTW_FORWARD, flags)
-        # C2C, backward
-        elif not fftobj.forward and (fftobj.invec.dtype in [complex64, complex128]):
-            plan = plan_func(1, n.ctypes.data, fftobj.nbatch,
-                             tmpin.ptr, inembed.ctypes.data, 1, fftobj.idist,
-                             tmpout.ptr, onembed.ctypes.data, 1, fftobj.odist,
-                             FFTW_BACKWARD, flags)
-        # R2C or C2R (hence no direction argument for plan creation)
-        else:
-            plan = plan_func(1, n.ctypes.data, fftobj.nbatch,
-                             tmpin.ptr, inembed.ctypes.data, 1, fftobj.idist,
-                             tmpout.ptr, onembed.ctypes.data, 1, fftobj.odist,
-                             flags)
-        del tmpin
-        del tmpout
-        return plan
+    n = _np.asarray([fftobj.size], dtype=_np.int32)
+    inembed = _np.asarray([len(fftobj.invec)], dtype=_np.int32)
+    onembed = _np.asarray([len(fftobj.outvec)], dtype=_np.int32)
+    nthreads = _scheme.mgr.state.num_threads
+    if not _fftw_threaded_set:
+        set_threads_backend()
+    if nthreads != _fftw_current_nthreads:
+        _fftw_plan_with_nthreads(nthreads)  
+    mlvl = get_measure_level()
+    aligned = fftobj.invec.data.isaligned and fftobj.outvec.data.isaligned
+    flags = get_flag(mlvl, aligned)
+    plan_func = _plan_funcs_dict[ (str(fftobj.invec.dtype), str(fftobj.outvec.dtype)) ]
+    tmpin = zeros(len(fftobj.invec), dtype = fftobj.invec.dtype)
+    tmpout = zeros(len(fftobj.outvec), dtype = fftobj.outvec.dtype)
+    # C2C, forward
+    if fftobj.forward and (fftobj.outvec.dtype in [complex64, complex128]):
+        plan = plan_func(1, n.ctypes.data, fftobj.nbatch,
+                         tmpin.ptr, inembed.ctypes.data, 1, fftobj.idist,
+                         tmpout.ptr, onembed.ctypes.data, 1, fftobj.odist,
+                         FFTW_FORWARD, flags)
+    # C2C, backward
+    elif not fftobj.forward and (fftobj.invec.dtype in [complex64, complex128]):
+        plan = plan_func(1, n.ctypes.data, fftobj.nbatch,
+                         tmpin.ptr, inembed.ctypes.data, 1, fftobj.idist,
+                         tmpout.ptr, onembed.ctypes.data, 1, fftobj.odist,
+                         FFTW_BACKWARD, flags)
+    # R2C or C2R (hence no direction argument for plan creation)
+    else:
+        plan = plan_func(1, n.ctypes.data, fftobj.nbatch,
+                         tmpin.ptr, inembed.ctypes.data, 1, fftobj.idist,
+                         tmpout.ptr, onembed.ctypes.data, 1, fftobj.odist,
+                         flags)
+    del tmpin
+    del tmpout
+    return plan
 
 class FFT(_BaseFFT):
     def __init__(self, invec, outvec, nbatch=1, size=None):

--- a/pycbc/filter/qtransform.py
+++ b/pycbc/filter/qtransform.py
@@ -30,12 +30,12 @@ the q-transform of that time series
 """
 
 import numpy
-from numpy import pi, ceil, log, exp
+from numpy import ceil, log, exp
 from pycbc.types.timeseries import FrequencySeries, TimeSeries
 from pycbc.fft import ifft
 from pycbc.types import zeros
 
-def qplane(qplane_tile_dict, fseries, frange, return_complex=False):
+def qplane(qplane_tile_dict, fseries, return_complex=False):
     """Performs q-transform on each tile for each q-plane and selects
        tile with the maximum energy. Q-transform can then
        be interpolated to a desired frequency and time resolution.
@@ -46,8 +46,6 @@ def qplane(qplane_tile_dict, fseries, frange, return_complex=False):
         Dictionary containing a list of q-tile tupples for each q-plane
     fseries: 'pycbc FrequencySeries'
         frequency-series data set
-    frange:
-        upper and lower bounds on frequency range
     return_complex: {False, bool}
         Return the raw complex series instead of the normalized power.
 

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -18,7 +18,6 @@
 """
 
 import logging
-import numpy
 import pycbc.inference.sampler
 from pycbc.inference import burn_in
 from pycbc import conversions

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -483,8 +483,8 @@ class InferenceFile(h5py.File):
             # plotting code expects it
             psd_dyn_dict = {}
             for key,val in psd_dict.iteritems():
-                 psd_dyn_dict[key] = FrequencySeries(val*DYN_RANGE_FAC**2,
-                                                     delta_f=val.delta_f)
+                psd_dyn_dict[key] = FrequencySeries(val*DYN_RANGE_FAC**2,
+                                                    delta_f=val.delta_f)
             self.write_psd(psds=psd_dyn_dict,
                            low_frequency_cutoff=low_frequency_cutoff_dict,
                            group=group)

--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -1135,14 +1135,14 @@ class FieldArray(numpy.recarray):
             dtype = columns.items()
         # get the values
         if _default_types_status['ilwd_as_int']:
-            input_array = [tuple(
-                        getattr(row, col) if dt != 'ilwd:char' \
-                        else int(getattr(row, col)) \
-                    for col,dt in columns.items()) \
-                for row in table]
+            input_array = \
+                [tuple(getattr(row, col) if dt != 'ilwd:char'
+                       else int(getattr(row, col)) 
+                       for col,dt in columns.items())
+                 for row in table]
         else:
-            input_array = [tuple(getattr(row, col) for col in columns) \
-                for row in table]
+            input_array = \
+                [tuple(getattr(row, col) for col in columns) for row in table]
         # return the values as an instance of cls
         return cls.from_records(input_array, dtype=dtype,
             name=name)

--- a/pycbc/libutils.py
+++ b/pycbc/libutils.py
@@ -131,7 +131,10 @@ def get_libpath_from_dirlist(libname, dirs):
         # Our directory might be no good, so try/except
         try:
             for libfile in os.listdir(nextdir):
-                if fnmatch.fnmatch(libfile,'lib'+libname+'.so*') or fnmatch.fnmatch(libfile,'lib'+libname+'.dylib*') or fnmatch.fnmatch(libfile,libname+'.dll') or fnmatch.fnmatch(libfile,'cyg'+libname+'-*.dll'):
+                if fnmatch.fnmatch(libfile,'lib'+libname+'.so*') or \
+                        fnmatch.fnmatch(libfile,'lib'+libname+'.dylib*') or \
+                        fnmatch.fnmatch(libfile,libname+'.dll') or \
+                        fnmatch.fnmatch(libfile,'cyg'+libname+'-*.dll'):
                     possible.append(libfile)
         except OSError:
             pass

--- a/pycbc/pnutils.py
+++ b/pycbc/pnutils.py
@@ -767,7 +767,7 @@ def energy(v, mass1, mass2, s1z=0, s2z=0, phase_order=-1, spin_order=-1):
     amp = - (1.0/2.0) * eta
     e = 0.0
     for i in numpy.arange(0, len(ecof), 1):
-            e += v**(i+2.0) * ecof[i]  
+        e += v**(i+2.0) * ecof[i]  
             
     return e * amp
     

--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -90,9 +90,9 @@ def welch(timeseries, seg_len=4096, seg_stride=2048, window='hann',
     }
 
     # sanity checks
-    if not window in window_map:
+    if window not in window_map:
         raise ValueError('Invalid window')
-    if not avg_method in ('mean', 'median', 'median-mean'):
+    if avg_method not in ('mean', 'median', 'median-mean'):
         raise ValueError('Invalid averaging method')
     if type(seg_len) is not int or type(seg_stride) is not int \
         or seg_len <= 0 or seg_stride <= 0:

--- a/pycbc/results/dq.py
+++ b/pycbc/results/dq.py
@@ -17,6 +17,30 @@ function redirect(form,way)
 }
 </script>"""
 
+search_form_string="""<form name="%s_alog_search" id="%s_alog_search" method="post">
+<input type="hidden" name="srcDateFrom" id="srcDateFrom" value="%s" size="20"/>
+<input type="hidden" name="srcDateTo" id="srcDateTo" value="%s" size="20"/>
+</form>"""
+
+data_h1_string = """H1
+&nbsp;
+<a href=https://ldas-jobs.ligo-wa.caltech.edu/~detchar/summary/day/%s>
+Summary</a>
+&nbsp;
+<a onclick="redirect('h1_alog_search',
+'https://alog.ligo-wa.caltech.edu/aLOG/includes/search.php?adminType=search');
+return true;">aLOG</a>"""
+
+data_l1_string="""L1
+&nbsp;
+<a href=https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day/%s>
+Summary</a>
+&nbsp;
+<a onclick="redirect('l1_alog_search',
+'https://alog.ligo-la.caltech.edu/aLOG/includes/search.php?adminType=search');
+return true;">aLOG</a>"""
+
+
 def get_summary_page_link(ifo, utc_time):
     """Return a string that links to the summary page and aLOG for this ifo
 
@@ -32,13 +56,8 @@ def get_summary_page_link(ifo, utc_time):
     return_string : string
         String containing HTML for links to summary page and aLOG search
     """
-    search_form = \
-        """<form name="%s_alog_search" id="%s_alog_search" method="post">
-<input type="hidden" name="srcDateFrom" id="srcDateFrom" value="%s" size="20"/>
-<input type="hidden" name="srcDateTo" id="srcDateTo" value="%s" size="20"/>
-           </form>"""
-    data = {'H1':"""H1&nbsp;<a href=https://ldas-jobs.ligo-wa.caltech.edu/~detchar/summary/day/%s>Summary</a>&nbsp;<a onclick="redirect('h1_alog_search','https://alog.ligo-wa.caltech.edu/aLOG/includes/search.php?adminType=search'); return true;">aLOG</a>""",
-            'L1':"""L1&nbsp;<a href=https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day/%s>Summary</a>&nbsp;<a onclick="redirect('l1_alog_search','https://alog.ligo-la.caltech.edu/aLOG/includes/search.php?adminType=search'); return true;">aLOG</a>""" }
+    search_form = search_form_string
+    data = {'H1': data_h1_string, 'L1': data_l1_string}
     if ifo not in data:
         return ifo
     else:

--- a/pycbc/results/followup.py
+++ b/pycbc/results/followup.py
@@ -31,7 +31,7 @@ import h5py, numpy, matplotlib
 # version dependenant. If this is a problem then remove this and control from
 # the executables directly.
 import sys
-if not 'matplotlib.backends' in sys.modules:
+if 'matplotlib.backends' not in sys.modules:
     matplotlib.use('agg')
 import pylab, mpld3, mpld3.plugins
 from pycbc_glue.segments import segment

--- a/pycbc/results/legacy_grb.py
+++ b/pycbc/results/legacy_grb.py
@@ -32,7 +32,7 @@ import matplotlib
 # version dependenant. If this is a problem then remove this and control from
 # the executables directly.
 import sys
-if not 'matplotlib.backends' in sys.modules:
+if 'matplotlib.backends' not in sys.modules:
     matplotlib.use('agg')
 import matplotlib.pyplot as plt
 from pycbc_glue import markup, segments
@@ -270,7 +270,7 @@ def write_antenna(page, args, seg_plot=None, grid=False, ipn=False):
 #    th2 = ['Response Diagram']
 #    td2 = [plot() ]
 
-        # FIXME: Add these in!!
+# FIXME: Add these in!!
 #    plot = markup.page()
 #    p = "ALL_TIMES/plots_clustered/GRB%s_search.png"\
 #        % args.grb_name

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -36,7 +36,7 @@ import matplotlib
 # version dependenant. If this is a problem then remove this and control from
 # the executables directly.
 import sys
-if not 'matplotlib.backends' in sys.modules:
+if 'matplotlib.backends' not in sys.modules:
     matplotlib.use('agg')
 from matplotlib import offsetbox
 from matplotlib import pyplot

--- a/pycbc/results/versioning.py
+++ b/pycbc/results/versioning.py
@@ -173,7 +173,7 @@ def get_code_version_numbers(cp):
         _, exe_name = os.path.split(value)
         version_string = None
         if value.startswith('gsiftp://') or value.startswith('http://'):
-           code_version_dict[exe_name] = "Using bundle downloaded from %s" % value
+            code_version_dict[exe_name] = "Using bundle downloaded from %s" % value
         else:
             try:
                 if value.startswith('file://'):

--- a/pycbc/strain.py
+++ b/pycbc/strain.py
@@ -1064,7 +1064,7 @@ class StrainSegments(object):
     @classmethod
     def insert_segment_option_group(cls, parser):
         segment_group = parser.add_argument_group(
-                                   "Options for segmenting the strain",
+                                  "Options for segmenting the strain",
                                   "These options are used to determine how to "
                                   "segment the strain into smaller chunks, "
                                   "and for determining the portion of each to "
@@ -1125,7 +1125,7 @@ class StrainSegments(object):
     @classmethod
     def insert_segment_option_group_multi_ifo(cls, parser):
         segment_group = parser.add_argument_group(
-                                   "Options for segmenting the strain",
+                                  "Options for segmenting the strain",
                                   "These options are used to determine how to "
                                   "segment the strain into smaller chunks, "
                                   "and for determining the portion of each to "

--- a/pycbc/tmpltbank/calc_moments.py
+++ b/pycbc/tmpltbank/calc_moments.py
@@ -453,7 +453,7 @@ def calculate_metric_comp(gs, unmax_metric, i, j, Js, logJs, loglogJs,
     unmax_metric[-1,-1] = (Js[1] - Js[4]*Js[4])
 
     # Normal terms
-    if mapping.has_key('Lambda%d'%i) and mapping.has_key('Lambda%d'%j):
+    if 'Lambda%d'%i in mapping and 'Lambda%d'%j in mapping:
         gammaij = Js[17-i-j] - Js[12-i]*Js[12-j]
         gamma0i = (Js[9-i] - Js[4]*Js[12-i])
         gamma0j = (Js[9-j] - Js[4] * Js[12-j])
@@ -463,7 +463,7 @@ def calculate_metric_comp(gs, unmax_metric, i, j, Js, logJs, loglogJs,
         unmax_metric[-1, mapping['Lambda%d'%j]] = gamma0j
         unmax_metric[mapping['Lambda%d'%i],mapping['Lambda%d'%j]] = gammaij
     # Normal,log cross terms
-    if mapping.has_key('Lambda%d'%i) and mapping.has_key('LogLambda%d'%j):
+    if 'Lambda%d'%i in mapping and 'LogLambda%d'%j in mapping:
         gammaij = logJs[17-i-j] - logJs[12-j] * Js[12-i]
         gamma0i = (Js[9-i] - Js[4] * Js[12-i])
         gamma0j = logJs[9-j] - logJs[12-j] * Js[4]
@@ -477,7 +477,7 @@ def calculate_metric_comp(gs, unmax_metric, i, j, Js, logJs, loglogJs,
         unmax_metric[mapping['Lambda%d'%i],mapping['LogLambda%d'%j]] = gammaij
         unmax_metric[mapping['LogLambda%d'%j],mapping['Lambda%d'%i]] = gammaij
     # Log,log terms
-    if mapping.has_key('LogLambda%d'%i) and mapping.has_key('LogLambda%d'%j):
+    if 'LogLambda%d'%i in mapping and 'LogLambda%d'%j in mapping:
         gammaij = loglogJs[17-i-j] - logJs[12-j] * logJs[12-i]
         gamma0i = (logJs[9-i] - Js[4] * logJs[12-i])
         gamma0j = logJs[9-j] - logJs[12-j] * Js[4]
@@ -489,7 +489,7 @@ def calculate_metric_comp(gs, unmax_metric, i, j, Js, logJs, loglogJs,
             gammaij
 
     # Normal,loglog cross terms
-    if mapping.has_key('Lambda%d'%i) and mapping.has_key('LogLogLambda%d'%j):
+    if 'Lambda%d'%i in mapping and 'LogLogLambda%d'%j in mapping:
         gammaij = loglogJs[17-i-j] - loglogJs[12-j] * Js[12-i]
         gamma0i = (Js[9-i] - Js[4] * Js[12-i])
         gamma0j = loglogJs[9-j] - loglogJs[12-j] * Js[4]
@@ -506,7 +506,7 @@ def calculate_metric_comp(gs, unmax_metric, i, j, Js, logJs, loglogJs,
             gammaij
 
     # log,loglog cross terms
-    if mapping.has_key('LogLambda%d'%i) and mapping.has_key('LogLogLambda%d'%j):
+    if 'LogLambda%d'%i in mapping and 'LogLogLambda%d'%j in mapping:
         gammaij = logloglogJs[17-i-j] - loglogJs[12-j] * logJs[12-i]
         gamma0i = (logJs[9-i] - Js[4] * logJs[12-i])
         gamma0j = loglogJs[9-j] - loglogJs[12-j] * Js[4]
@@ -523,7 +523,7 @@ def calculate_metric_comp(gs, unmax_metric, i, j, Js, logJs, loglogJs,
             gammaij
 
     # Loglog,loglog terms
-    if mapping.has_key('LogLogLambda%d'%i) and mapping.has_key('LogLogLambda%d'%j):
+    if 'LogLogLambda%d'%i in mapping and 'LogLogLambda%d'%j in mapping:
         gammaij = loglogloglogJs[17-i-j] - loglogJs[12-j] * loglogJs[12-i]
         gamma0i = (loglogJs[9-i] - Js[4] * loglogJs[12-i])
         gamma0j = loglogJs[9-j] - loglogJs[12-j] * Js[4]

--- a/pycbc/tmpltbank/calc_moments.py
+++ b/pycbc/tmpltbank/calc_moments.py
@@ -130,8 +130,8 @@ def determine_eigen_directions(metricParams, preserveMoments=False,
         # Numerical error can lead to small negative eigenvalues.
         for i in xrange(len(evals[item])):
             if evals[item][i] < 0:
-#                print "WARNING: Negative eigenvalue %e. Setting as positive." \
-#                      %(evals[item][i])
+                # Due to numerical imprecision the very small eigenvalues can
+                # be negative. Make these positive.
                 evals[item][i] = -evals[item][i]
             if evecs[item][i,i] < 0:
                 # We demand a convention that all diagonal terms in the matrix

--- a/pycbc/tmpltbank/lambda_mapping.py
+++ b/pycbc/tmpltbank/lambda_mapping.py
@@ -149,7 +149,7 @@ def ethinca_order_from_string(order):
     int
     """
     if order in get_ethinca_orders().keys():
-      return get_ethinca_orders()[order]
+        return get_ethinca_orders()[order]
     else: raise ValueError("Order "+str(order)+" is not valid for ethinca"
                            "calculation! Valid orders: "+
                            str(get_ethinca_orders().keys()))

--- a/pycbc/tmpltbank/lambda_mapping.py
+++ b/pycbc/tmpltbank/lambda_mapping.py
@@ -18,7 +18,6 @@ import re
 import numpy
 from lal import MTSUN_SI, PI, CreateREAL8Vector
 import lalsimulation
-from pycbc import pnutils
 
 # PLEASE ENSURE THESE ARE KEPT UP TO DATE WITH THE REST OF THIS FILE
 pycbcValidTmpltbankOrders = ['zeroPN','onePN','onePointFivePN','twoPN',\

--- a/pycbc/tmpltbank/lattice_utils.py
+++ b/pycbc/tmpltbank/lattice_utils.py
@@ -46,9 +46,9 @@ def generate_hexagonal_lattice(maxv1, minv1, maxv2, minv2, mindist):
         Array of positions in the second dimension
     """
     if minv1 > maxv1:
-      raise ValueError("Invalid input to function.")
+        raise ValueError("Invalid input to function.")
     if minv2 > maxv2:
-      raise ValueError("Invalid input to function.")
+        raise ValueError("Invalid input to function.")
     # Place first point
     v1s = [minv1]
     v2s = [minv2]

--- a/pycbc/tmpltbank/option_utils.py
+++ b/pycbc/tmpltbank/option_utils.py
@@ -920,8 +920,8 @@ class massRangeParameters(object):
         self.delta_ns_mass = (
             delta_ns_mass or self.default_delta_ns_mass)
         self.use_eos_max_ns_mass = use_eos_max_ns_mass
-        if not self.remnant_mass_threshold is None:
-            if not self.ns_eos is '2H':
+        if self.remnant_mass_threshold is not None:
+            if self.ns_eos is not '2H':
                 errMsg = """
                          By setting a value for --remnant-mass-threshold
                          you have asked to filter out EM dim NS-BH templates.

--- a/pycbc/tmpltbank/partitioned_bank.py
+++ b/pycbc/tmpltbank/partitioned_bank.py
@@ -220,12 +220,12 @@ class PartitionedTmpltbank(object):
              (chi2_bin > self.max_chi2_bin-bin_range_check) ):
             for temp_chi1 in xrange(chi1_bin-bin_range_check,
                                                    chi1_bin+bin_range_check+1):
-                if not self.massbank.has_key(temp_chi1):
+                if temp_chi1 not in self.massbank:
                     self.massbank[temp_chi1] = {}
                     self.bank[temp_chi1] = {}
                 for temp_chi2 in xrange(chi2_bin-bin_range_check, 
                                                    chi2_bin+bin_range_check+1):
-                    if not self.massbank[temp_chi1].has_key(temp_chi2):
+                    if temp_chi2 not in self.massbank[temp_chi1]:
                         self.massbank[temp_chi1][temp_chi2] = {}
                         self.massbank[temp_chi1][temp_chi2]['mass1s'] =\
                                                                 numpy.array([])

--- a/pycbc/types/array_cuda.py
+++ b/pycbc/types/array_cuda.py
@@ -73,13 +73,13 @@ def call_prepare(self, sz, allocator):
 
 class LowerLatencyReductionKernel(ReductionKernel):
     def __init__(self, dtype_out,
-            neutral, reduce_expr, map_expr=None, arguments=None,
-            name="reduce_kernel", keep=False, options=None, preamble=""):
-            ReductionKernel.__init__(self, dtype_out,
-                neutral, reduce_expr, map_expr, arguments,
-                name, keep, options, preamble)
+                 neutral, reduce_expr, map_expr=None, arguments=None,
+                 name="reduce_kernel", keep=False, options=None, preamble=""):
+        ReductionKernel.__init__(self, dtype_out,
+                                 neutral, reduce_expr, map_expr, arguments,
+                                 name, keep, options, preamble)
 
-            self.shared_size=self.block_size*self.dtype_out.itemsize
+        self.shared_size=self.block_size*self.dtype_out.itemsize
 
 
     def __call__(self, *args, **kwargs):

--- a/pycbc/types/optparse.py
+++ b/pycbc/types/optparse.py
@@ -136,7 +136,7 @@ class MultiDetOptionActionSpecial(MultiDetOptionAction):
             value_split = value.split(':')
             if len(value_split) == 2:
                 # "Normal" case, all ifos supplied independetly as "H1:VALUE"
-                if items.has_key(value_split[0]):
+                if value_split[0] in items:
                     err_msg += "Multiple values supplied for ifo %s.\n" \
                                %(value_split[0],)
                     err_msg += "Already have %s." %(items[value_split[0]])
@@ -148,7 +148,7 @@ class MultiDetOptionActionSpecial(MultiDetOptionAction):
                 # want to pretend H1 data is actually L1 (or similar). So if I
                 # supply --channel-name H1:L1:LDAS-STRAIN I can use L1 data and
                 # pretend it is H1 internally.
-                if items.has_key(value_split[0]):
+                if value_split[0] in items:
                     err_msg += "Multiple values supplied for ifo %s.\n" \
                                %(value_split[0],)
                     err_msg += "Already have %s." %(items[value_split[0]])
@@ -174,7 +174,7 @@ class MultiDetOptionAppendAction(MultiDetOptionAction):
             value = value.split(':')
             if len(value) == 2:
                 # "Normal" case, all ifos supplied independetly as "H1:VALUE"
-                if items.has_key(value[0]):
+                if value[0] in items:
                     items[value[0]].append(self.internal_type(value[1]))
                 else:
                     items[value[0]] = [self.internal_type(value[1])]

--- a/pycbc/types/timeseries.py
+++ b/pycbc/types/timeseries.py
@@ -536,8 +536,8 @@ class TimeSeries(Array):
             frange = (30, int(self.sample_rate / 2 * 8))
         
         q_base = qtiling(self, qrange, frange, mismatch)
-        q, times, freqs, q_plane = qplane(q_base, self.to_frequencyseries(),
-                                          frange, return_complex=return_complex)
+        _, times, freqs, q_plane = qplane(q_base, self.to_frequencyseries(),
+                                          return_complex=return_complex)
         if logfsteps and delta_f:
             raise ValueError("Provide only one (or none) of delta_f and logfsteps")
 

--- a/pycbc/waveform/SpinTaylorF2.py
+++ b/pycbc/waveform/SpinTaylorF2.py
@@ -114,11 +114,31 @@ spintaylorf2_text = """
     const double gamma02 = gamma0 * gamma0;
     const double gamma03 = gamma02 *gamma0;
 
-    const double alpha =prec_fac0*(  logfac2 *( dtdv2*gamma0 + dtdv3*kappa - dtdv5*kappa/(2.*gamma02) + dtdv4/(2.*gamma0) - dtdv4*kappa2/(2.*gamma0) + (dtdv5*kappa3)/(2.*gamma02) )  +  logfac1*( - dtdv2*gamma0*kappa - dtdv3 + kappa*gamma03/2. - gamma03*kappa3/2. ) + logv *( dtdv2*gamma0*kappa + dtdv3 - kappa*gamma03/2. + gamma03*kappa3/2. ) + sqrtfac *( dtdv3 + dtdv4*v/2. + dtdv5/gamma02/3. + dtdv4*kappa/(2.*gamma0) + dtdv5*kappa*v/(6.*gamma0) - dtdv5*kappa2/(2.*gamma02) - 1/(3.*v3) - gamma0*kappa/(6.*v2) - dtdv2/v - gamma02/(3.*v) + gamma02*kappa2/(2.*v) + dtdv5*v2/3. )) - alpha_ref;
+    const double alpha = prec_fac0*(  logfac2 *( dtdv2*gamma0 + dtdv3*kappa -
+        dtdv5*kappa/(2.*gamma02) + dtdv4/(2.*gamma0) - 
+        dtdv4*kappa2/(2.*gamma0) + (dtdv5*kappa3)/(2.*gamma02) )  +
+        logfac1*( - dtdv2*gamma0*kappa - dtdv3 + kappa*gamma03/2. -
+        gamma03*kappa3/2. ) + logv *( dtdv2*gamma0*kappa + dtdv3 -
+        kappa*gamma03/2. + gamma03*kappa3/2. ) + sqrtfac *( dtdv3 +
+        dtdv4*v/2. + dtdv5/gamma02/3. + dtdv4*kappa/(2.*gamma0) +
+        dtdv5*kappa*v/(6.*gamma0) - dtdv5*kappa2/(2.*gamma02) - 1/(3.*v3) -
+        gamma0*kappa/(6.*v2) - dtdv2/v - gamma02/(3.*v) +
+        gamma02*kappa2/(2.*v) + dtdv5*v2/3. )) - alpha_ref;
 
     const double beta = acos((1. + kappa*gamma0*v)/sqrt(1. + 2.*kappa*gamma0*v + gamma0*gamma0*v*v));
 
-    const double zeta = prec_fac0*( dtdv3*gamma0*kappa*v + dtdv4*v + logfac2 *(-dtdv2*gamma0 - dtdv3*kappa + dtdv5*kappa/(2.*gamma02) - dtdv4/(2.*gamma0) + dtdv4*kappa2/(2.*gamma0) - dtdv5*kappa3/(2.*gamma02) ) + logv *( kappa*gamma03/2. - gamma03*kappa3/2. ) + logfac1 *( dtdv2*gamma0*kappa + dtdv3 - kappa*gamma03/2. + gamma03*kappa3/2. ) - 1/(3.*v3) - gamma0*kappa/(2.*v2) - dtdv2/v + dtdv4*gamma0*kappa*v2/2. + dtdv5*v2/2. + sqrtfac *( -dtdv3 - dtdv4*v/2. - dtdv5/(3.*gamma02) - dtdv4*kappa/(2.*gamma0) - dtdv5*kappa*v/(6.*gamma0) + dtdv5*kappa2/(2.*gamma02) + 1/(3.*v3) + gamma0*kappa/(6.*v2) + dtdv2/v + gamma02/(3.*v) - gamma02*kappa2/(2.*v) - dtdv5*v2/3. ) + dtdv5*gamma0*kappa*v3/3. ) - zeta_ref;
+    const double zeta = prec_fac0*( dtdv3*gamma0*kappa*v + dtdv4*v +
+        logfac2 *(-dtdv2*gamma0 - dtdv3*kappa + dtdv5*kappa/(2.*gamma02) -
+        dtdv4/(2.*gamma0) + dtdv4*kappa2/(2.*gamma0) -
+        dtdv5*kappa3/(2.*gamma02) ) + logv *( kappa*gamma03/2. -
+        gamma03*kappa3/2. ) + logfac1 *( dtdv2*gamma0*kappa + dtdv3 -
+        kappa*gamma03/2. + gamma03*kappa3/2. ) - 1/(3.*v3) -
+        gamma0*kappa/(2.*v2) - dtdv2/v + dtdv4*gamma0*kappa*v2/2. +
+        dtdv5*v2/2. + sqrtfac *( -dtdv3 - dtdv4*v/2. - dtdv5/(3.*gamma02) -
+        dtdv4*kappa/(2.*gamma0) - dtdv5*kappa*v/(6.*gamma0) +
+        dtdv5*kappa2/(2.*gamma02) + 1/(3.*v3) + gamma0*kappa/(6.*v2) +
+        dtdv2/v + gamma02/(3.*v) - gamma02*kappa2/(2.*v) - dtdv5*v2/3. ) +
+        dtdv5*gamma0*kappa*v3/3. ) - zeta_ref;
 
     double CBeta;
     double SBeta;
@@ -319,7 +339,7 @@ def spintaylorf2(**kwds):
     gamma02 = gamma0 * gamma0
     gamma03 = gamma02 *gamma0
 
-    alpha_ref =prec_fac0*(  logfac2 *( dtdv2*gamma0 + dtdv3*kappa - dtdv5*kappa/(2.*gamma02) + dtdv4/(2.*gamma0) - dtdv4*kappa2/(2.*gamma0) + (dtdv5*kappa3)/(2.*gamma02) )  +  logfac1*( - dtdv2*gamma0*kappa - dtdv3 + kappa*gamma03/2. - gamma03*kappa3/2. ) + logv0 *( dtdv2*gamma0*kappa + dtdv3 - kappa*gamma03/2. + gamma03*kappa3/2. ) + sqrtfac *( dtdv3 + dtdv4*v0/2. + dtdv5/gamma02/3. + dtdv4*kappa/(2.*gamma0) + dtdv5*kappa*v0/(6.*gamma0) - dtdv5*kappa2/(2.*gamma02) - 1/(3.*v03) - gamma0*kappa/(6.*v02) - dtdv2/v0 - gamma02/(3.*v0) + gamma02*kappa2/(2.*v0) + dtdv5*v02/3. ))  - alpha0
+    alpha_ref = prec_fac0*(  logfac2 *( dtdv2*gamma0 + dtdv3*kappa - dtdv5*kappa/(2.*gamma02) + dtdv4/(2.*gamma0) - dtdv4*kappa2/(2.*gamma0) + (dtdv5*kappa3)/(2.*gamma02) )  +  logfac1*( - dtdv2*gamma0*kappa - dtdv3 + kappa*gamma03/2. - gamma03*kappa3/2. ) + logv0 *( dtdv2*gamma0*kappa + dtdv3 - kappa*gamma03/2. + gamma03*kappa3/2. ) + sqrtfac *( dtdv3 + dtdv4*v0/2. + dtdv5/gamma02/3. + dtdv4*kappa/(2.*gamma0) + dtdv5*kappa*v0/(6.*gamma0) - dtdv5*kappa2/(2.*gamma02) - 1/(3.*v03) - gamma0*kappa/(6.*v02) - dtdv2/v0 - gamma02/(3.*v0) + gamma02*kappa2/(2.*v0) + dtdv5*v02/3. ))  - alpha0
 
     zeta_ref = prec_fac0*( dtdv3*gamma0*kappa*v0 + dtdv4*v0 + logfac2 *(-dtdv2*gamma0 - dtdv3*kappa + dtdv5*kappa/(2.*gamma02) - dtdv4/(2.*gamma0) + dtdv4*kappa2/(2.*gamma0) - dtdv5*kappa3/(2.*gamma02) ) + logv0 *( kappa*gamma03/2. - gamma03*kappa3/2. ) + logfac1 *( dtdv2*gamma0*kappa + dtdv3 - kappa*gamma03/2. + gamma03*kappa3/2. ) - 1/(3.*v03) - gamma0*kappa/(2.*v02) - dtdv2/v0 + dtdv4*gamma0*kappa*v02/2. + dtdv5*v02/2. + sqrtfac *( -dtdv3 - dtdv4*v0/2. - dtdv5/(3.*gamma02) - dtdv4*kappa/(2.*gamma0) - dtdv5*kappa*v0/(6.*gamma0) + dtdv5*kappa2/(2.*gamma02) + 1/(3.*v03) + gamma0*kappa/(6.*v02) + dtdv2/v0 + gamma02/(3.*v0) - gamma02*kappa2/(2.*v0) - dtdv5*v02/3. ) + dtdv5*gamma0*kappa*v03/3. )
 

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -313,7 +313,7 @@ class TemplateBank(object):
         """
         fields = self.table.fieldnames
         if 'template_hash' in fields:
-             return
+            return
 
         # The fields to use in making a template hash
         hash_fields = ['mass1', 'mass2', 'inclination',
@@ -561,9 +561,9 @@ class LiveFilterBank(TemplateBank):
         # erased by the type conversion below.
         ttotal = template_duration = -1
         if hasattr(htilde, 'length_in_time'):
-                ttotal = htilde.length_in_time
+            ttotal = htilde.length_in_time
         if hasattr(htilde, 'chirp_length'):
-                template_duration = htilde.chirp_length
+            template_duration = htilde.chirp_length
 
         self.table[index].template_duration = template_duration
 
@@ -732,9 +732,9 @@ class FilterBank(TemplateBank):
         # erased by the type conversion below.
         ttotal = template_duration = None
         if hasattr(htilde, 'length_in_time'):
-                ttotal = htilde.length_in_time
+            ttotal = htilde.length_in_time
         if hasattr(htilde, 'chirp_length'):
-                template_duration = htilde.chirp_length
+            template_duration = htilde.chirp_length
 
         self.table[index].template_duration = template_duration
 

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -181,8 +181,8 @@ class BaseCBCGenerator(BaseGenerator):
                               .difference(self.possible_args)
         if len(unused_args):
             logging.warning("WARNING: The following args are not being used "
-                            "for waveform generation: {opts}".format(
-                            opts=', '.join(unused_args)))
+                            "for waveform generation: %s",
+                            ', '.join(unused_args))
 
 
 class FDomainCBCGenerator(BaseCBCGenerator):

--- a/pycbc/waveform/pycbc_phenomC_tmplt.py
+++ b/pycbc/waveform/pycbc_phenomC_tmplt.py
@@ -131,28 +131,28 @@ phenomC_kernel = ElementwiseKernel("""pycuda::complex<double> *htilde, int kmin,
 
 
 def FinalSpin( Xi, eta ):
-  """Computes the spin of the final BH that gets formed after merger. This is done usingn Eq 5-6 of arXiv:0710.3345"""
-  s4 = -0.129
-  s5 = -0.384
-  t0 = -2.686
-  t2 = -3.454
-  t3 = 2.353
-  etaXi = eta * Xi
-  eta2 = eta*eta
-  finspin = (Xi + s4*Xi*etaXi + s5*etaXi*eta + t0*etaXi + 2.*(3.**0.5)*eta + t2*eta2 + t3*eta2*eta)
-  if finspin > 1.0:
-    raise ValueError("Value of final spin > 1.0. Aborting")
-  else:
-    return finspin
+    """Computes the spin of the final BH that gets formed after merger. This is done usingn Eq 5-6 of arXiv:0710.3345"""
+    s4 = -0.129
+    s5 = -0.384
+    t0 = -2.686
+    t2 = -3.454
+    t3 = 2.353
+    etaXi = eta * Xi
+    eta2 = eta*eta
+    finspin = (Xi + s4*Xi*etaXi + s5*etaXi*eta + t0*etaXi + 2.*(3.**0.5)*eta + t2*eta2 + t3*eta2*eta)
+    if finspin > 1.0:
+        raise ValueError("Value of final spin > 1.0. Aborting")
+    else:
+        return finspin
 
 def fRD( a, M):
-  """Calculate the ring-down frequency for the final Kerr BH. Using Eq. 5.5 of Main paper"""
-  f = (lal.C_SI**3.0 / (2.0*lal.PI*lal.G_SI*M*lal.MSUN_SI)) * (1.5251 - 1.1568*(1.0-a)**0.1292)
-  return f
+    """Calculate the ring-down frequency for the final Kerr BH. Using Eq. 5.5 of Main paper"""
+    f = (lal.C_SI**3.0 / (2.0*lal.PI*lal.G_SI*M*lal.MSUN_SI)) * (1.5251 - 1.1568*(1.0-a)**0.1292)
+    return f
 
 def Qa( a ):
-  """Calculate the quality factor of ring-down, using Eq 5.6 of Main paper"""
-  return (0.7 + 1.4187*(1.0-a)**-0.4990)
+    """Calculate the quality factor of ring-down, using Eq 5.6 of Main paper"""
+    return (0.7 + 1.4187*(1.0-a)**-0.4990)
 
 #Functions to calculate the Tanh window, defined in Eq 5.8 of the main paper
 def imrphenomc_tmplt(**kwds):
@@ -193,7 +193,7 @@ def imrphenomc_tmplt(**kwds):
     # from Eq.(4.18) of http://arxiv.org/pdf/0710.2335 and 
     # Table I of http://arxiv.org/pdf/0712.0343
     if not f_max:
-      f_max = (1.7086 * eta * eta - 0.26592 * eta + 0.28236) / piM
+        f_max = (1.7086 * eta * eta - 0.26592 * eta + 0.28236) / piM
 
     # Transform the eta, chi to Lambda parameters, using Eq 5.14, Table II of Main
     # paper.

--- a/pycbc/waveform/ringdown.py
+++ b/pycbc/waveform/ringdown.py
@@ -481,7 +481,7 @@ def get_fd_qnm(template=None, **kwargs):
     if f_final is None:
         f_final = qnm_freq_decay(f_0, tau, 1./1000)
     if f_final > max_freq:
-            f_final = max_freq
+        f_final = max_freq
     kmax = int(f_final / delta_f) + 1
 
     freqs = numpy.arange(kmin, kmax)*delta_f

--- a/pycbc/waveform/spa_tmplt.py
+++ b/pycbc/waveform/spa_tmplt.py
@@ -43,7 +43,11 @@ def findchirp_chirptime(m1, m2, fLower, porder):
         c7T = lal.PI * (14809.0 * eta * eta / 378.0 - 75703.0 * eta / 756.0 - 15419335.0 / 127008.0)
 
     if porder >= 6:
-        c6T = lal.GAMMA * 6848.0 / 105.0 - 10052469856691.0 / 23471078400.0 + lal.PI * lal.PI * 128.0 / 3.0 + eta * (3147553127.0 / 3048192.0 - lal.PI * lal.PI * 451.0 / 12.0) - eta * eta * 15211.0 / 1728.0 + eta * eta * eta * 25565.0 / 1296.0 + numpy.log(4.0) * 6848.0 / 105.0
+        c6T = lal.GAMMA * 6848.0 / 105.0 - 10052469856691.0 / 23471078400.0 +\
+            lal.PI * lal.PI * 128.0 / 3.0 + \
+            eta * (3147553127.0 / 3048192.0 - lal.PI * lal.PI * 451.0 / 12.0) -\
+            eta * eta * 15211.0 / 1728.0 + eta * eta * eta * 25565.0 / 1296.0 +\
+            eta * eta * eta * 25565.0 / 1296.0 + numpy.log(4.0) * 6848.0 / 105.0
         c6LogT = 6848.0 / 105.0
 
     if porder >= 5:

--- a/pycbc/waveform/utils.py
+++ b/pycbc/waveform/utils.py
@@ -341,7 +341,7 @@ def taper_timeseries(tsdata, tapermethod=None, return_lal=False):
     if tapermethod not in taper_map.keys():
         raise ValueError("Unknown tapering method %s, valid methods are %s" % \
                          (tapermethod, ", ".join(taper_map.keys())))
-    if not tsdata.dtype in (float32, float64):
+    if tsdata.dtype not in (float32, float64):
         raise TypeError("Strain dtype must be float32 or float64, not "
                     + str(tsdata.dtype))
     taper_func = taper_func_map[tsdata.dtype]
@@ -349,7 +349,7 @@ def taper_timeseries(tsdata, tapermethod=None, return_lal=False):
     ts_lal = tsdata.astype(tsdata.dtype).lal()
     if taper_map[tapermethod] is not None:
         taper_func(ts_lal.data, taper_map[tapermethod])
-    if return_lal == True:
+    if return_lal:
         return ts_lal
     else:
         return TimeSeries(ts_lal.data.data[:], delta_t=ts_lal.deltaT,

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -497,9 +497,9 @@ def get_fd_waveform(template=None, **kwargs):
             input_params['f_final'] = pnutils.named_frequency_cutoffs[ffunc](
                 input_params)
             # if the f_final is < f_lower, raise a NoWaveformError
-            if 'f_final' in input_params and (
-                    input_params['f_lower']+input_params['delta_f']
-                                        >= input_params['f_final']):
+            if 'f_final' in input_params and \
+                    (input_params['f_lower']+input_params['delta_f'] >=
+                     input_params['f_final']):
                 raise NoWaveformError("cannot generate waveform: f_lower >= f_final")
     except KeyError:
         pass
@@ -746,8 +746,8 @@ def get_waveform_filter(out, template=None, **kwargs):
         wav_gen = td_wav[type(_scheme.mgr.state)]
         hp, _ = wav_gen[input_params['approximant']](**input_params)
         # taper the time series hp if required
-        if ('taper' in input_params.keys() and \
-            input_params['taper'] is not None):
+        if 'taper' in input_params.keys() and \
+                input_params['taper'] is not None:
             hp = wfutils.taper_timeseries(hp, input_params['taper'],
                                           return_lal=False)
         return td_waveform_to_fd_waveform(hp, out=out)
@@ -813,8 +813,7 @@ def get_two_pol_waveform_filter(outplus, outcross, template, **kwargs):
     n = len(outplus)
 
     # If we don't have an inclination column alpha3 might be used
-    if not hasattr(template, 'inclination')\
-                                         and not kwargs.has_key('inclination'):
+    if not hasattr(template, 'inclination') and 'inclination' not in kwargs:
         if hasattr(template, 'alpha3'):
             kwargs['inclination'] = template.alpha3
 
@@ -841,8 +840,8 @@ def get_two_pol_waveform_filter(outplus, outcross, template, **kwargs):
         wav_gen = td_wav[type(_scheme.mgr.state)]
         hp, hc = wav_gen[input_params['approximant']](**input_params)
         # taper the time series hp if required
-        if ('taper' in input_params.keys() and \
-            input_params['taper'] is not None):
+        if 'taper' in input_params.keys() and \
+                input_params['taper'] is not None:
             hp = wfutils.taper_timeseries(hp, input_params['taper'],
                                           return_lal=False)
             hc = wfutils.taper_timeseries(hc, input_params['taper'],
@@ -907,14 +906,14 @@ def get_waveform_filter_norm(approximant, psd, length, delta_f, f_lower):
         return None
 
 def get_waveform_end_frequency(template=None, **kwargs):
-   """Return the stop frequency of a template
-   """
-   input_params = props(template,**kwargs)
-   approximant = kwargs['approximant']
+    """Return the stop frequency of a template
+    """
+    input_params = props(template,**kwargs)
+    approximant = kwargs['approximant']
 
-   if approximant in _filter_ends:
+    if approximant in _filter_ends:
         return _filter_ends[approximant](**input_params)
-   else:
+    else:
         return None
 
 def get_waveform_filter_length_in_time(approximant, template=None, **kwargs):

--- a/pycbc/weave.py
+++ b/pycbc/weave.py
@@ -62,6 +62,7 @@ def pycbc_compile_function(code,arg_names,local_dict,global_dict,
     return func
 
 inline_tools.compile_function = pycbc_compile_function
+from weave import inline
 
 def insert_weave_option_group(parser):
     """

--- a/pycbc/weave.py
+++ b/pycbc/weave.py
@@ -62,7 +62,6 @@ def pycbc_compile_function(code,arg_names,local_dict,global_dict,
     return func
 
 inline_tools.compile_function = pycbc_compile_function
-from weave import inline
 
 def insert_weave_option_group(parser):
     """

--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -206,11 +206,12 @@ class Executable(pegasus_workflow.Executable):
 
             if exe_url.scheme in ['', 'file']:
                 if exe_site is 'local':
-                # Check that executables at file urls on the local site exist
-                   if os.path.isfile(exe_url.path) is False:
-                       raise TypeError("Failed to find %s executable " 
-                                       "at %s on site %s" % (name, exe_path,
-                                       exe_site))
+                    # Check that executables at file urls
+                    #  on the local site exist
+                    if os.path.isfile(exe_url.path) is False:
+                        raise TypeError("Failed to find %s executable " 
+                                        "at %s on site %s" % (name, exe_path,
+                                        exe_site))
             else:
                 # Could be http, gsiftp, etc. so it needs fetching if run now
                 self.needs_fetching = True
@@ -1155,35 +1156,35 @@ class FileList(list):
         return outFile
 
     def find_output_at_time(self, ifo, time):
-       '''
-       Return File that covers the given time.
-
-       Parameters
-       -----------
-       ifo : string
-          Name of the ifo (or ifos) that the File should correspond to
-       time : int/float/LIGOGPStime
-          Return the Files that covers the supplied time. If no
-          File covers the time this will return None.
-
-       Returns
-       --------
-       list of File classes
-          The Files that corresponds to the time.
         '''
-       # Get list of Files that overlap time, for given ifo
-       outFiles = [i for i in self if ifo in i.ifo_list and time in i.segment_list] 
-       if len(outFiles) == 0:
-           # No OutFile at this time
-           return None
-       elif len(outFiles) == 1:
-           # 1 OutFile at this time (good!)
-           return outFiles
-       else:
-           # Multiple output files. Currently this is valid, but we may want
-           # to demand exclusivity later, or in certain cases. Hence the
-           # separation.
-           return outFiles
+        Return File that covers the given time.
+
+        Parameters
+        -----------
+        ifo : string
+           Name of the ifo (or ifos) that the File should correspond to
+        time : int/float/LIGOGPStime
+           Return the Files that covers the supplied time. If no
+           File covers the time this will return None.
+
+        Returns
+        --------
+        list of File classes
+           The Files that corresponds to the time.
+         '''
+        # Get list of Files that overlap time, for given ifo
+        outFiles = [i for i in self if ifo in i.ifo_list and time in i.segment_list] 
+        if len(outFiles) == 0:
+            # No OutFile at this time
+            return None
+        elif len(outFiles) == 1:
+            # 1 OutFile at this time (good!)
+            return outFiles
+        else:
+            # Multiple output files. Currently this is valid, but we may want
+            # to demand exclusivity later, or in certain cases. Hence the
+            # separation.
+            return outFiles
 
     def find_outputs_in_range(self, ifo, current_segment, useSplitLists=False):
         """
@@ -1323,7 +1324,7 @@ class FileList(list):
         """
         # Enforce upper case
         tag = tag.upper()
-        return FileList([i for i in self if not tag in i.tags])
+        return FileList([i for i in self if tag not in i.tags])
 
     def find_output_with_ifo(self, ifo):
         """

--- a/pycbc/workflow/datafind.py
+++ b/pycbc/workflow/datafind.py
@@ -39,7 +39,7 @@ from pycbc.workflow.core import SegFile, File, FileList, make_analysis_dir
 from pycbc.frame import datafind_connection
 
 class ContentHandler(ligolw.LIGOLWContentHandler):
-        pass
+    pass
 
 lsctables.use_in(ContentHandler)
 
@@ -195,7 +195,7 @@ def setup_datafind_workflow(workflow, scienceSegs, outputDir, seg_file=None,
                 msg += "times."
                 logging.warning(msg)
                 continue
-            if not newScienceSegs.has_key(ifo):
+            if ifo not in newScienceSegs:
                 msg = "No data frames were found corresponding to the science "
                 msg += "segments for ifo %s" %(ifo)
                 logging.error(msg)
@@ -747,7 +747,7 @@ def get_science_segs_from_datafind_outs(datafindcaches):
         if len(cache) > 0:
             groupSegs = segments.segmentlist(e.segment for e in cache).coalesce()
             ifo = cache.ifo
-            if not newScienceSegs.has_key(ifo):
+            if ifo not in newScienceSegs:
                 newScienceSegs[ifo] = groupSegs
             else:
                 newScienceSegs[ifo].extend(groupSegs)
@@ -787,7 +787,7 @@ def get_missing_segs_from_frame_file_cache(datafindcaches):
             missingSegs = segments.segmentlist(e.segment \
                                          for e in currMissingFrames).coalesce()
             ifo = cache.ifo
-            if not missingFrameSegs.has_key(ifo):
+            if ifo not in missingFrameSegs:
                 missingFrameSegs[ifo] = missingSegs
                 missingFrames[ifo] = lal.Cache(currMissingFrames)
             else:

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -385,8 +385,7 @@ def make_single_template_plots(workflow, segs, data_read_name, analyzed_name,
                 node.add_opt('--template-start-frequency',
                              "%.6f" % params['f_lower'])
                 # Is this precessing?
-                if params.has_key('u_vals') or \
-                                             params.has_key('u_vals_%s' % ifo):
+                if 'u_vals' in params or 'u_vals_%s' % ifo in params:
                     node.add_opt('--spin1x',"%.6f" % params['spin1x'])
                     node.add_opt('--spin1y',"%.6f" % params['spin1y'])
                     node.add_opt('--spin2x',"%.6f" % params['spin2x'])
@@ -453,7 +452,7 @@ def make_plot_waveform_plot(workflow, params, out_dir, ifos, exclude=None,
         node.add_opt('--mass2', "%.6f" % params['mass2'])
         node.add_opt('--spin1z',"%.6f" % params['spin1z'])
         node.add_opt('--spin2z',"%.6f" % params['spin2z'])
-        if params.has_key('u_vals'):
+        if 'u_vals' in params:
             # Precessing options
             node.add_opt('--spin1x',"%.6f" % params['spin1x'])
             node.add_opt('--spin2x',"%.6f" % params['spin2x'])

--- a/pycbc/workflow/plotting.py
+++ b/pycbc/workflow/plotting.py
@@ -220,7 +220,7 @@ def make_seg_table(workflow, seg_files, seg_names, out_dir, tags=None,
     node.add_input_list_opt('--segment-files', seg_files)
     quoted_seg_names = []
     for s in seg_names:
-      quoted_seg_names.append("'" + s + "'")
+        quoted_seg_names.append("'" + s + "'")
     node.add_opt('--segment-names', ' '.join(quoted_seg_names))
     if description:
         node.add_opt('--description', "'" + description + "'")
@@ -266,7 +266,7 @@ def make_seg_plot(workflow, seg_files, out_dir, seg_names=None, tags=None):
     node.add_input_list_opt('--segment-files', seg_files)
     quoted_seg_names = []
     for s in seg_names:
-      quoted_seg_names.append("'" + s + "'")
+        quoted_seg_names.append("'" + s + "'")
     node.add_opt('--segment-names', ' '.join(quoted_seg_names))
     node.new_output_file_opt(workflow.analysis_time, '.html', '--output-file')
     workflow += node


### PR DESCRIPTION
Okay, I didn't do very well waiting for my kid to arrive when we wife went overdue.

One of the things I did to keep myself occupied was to try to deal with all of the style issues reported by landscape in the PyCBC repository (yes, I'm weird, I know!). As landscape has been non-functional since October (and is still flaky) I haven't been able to open a pull-request. But as I at least got landscape to run a few times this morning, here it is.

I also fixed some problems that have been introduced in the last few months, except for some inference "accessing hidden built in" problems (there are lots of these now).

The only remaining style issues are some "too-long-lines" where we have code equations in documentation, and some long algebra in SpinTaylorF2 .... Should we remove SpinTaylorF2, it's probably out-of-date?

Compare this code:

https://landscape.io/github/spxiwh/pycbc/436

to current master:

https://landscape.io/github/ligo-cbc/pycbc/2554