### PR TITLE
Fix Debian4 Einstein@Home/OSG build

### DIFF
--- a/tools/einsteinathome/pycbc_etch64_compile-usr-local.sh
+++ b/tools/einsteinathome/pycbc_etch64_compile-usr-local.sh
@@ -15,7 +15,7 @@ apt-get -y install libpcre3-dev libfreetype6-dev libjpeg-dev libpng-dev libmysql
 # make sure these libraries aren't on the system
 apt-get -y remove lapack3-dev atlas3-base atlas3-headers refblas3
 # further necessary / useful tools
-apt-get -y install openssh-server ntpdate zip gettext curl libcurl3-openssl-dev wget bzip2 screen emacs
+apt-get -y install openssh-server ntpdate zip gettext curl libcurl3-openssl-dev wget bzip2 libbz2-dev screen emacs
 
 test ".$PREFIX" = "." &&
   PREFIX=/usr/local


### PR DESCRIPTION
These two commit fix issues with the PyCBC build for Einstein@Home on Debian 4:

- 'wget' links to the system's openssl library, which is too old for github's ssl (which the script uses to determine the 'blessed' version of LALSuite). There is a version of 'curl' built manually and linked with a newer version of openssl on that machine. Howver, 'curl' is not installed e.g. on the Cygwin build system. So I introduced a (shell function) wrapper that uses 'curl' when available and falls back to 'wget' if not.

- Recent versions e.g. of matplotlib require the Python module 'bz'. This requires the package `libbz2-dev` to be installed on the machine, so I added this to the catalog of packages to be installed when setting up the machine.
