### PR TITLE
Make acceptance function plotting code work for all current samplers

### DIFF
--- a/bin/inference/pycbc_inference_plot_acceptance_rate
+++ b/bin/inference/pycbc_inference_plot_acceptance_rate
@@ -26,29 +26,38 @@ from pycbc import results
 from pycbc.io.inference_hdf import InferenceFile
 
 # command line usage
-parser = argparse.ArgumentParser(usage="pycbc_inference_plot_acceptance_rate [--options]",
-    description="Plots fraction of walkers that accepted each step.")
+parser = argparse.ArgumentParser(
+            usage="pycbc_inference_plot_acceptance_rate [--options]",
+            description="Plots histogram of the fractions of steps accepted by walkers.")
 
 # add data options
 parser.add_argument("--input-file", type=str, required=True,
-    help="Path to input HDF file.")
+                    help="Path to input HDF file.")
 
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
-    help="Path to output plot.")
+                    help="Path to output plot.")
 
-# add thinning options
-parser.add_argument("--thin-start", type=int, default=None,
-    help="Sample number to start collecting samples to plot.")
-parser.add_argument("--thin-interval", type=int, default=None,
-    help="Interval to use for thinning samples.")
-parser.add_argument("--thin-end", type=int, default=None,
-    help="Sample number to stop collecting samples to plot. If none "
-         "provided, will stop at the last sample from the sampler.")
+# add walkers to plot
+parser.add_argument("--walkers", type=int, nargs='+', default=None,
+                    help="Specify walkers whose acceptance fraction would "
+                    "be plotted. The acceptance fraction for a walker is the "
+                    "fraction of steps accepted by it. Default is plot for "
+                    "all walkers.")
+
+# add temperatures if using parallel tempered samplers
+parser.add_argument("--temps", type=int, nargs='+', default=None,
+                    help="Specify temperatures, the acceptance fraction of "
+                    "whose walkers would be plotted. Default is plot for all "
+                    "temperatures.")
+
+# add number of bins for histogram
+parser.add_argument("--bins", type=int, default=10,
+                    help="Specify number of bins for the histogram plot.")
 
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
-    help="")
+                    help="")
 
 # parse the command line
 opts = parser.parse_args()
@@ -60,23 +69,27 @@ else:
     log_level = logging.WARN
 logging.basicConfig(format="%(asctime)s : %(message)s", level=log_level)
 
+# if using a parallel-tempered sampler, add the temperature arguments if it is specified
+additional_args = {}
+if opts.temps is not None:
+    additional_args['temps'] = opts.temps
+
 # read input file
 logging.info("Reading input file")
 fp = InferenceFile(opts.input_file, "r")
-acceptance_fraction = fp.read_acceptance_fraction(thin_start=opts.thin_start,
-                                              thin_interval=opts.thin_interval,
-                                              thin_end=opts.thin_end)
-
+acceptance_fraction = fp.read_acceptance_fraction(walkers=opts.walkers,
+                                                  **additional_args)
 # plot acceptance rate and drawn values
 logging.info("Plotting acceptance fraction")
 fig = plt.figure()
-plt.plot(acceptance_fraction, 'k', alpha=.5)
-plt.ylabel("Mean Acceptance Rate")
-plt.xlabel("Iteration")
+plt.hist(acceptance_fraction, opts.bins, histtype="step", lw=2, normed=True)
+plt.ylabel("Number of walkers")
+plt.xlabel("Mean Acceptance Rate")
 
 # save figure with meta-data
-caption = """This plot shows the fraction of samples accepted at each
-iteration."""
+caption = """This plot shows a histogram of the acceptance rate of the
+walkers. The acceptance rate of a walker is the fraction of steps accepted 
+by it."""
 results.save_fig_with_metadata(fig, opts.output_file,
                                cmd=" ".join(sys.argv),
                                title="Acceptance Rate",

--- a/bin/inference/pycbc_inference_plot_acceptance_rate
+++ b/bin/inference/pycbc_inference_plot_acceptance_rate
@@ -88,7 +88,7 @@ plt.xlabel("Mean Acceptance Rate")
 
 # save figure with meta-data
 caption = """This plot shows a histogram of the acceptance rate of the
-walkers. The acceptance rate of a walker is the fraction of steps accepted 
+walkers. The acceptance rate of a walker is the fraction of steps accepted
 by it."""
 results.save_fig_with_metadata(fig, opts.output_file,
                                cmd=" ".join(sys.argv),

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -170,8 +170,8 @@ class _BaseSampler(object):
 
     @property
     def acceptance_fraction(self):
-        """This function should return the fraction of walkers that accepted
-        each step as an array.
+        """This function should return the fraction of steps accepted by each 
+        walker as an array.
         """
         return NotImplementedError("acceptance_fraction function not set.")
 
@@ -394,7 +394,7 @@ class BaseMCMCSampler(_BaseSampler):
 
     @property
     def acceptance_fraction(self):
-        """Get the fraction of walkers that accepted each step as an array.
+        """Get the fraction of steps accepted by each walker as an array.
         """
         return self._sampler.acceptance_fraction
 
@@ -603,8 +603,7 @@ class BaseMCMCSampler(_BaseSampler):
                                  max_iterations=max_iterations)
         return samples
 
-    def write_acceptance_fraction(self, fp, start_iteration=None,
-                                  max_iterations=None):
+    def write_acceptance_fraction(self, fp):
         """Write acceptance_fraction data to file. Results are written to
         `fp[acceptance_fraction]`.
 
@@ -612,41 +611,13 @@ class BaseMCMCSampler(_BaseSampler):
         -----------
         fp : InferenceFile
             A file handler to an open inference file.
-        start_iteration : int, optional
-            Write results to the file's datasets starting at the given
-            iteration. Default is to append after the last iteration in the
-            file.
-        max_iterations : int, optional
-            Set the maximum size that the arrays in the hdf file may be resized
-            to. Only applies if the acceptance fraction has not previously been
-            written to the file. The default (None) is to use the maximum size
-            allowed by h5py.
         """
         dataset_name = "acceptance_fraction"
-        acf = self.acceptance_fraction
-        if max_iterations is not None and max_iterations < acf.size:
-            raise IndexError("The provided max size is less than the "
-                             "number of iterations")
-        istart = start_iteration
         try:
-            if istart is None:
-                istart = fp[dataset_name].size
-            istop = istart + acf.size
-            if istop > fp[dataset_name].size:
-                # resize the dataset
-                fp[dataset_name].resize(istop, axis=0)
-            fp[dataset_name][istart:istop] = acf
+            fp[dataset_name][:] = self.acceptance_fraction
         except KeyError:
-            # dataset doesn't exist yet
-            if istart is not None and istart != 0:
-                raise ValueError("non-zero start_iteration provided, "
-                                 "but dataset doesn't exist yet")
-            istart = 0
-            istop = istart + acf.size
-            fp.create_dataset(dataset_name, (istop,),
-                              maxshape=(max_iterations,),
-                              dtype=acf.dtype, fletcher32=True)
-            fp[dataset_name][istart:istop] = acf
+            # dataset doesn't exist yet, create it
+            fp[dataset_name] = self.acceptance_fraction
 
     def write_results(self, fp, start_iteration=None,
                       max_iterations=None, **metadata):
@@ -675,8 +646,7 @@ class BaseMCMCSampler(_BaseSampler):
                          max_iterations=max_iterations)
         self.write_likelihood_stats(fp, start_iteration=start_iteration,
                                     max_iterations=max_iterations)
-        self.write_acceptance_fraction(fp, start_iteration=0,
-                                       max_iterations=max_iterations)
+        self.write_acceptance_fraction(fp)
 
 
     @staticmethod
@@ -880,8 +850,7 @@ class BaseMCMCSampler(_BaseSampler):
         return samples.size
 
     @staticmethod
-    def read_acceptance_fraction(fp, thin_start=None, thin_interval=None,
-                                 thin_end=None, iteration=None):
+    def read_acceptance_fraction(fp, walkers=None):
         """Reads the acceptance fraction from the given file.
 
         Parameters
@@ -891,39 +860,19 @@ class BaseMCMCSampler(_BaseSampler):
         walkers : {None, (list of) int}
             The walker index (or a list of indices) to retrieve. If None,
             samples from all walkers will be obtained.
-        thin_start : int
-            Index of the sample to begin returning samples. Default is to read
-            samples after burn in. To start from the beginning set thin_start
-            to 0.
-        thin_interval : int
-            Interval to accept every i-th sample. Default is to use the
-            `fp.acl`. If `fp.acl` is not set, then use all samples
-            (set thin_interval to 1).
-        thin_end : int
-            Index of the last sample to read. If not given then
-            `fp.niterations` is used.
-        iteration : int
-            Get a single iteration. If provided, will override the
-            `thin_{start/interval/end}` arguments.
 
         Returns
         -------
         array
-            Array of acceptance fractions with shape (requested iterations,).
+            Array of acceptance fractions with shape (requested walkers,).
         """
-        # get the slice to use
-        if iteration is not None:
-            get_index = iteration
+        group = 'acceptance_fraction'
+        if walkers is None:
+            wmask = numpy.ones(fp.nwalkers, dtype=bool)
         else:
-            if thin_end is None:
-                # use the number of current iterations
-                thin_end = fp.niterations
-            get_index = fp.get_slice(thin_start=thin_start, thin_end=thin_end,
-                                     thin_interval=thin_interval)
-        acfs = fp['acceptance_fraction'][get_index]
-        if iteration is not None:
-            acfs = numpy.array([acfs])
-        return acfs
+            wmask = numpy.zeros(fp.nwalkers, dtype=bool)
+            wmask[walkers] = True
+        return fp[group][wmask]
 
     @classmethod
     def compute_acfs(cls, fp, start_index=None, end_index=None,

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -156,7 +156,7 @@ class _BaseSampler(object):
         of the sampling args and the variable args.
         """
         return NotImplementedError("samples function not set.")
- 
+
     @property
     def clear_chain(self):
         """This function should clear the current chain of samples from memory.
@@ -170,7 +170,7 @@ class _BaseSampler(object):
 
     @property
     def acceptance_fraction(self):
-        """This function should return the fraction of steps accepted by each 
+        """This function should return the fraction of steps accepted by each
         walker as an array.
         """
         return NotImplementedError("acceptance_fraction function not set.")
@@ -464,9 +464,9 @@ class BaseMCMCSampler(_BaseSampler):
         """Writes samples to the given file.
 
         Results are written to:
-        
+
             ``fp[samples_group/{vararg}]``,
-            
+
         where ``{vararg}`` is the name of a variable arg. The samples are
         written as an ``nwalkers x niterations`` array.
 
@@ -522,11 +522,11 @@ class BaseMCMCSampler(_BaseSampler):
 
     def write_chain(self, fp, start_iteration=None, max_iterations=None):
         """Writes the samples from the current chain to the given file.
-        
+
         Results are written to:
-        
+
             `fp[fp.samples_group/{field}/(temp{k}/)walker{i}]`,
-        
+
         where `{i}` is the index of a walker, `{field}` is the name of each
         field returned by `likelihood_stats`, and, if the sampler is
         multitempered, `{k}` is the temperature.
@@ -559,11 +559,11 @@ class BaseMCMCSampler(_BaseSampler):
     def write_likelihood_stats(self, fp, start_iteration=None,
                                max_iterations=None):
         """Writes the `likelihood_stats` to the given file.
-        
+
         Results are written to:
-        
+
             `fp[fp.stats_group/{field}/(temp{k}/)walker{i}]`,
-        
+
         where `{i}` is the index of a walker, `{field}` is the name of each
         field returned by `likelihood_stats`, and, if the sampler is
         multitempered, `{k}` is the temperature.  If nothing is returned by
@@ -979,7 +979,7 @@ class BaseMCMCSampler(_BaseSampler):
     @staticmethod
     def write_acls(fp, acls):
         """Writes the given autocorrelation lengths to the given file.
-        
+
         The ACL of each parameter is saved to ``fp['acls/{param}']``.
         The maximum over all the parameters is saved to the file's 'acl'
         attribute.

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -190,49 +190,6 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
         self._pos = p
         return p, lnpost, rstate
 
-    # Emcee defines acceptance fraction differently, so have to override
-    # write functions
-    def write_acceptance_fraction(self, fp):
-        """Write acceptance_fraction data to file. Results are written to
-        `fp[acceptance_fraction]`.
-
-        Parameters
-        -----------
-        fp : InferenceFile
-            A file handler to an open inference file.
-        """
-        dataset_name = "acceptance_fraction"
-        try:
-            fp[dataset_name][:] = self.acceptance_fraction
-        except KeyError:
-            # dataset doesn't exist yet, create it
-            fp[dataset_name] = self.acceptance_fraction
-
-    @staticmethod
-    def read_acceptance_fraction(fp, walkers=None):
-        """Reads the acceptance fraction from the given file.
-
-        Parameters
-        -----------
-        fp : InferenceFile
-            An open file handler to read the samples from.
-        walkers : {None, (list of) int}
-            The walker index (or a list of indices) to retrieve. If None,
-            samples from all walkers will be obtained.
-
-        Returns
-        -------
-        array
-            Array of acceptance fractions with shape (requested walkers,).
-        """
-        group = 'acceptance_fraction'
-        if walkers is None:
-            wmask = numpy.ones(fp.nwalkers, dtype=bool)
-        else:
-            wmask = numpy.zeros(fp.nwalkers, dtype=bool)
-            wmask[walkers] = True
-        return fp[group][wmask]
-
     def write_results(self, fp, start_iteration=None,
                       max_iterations=None, **metadata):
         """Writes metadata, samples, likelihood stats, and acceptance fraction
@@ -537,8 +494,8 @@ class EmceePTSampler(BaseMCMCSampler):
             wmask[walkers] = True
         arrays = []
         for tk in temps:
-            arrays.append(fp[group.format(tk=tk)][wmask])
-        return numpy.vstack(arrays)
+            arrays.extend(fp[group.format(tk=tk)][wmask])
+        return arrays
 
     @staticmethod
     def write_samples_group(fp, samples_group, parameters, samples,

--- a/pycbc/inference/sampler_emcee.py
+++ b/pycbc/inference/sampler_emcee.py
@@ -221,7 +221,7 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
 
 # This is needed for two reason
 # 1) pools freeze state when created and so classes *cannot be updated*
-# 2) methods cannot be pickled. 
+# 2) methods cannot be pickled.
 class _callprior(object):
     """Calls the likelihood function's prior function, and ensures that no
     metadata is returned."""
@@ -505,7 +505,7 @@ class EmceePTSampler(BaseMCMCSampler):
         Results are written to:
 
             ``fp[samples_group/{vararg}]``,
-            
+
         where ``{vararg}`` is the name of a variable arg. The samples are
         written as an ``ntemps x nwalkers x niterations`` array.
 
@@ -918,7 +918,7 @@ class EmceePTSampler(BaseMCMCSampler):
     def compute_acls(cls, fp, start_index=None, end_index=None):
         """Computes the autocorrleation length for all variable args and
         temperatures in the given file.
-        
+
         Parameter values are averaged over all walkers at each iteration and
         temperature.  The ACL is then calculated over the averaged chain. If
         the returned ACL is `inf`,  will default to the number of current

--- a/pycbc/inference/sampler_kombine.py
+++ b/pycbc/inference/sampler_kombine.py
@@ -86,6 +86,13 @@ class KombineSampler(BaseMCMCSampler):
         self._nwalkers = nwalkers
         self.update_interval = update_interval
 
+    @property
+    def acceptance_fraction(self):
+        """Get the fraction of steps accepted by each walker as an array.
+        """
+        # acceptance returned by kombine has shape iterations x nwalkers
+        return numpy.mean(self._sampler.acceptance, axis=0)
+
     @classmethod
     def from_cli(cls, opts, likelihood_evaluator, pool=None, likelihood_call=None):
         """Create an instance of this sampler from the given command-line


### PR DESCRIPTION
This PR :
* Redefines `acceptance_fraction` for `kombine` in pycbc as "array of fraction of steps accepted by each walker" (like in emcee) ie of dimension `nwalkers` instead of "array of fraction of walkers accepted by each iteration", ie. dimension `niterations`. 
* Generalizes reading and writing acceptance_fraction for `kombine` and `emcee` samplers.
* Make changes in`pycbc_inference_plot_acceptance_rate` so as to specify the list of indices of temperatures (for parallel-tempered samplers) and list of indices of the walkers whose `acceptance_fraction`s will be plotted.
* Makes `pycbc_inference_plot_acceptance_rate` plot a histogram of the `acceptance_rate`s for all walkers. This used to plot a line plot before because it used to plot the acceptance fraction over the iterations based on how it was defined before. This worked specifically for kombine before.
Here's an example of the histogram plot https://sugwg-jobs.phy.syr.edu/~soumi.de/tmp/emcee_pt_temps1.png this will make.