### PR TITLE
Use None for required args default

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -343,12 +343,15 @@ def get_obj_attrs(obj):
 
     return pr
 
-def props(obj, required_args=[], **kwargs):
+def props(obj, required_args=None, **kwargs):
     """ Return a dictionary built from the combination of defaults, kwargs,
     and the attributes of the given object.
     """
     pr = get_obj_attrs(obj)
     pr.update(kwargs)
+
+    if required_args is None:
+        required_args = []
 
     # check that required args are given
     missing = set(required_args) - set(pr.keys())


### PR DESCRIPTION
As caught by landscape, using an empty list as a default is dangerous. This make the default `required_args` in `waveform.props` `None` instead of `[]`. The `None` is replaced with `[]` in the function.