### PR TITLE
Plot injection values in plot posterior

### DIFF
--- a/bin/inference/pycbc_inference_plot_inj_intervals
+++ b/bin/inference/pycbc_inference_plot_inj_intervals
@@ -49,20 +49,11 @@ logging.info("Plotting")
 measured_percentiles = {}
 for input_file, input_parameters, input_samples in zip(
                                         opts.input_file, parameters, samples):
-
-    # read injections from HDF input file
-    injs = inject.InjectionSet(input_file, hdf_group=opts.injection_hdf_group)
-    injs.table = injs.table.view(FieldArray)
-
-    # check if need extra parameters than parameters stored in injection file
-    _, ts = transforms.get_common_cbc_transforms(opts.parameters,
-                                                 injs.table.fieldnames)
-
-    # add parameters not included in injection file
-    inj_parameters = transforms.apply_transforms(injs.table, ts)
+    # load the injections
+    opts.input_file = input_file
+    inj_parameters = option_utils.injections_from_cli(opts)
 
     for p in input_parameters:
-
         inj_val = inj_parameters[p]
         sample_vals = input_samples[p]
         measured = stats.percentileofscore(sample_vals, inj_val, kind='weak')

--- a/bin/inference/pycbc_inference_plot_movie
+++ b/bin/inference/pycbc_inference_plot_movie
@@ -224,8 +224,22 @@ else:
 
 fp.close()
 
-# get expected parameters
-expected_parameters = option_utils.expected_parameters_from_cli(opts)
+# get injection values if desired
+expected_parameters = {}
+if opts.plot_injection_parameters:
+    injections = option_utils.injections_from_cli(opts)
+    for p in parameters:
+        # check that all of the injections are the same
+        unique_vals = numpy.unique(injections[p])
+        if unique_vals.size != 1:
+            raise ValueError("More than one injection found! To use "
+                "plot-injection-parameters, there must be a single unique "
+                "injection in all input files. Use the expected-parameters "
+                "option to specify an expected parameter instead.")
+        # passed: use the value for the expected
+        expected_parameters[p] = unique_vals[0]
+# get expected parameter values from command line
+expected_parameters.update(option_utils.expected_parameters_from_cli(opts))
 expected_parameters_color = opts.expected_parameters_color
 
 logging.info('Choosing common characteristics for all figures')

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -134,8 +134,23 @@ for p in parameters[0]:
     if p not in maxs:
         maxs[p] = numpy.array([s[p].max() for s in samples]).max()
 
+# get injection values if desired
+expected_parameters = {}
+if opts.plot_injection_parameters:
+    injections = option_utils.injections_from_cli(opts)
+    for p in parameters:
+        # check that all of the injections are the same
+        unique_vals = numpy.unique(injections[p])
+        if unique_vals.size != 1:
+            raise ValueError("More than one injection found! To use "
+                "plot-injection-parameters, there must be a single unique "
+                "injection in all input files. Use the expected-parameters "
+                "option to specify an expected parameter instead.")
+        # passed: use the value for the expected
+        expected_parameters[p] = unique_vals[0]
+
 # get expected parameter values from command line
-expected_parameters = option_utils.expected_parameters_from_cli(opts)
+expected_parameters.update(option_utils.expected_parameters_from_cli(opts))
 
 # assign some colors
 colors = itertools.cycle(["black"] + ["C{}".format(i) for i in range(10)])

--- a/bin/inference/pycbc_inference_plot_posterior
+++ b/bin/inference/pycbc_inference_plot_posterior
@@ -138,7 +138,7 @@ for p in parameters[0]:
 expected_parameters = {}
 if opts.plot_injection_parameters:
     injections = option_utils.injections_from_cli(opts)
-    for p in parameters:
+    for p in parameters[0]:
         # check that all of the injections are the same
         unique_vals = numpy.unique(injections[p])
         if unique_vals.size != 1:

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -887,7 +887,18 @@ def plot_ranges_from_cli(opts):
 
 
 def injections_from_cli(opts):
-    """Gets injection parameters from the list of files.
+    """Gets injection parameters from the inference file(s).
+
+    Parameters
+    ----------
+    opts : argparser
+        Argparser object that has the command-line objects to parse.
+
+    Returns
+    -------
+    FieldArray
+        Array of the injection parameters from all of the input files given
+        by ``opts.input_file``.
     """
     input_files = opts.input_file
     if isinstance(input_files, str):

--- a/pycbc/inference/option_utils.py
+++ b/pycbc/inference/option_utils.py
@@ -847,7 +847,7 @@ def add_plot_posterior_option_group(parser):
                              "the values obtained for the injection.")
     # FIXME: the following should be made an attribute of the results file
     pgroup.add_argument("--injection-hdf-group", default="H1/injections",
-                        help="HDF group that contains injection values."))
+                        help="HDF group that contains injection values.")
     return pgroup
 
 
@@ -892,7 +892,10 @@ def injections_from_cli(opts):
     input_files = opts.input_file
     if isinstance(input_files, str):
         input_files = [input_files]
-    parameters, _ = parse_parameters_opt(parameters)
+    parameters, _ = parse_parameters_opt(opts.parameters)
+    if parameters is None:
+        with InferenceFile(input_files[0], 'r') as fp:
+            parameters = fp.variable_args
     injections = None
     # loop over all input files getting the injection files
     for input_file in input_files:

--- a/pycbc/results/scatter_histograms.py
+++ b/pycbc/results/scatter_histograms.py
@@ -611,6 +611,12 @@ def create_multidim_plot(parameters, samples, labels=None,
             samples[param] = values
             mins[param] = mins[param] - float(offset)
             maxs[param] = maxs[param] - float(offset)
+        # also remove from expected parameters, if they were provided
+        if expected_parameters is not None:
+            try:
+                expected_parameters[param] -= offset
+            except KeyError:
+                pass
 
     # create the axis grid
     if fig is None and axis_dict is None:


### PR DESCRIPTION
This adds a `--plot-injection-parameters` to `plot_posterior` and `plot_movie`. With it on, the injection parameters will be retrieved from the file and plotted as the expected parameters. Example:
```
pycbc_inference_plot_posterior --input-file marginalization.hdf --output-file posterior.png --plot-scatter --plot-marginal --z-arg snr --verbose --plot-injection-parameters
```
yields [this](https://www2.atlas.aei.uni-hannover.de/~work-cdcapano/projects/test_phase_marginalization/marginalization_no_coa_phase/posterior.png) and
```
pycbc_inference_plot_movie --input-file marginalization.hdf --output-prefix movie_frames --movie-file movie.mp4 --frame-step 25 --plot-scatter --plot-marginal --z-arg snr --verbose --plot-injection-parameters --nprocesses 16
```
yields [this](https://www2.atlas.aei.uni-hannover.de/~work-cdcapano/projects/test_phase_marginalization/marginalization_no_coa_phase/movie.mp4).

To get the injection parameters, I moved the code currently in `pycbc_inference_plot_inj_intervals` to a function in `option_utils`, which `plot_inj_intervals`, `plot_posterior`, and `plot_movie` call.

This also fixes a bug in `scatter_histograms` I came across while testing this. Expected values were not being adjusted for constant offsets, as the plotting parameters were.
