### PR TITLE
Check for burn in when counting number of independent samples

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -456,10 +456,7 @@ with ctx:
         # update nsamples for next loop
         if opts.n_independent_samples is not None:
             with InferenceFile(checkpoint_file, 'r') as fp:
-                if fp.is_burned_in:
-                    nsamples = fp.n_independent_samples
-                else:
-                    nsamples = 0
+                nsamples = fp.n_independent_samples
             logging.info("Have {} independent samples".format(nsamples))
         else:
             nsamples += interval

--- a/pycbc/inference/sampler_base.py
+++ b/pycbc/inference/sampler_base.py
@@ -836,6 +836,9 @@ class BaseMCMCSampler(_BaseSampler):
     def n_independent_samples(cls, fp):
         """Returns the number of independent samples stored in a file.
 
+        The number of independent samples are counted starting from after
+        burn-in. If the sampler hasn't burned in yet, then 0 is returned.
+
         Parameters
         -----------
         fp : InferenceFile
@@ -846,6 +849,9 @@ class BaseMCMCSampler(_BaseSampler):
         int
             The number of independent samples.
         """
+        # check if burned in
+        if not fp.is_burned_in:
+            return 0
         # we'll just read a single parameter from the file
         samples = cls.read_samples(fp, fp.variable_args[0])
         return samples.size


### PR DESCRIPTION
Currently, `BaseMCMCSampler.n_independent_samples` returns at least the number of walkers even if the sampler has not burned in yet. This results in a `pycbc_inference` quitting prematurely when resuming from checkpoint: if you are resuming from a checkpoint, then at start up the number of independent samples are retrieved, here: https://github.com/ligo-cbc/pycbc/blob/master/bin/inference/pycbc_inference#L394. If you have requested the number independent samples to be the same as the number of walkers, then the code will immediately think it has enough samples, and will exit.

This patch fixes that by having `BaseMCMCSampler.n_independent_samples` return 0 if it has not burned in yet. Since this is now checked by the sampler, it removes needing to check for burn in the loop over iterations.