### PR TITLE
Move the parsed configuration files

### DIFF
--- a/pycbc/workflow/core.py
+++ b/pycbc/workflow/core.py
@@ -545,23 +545,6 @@ class Workflow(pegasus_workflow.Workflow):
         # Parse ini file
         self.cp = WorkflowConfigParser.from_args(args)
         
-        # Dump the parsed config file
-        symlink = os.path.abspath(self.name + '_parsed.ini')
-
-        if os.path.isfile(symlink):
-            os.remove(symlink)
-
-        ini_file = os.path.abspath(self.name + '_parsed_%d.ini' % time.time())
-        # This shouldn't already exist, but just in case
-        if os.path.isfile(ini_file):
-            os.remove(ini_file)
-
-        fp = open(ini_file, 'w')
-        self.cp.write(fp)
-        fp.close()
-
-        os.symlink(ini_file, symlink)
-
         # Set global values
         start_time = int(self.cp.get("workflow", "start-time"))
         end_time = int(self.cp.get("workflow", "end-time"))
@@ -676,6 +659,20 @@ class Workflow(pegasus_workflow.Workflow):
         # add workflow input files pfns for local site to dax
         for fil in self._inputs:
             fil.insert_into_dax(self._adag)
+
+        # save the configuration file
+        ini_file = os.path.abspath(self.name + '.ini')
+
+        # This shouldn't already exist, but just in case
+        if os.path.isfile(ini_file):
+            err_msg = "Refusing to overwrite configuration file that "
+            err_msg += "shouldn't be there: "
+            err_msg += os.path.join(os.getcwd(), ini_file)
+            raise ValueError(err_msg)
+
+        fp = open(ini_file, 'w')
+        self.cp.write(fp)
+        fp.close()
             
         # save the dax file
         super(Workflow, self).save(filename=filename)


### PR DESCRIPTION
I got frustrated with the multitude of _parsed_21312342345.ini files.

This patch swaps stuff around so the ini files are written when saving the workflow. This means they get written in the same directory as the .dax files and .map files. Now I am not frustrated :-).