### PR TITLE
FIx edge effect bug

### DIFF
--- a/bin/plotting/pycbc_plot_qscan
+++ b/bin/plotting/pycbc_plot_qscan
@@ -111,7 +111,11 @@ elif opts.qtransform_frange_upper is None or \
 else:
     curr_frange = (opts.qtransform_frange_lower, opts.qtransform_frange_upper)
 
-strain = strain.whiten(4, 4)
+rem_corrupted = True
+if (center_time - strain.start_time) < 2 or (strain.end_time - center_time) < 2:
+    rem_corrupted = False
+
+strain = strain.whiten(4, 4, remove_corrupted=rem_corrupted)
 
 wins = opts.time_windows
 fig, axes = plt.subplots(len(wins),1)


### PR DESCRIPTION
There's an issue with the `pycbc_plot_qscan` code with events right at the edge of science times. I hadn't realised that the whitening was removing data, which is causing issues where the trigger itself can be removed in the whitening.

It's not ideal, but I propose to fix this by just not removing the "corrupted" data in the case that the trigger is within the corrupted times.

This issue can cause failures in the current code, but it seems that in most cases you get non-sensical output rather than a failure.