### PR TITLE
Updated psd.estimate.welch to allow window as ndarray

### DIFF
--- a/pycbc/psd/estimate.py
+++ b/pycbc/psd/estimate.py
@@ -64,7 +64,7 @@ def welch(timeseries, seg_len=4096, seg_stride=2048, window='hann',
         Segment length in samples.
     seg_stride : int
         Separation between consecutive segments, in samples.
-    window : {'hann'}
+    window : {'hann', numpy.ndarray}
         Function used to window segments before Fourier transforming, or
         a `numpy.ndarray` that specifies the window.
     avg_method : {'median', 'mean', 'median-mean'}


### PR DESCRIPTION
This PR modifies `pycbc.psd.estimate.welch()` to accept `window` as a `numpy.ndarray`. This allows users to specify their own arbitrary window, without requiring pycbc to handle more name->function mappings.

The sanity checks have been updated to fail if

- `window` is given as an array that doesn't match `seg_len`
- `window` is not an array, and isn't in the `window_map`