### PR TITLE
Fix checking for required args in waveform

### DIFF
--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -511,8 +511,8 @@ td_waveform_params = cbc_rframe_params + ParameterList([delta_t]) + \
 # defined above. Defaults of None simply mean that the value is not passed into
 # the lal_dict structure and the waveform generator will take whatever default
 # behaviour
-cbc_td_required = ParameterList([mass1, mass2, delta_t, approximant])
-cbc_fd_required = ParameterList([mass1, mass2, delta_f, approximant])
+cbc_td_required = ParameterList([mass1, mass2, f_lower, delta_t, approximant])
+cbc_fd_required = ParameterList([mass1, mass2, f_lower, delta_f, approximant])
 
 # the following are parameters that can be used to generate a
 # frequency series waveform


### PR DESCRIPTION
By making required arguments have defaults of `None`, PR #2050 caused required arguments to not actually be checked for in `get_td_waveform` and `get_fd_waveform`. The result is that if you do not pass a required argument, you get unhelpful error messages about `None` not being a float. This fixes that by moving the check for required arguments to the `props` function, before the `input_params` are populated with default values.

This also adds `f_lower` to the list of required arguments, which we had forgotten about in PR #2050.