### PR TITLE
Fix inconsistency in FieldArray's getsubitem

### DIFF
--- a/pycbc/io/record.py
+++ b/pycbc/io/record.py
@@ -830,13 +830,19 @@ class FieldArray(numpy.recarray):
     def __getbaseitem__(self, item):
         """Gets an item assuming item is either an index or a fieldname.
         """
-        # We cast to ndarray to avoid calling array_finalize, which can be slow
+        # We cast to a ndarray to avoid calling array_finalize, which can be
+        # slow
         out = self.view(numpy.ndarray)[item]
-        # cast back to an instance of self if there are more than one field and
-        # element
-        if out.size > 1 and out.dtype.fields is not None:
-            out = out.view(type(self))
-        return out
+        # if there are no fields, then we can just return
+        if out.dtype.fields is None:
+            return out
+        # if there are fields, but only a single entry, we'd just get a
+        # record by casting to self, so just cast immediately to recarray
+        elif out.ndim == 0:
+            return out.view(numpy.recarray)
+        # otherwise, cast back to an instance of self
+        else:
+            return out.view(type(self))
 
     def __getsubitem__(self, item):
         """Gets a subfield using `field.subfield` notation.


### PR DESCRIPTION
Currently, if you take a slice of a length-1 `FieldArray`, you get back a `numpy.ndarray` object instead of a `record` object. This can (and does, in `waveform.bank.TemplateBank.table`) lead to issues. The code using the array expects that it can call fields as attributes, but instead gets an attribute error. Example:
```
# the following works: note that you get a FieldArray back
>>> fa = FieldArray(2, dtype=[('mass1', float), ('mass2', float)])
>>> type(fa[None:None])
pycbc.io.record.FieldArray
>>> fa[None:None].mass1
array([ 0.,  0.])
# the following does not work: just because the length of the array is 1, you
# get an ndarray back, which causes an AttributeError later on
>>> fa = FieldArray(1, dtype=[('mass1', float), ('mass2', float)])
>>> type(fa[None:None])
numpy.ndarray
>>> fa[None:None].mass1
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
```

This patch fixes this by recasting the output to a record array if the ndim is 0.