### PR TITLE
Several changes to FFT infrastructure

### DIFF
--- a/bin/pycbc_inspiral
+++ b/bin/pycbc_inspiral
@@ -196,6 +196,7 @@ pycbc.weave.verify_weave_options(opt, parser)
 
 pycbc.init_logging(opt.verbose)
 
+fft.from_cli(opt)
 inj_filter_rejector = pycbc.inject.InjFilterRejector.from_cli(opt)
 ctx = scheme.from_cli(opt)
 gwstrain = strain.from_cli(opt, dyn_range_fac=DYN_RANGE_FAC,
@@ -204,7 +205,19 @@ strain_segments = strain.StrainSegments.from_cli(opt, gwstrain)
 
 
 with ctx:
-    fft.from_cli(opt)
+    # The following FFTW specific options needed to wait until
+    # we were inside the scheme context
+
+    # Import system wisdom.
+    if opt.fftw_import_system_wisdom:
+        import_sys_wisdom()
+
+    # Read specified user-provided wisdom files
+    if opt.fftw_input_float_wisdom_file is not None:
+        import_single_wisdom_from_filename(opt.fftw_input_float_wisdom_file)        
+
+    if opt.fftw_input_double_wisdom_file is not None:
+        import_double_wisdom_from_filename(opt.fftw_input_double_wisdom_file)    
 
     flow = opt.low_frequency_cutoff
     flen = strain_segments.freq_len

--- a/bin/pycbc_live
+++ b/bin/pycbc_live
@@ -279,12 +279,14 @@ fft.insert_fft_option_group(parser)
 LiveCoincTimeslideBackgroundEstimator.insert_args(parser)
 args = parser.parse_args()
 scheme.verify_processing_options(args, parser)
+fft.verify_fft_options(args, parser)
 
 import platform
 log_format = "%(asctime)s {0} %(message)s".format(platform.node())
 pycbc.init_logging(args.verbose, format=log_format)
 
 ctx = scheme.from_cli(args)
+fft.from_cli(args)
 
 sr = args.sample_rate
 flow = args.low_frequency_cutoff
@@ -326,10 +328,17 @@ if evnt.rank == 0 and args.enable_gracedb_upload:
 
 # I'm not the root, so do some actually filtering.
 with ctx:
-    try:
-        fft.from_cli(args)
-    except:
-        pass
+    # Import system wisdom.
+    if args.fftw_import_system_wisdom:
+        fft.fftw.import_sys_wisdom()
+
+    # Read specified user-provided wisdom files
+    if args.fftw_input_float_wisdom_file is not None:
+        fft.fftw.import_single_wisdom_from_filename(args.fftw_input_float_wisdom_file)
+
+    if args.fftw_input_double_wisdom_file is not None:
+        fft.fftw.import_double_wisdom_from_filename(args.fftw_input_double_wisdom_file)
+
     maxlen = args.psd_segment_length * (args.psd_samples / 2 + 1)
     if evnt.rank > 0:
         bank.table.sort(order='mchirp')

--- a/pycbc/fft/backend_cpu.py
+++ b/pycbc/fft/backend_cpu.py
@@ -24,7 +24,7 @@ _backend_list = ['fftw','mkl','numpy']
 
 _alist, _adict = _list_available(_backend_list, _backend_dict)
 
-cpu_backend = 'fftw'
+cpu_backend = None
 
 def set_backend(backend_list):
     global cpu_backend
@@ -35,4 +35,6 @@ def set_backend(backend_list):
 
 def get_backend():
     return _adict[cpu_backend]
+
+set_backend(_backend_list)
 

--- a/pycbc/fft/backend_cuda.py
+++ b/pycbc/fft/backend_cuda.py
@@ -27,9 +27,8 @@ _adict = {}
 
 if pycbc.HAVE_CUDA:
     _alist, _adict = _list_available(_backend_list,_backend_dict)
-    cuda_backend = 'cuda'
-else:
-    cuda_backend = None
+
+cuda_backend = None
 
 def set_backend(backend_list):
     global cuda_backend
@@ -40,3 +39,5 @@ def set_backend(backend_list):
 
 def get_backend():
     return _adict[cuda_backend]
+
+set_backend(_backend_list)

--- a/pycbc/fft/backend_mkl.py
+++ b/pycbc/fft/backend_mkl.py
@@ -22,7 +22,7 @@ _backend_list = ['mkl']
 
 _alist, _adict = _list_available(_backend_list, _backend_dict)
 
-mkl_backend = 'mkl'
+mkl_backend = None
 
 def set_backend(backend_list):
     global mkl_backend
@@ -33,3 +33,5 @@ def set_backend(backend_list):
 
 def get_backend():
     return _adict[mkl_backend]
+
+set_backend(_backend_list)

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -12,17 +12,6 @@ from .core import _BaseFFT, _BaseIFFT
 # to set the threading backend, it is ESSENTIAL that simply loading this
 # module should not actually *call* ANY functions.
 
-def memoize(obj):
-    cache = obj.cache = {}
-
-    @functools.wraps(obj)
-    def memoizer(*args, **kwargs):
-        key = str(args) + str(kwargs)
-        if key not in cache:
-            cache[key] = obj(*args, **kwargs)
-        return cache[key]
-    return memoizer
-
 #FFTW constants, these are pulled from fftw3.h
 FFTW_FORWARD = -1
 FFTW_BACKWARD = 1
@@ -246,7 +235,6 @@ execute_function = {'float32': {'complex64': float_lib.fftwf_execute_dft_r2c},
                                    'complex128': double_lib.fftw_execute_dft}
                    }
 
-@memoize
 def plan(size, idtype, odtype, direction, mlvl, aligned, nthreads, inplace):
     if not _fftw_threaded_set:
         set_threads_backend()

--- a/pycbc/fft/fftw.py
+++ b/pycbc/fft/fftw.py
@@ -499,16 +499,5 @@ def from_cli(opt):
     # appropriate:
     set_threads_backend(opt.fftw_threads_backend)
 
-    # Import system wisdom.  Should really add error checking and logging to that...
-    if opt.fftw_import_system_wisdom:
-        import_sys_wisdom()
-
-    # Read specified user-provided wisdom files
-    if opt.fftw_input_float_wisdom_file is not None:
-        import_single_wisdom_from_filename(opt.fftw_input_float_wisdom_file)        
-
-    if opt.fftw_input_double_wisdom_file is not None:
-        import_double_wisdom_from_filename(opt.fftw_input_double_wisdom_file)        
-
     # Set the user-provided measure level
     set_measure_level(opt.fftw_measure_level)

--- a/pycbc/fft/mkl.py
+++ b/pycbc/fft/mkl.py
@@ -3,17 +3,6 @@ from pycbc.types import zeros
 from .core import _BaseFFT, _BaseIFFT
 import pycbc.scheme as _scheme
 
-def memoize(obj):
-    cache = obj.cache = {}
-
-    @functools.wraps(obj)
-    def memoizer(*args, **kwargs):
-        key = str(args) + str(kwargs)
-        if key not in cache:
-            cache[key] = obj(*args, **kwargs)
-        return cache[key]
-    return memoizer
-
 lib = pycbc.libutils.get_ctypes_library('mkl_rt', [])
 if lib is None:
     raise ImportError
@@ -84,7 +73,6 @@ def check_status(status):
         msg = ctypes.c_char_p(msg).value
         raise RuntimeError(msg)
    
-@memoize     
 def create_descriptor(size, idtype, odtype, inplace):
     invec = zeros(1, dtype=idtype)
     outvec = zeros(1, dtype=odtype)


### PR DESCRIPTION
This pull request makes several changes to how FFTs are handled in PyCBC. The main changes are:
 
  * Always set a default backend (same as #2034, but for all schemes not just CPU)
  * Remove the caching of 'plans' and similar data structures in FFTW/MKL support. This means that plans will be re-generated for the function-based API; users wanting to amortize that overhead should instead used the class-based API
  * The options related to wisdom files are no longer performed as part of `fftw.from_cli`. This change allows that function to now occur anywhere within an executable, not just after entering a processing scheme context. So if specifying `--fft-backend mkl` users should see MKL used for all FFTs, not just those in the context block. This requires making explicit calls to the import wisdom functions (as was already the case for export) and has been changed for `pycbc_inspiral`, but no other executables.