### PR TITLE
Fix Travis build failure

### DIFF
--- a/pycbc/events/events.py
+++ b/pycbc/events/events.py
@@ -69,7 +69,7 @@ class ThresholdCluster(object):
     """Create a threshold and cluster engine
 
     Parameters
-    ----------
+    -----------
     series : complex64
       Input pycbc.types.Array (or subclass); it will be searched for
       points above threshold that are then clustered
@@ -92,7 +92,7 @@ class _BaseThresholdCluster(object):
         Threshold and cluster the memory specified at instantiation with the
         threshold specified at creation and the window size specified at creation.
 
-        Parameters:
+        Parameters
         -----------
         threshold : float32
           The minimum absolute value of the series given at object initialization


### PR DESCRIPTION
There was an erroneous `:` in events.py that is causing a Sphinx failure. This fixes it.