### PR TITLE
Segments need coalescing

### DIFF
--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -118,6 +118,7 @@ insp_segs = to_file(args.inspiral_segments)
 insp_data_seglists = select_segments_by_definer\
         (args.inspiral_segments, segment_name=args.inspiral_data_read_name,
          ifo=args.instrument)
+insp_data_seglists.coalesce()
 
 num_events = int(workflow.cp.get_opt_tags('workflow-sngl_minifollowups',
                  'num-sngl-events', ''))


### PR DESCRIPTION
The addition of the omega scans executable has highlighted a bug in pycbc_sngl_minifollowup, which would have caused some odd looking singles_timefreq plots on occasion. Basically `insp_data_seglists` is used to identify data that should be read in. It needs to be coalesced in these codes (as it is in the other two minifollowups executables). There are comments in the sub-functions in minifollowups.py where this variable is used saying "This input must be coalesced".