### PR TITLE
allow injection of fourier domain approximants

### DIFF
--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -541,6 +541,10 @@ def get_td_waveform_from_fd(**params):
     # increase in computational cost
     rwrap = 0.2
     fudge_duration = (max(0, full_duration) + .1 + rwrap) * 1.5
+    fsamples = int(fudge_duration / params['delta_t'])
+    N = pnutils.nearest_larger_binary_number(fsamples)
+    fudge_duration = N * params['delta_t']
+
     nparams['delta_f'] = 1.0 / fudge_duration
     hp, hc = get_fd_waveform(**nparams)
 

--- a/pycbc/waveform/waveform.py
+++ b/pycbc/waveform/waveform.py
@@ -509,7 +509,7 @@ def get_td_waveform_from_fd(**params):
     This returns a time domain version of a fourier domain approximant, with
     padding and tapering at the start of the waveform.
 
-    Paramaters
+    Parameters
     ----------
     params: dict
         The parameters defining the waveform to generator.


### PR DESCRIPTION
This allows injection of fourier domain approximants by exposing them all through the get_td_waveform interface. This is done in a way that ensures no time offset / phase offset is introduced in the conversion from fd to td. 

These are added with a new approximant name to differentiate.

The following all generated IMRPhenomD in the time domain now, but the get_td_waveform version will apply reasonable tapering at the start. 

In case anyone is wondering, injection in the time domain is still desired to avoid wraparound issues. An example would be where we want only part of the waveform to be injected since we are looking at a segment of strain that only contains a part of the signal. The waveform should *not* wrap around to the other end of the segment. Ensuring this is straightforward in the time domain.

```
hp, hc = get_td_waveform(approximant="IMRPhenomD_FD", mass1=10, mass2=10,
                                 f_lower=30, delta_t=1.0/4096)

rp, cc = get_td_waveform(approximant="IMRPhenomD", mass1=10, mass2=10,
                                 f_lower=30, delta_t=1.0/4096)

sp = get_fd_waveform(approximant="IMRPhenomD", mass1=10, mass2=10,
                                 f_lower=30, delta_f=hp.delta_f)[0].to_timeseries()
```
depends on #2115 