### PR TITLE
Make conversions module consistent with numpy

### DIFF
--- a/pycbc/conversions.py
+++ b/pycbc/conversions.py
@@ -40,7 +40,7 @@ from pycbc.detector import Detector
 #
 # =============================================================================
 #
-def _ensurearray(arg):
+def ensurearray(arg):
     """Ensures that the given argument is a numpy array. If it is not, the
     argument is converted to an array.
     """
@@ -51,7 +51,7 @@ def _ensurearray(arg):
     return arg, input_is_array
 
 
-def _formatreturn(arg, input_is_array=False):
+def formatreturn(arg, input_is_array=False):
     """If the given argument is a numpy array with shape (1,), just returns
     that value."""
     if not input_is_array and arg.size == 1:
@@ -67,28 +67,28 @@ def _formatreturn(arg, input_is_array=False):
 #
 def primary_mass(mass1, mass2):
     """Returns the larger of mass1 and mass2 (p = primary)."""
-    mass1, ia1 = _ensurearray(mass1)
-    mass2, ia2 = _ensurearray(mass2)
+    mass1, ia1 = ensurearray(mass1)
+    mass2, ia2 = ensurearray(mass2)
     input_is_array = ia1 or ia2
     if mass1.shape != mass2.shape:
         raise ValueError("mass1 and mass2 must have same shape")
     mp = copy.copy(mass1)
     mask = mass1 < mass2
     mp[mask] = mass2[mask]
-    return _formatreturn(mp, input_is_array)
+    return formatreturn(mp, input_is_array)
 
 
 def secondary_mass(mass1, mass2):
     """Returns the smaller of mass1 and mass2 (s = secondary)."""
-    mass1, ia1 = _ensurearray(mass1)
-    mass2, ia2 = _ensurearray(mass2)
+    mass1, ia1 = ensurearray(mass1)
+    mass2, ia2 = ensurearray(mass2)
     input_is_array = ia1 or ia2
     if mass1.shape != mass2.shape:
         raise ValueError("mass1 and mass2 must have same shape")
     ms = copy.copy(mass2)
     mask = mass1 < mass2
     ms[mask] = mass1[mask]
-    return _formatreturn(ms, input_is_array)
+    return formatreturn(ms, input_is_array)
 
 
 def mtotal_from_mass1_mass2(mass1, mass2):
@@ -363,17 +363,17 @@ def lambda_tilde(mass1, mass2, lambda1, lambda2):
     The mass-weighted dominant effective lambda parameter defined in
     https://journals.aps.org/prd/pdf/10.1103/PhysRevD.91.043002
     """
-    m1, ia1 = _ensurearray(mass1)
-    m2, ia2 = _ensurearray(mass2)
-    lsum, ia3 = _ensurearray(lambda1 + lambda2)
-    ldiff, ia4 = _ensurearray(lambda1 - lambda2)
+    m1, ia1 = ensurearray(mass1)
+    m2, ia2 = ensurearray(mass2)
+    lsum, ia3 = ensurearray(lambda1 + lambda2)
+    ldiff, ia4 = ensurearray(lambda1 - lambda2)
     input_is_array = any([ia1, ia2, ia3, ia4])
     mask = m1 < m2
     ldiff[mask] = -ldiff[mask]
     eta = eta_from_mass1_mass2(m1, m2)
     p1 = (lsum) * (1 + 7. * eta - 31 * eta ** 2.0)
     p2 = (1 - 4 * eta)**0.5 * (1 + 9 * eta - 11 * eta ** 2.0) * (ldiff)
-    return _formatreturn(8.0 / 13.0 * (p1 + p2), input_is_array)
+    return formatreturn(8.0 / 13.0 * (p1 + p2), input_is_array)
 
 #
 # =============================================================================
@@ -420,10 +420,10 @@ def phi_s(spin1x, spin1y, spin2x, spin2y):
 
 def primary_spin(mass1, mass2, spin1, spin2):
     """Returns the dimensionless spin of the primary mass."""
-    mass1, ia1 = _ensurearray(mass1)
-    mass2, ia2 = _ensurearray(mass2)
-    spin1, ia3 = _ensurearray(spin1)
-    spin2, ia4 = _ensurearray(spin2)
+    mass1, ia1 = ensurearray(mass1)
+    mass2, ia2 = ensurearray(mass2)
+    spin1, ia3 = ensurearray(spin1)
+    spin2, ia4 = ensurearray(spin2)
     input_is_array = any([ia1, ia2, ia3, ia4])
     if (mass1.shape != mass2.shape) or (mass1.shape != spin1.shape) or (
         mass1.shape != spin2.shape):
@@ -431,14 +431,14 @@ def primary_spin(mass1, mass2, spin1, spin2):
     sp = copy.copy(spin1)
     mask = mass1 < mass2
     sp[mask] = spin2[mask]
-    return _formatreturn(sp, input_is_array)
+    return formatreturn(sp, input_is_array)
 
 def secondary_spin(mass1, mass2, spin1, spin2):
     """Returns the dimensionless spin of the secondary mass."""
-    mass1, ia1 = _ensurearray(mass1)
-    mass2, ia2 = _ensurearray(mass2)
-    spin1, ia3 = _ensurearray(spin1)
-    spin2, ia4 = _ensurearray(spin2)
+    mass1, ia1 = ensurearray(mass1)
+    mass2, ia2 = ensurearray(mass2)
+    spin1, ia3 = ensurearray(spin1)
+    spin2, ia4 = ensurearray(spin2)
     input_is_array = any([ia1, ia2, ia3, ia4])
     if (mass1.shape != mass2.shape) or (mass1.shape != spin1.shape) or (
         mass1.shape != spin2.shape):
@@ -446,7 +446,7 @@ def secondary_spin(mass1, mass2, spin1, spin2):
     ss = copy.copy(spin2)
     mask = mass1 < mass2
     ss[mask] = spin1[mask]
-    return _formatreturn(ss, input_is_array)
+    return formatreturn(ss, input_is_array)
 
 def primary_xi(mass1, mass2, spin1x, spin1y, spin2x, spin2y):
     """Returns the effective precession spin argument for the larger mass.
@@ -494,15 +494,15 @@ def chi_perp_from_mass1_mass2_xi2(mass1, mass2, xi2):
 def chi_p_from_xi1_xi2(xi1, xi2):
     """Returns effective precession spin from xi1 and xi2.
     """
-    xi1, ia1 = _ensurearray(xi1)
-    xi2, ia2 = _ensurearray(xi2)
+    xi1, ia1 = ensurearray(xi1)
+    xi2, ia2 = ensurearray(xi2)
     input_is_array = ia1 or ia2
     if xi1.shape != xi2.shape:
         raise ValueError("xi1, xi2 must have same shape")
     chi_p = copy.copy(xi1)
     mask = xi1 < xi2
     chi_p[mask] = xi2[mask]
-    return _formatreturn(chi_p, input_is_array)
+    return formatreturn(chi_p, input_is_array)
 
 def phi1_from_phi_a_phi_s(phi_a, phi_s):
     """Returns the angle between the x-component axis and the in-plane

--- a/pycbc/cosmology.py
+++ b/pycbc/cosmology.py
@@ -29,7 +29,7 @@ redshift.
 import numpy
 import lal
 from scipy import interpolate
-from pycbc.conversions import _ensurearray, _formatreturn
+from pycbc.conversions import ensurearray, formatreturn
 
 class _DistToZ(object):
     """Class to convert luminosity distance to redshift using the given
@@ -113,7 +113,7 @@ class _DistToZ(object):
     def get_redshift(self, dist):
         """Returns the redshift for the given distance.
         """
-        dist = _ensurearray(dist)
+        dist, input_is_array = ensurearray(dist)
         zs = self.nearby_d2z(dist)
         # if any points had red shifts beyond the nearby, will have nans;
         # replace using the faraway interpolation
@@ -138,7 +138,7 @@ class _DistToZ(object):
                     replacemask = numpy.isnan(zs)
                     minz = maxz - 1
                     maxz = minz + 5
-        return _formatreturn(zs)
+        return formatreturn(zs, input_is_array)
 
     def __call__(self, dist):
         return self.get_redshift(dist)

--- a/pycbc/distributions/spins.py
+++ b/pycbc/distributions/spins.py
@@ -144,14 +144,14 @@ class IndependentChiPChiEff(Arbitrary):
         bool
             Whether or not the values satisfy physical
         """
-        mass1 = conversions._ensurearray(values['mass1'])
-        mass2 = conversions._ensurearray(values['mass2'])
-        phi_a = conversions._ensurearray(values['phi_a'])
-        phi_s = conversions._ensurearray(values['phi_s'])
-        chi_eff = conversions._ensurearray(values['chi_eff'])
-        chi_a = conversions._ensurearray(values['chi_a'])
-        xi1 = conversions._ensurearray(values['xi1'])
-        xi2 = conversions._ensurearray(values['xi2'])
+        mass1, _ = conversions.ensurearray(values['mass1'])
+        mass2, _ = conversions.ensurearray(values['mass2'])
+        phi_a, _ = conversions.ensurearray(values['phi_a'])
+        phi_s, _ = conversions.ensurearray(values['phi_s'])
+        chi_eff, _ = conversions.ensurearray(values['chi_eff'])
+        chi_a, _ = conversions.ensurearray(values['chi_a'])
+        xi1, _ = conversions.ensurearray(values['xi1'])
+        xi2, _ = conversions.ensurearray(values['xi2'])
         s1x = conversions.spin1x_from_xi1_phi_a_phi_s(xi1, phi_a, phi_s)
         s2x = conversions.spin2x_from_mass1_mass2_xi2_phi_a_phi_s(mass1, mass2,
             xi2, phi_a, phi_s)


### PR DESCRIPTION
Currently, functions in the conversions module that need to do boolean operations (such as `primary_mass`) use the `ensurearray` function to make sure all inputs are arrays, so it can use the masking features of numpy. The results are passed through `formatreturn` before being returned. If the results have length 1, `formatreturn` will just return the single item in the array. This way, if you input floats, you get back floats.

The problem is if you give one of these functions a length-1 array you get back a float. This is inconsistent with how you would normally expect a python function to act when given a numpy array, and it can cause errors when using these functions. For example:

```
# expect float
>>> conversions.primary_mass(10., 20.)
20.0
# expect array, get array
>>> conversions.primary_mass(numpy.array([10., 1.4]), numpy.array([20., 1.]))
array([ 20. ,   1.4])
# still expect array, get float
>>> conversions.primary_mass(numpy.array([10.]), numpy.array([20.]))
20.0
```

This patch fixes this by keeping track of the type of the inputs; `formatarray` only pops the item out of a length-1 array if none of the inputs were arrays. Repeating the above:

```
>>> conversions.primary_mass(10., 20.)
20.0
>>> conversions.primary_mass(numpy.array([10., 1.4]), numpy.array([20., 1.]))
array([ 20. ,   1.4])
>>> conversions.primary_mass(numpy.array([10.]), numpy.array([20.]))
array([ 20.])
```