### PR TITLE
record runtime of inspiral jobs

### DIFF
--- a/bin/hdfcoinc/pycbc_coinc_mergetrigs
+++ b/bin/hdfcoinc/pycbc_coinc_mergetrigs
@@ -73,6 +73,7 @@ end = numpy.array([], dtype=numpy.float64)
 tpc = numpy.array([], dtype=numpy.float64)
 frpc = numpy.array([], dtype=numpy.float64)
 stf = numpy.array([], dtype=numpy.float64)
+rtime = numpy.array([], dtype=numpy.float64)
 gating = {}
 for filename in args.trigger_files:
     try:
@@ -90,6 +91,8 @@ for filename in args.trigger_files:
         frpc = numpy.append(frpc, ifo_data['search/filter_rate_per_core'][:])
     if 'setup_time_fraction' in ifo_data['search'].keys():
         stf = numpy.append(stf, ifo_data['search/setup_time_fraction'][:])
+    if 'run_time' in ifo_data['search'].keys():
+        rtime = numpy.append(rtime, ifo_data['search/run_time'][:])
 
     if 'gating' in ifo_data:
         gating_keys = []
@@ -109,6 +112,8 @@ if len(frpc) > 0:
     f['%s/search/filter_rate_per_core' % ifo] = frpc
 if len(stf) > 0:
     f['%s/search/setup_time_fraction' % ifo] = stf
+if len(rtime) > 0:
+    f['%s/search/run_time' % ifo] = rtime
 
 for gk, gv in gating.items():
     f[ifo + '/gating/' + gk] = gv

--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -510,6 +510,7 @@ class EventManager(object):
                 numpy.array([filters_per_core / float(self.run_time)])
             f['search/setup_time_fraction'] = \
                 numpy.array([float(self.setup_time) / float(self.run_time)])
+            f['search/run_time'] = numpy.array([float(self.run_time)])
 
         if 'q_trans' in self.global_params:
             qtrans = self.global_params['q_trans']


### PR DESCRIPTION
This is helpful when tracking overall usage of a workflow.  It doesn't add anything to the results pages, but does record into merged trigger files the runtime of each inspiral job.

If possible, I'd really like this in the release we're making for reruns.