### PR TITLE
Updates to plot_inj_interval

### DIFF
--- a/bin/inference/pycbc_inference_plot_inj_intervals
+++ b/bin/inference/pycbc_inference_plot_inj_intervals
@@ -10,6 +10,7 @@ import matplotlib.colorbar as cbar
 import matplotlib.pyplot as plt
 import numpy
 import pycbc
+from scipy import stats
 from matplotlib import cm
 from pycbc import inject
 from pycbc import transforms
@@ -23,9 +24,6 @@ parser.add_argument("--output-file", required=True, type=str,
                     help="Path to save output plot.")
 parser.add_argument("--verbose", action="store_true",
                     help="Allows print statements.")
-parser.add_argument("--quantiles", nargs="+", type=float,
-                    default=numpy.arange(0.05, 1.05, 0.05),
-                    help="List of quantiles to plot.")
 parser.add_argument("--injection-hdf-group", default="H1/injections",
                     help="HDF group that contains injection values.")
 option_utils.add_inference_results_option_group(parser)
@@ -37,22 +35,16 @@ pycbc.init_logging(opts.verbose)
 
 # read results
 _, parameters, labels, samples = option_utils.results_from_cli(opts)
-
-# create figure
-fig = plt.figure()
-ax = fig.add_subplot(111)
+labels = labels[0]
 
 # typecast to list for iteration
 parameters = [parameters] if not isinstance(samples, list) else parameters
-label = [labels] if not isinstance(labels, list) else labels
+labels = [labels] if not isinstance(labels, list) else labels
 samples = [samples] if not isinstance(samples, list) else samples
-
-# dict to hold counts of injections parameters recovered in or out interval
-inj_inside = {p : opts.quantiles.size * [0] for p in parameters[0]}
-inj_outside = {p : opts.quantiles.size * [0] for p in parameters[0]}
 
 # loop over input files and its samples
 logging.info("Plotting")
+measured_percentiles = {}
 for input_file, input_parameters, input_samples in zip(
                                         opts.input_file, parameters, samples):
 
@@ -67,36 +59,32 @@ for input_file, input_parameters, input_samples in zip(
     # add parameters not included in injection file
     inj_parameters = transforms.apply_transforms(injs.table, ts)
 
-    # loop over parameters and quantiles
     for p in input_parameters:
-        for i, q in enumerate(opts.quantiles):
 
-            # compute quantiles of sampled results
-            q *= 100
-            low = 50 - q / 2.0
-            high = 50 + q / 2.0
-            low_val, high_val = numpy.array([
-                                         numpy.percentile(input_samples[p], q)
-                                         for q in [low, high]])
+        inj_val = inj_parameters[p]
+        sample_vals = input_samples[p]
+        measured = stats.percentileofscore(sample_vals, inj_val)
+        try:
+            measured_percentiles[p].append(measured)
+        except KeyError:
+            measured_percentiles[p] = []
+            measured_percentiles[p].append(measured)
 
-            # determine if inside or outside interval
-            injected_vals = inj_parameters[p]
-            for inj_val in injected_vals:
-                if inj_val > low_val and inj_val < high_val:
-                    inj_inside[p][i] += 1
-                else:
-                    inj_outside[p][i] += 1
+# create figure for plotting
+fig = plt.figure()
+ax = fig.add_subplot(111)
 
-# determine the fraction found within each credible interval
-fractions = {p : numpy.zeros(opts.quantiles.size) for p in inj_inside.keys()}
-for p in fractions.keys():
-    for i, q in enumerate(opts.quantiles):
-        fractions[p][i] = inj_inside[p][i] / \
-                                 float(inj_outside[p][i] + inj_inside[p][i])
-
-    # plot parameter
-    j = parameters[0].index(p)
-    ax.plot(opts.quantiles, fractions[p], label=r"{}".format(labels[j][0]))
+# calculate the expected percentile for each injection and plot
+for param,label in zip(input_parameters, labels):
+    # calculate expected
+    meas = numpy.array(measured_percentiles[param])
+    meas.sort()
+    expected = numpy.array([stats.percentileofscore(meas, x)
+                            for x in meas])
+    # perform ks test
+    ks, p = stats.kstest(meas/100., 'uniform')
+    ax.plot(meas/100., expected/100.,
+                label='{} p-value: {:.3f}'.format(label, p))
 
 # set legend
 ax.legend()

--- a/bin/inference/pycbc_inference_plot_inj_intervals
+++ b/bin/inference/pycbc_inference_plot_inj_intervals
@@ -14,6 +14,7 @@ from matplotlib import cm
 from pycbc import inject
 from pycbc import transforms
 from pycbc.inference import option_utils
+from pycbc.io.record import FieldArray
 
 # parse command line
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
@@ -57,6 +58,7 @@ for input_file, input_parameters, input_samples in zip(
 
     # read injections from HDF input file
     injs = inject.InjectionSet(input_file, hdf_group=opts.injection_hdf_group)
+    injs.table = injs.table.view(FieldArray)
 
     # check if need extra parameters than parameters stored in injection file
     _, ts = transforms.get_common_cbc_transforms(opts.parameters,

--- a/bin/inference/pycbc_inference_plot_inj_intervals
+++ b/bin/inference/pycbc_inference_plot_inj_intervals
@@ -3,6 +3,7 @@
 within a credible interval versus credible interval.
 """
 
+import sys
 import argparse
 import logging
 import matplotlib as mpl; mpl.use("Agg")
@@ -14,6 +15,7 @@ from scipy import stats
 from matplotlib import cm
 from pycbc import inject
 from pycbc import transforms
+from pycbc.results import save_fig_with_metadata
 from pycbc.inference import option_utils
 from pycbc.io.record import FieldArray
 
@@ -84,7 +86,7 @@ for param,label in zip(input_parameters, labels):
     # perform ks test
     ks, p = stats.kstest(meas/100., 'uniform')
     ax.plot(meas/100., expected/100.,
-                label='{} p-value: {:.3f}'.format(label, p))
+                label='{} $D_{{KS}}$: {:.3f} p-value: {:.3f}'.format(label, ks, p))
 
 # set legend
 ax.legend()
@@ -100,7 +102,20 @@ ax.grid()
 ax.plot([0, 1], [0, 1], linestyle="dashed", color="gray", zorder=9)
 
 # save plot
-plt.savefig(opts.output_file)
+caption = ('Percentile-percentile plot. The value of the KS statistic '
+           '$D_{KS}$ is given in the legend. This gives the maximum distance '
+           'between the observed line and the expected (dashed) line; i.e., '
+           'it gives the maximum distance between the measured CDF and the '
+           'expected (uniform) CDF. The associated two-tailed p-value gives '
+           'the probability of getting a maximum distance (either above '
+           'or below the expected line) larger than the observed $D_{KS}$ '
+           'assuming that the measured CDF is the same as the expected. '
+           'In other words, the larger (smaller) the p-value ($D_{KS}$), the '
+           'more likely the measured distribution is the same as the '
+           'expected.')
+save_fig_with_metadata(fig, opts.output_file,
+    caption=caption,
+    cmd=' '.join(sys.argv))
 
 # done
 logging.info("Done")

--- a/bin/inference/pycbc_inference_plot_inj_intervals
+++ b/bin/inference/pycbc_inference_plot_inj_intervals
@@ -63,7 +63,7 @@ for input_file, input_parameters, input_samples in zip(
 
         inj_val = inj_parameters[p]
         sample_vals = input_samples[p]
-        measured = stats.percentileofscore(sample_vals, inj_val)
+        measured = stats.percentileofscore(sample_vals, inj_val, kind='weak')
         try:
             measured_percentiles[p].append(measured)
         except KeyError:
@@ -79,7 +79,7 @@ for param,label in zip(input_parameters, labels):
     # calculate expected
     meas = numpy.array(measured_percentiles[param])
     meas.sort()
-    expected = numpy.array([stats.percentileofscore(meas, x)
+    expected = numpy.array([stats.percentileofscore(meas, x, kind='weak')
                             for x in meas])
     # perform ks test
     ks, p = stats.kstest(meas/100., 'uniform')


### PR DESCRIPTION
This patch does a few things to `pycbc_inference_plot_inj_interval`:
 * Drops the quantiles option, instead using `scipy.stats.percentileofscore` to calculate the x and y axes. This results in a more fine-grained line that always terminates at (1,1), as expected.
 * Adds a KS test, and reports the results in the legend.
 * Adds metadata to the plot so it'll appear in the results pages.
 * Casts the injection table to a `FieldArray` so that the same functions can be used on both the samples and the injection parameters (e.g., currently, you'll get an error if you try to use the `primary_mass` function).

Old plot:
https://www2.atlas.aei.uni-hannover.de/~work-cdcapano/projects/pycbc_inference/pp_tests/emcee_pt/nonspinning_phenomd_n100-extra_plots/mass1_pp.png

New plot:
https://www2.atlas.aei.uni-hannover.de/~work-cdcapano/projects/pycbc_inference/pp_tests/emcee_pt/nonspinning_phenomd_n100-extra_plots/mass1_new_pp.png

Compare to Fig. 10 of https://arxiv.org/abs/1409.7215.