### PR TITLE
Give option to save backup

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -109,6 +109,9 @@ parser.add_argument("--resume-from-checkpoint", action="store_true",
                     default=False,
                     help="Automatically load results from checkpoint/backup "
                          "file.")
+parser.add_argument("--delete-backup", action="store_true",
+                    default=False,
+                    help="Delete the backup file after the run has completed.")
 parser.add_argument("--checkpoint-fast", action="store_true",
                     help="Do not calculate ACL after each checkpoint, only at "
                          "the end. Not applicable if n-independent-samples "
@@ -483,8 +486,9 @@ with ctx:
 # rename checkpoint to output and delete backup
 logging.info("Moving checkpoint to output")
 os.rename(checkpoint_file, opts.output_file)
-logging.info("Deleting backup file")
-os.remove(backup_file)
+if opts.delete_backup:
+    logging.info("Deleting backup file")
+    os.remove(backup_file)
 
 # exit
 logging.info("Done")

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -109,9 +109,10 @@ parser.add_argument("--resume-from-checkpoint", action="store_true",
                     default=False,
                     help="Automatically load results from checkpoint/backup "
                          "file.")
-parser.add_argument("--delete-backup", action="store_true",
+parser.add_argument("--save-backup", action="store_true",
                     default=False,
-                    help="Delete the backup file after the run has completed.")
+                    help="Don't delete the backup file after the run has "
+                         "completed.")
 parser.add_argument("--checkpoint-fast", action="store_true",
                     help="Do not calculate ACL after each checkpoint, only at "
                          "the end. Not applicable if n-independent-samples "
@@ -486,7 +487,7 @@ with ctx:
 # rename checkpoint to output and delete backup
 logging.info("Moving checkpoint to output")
 os.rename(checkpoint_file, opts.output_file)
-if opts.delete_backup:
+if not opts.save_backup:
     logging.info("Deleting backup file")
     os.remove(backup_file)
 


### PR DESCRIPTION
Adds a `--save-backup` option to `pycbc_inference`. If turned on, the backup file will not be deleted.