### PR TITLE
add times for O1 data

### DIFF
--- a/pycbc/frame/losc.py
+++ b/pycbc/frame/losc.py
@@ -20,9 +20,11 @@ This modules contains functions for getting data from the LOSC
 _losc_url = "https://losc.ligo.org/archive/links/%s/%s/%s/%s/json/"
 
 def _get_run(time):
-    if 815011213 < time < 875318414:
+    if 1126051217 <= time <= 1137254417:
+        return 'O1'
+    elif 815011213 <= time <= 875318414:
         return 'S5'
-    elif 930787215 < time < 971568015:
+    elif 930787215 <= time <= 971568015:
         return 'S6'
     else:
         raise ValueError('Time %s not available in a public dataset' % time)


### PR DESCRIPTION
This updates the losc module to add the O1 start end times. One can now do. 

>>> ts = pycbc.frame.query_and_read_frame('LOSC', 'L1:LOSC-STRAIN', 1126259362, 1126259662)

In addition, the standard strain cli functions can now operate on O1 events without needing for the instructions to explicitly name frame files. Simple change the frame-type to LOSC and set the channel name to H1/L1:LOSC-STRAIN. 