### PR TITLE
Fixed bug in import version info to __init__

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -38,6 +38,9 @@ except:
     git_hash = 'none'
     pycbc_version = 'none'
 
+__version__ = pycbc_version
+
+
 def init_logging(verbose=False, format='%(asctime)s %(message)s'):
     """ Common utility for setting up logging in PyCBC.
 

--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -32,8 +32,8 @@ import signal
 try:
     # This will fail when pycbc is imported during the build process,
     # before version.py has been generated.
-    from version import git_hash
-    from version import version as pycbc_version
+    from .version import git_hash
+    from .version import version as pycbc_version
 except:
     git_hash = 'none'
     pycbc_version = 'none'


### PR DESCRIPTION
This PR fixes #2106 by modifying `pycbc/__init__.py` to use a relative import (which will be required for python3 anyway), and also provides `pycbc.__version__`, the standard metadata variable.