### PR TITLE
Import IFO colour scheme from GWpy (if available)

### DIFF
--- a/pycbc/results/color.py
+++ b/pycbc/results/color.py
@@ -1,7 +1,20 @@
 """ Utilities for managing matplotlib colors and mapping ifos to color
 """
 
-_ifo_color_map = {'H1':'red', 'L1':'green', 'V1':'magenta'}
+# try and import color scheme from GWpy, see
+# https://gwpy.github.io/docs/stable/plotter/colors.html for details
+try:
+    from gwpy.plotter.colors import GW_OBSERVATORY_COLORS as _ifo_color_map
+except ImportError:
+    _ifo_color_map = {
+        'G1': '#222222',  # dark gray
+        'K1': '#ffb200',  # yellow/orange
+        'H1': '#ee0000',  # red
+        'I1': '#b0dd8b',  # light green
+        'L1': '#4ba6ff',  # blue
+        'V1': '#9b59b6',  # magenta/purple
+    }
+
 
 def ifo_color(ifo):
     return _ifo_color_map[ifo]


### PR DESCRIPTION
This PR modifies `pycbc.results.color` to import the IFO-prefix-based colour scheme from `gwpy.plotter.colors`, falling back to a copy from gwpy-0.7.

This will modify the PyCBC results pages to use the same colour schemes as recent publications (mainly H1=red, L1=blue), and the summary pages, which should improve the readability of the figures.