### PR TITLE
Distinguish between dQuadMon = 0 and dQuadMon not given.

### DIFF
--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -465,14 +465,16 @@ location_params = ParameterList([tc, ra, dec, polarization])
 # parameters describing the orientation of a binary w.r.t. the radiation
 # frame. Note: we include distance here, as it is typically used for generating
 # waveforms.
-orientation_params = ParameterList([distance, coa_phase, inclination, long_asc_nodes, mean_per_ano])
+orientation_params = ParameterList\
+    ([distance, coa_phase, inclination, long_asc_nodes, mean_per_ano])
 
 # the extrinsic parameters of a waveform
 extrinsic_params = orientation_params + location_params
 
 # intrinsic parameters of a CBC waveform, required by waveform generation
 cbc_intrinsic_params = ParameterList\
-    ([mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z])
+    ([mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z,
+      eccentricity])
 
 # intrinsic parameters of a CBC waveform, optional for waveform generation
 # if not given, the waveform generator will choose a default value according

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -510,7 +510,7 @@ common_gen_equal_sampled_params = ParameterList([f_lower]) + \
 # the following are parameters needed to generate an FD waveform
 fd_waveform_params = cbc_rframe_params + ParameterList([delta_f]) + \
     common_gen_equal_sampled_params + ParameterList([f_final, f_final_func])
-fd_waveform_params_full = fd_waveform_params + cbc_optional_params 
+fd_waveform_params_full = fd_waveform_params + cbc_optional_params
 
 # the following are parameters needed to generate a TD waveform
 td_waveform_params = cbc_rframe_params + ParameterList([delta_t]) + \

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -519,4 +519,3 @@ cbc_fd_required = ParameterList([mass1, mass2, delta_f, approximant])
 fd_waveform_sequence_params = cbc_rframe_params + \
     ParameterList([sample_points]) + common_generation_params + \
     flags_generation_params
-    cbc_optional_params

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -470,15 +470,21 @@ orientation_params = ParameterList([distance, coa_phase, inclination, long_asc_n
 # the extrinsic parameters of a waveform
 extrinsic_params = orientation_params + location_params
 
-# intrinsic parameters of a CBC waveform
-cbc_intrinsic_params = ParameterList([
-    mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z,
-    eccentricity, lambda1, lambda2, dquad_mon1, dquad_mon2,
-    lambda_octu1, lambda_octu2, quadfmode1, quadfmode2,
-    octufmode1, octufmode2])
+# intrinsic parameters of a CBC waveform, required by waveform generation
+cbc_intrinsic_params = ParameterList\
+    ([mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z])
+
+# intrinsic parameters of a CBC waveform, optional for waveform generation
+# if not given, the waveform generator will choose a default value according
+# to its own documentation, or does not use the term.
+cbc_optional_params = ParameterList\
+    ([lambda1, lambda2, dquad_mon1, dquad_mon2, lambda_octu1, lambda_octu2,
+      quadfmode1, quadfmode2, octufmode1, octufmode2])
 
 # the parameters of a cbc in the radiation frame
 cbc_rframe_params = cbc_intrinsic_params + orientation_params
+cbc_rframe_params_full = cbc_intrinsic_params + orientation_params + \
+    cbc_optional_params
 
 # calibration parameters
 calibration_params = ParameterList([
@@ -502,13 +508,17 @@ common_gen_equal_sampled_params = ParameterList([f_lower]) + \
 # the following are parameters needed to generate an FD waveform
 fd_waveform_params = cbc_rframe_params + ParameterList([delta_f]) + \
     common_gen_equal_sampled_params + ParameterList([f_final, f_final_func])
+fd_waveform_params_full = fd_waveform_params + cbc_optional_params 
 
 # the following are parameters needed to generate a TD waveform
 td_waveform_params = cbc_rframe_params + ParameterList([delta_t]) + \
     common_gen_equal_sampled_params + ParameterList([numrel_data]) + \
     flags_generation_params
+td_waveform_params_full = td_waveform_params + cbc_optional_params
 
 # the following are parameters needed to generate a frequency series waveform
 fd_waveform_sequence_params = cbc_rframe_params + \
     ParameterList([sample_points]) + common_generation_params + \
     flags_generation_params
+fd_waveform_sequence_params_full = fd_waveform_sequence_params + \
+    cbc_optional_params

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -86,20 +86,17 @@ class ParameterList(UserList):
         """Returns a dictionary of the parameters keyed by the parameters."""
         return dict([[x, x] for x in self])
 
-    def defaults(self, include_nulls=False):
+    def defaults(self):
         """Returns a list of the name and default value of each parameter,
-        as tuples. If include_nulls is False, only parameters that do not
-        have None as a default are returnted. Otherwise, all parameters
-        are returned.
+        as tuples.
         """
-        return [(x, x.default) for x in self
-                    if include_nulls or x.default is not None]
+        return [(x, x.default) for x in self]
 
-    def default_dict(self, include_nulls=False):
+    def default_dict(self):
         """Returns a dictionary of the name and default value of each
         parameter.
         """
-        return dict(self.defaults(include_nulls=include_nulls))
+        return dict(self.defaults())
 
     @property
     def nodefaults(self):
@@ -471,22 +468,15 @@ orientation_params = ParameterList\
 # the extrinsic parameters of a waveform
 extrinsic_params = orientation_params + location_params
 
-# intrinsic parameters of a CBC waveform, required by waveform generation
+# intrinsic parameters of a CBC waveform. Some of these are not recognized
+# by every waveform model
 cbc_intrinsic_params = ParameterList\
     ([mass1, mass2, spin1x, spin1y, spin1z, spin2x, spin2y, spin2z,
-      eccentricity])
-
-# intrinsic parameters of a CBC waveform, optional for waveform generation
-# if not given, the waveform generator will choose a default value according
-# to its own documentation, or does not use the term.
-cbc_optional_params = ParameterList\
-    ([lambda1, lambda2, dquad_mon1, dquad_mon2, lambda_octu1, lambda_octu2,
-      quadfmode1, quadfmode2, octufmode1, octufmode2])
+      eccentricity, lambda1, lambda2, dquad_mon1, dquad_mon2, lambda_octu1,
+      lambda_octu2, quadfmode1, quadfmode2, octufmode1, octufmode2])
 
 # the parameters of a cbc in the radiation frame
 cbc_rframe_params = cbc_intrinsic_params + orientation_params
-cbc_rframe_params_full = cbc_intrinsic_params + orientation_params + \
-    cbc_optional_params
 
 # calibration parameters
 calibration_params = ParameterList([
@@ -507,20 +497,26 @@ flags_generation_params = ParameterList([frame_axis, modes_choice, side_bands, m
 common_gen_equal_sampled_params = ParameterList([f_lower]) + \
     common_generation_params + flags_generation_params
 
-# the following are parameters needed to generate an FD waveform
+# the following are parameters that can be used to generate an FD waveform
 fd_waveform_params = cbc_rframe_params + ParameterList([delta_f]) + \
     common_gen_equal_sampled_params + ParameterList([f_final, f_final_func])
-fd_waveform_params_full = fd_waveform_params + cbc_optional_params
 
-# the following are parameters needed to generate a TD waveform
+# the following are parameters that can be used to generate a TD waveform
 td_waveform_params = cbc_rframe_params + ParameterList([delta_t]) + \
     common_gen_equal_sampled_params + ParameterList([numrel_data]) + \
     flags_generation_params
-td_waveform_params_full = td_waveform_params + cbc_optional_params
 
-# the following are parameters needed to generate a frequency series waveform
+# The following are the minimum set of parameters that are required to
+# generate a FD or TD waveform. All other parameters have some default value as
+# defined above. Defaults of None simply mean that the value is not passed into
+# the lal_dict structure and the waveform generator will take whatever default
+# behaviour
+cbc_td_required = ParameterList([mass1, mass2, delta_t, approximant])
+cbc_fd_required = ParameterList([mass1, mass2, delta_f, approximant])
+
+# the following are parameters that can be used to generate a
+# frequency series waveform
 fd_waveform_sequence_params = cbc_rframe_params + \
     ParameterList([sample_points]) + common_generation_params + \
     flags_generation_params
-fd_waveform_sequence_params_full = fd_waveform_sequence_params + \
     cbc_optional_params

--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -244,35 +244,41 @@ spin_sz = Parameter("spin_sz",
                 description="The z component of the dimensionless spin of the "
                             "secondary object.")
 lambda1 = Parameter("lambda1",
-                dtype=float, default=0., label=r"$\lambda_1$",
+                dtype=float, default=None, label=r"$\lambda_1$",
                 description="The tidal deformability parameter of object 1.")
 lambda2 = Parameter("lambda2",
-                dtype=float, default=0., label=r"$\lambda_2$",
+                dtype=float, default=None, label=r"$\lambda_2$",
                 description="The tidal deformability parameter of object 2.")
 dquad_mon1 = Parameter("dquad_mon1",
-                dtype=float, default=0., label=r"$qm_1$",
+                dtype=float, default=None, label=r"$qm_1$",
                 description="Quadrupole-monopole parameter / m_1^5 -1.")
 dquad_mon2 = Parameter("dquad_mon2",
-                dtype=float, default=0., label=r"$qm_2$",
+                dtype=float, default=None, label=r"$qm_2$",
                 description="Quadrupole-monopole parameter / m_2^5 -1.")
 lambda_octu1 = Parameter("lambda_octu1",
-                dtype=float, default=0., label=r"$\Lambda_3^{(1)}$",
-                description="The octupolar tidal deformability parameter of object 1.")
+                dtype=float, default=None, label=r"$\Lambda_3^{(1)}$",
+                description="The octupolar tidal deformability parameter of "
+                            "object 1.")
 lambda_octu2 = Parameter("lambda_octu2",
-                dtype=float, default=0., label=r"$\Lambda_3^{(2)}$",
-                description="The octupolar tidal deformability parameter of object 2.")
+                dtype=float, default=None, label=r"$\Lambda_3^{(2)}$",
+                description="The octupolar tidal deformability parameter of "
+                            "object 2.")
 quadfmode1 = Parameter("quadfmode1",
-                dtype=float, default=0., label=r"$m_1 \omega_{02}^{(1)}$",
-                description="The quadrupolar f-mode angular frequency of object 1.")
+                dtype=float, default=None, label=r"$m_1 \omega_{02}^{(1)}$",
+                description="The quadrupolar f-mode angular frequency of "
+                            "object 1.")
 quadfmode2 = Parameter("quadfmode2",
-                dtype=float, default=0., label=r"$m_ \omega_{02}^{(2)}$",
-                description="The quadrupolar f-mode angular frequency of object 2.")
+                dtype=float, default=None, label=r"$m_ \omega_{02}^{(2)}$",
+                description="The quadrupolar f-mode angular frequency of "
+                            "object 2.")
 octufmode1 = Parameter("octufmode1",
-                dtype=float, default=0., label=r"$m_1 \omega_{03}^{(1)}$",
-                description="The octupolar f-mode angular frequency of object 1.")
+                dtype=float, default=None, label=r"$m_1 \omega_{03}^{(1)}$",
+                description="The octupolar f-mode angular frequency of "
+                            "object 1.")
 octufmode2 = Parameter("octufmode2",
-                dtype=float, default=0., label=r"$m_ \omega_{03}^{(2)}$",
-                description="The octupolar f-mode angular frequency of object 2.")
+                dtype=float, default=None, label=r"$m_ \omega_{03}^{(2)}$",
+                description="The octupolar f-mode angular frequency of "
+                            "object 2.")
 
 # derived parameters for component spin magnitude and angles
 spin1_a = Parameter("spin1_a",

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -53,8 +53,9 @@ class NoWaveformError(Exception):
 # If this is set to False waveform failures will always raise exceptions
 fail_tolerant_waveform_generation = True
 
-default_args = (parameters.fd_waveform_params.default_dict() + \
-    parameters.td_waveform_params).default_dict()
+default_args = \
+    (parameters.fd_waveform_params.default_dict(include_nulls=True)
+     parameters.td_waveform_params).default_dict(include_nulls=True)
 
 default_sgburst_args = {'eccentricity':0, 'polarization':0}
 

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -54,7 +54,7 @@ class NoWaveformError(Exception):
 fail_tolerant_waveform_generation = True
 
 default_args = \
-    (parameters.fd_waveform_params.default_dict(include_nulls=True)
+    (parameters.fd_waveform_params.default_dict(include_nulls=True) +
      parameters.td_waveform_params).default_dict(include_nulls=True)
 
 default_sgburst_args = {'eccentricity':0, 'polarization':0}

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -54,8 +54,8 @@ class NoWaveformError(Exception):
 fail_tolerant_waveform_generation = True
 
 default_args = \
-    (parameters.fd_waveform_params_full.default_dict() +
-     parameters.td_waveform_params_full).default_dict()
+    (parameters.fd_waveform_params.default_dict() +
+     parameters.td_waveform_params).default_dict()
 
 default_sgburst_args = {'eccentricity':0, 'polarization':0}
 

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -54,13 +54,13 @@ class NoWaveformError(Exception):
 fail_tolerant_waveform_generation = True
 
 default_args = \
-    (parameters.fd_waveform_params_full.default_dict(include_nulls=True) +
-     parameters.td_waveform_params_full).default_dict(include_nulls=True)
+    (parameters.fd_waveform_params_full.default_dict() +
+     parameters.td_waveform_params_full).default_dict()
 
 default_sgburst_args = {'eccentricity':0, 'polarization':0}
 
-td_required_args = parameters.td_waveform_params.nodefaults.aslist
-fd_required_args = parameters.fd_waveform_params.nodefaults.aslist
+td_required_args = parameters.cbc_td_required
+fd_required_args = parameters.cbc_fd_required
 sgburst_required_args = ['q','frequency','hrss']
 
 # td, fd, filter waveforms generated on the CPU

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -94,25 +94,25 @@ def _check_lal_pars(p):
         lalsimulation.SimInspiralWaveformParamsInsertPNTidalOrder(lal_pars, p['tidal_order'])
     if p['eccentricity_order']!=-1:
         lalsimulation.SimInspiralWaveformParamsInsertPNEccentricityOrder(lal_pars, p['eccentricity_order'])
-    if p['lambda1']:
+    if p['lambda1'] is not None:
         lalsimulation.SimInspiralWaveformParamsInsertTidalLambda1(lal_pars, p['lambda1'])
-    if p['lambda2']:
+    if p['lambda2'] is not None:
         lalsimulation.SimInspiralWaveformParamsInsertTidalLambda2(lal_pars, p['lambda2'])
-    if p['lambda_octu1'] != parameters.lambda_octu1.default:
+    if p['lambda_octu1'] is not None:
         lalsimulation.SimInspiralWaveformParamsInsertTidalOctupolarLambda1(lal_pars, p['lambda_octu1'])
-    if p['lambda_octu2'] != parameters.lambda_octu2.default:
+    if p['lambda_octu2'] is not None:
         lalsimulation.SimInspiralWaveformParamsInsertTidalOctupolarLambda2(lal_pars, p['lambda_octu2'])
-    if p['quadfmode1'] != parameters.quadfmode1.default:
+    if p['quadfmode1'] is not None:
         lalsimulation.SimInspiralWaveformParamsInsertTidalQuadrupolarFMode1(lal_pars, p['quadfmode1'])
-    if p['quadfmode2'] != parameters.quadfmode2.default:
+    if p['quadfmode2'] is not None:
         lalsimulation.SimInspiralWaveformParamsInsertTidalQuadrupolarFMode2(lal_pars, p['lambda_octu2'])
-    if p['octufmode1'] != parameters.octufmode1.default:
+    if p['octufmode1'] is not None:
         lalsimulation.SimInspiralWaveformParamsInsertTidalOctupolarFMode1(lal_pars, p['octufmode1'])
-    if p['octufmode2'] != parameters.octufmode2.default:
+    if p['octufmode2'] is not None:
         lalsimulation.SimInspiralWaveformParamsInsertTidalOctupolarFMode2(lal_pars, p['octufmode2'])
-    if p['dquad_mon1']:
+    if p['dquad_mon1'] is not None:
         lalsimulation.SimInspiralWaveformParamsInsertdQuadMon1(lal_pars, p['dquad_mon1'])
-    if p['dquad_mon2']:
+    if p['dquad_mon2'] is not None:
         lalsimulation.SimInspiralWaveformParamsInsertdQuadMon2(lal_pars, p['dquad_mon2'])
     if p['numrel_data']:
         lalsimulation.SimInspiralWaveformParamsInsertNumRelData(lal_pars, str(p['numrel_data']))

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -54,8 +54,8 @@ class NoWaveformError(Exception):
 fail_tolerant_waveform_generation = True
 
 default_args = \
-    (parameters.fd_waveform_params.default_dict(include_nulls=True) +
-     parameters.td_waveform_params).default_dict(include_nulls=True)
+    (parameters.fd_waveform_params_full.default_dict(include_nulls=True) +
+     parameters.td_waveform_params_full).default_dict(include_nulls=True)
 
 default_sgburst_args = {'eccentricity':0, 'polarization':0}
 


### PR DESCRIPTION
Problem: EOB tidal wants to move to a mode where a user supplies lambda1 and lambda2, and, if the dQuadMon parameters are not set, the values of the dQuadMon terms will be calculated using universal relations. Alternatively the user can supply both lambda *and* dQuadMon input quantities. Therefore in this case dQuadMon = 0 and dQuadMon not set in the lal_dict structure are handled differently. Generically, this case might need to be handled in other instances as well, pycbc is supposed to be a connection to lalsimulation, and needs to be able to supply the same functionality as possible with lalsimulation commands directly.

@ahnitz suggested setting a default value of -1. This would work for this case, for most users, but one *might* consider a case where negative values of dQuadMon are possible (alternative gravity). And again, more generically, this case might be more meaningful with other variables.

In short, we need to be able to correctly distinguish between "The user didn't give that value" and "The user set that value to 0, or -1, or any other value" without having one case (the default floating point value) handled specially.

I thought this would be easily handled by setting the default value to None for these cases, but the `parameters.py` interaction with `waveform.py` seems to handle that case specially. I found the interaction between these two modules very confusing (and in some cases, e.g. eccentricity, inconsistent). I've tried to edit the existing setup to do what I believe to be the correct behaviour. I don't know if inference does anything special that I should be aware about. This worked in my short test cases, but it would be good if @sturani or Sylvain could also test this ... Although simplifying how these two modules interact might also be useful!