### PR TITLE
Removed print of mkl ImportError from __init__.py

### DIFF
--- a/pycbc/__init__.py
+++ b/pycbc/__init__.py
@@ -135,10 +135,9 @@ os.environ['PYTHONCOMPILED'] = _cache_dir_path
 try:
     import pycbc.fft.mkl
     HAVE_MKL=True
-except ImportError as e:
-    print(e)
+except ImportError:
     HAVE_MKL=False
-    
+
 
 # Check for site-local flags to pass to gcc
 WEAVE_FLAGS = '-march=native -O3 -w '


### PR DESCRIPTION
This PR removes the printing of the `ImportError` raised from the attempt to import `pycbc.fft.mkl` in `pycbc/__init__.py`.

The upstream error will always be empty:

https://github.com/ligo-cbc/pycbc/blob/e5a335efb8c4dae4a529f5ba86b132d00918bdbb/pycbc/fft/mkl.py#L6-L8

and as such is just annoying to print.