### PR TITLE
remove astropy from setup.py requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'corner>=2.0.1',
                       'requests>=1.2.1',
                       'beautifulsoup4>=4.6.0',
-                      'astropy>=2.0.1'
                       ]
 
 #FIXME Remove me when we bump to h5py > 2.5


### PR DESCRIPTION
The PyCBC library does not currently use astropy, so remove from setup.py requirements. It will still be installed onto CVMFS builds though so people who may be interested in using that can. It may be re-added in the future if the library itself is used.