### PR TITLE
Fix Lambda label

### DIFF
--- a/pycbc/waveform/parameters.py
+++ b/pycbc/waveform/parameters.py
@@ -241,11 +241,11 @@ spin_sz = Parameter("spin_sz",
                 description="The z component of the dimensionless spin of the "
                             "secondary object.")
 lambda1 = Parameter("lambda1",
-                dtype=float, default=None, label=r"$\lambda_1$",
-                description="The tidal deformability parameter of object 1.")
+                dtype=float, default=None, label=r"$\Lambda_1$",
+                description="The dimensionless tidal deformability parameter of object 1.")
 lambda2 = Parameter("lambda2",
-                dtype=float, default=None, label=r"$\lambda_2$",
-                description="The tidal deformability parameter of object 2.")
+                dtype=float, default=None, label=r"$\Lambda_2$",
+                description="The dimensionless tidal deformability parameter of object 2.")
 dquad_mon1 = Parameter("dquad_mon1",
                 dtype=float, default=None, label=r"$qm_1$",
                 description="Quadrupole-monopole parameter / m_1^5 -1.")


### PR DESCRIPTION
According to the general convention in literature, \lambda is the deformability parameter which has units [gm cm^2 s^2], amd \Lambda is the dimensionless tidal deformability parameter. What we use in our calculations in pycbc is \Lambda. This label is also used in plotting PE posteriors, so using the correct symbol might help in avoiding any confusion.  